### PR TITLE
fix: prefer installed dist over source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.56.4] - 2026-04-07
+
+### Added
+- fix update to use installed files instead of source
+
 ## [1.56.3] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.56.3] - 2026-04-07
+
+### Added
+- fix update to use installed files instead of source
+
 ## [1.56.2] - 2026-04-06
 
 ### Bug Fixes

--- a/bin/prjct
+++ b/bin/prjct
@@ -98,14 +98,22 @@ check_node() {
   command -v node >/dev/null 2>&1
 }
 
-# Run with bun (native TypeScript in dev, compiled in production)
+# Run with bun (compiled dist preferred, TypeScript only for explicit dev)
 run_with_bun() {
-  # Dev mode: raw TypeScript is faster
+  # Always prefer compiled dist — works for npm install, npm link, bun link
+  if [ -f "$ROOT_DIR/dist/bin/prjct.mjs" ]; then
+    # Explicit dev mode: PRJCT_DEV=1 forces raw TypeScript (faster iteration)
+    if [ "$PRJCT_DEV" = "1" ] && [ -f "$SCRIPT_DIR/prjct.ts" ]; then
+      exec bun "$SCRIPT_DIR/prjct.ts" "$@"
+    fi
+    exec bun "$ROOT_DIR/dist/bin/prjct.mjs" "$@"
+  fi
+  # No dist: fall back to raw TypeScript (first run before build)
   if [ -f "$SCRIPT_DIR/prjct.ts" ]; then
     exec bun "$SCRIPT_DIR/prjct.ts" "$@"
   fi
-  # Production: use compiled dist
-  exec bun "$ROOT_DIR/dist/bin/prjct.mjs" "$@"
+  echo "Error: No entry point found. Run 'npm run build' first."
+  exit 1
 }
 
 # Run with node (compiled JavaScript)
@@ -113,7 +121,7 @@ run_with_node() {
   DIST_BIN="$ROOT_DIR/dist/bin/prjct.mjs"
 
   if [ ! -f "$DIST_BIN" ]; then
-    # Dev mode: try to build
+    # No dist: try to build if this looks like a dev checkout
     if [ -f "$ROOT_DIR/scripts/build.js" ] && [ -d "$ROOT_DIR/core" ]; then
       echo "Building for Node.js (first run)..."
       node "$ROOT_DIR/scripts/build.js" || {

--- a/core/agentic/template-loader.ts
+++ b/core/agentic/template-loader.ts
@@ -145,6 +145,16 @@ export function clearCache(): void {
 }
 
 /**
+ * Reset the template bundle so the next loadBundle() re-reads from disk.
+ * Called after `prjct update` installs a new version to pick up new templates.
+ */
+export function resetBundle(): void {
+  templateBundle = null
+  bundleLoaded = false
+  clearCache()
+}
+
+/**
  * Get raw template content by relative path (e.g., "global/CLAUDE.md")
  * Used by command-installer and other modules that need non-command templates.
  */

--- a/core/commands/update.ts
+++ b/core/commands/update.ts
@@ -19,7 +19,7 @@ import { migrateJsonToSqlite, sweepLegacyJson } from '../storage/migrate-json'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import out from '../utils/output'
-import { VERSION } from '../utils/version'
+import { VERSION, resetPackageRoot } from '../utils/version'
 import { PrjctCommandsBase } from './base'
 
 interface UpdateOptions {
@@ -85,6 +85,14 @@ export class UpdateCommands extends PrjctCommandsBase {
       if (!md) out.step(1, 3, 'Updating package...')
       results.phase1 = await this.phasePackageUpdate(dryRun)
       if (!md) out.stop()
+
+      // After Phase 1, redirect to the INSTALLED package.
+      // The running process may have started from source (npm link / bun link)
+      // or from the old install. All Phase 2+3 operations must use the
+      // newly installed files, not the source/old paths.
+      if (!dryRun && results.phase1.success) {
+        this.redirectToInstalledPackage()
+      }
 
       // ── Phase 2: Global Cleanup ──
       if (!md) out.step(2, 3, 'Cleaning up all projects...')
@@ -273,36 +281,34 @@ export class UpdateCommands extends PrjctCommandsBase {
             const endMarker = '<!-- prjct:end - DO NOT REMOVE THIS MARKER -->'
 
             if (geminiContent.includes(startMarker) && geminiContent.includes(endMarker)) {
-              // Read fresh template
-              const templatePath = path.join(
-                path.dirname(require.resolve('../../package.json')),
-                'templates',
-                'global',
-                'GEMINI.md'
-              )
-              const template = await fs.readFile(templatePath, 'utf-8')
-              const prjctSection = template.substring(
-                template.indexOf(startMarker),
-                template.indexOf(endMarker) + endMarker.length
-              )
+              // Read template from bundle (installed files), not source
+              const { getTemplateContent } = await import('../agentic/template-loader')
+              const template = getTemplateContent('global/GEMINI.md')
 
-              const before = geminiContent.substring(0, geminiContent.indexOf(startMarker))
-              const after = geminiContent.substring(
-                geminiContent.indexOf(endMarker) + endMarker.length
-              )
+              if (template && template.includes(startMarker) && template.includes(endMarker)) {
+                const prjctSection = template.substring(
+                  template.indexOf(startMarker),
+                  template.indexOf(endMarker) + endMarker.length
+                )
 
-              // Strip legacy prjct-project sections
-              let cleaned = before + prjctSection + after
-              const projStart = '<!-- prjct-project:start - DO NOT REMOVE THIS MARKER -->'
-              const projEnd = '<!-- prjct-project:end - DO NOT REMOVE THIS MARKER -->'
-              if (cleaned.includes(projStart) && cleaned.includes(projEnd)) {
-                const bp = cleaned.substring(0, cleaned.indexOf(projStart))
-                const ap = cleaned.substring(cleaned.indexOf(projEnd) + projEnd.length)
-                cleaned = `${(bp + ap).replace(/\n{3,}/g, '\n\n').trim()}\n`
+                const before = geminiContent.substring(0, geminiContent.indexOf(startMarker))
+                const after = geminiContent.substring(
+                  geminiContent.indexOf(endMarker) + endMarker.length
+                )
+
+                // Strip legacy prjct-project sections
+                let cleaned = before + prjctSection + after
+                const projStart = '<!-- prjct-project:start - DO NOT REMOVE THIS MARKER -->'
+                const projEnd = '<!-- prjct-project:end - DO NOT REMOVE THIS MARKER -->'
+                if (cleaned.includes(projStart) && cleaned.includes(projEnd)) {
+                  const bp = cleaned.substring(0, cleaned.indexOf(projStart))
+                  const ap = cleaned.substring(cleaned.indexOf(projEnd) + projEnd.length)
+                  cleaned = `${(bp + ap).replace(/\n{3,}/g, '\n\n').trim()}\n`
+                }
+
+                await fs.writeFile(geminiPath, cleaned, 'utf-8')
+                result.details.push('Gemini global config updated')
               }
-
-              await fs.writeFile(geminiPath, cleaned, 'utf-8')
-              result.details.push('Gemini global config updated')
             }
           } catch {
             // Gemini not configured — skip
@@ -452,6 +458,46 @@ export class UpdateCommands extends PrjctCommandsBase {
   }
 
   // ── Helpers ──
+
+  /**
+   * After Phase 1 installs the new package via npm, redirect PACKAGE_ROOT
+   * and template cache to the INSTALLED package location.
+   *
+   * Without this, the running process keeps using paths from whatever
+   * started it (source tree via npm link, old install, etc.).
+   * Phase 2+3 must operate on the installed files, not source.
+   */
+  private redirectToInstalledPackage(): void {
+    try {
+      const npmRoot = execSync('npm root -g', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+      const installedPkg = path.join(npmRoot, 'prjct-cli')
+      const pkgJsonPath = path.join(installedPkg, 'package.json')
+
+      // Verify it's a real install (not a symlink back to source)
+      const { existsSync, lstatSync, readFileSync } = require('node:fs')
+      if (!existsSync(pkgJsonPath)) return
+
+      const stat = lstatSync(installedPkg)
+      if (stat.isSymbolicLink()) return // still linked to source — can't redirect
+
+      // Verify it's actually prjct-cli
+      try {
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+        if (pkg.name !== 'prjct-cli') return
+      } catch {
+        return
+      }
+
+      // Reset PACKAGE_ROOT to the installed location
+      resetPackageRoot(installedPkg)
+
+      // Reset template bundle cache so next read picks up installed templates
+      const { resetBundle } = require('../agentic/template-loader')
+      resetBundle()
+    } catch {
+      // Non-blocking: fall through to use current PACKAGE_ROOT
+    }
+  }
 
   /**
    * Scan ~/.prjct-cli/projects/ for all project directories

--- a/core/utils/version.ts
+++ b/core/utils/version.ts
@@ -124,5 +124,16 @@ export function needsMigration(fromVersion: string, toVersion: string | null = n
   return compareVersions(fromVersion, target) < 0
 }
 
+/**
+ * Reset the cached package root to a new path.
+ * Used by `prjct update` after npm install to redirect
+ * from source/old paths to the newly installed package.
+ */
+export function resetPackageRoot(newRoot: string): void {
+  cachedPackageRoot = newRoot
+  cachedVersion = null
+  cachedPackageJson = null
+}
+
 export const VERSION = getVersion()
 export const PACKAGE_ROOT = getPackageRoot()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "1.56.3",
+  "version": "1.56.4",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "1.56.2",
+  "version": "1.56.3",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- `bin/prjct` now always prefers `dist/bin/prjct.mjs` over raw TypeScript source. Source mode only via `PRJCT_DEV=1` or when dist doesn't exist.
- `prjct update` redirects `PACKAGE_ROOT` and template cache to the installed npm package after Phase 1, so Phase 2/3 operate on installed files.
- Gemini template update uses `getTemplateContent()` (bundle-first) instead of `require.resolve` filesystem path.

Fixes the `ENOENT while resolving package 'zod'` error clients hit when the CLI resolved to source files instead of the compiled dist.

## Test plan
- [x] `prjct --version` runs without errors
- [x] `prjct ship --md` runs without zod ENOENT
- [x] `prjct status --md` runs correctly
- [ ] `prjct update --dry-run` shows correct phases
- [ ] Fresh `npm install -g prjct-cli` uses dist entry point

Generated with [p/](https://www.prjct.app/)