### PR TITLE
fix(templates): prefer direct Glob/Grep over Explore subagent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.56.9] - 2026-04-11
+
+### Changed
+- `templates/tools/task.txt`: prefer direct `Glob`/`Grep` for simple
+  exploration; only delegate to `Explore` subagent when the search is
+  open-ended. Subagents inherit all MCP tool schemas from the parent
+  session and can start with heavy context, so prescriptive delegation
+  was hurting more than helping.
+
 ## [1.56.8] - 2026-04-10
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "1.56.8",
+  "version": "1.56.9",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/tools/task.txt
+++ b/templates/tools/task.txt
@@ -16,5 +16,5 @@ When to use:
 Best practices:
 - Provide clear, detailed prompts
 - Launch multiple agents in parallel when independent
-- Use Explore for codebase questions
+- Prefer direct Glob/Grep for simple exploration. Subagents inherit all MCP tool schemas from the parent session and can start heavy — only delegate to Explore when the search is genuinely open-ended and benefits from parallel rounds
 - Use Plan for implementation design


### PR DESCRIPTION
## Summary

- `templates/tools/task.txt` no longer prescribes `Explore` for codebase questions — it now prefers direct `Glob`/`Grep` and only suggests delegating to `Explore` when the search is genuinely open-ended.
- Bumps version to `1.56.9` and records the change in `CHANGELOG.md`.

## Why

Subagents inherit **all** MCP tool schemas from the parent session. In sessions with many `claude.ai` integrations active (Atlassian, ClickUp, Figma, Linear, PostHog, Stripe, Supabase, Google Drive), the `Explore` subagent arrives with tens of thousands of schema tokens before doing anything — sometimes unusable, always wasteful. The old guidance pushed the LLM into that broken path by default.

The real fix (filtering MCP tools by subagent allowlist) is upstream in Claude Code. This PR is the defensive change at the prjct-cli layer.

## Test plan

- [ ] `biome check` clean (pre-commit hook passed)
- [ ] `tsc --noEmit` clean (pre-push hook passed)
- [ ] In a fresh session in this repo, confirm the LLM prefers `Glob`/`Grep` for simple exploration and does not auto-delegate to `Explore`

Generated with [p/](https://www.prjct.app/)