### PR TITLE
refactor(ship): workflow-first dispatcher + ambiguity gate

### DIFF
--- a/core/__tests__/commands/shipping.test.ts
+++ b/core/__tests__/commands/shipping.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ship() workflow-first dispatcher coverage.
+ *
+ * Ship used to hardcode version bump + changelog + git commit/push.
+ * After the refactor, ship is a dispatcher: it runs configured
+ * workflow rules, records the shipped row, and asks the user via
+ * `clarification` when the state is ambiguous.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { ShippingCommands } from '../../commands/shipping'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
+
+async function freshProject(): Promise<{ projectPath: string; projectId: string }> {
+  const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-ship-test-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  const projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  })
+  // ensureProjectStructure initialises the DB and seeds the built-in
+  // 'ship' workflow row — no need to create a custom_workflows entry.
+  await pathManager.ensureProjectStructure(projectId)
+  return { projectPath, projectId }
+}
+
+function initGit(projectPath: string): void {
+  execFileSync('git', ['init', '-q', '-b', 'develop'], { cwd: projectPath })
+  execFileSync('git', ['config', 'user.email', 'test@prjct.local'], { cwd: projectPath })
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: projectPath })
+}
+
+describe('ship() — workflow-first', () => {
+  let projectPath: string
+  let projectId: string
+  let cmd: ShippingCommands
+
+  beforeEach(async () => {
+    ;({ projectPath, projectId } = await freshProject())
+    cmd = new ShippingCommands()
+  })
+
+  afterEach(async () => {
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('non-code project with no rules → returns clarification, does not touch anything', async () => {
+    const result = await cmd.ship('release notes', projectPath, { md: true })
+    expect(result.success).toBe(false)
+    expect(result.clarification).toBeDefined()
+    const c = result.clarification as { options: string[] }
+    expect(c.options).toContain('register-only')
+    expect(c.options).toContain('seed-code-workflow')
+    expect(c.options).toContain('abort')
+    // No CHANGELOG should have been written.
+    const exists = await fs
+      .access(path.join(projectPath, 'CHANGELOG.md'))
+      .then(() => true)
+      .catch(() => false)
+    expect(exists).toBe(false)
+  })
+
+  test('register-only intent records the shipped row without touching files', async () => {
+    const result = await cmd.ship('write blog post', projectPath, {
+      md: true,
+      intent: 'register-only',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.version).toBe('unversioned')
+    expect(result.feature).toBe('write blog post')
+
+    const pkgExists = await fs
+      .access(path.join(projectPath, 'package.json'))
+      .then(() => true)
+      .catch(() => false)
+    expect(pkgExists).toBe(false)
+  })
+
+  test('code project auto-seeds ship rules on first run (migration path)', async () => {
+    await fs.writeFile(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ name: 'codeproj', version: '0.5.0' }, null, 2)
+    )
+    initGit(projectPath)
+    execFileSync('git', ['commit', '--allow-empty', '-m', 'init', '-q'], { cwd: projectPath })
+
+    // No rules pre-seeded — ship should auto-seed then proceed (push will
+    // fail for lack of remote, but commit should land).
+    await cmd.ship('first ship', projectPath, { md: true })
+
+    const rules = workflowRuleStorage.getRulesForCommand(projectId, 'ship')
+    const actions = rules.map((r) => r.action)
+    expect(actions).toContain('version:bump')
+    expect(actions).toContain('changelog:add')
+    expect(actions).toContain('git:commit')
+    expect(actions).toContain('git:push')
+
+    const pkg = JSON.parse(await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8'))
+    expect(pkg.version).toBe('0.5.1')
+  })
+
+  test('seed-code-workflow on a non-code project returns a helpful error', async () => {
+    const result = await cmd.ship(null, projectPath, {
+      md: true,
+      intent: 'seed-code-workflow',
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/does not look like code/i)
+  })
+})

--- a/core/__tests__/workflow/action-prefixes.test.ts
+++ b/core/__tests__/workflow/action-prefixes.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Coverage for the `version:bump`, `changelog:add`, `git:commit`, and
+ * `git:push` action prefixes. The `git:*` tests assert cwd behaviour
+ * explicitly — these were introduced to fix a bug where the daemon's
+ * cwd (not the project's) was driving git commands.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
+import type { WorkflowRunContext } from '../../types/workflow.js'
+import { executeWorkflowRules } from '../../workflow/workflow-engine'
+
+async function freshProject(): Promise<{ projectPath: string; projectId: string }> {
+  const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-prefix-test-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  const projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  })
+  // Built-in 'ship' workflow row is seeded by ensureProjectStructure.
+  await pathManager.ensureProjectStructure(projectId)
+  return { projectPath, projectId }
+}
+
+function addStep(projectId: string, action: string, sortOrder = 0): void {
+  workflowRuleStorage.addRule(projectId, {
+    type: 'step',
+    command: 'ship',
+    position: 'before',
+    action,
+    description: action,
+    enabled: true,
+    timeoutMs: 30000,
+    createdAt: new Date().toISOString(),
+    sortOrder,
+  })
+}
+
+describe('action prefix: version:bump', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    ;({ projectPath, projectId } = await freshProject())
+  })
+
+  afterEach(async () => {
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('bumps package.json version AND writes the new version into runContext', async () => {
+    await fs.writeFile(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ name: 'tmp', version: '1.2.3' }, null, 2)
+    )
+    addStep(projectId, 'version:bump')
+
+    const runCtx: WorkflowRunContext = {}
+    const result = await executeWorkflowRules(projectId, 'ship', 'before', {
+      projectPath,
+      runContext: runCtx,
+    })
+
+    expect(result.success).toBe(true)
+    expect(runCtx.version).toBe('1.2.4')
+    const pkg = JSON.parse(await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8'))
+    expect(pkg.version).toBe('1.2.4')
+  })
+
+  test('does not touch a different cwd when projectPath is explicit', async () => {
+    // Build a SECOND project that should remain untouched.
+    const otherPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-prefix-other-'))
+    await fs.writeFile(
+      path.join(otherPath, 'package.json'),
+      JSON.stringify({ name: 'other', version: '9.9.9' }, null, 2)
+    )
+
+    await fs.writeFile(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ name: 'tmp', version: '1.2.3' }, null, 2)
+    )
+    addStep(projectId, 'version:bump')
+
+    const runCtx: WorkflowRunContext = {}
+    await executeWorkflowRules(projectId, 'ship', 'before', { projectPath, runContext: runCtx })
+
+    const other = JSON.parse(await fs.readFile(path.join(otherPath, 'package.json'), 'utf-8'))
+    expect(other.version).toBe('9.9.9')
+    await fs.rm(otherPath, { recursive: true, force: true })
+  })
+})
+
+describe('action prefix: changelog:add', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    ;({ projectPath, projectId } = await freshProject())
+  })
+
+  afterEach(async () => {
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('requires version + feature in runContext', async () => {
+    addStep(projectId, 'changelog:add')
+
+    const result = await executeWorkflowRules(projectId, 'ship', 'before', {
+      projectPath,
+      runContext: {},
+    })
+    expect(result.success).toBe(false)
+    expect(result.output).toMatch(/version:bump|runContext/i)
+  })
+
+  test('appends a CHANGELOG entry when version + feature are present', async () => {
+    await fs.writeFile(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ name: 'tmp', version: '1.0.0' }, null, 2)
+    )
+    addStep(projectId, 'version:bump', 0)
+    addStep(projectId, 'changelog:add', 1)
+
+    const runCtx: WorkflowRunContext = { feature: 'flux capacitor' }
+    const result = await executeWorkflowRules(projectId, 'ship', 'before', {
+      projectPath,
+      runContext: runCtx,
+    })
+
+    expect(result.success).toBe(true)
+    const changelog = await fs.readFile(path.join(projectPath, 'CHANGELOG.md'), 'utf-8')
+    expect(changelog).toContain('1.0.1')
+    expect(changelog).toContain('flux capacitor')
+  })
+})
+
+describe('action prefix: git:commit / git:push', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    ;({ projectPath, projectId } = await freshProject())
+  })
+
+  afterEach(async () => {
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('git:commit runs against projectPath, not process.cwd()', async () => {
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: projectPath })
+    execFileSync('git', ['config', 'user.email', 'test@prjct.local'], { cwd: projectPath })
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: projectPath })
+    await fs.writeFile(path.join(projectPath, 'README.md'), '# tmp\n')
+    execFileSync('git', ['add', '.'], { cwd: projectPath })
+    execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: projectPath })
+
+    // Stage a new file via the rule.
+    await fs.writeFile(path.join(projectPath, 'new.txt'), 'hi\n')
+    addStep(projectId, 'git:commit')
+
+    const runCtx: WorkflowRunContext = { feature: 'welcome' }
+    const result = await executeWorkflowRules(projectId, 'ship', 'before', {
+      projectPath,
+      runContext: runCtx,
+    })
+
+    expect(result.success).toBe(true)
+    const log = execFileSync('git', ['log', '-1', '--pretty=%s'], {
+      cwd: projectPath,
+      encoding: 'utf-8',
+    })
+    expect(log.trim()).toMatch(/welcome/)
+  })
+
+  test('git:push surfaces the real error when no remote is configured', async () => {
+    execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: projectPath })
+    execFileSync('git', ['config', 'user.email', 'test@prjct.local'], { cwd: projectPath })
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: projectPath })
+    await fs.writeFile(path.join(projectPath, 'README.md'), '# tmp\n')
+    execFileSync('git', ['add', '.'], { cwd: projectPath })
+    execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: projectPath })
+
+    addStep(projectId, 'git:push')
+
+    const result = await executeWorkflowRules(projectId, 'ship', 'before', {
+      projectPath,
+      runContext: {},
+    })
+    expect(result.success).toBe(false)
+    // Message varies by git version; accept "No configured push", "no remote",
+    // or anything that clearly references pushing — just don't accept the old
+    // "No changes to commit" lie.
+    expect(result.output).not.toMatch(/No changes to commit/)
+  })
+})

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -103,7 +103,11 @@ class PrjctCommands {
   async ship(
     feature: string | null,
     projectPath: string = process.cwd(),
-    options: { md?: boolean } = {}
+    options: {
+      md?: boolean
+      skipHooks?: boolean
+      intent?: 'register-only' | 'seed-code-workflow' | 'proceed'
+    } = {}
   ): Promise<CommandResult> {
     return this.shipping.ship(feature, projectPath, { ...options })
   }

--- a/core/commands/planning.ts
+++ b/core/commands/planning.ts
@@ -283,6 +283,18 @@ export class PlanningCommands extends PrjctCommandsBase {
     const detected = await detectProjectCommands(projectPath)
     let sortOrder = 0
 
+    // Workflow-first core: version bump, changelog, git commit/push live
+    // as rules seeded here. Non-code projects get none and ship reduces
+    // to a shipped_features write + clarification for ambiguous runs.
+    const { seedCodeShipRules } = await import('./shipping')
+    await seedCodeShipRules(projectId, projectPath)
+    // seedCodeShipRules picks its own sortOrder starting after existing
+    // rules. Re-align our local counter so gate/lint/test land after.
+    sortOrder =
+      workflowRuleStorage
+        .getRulesForCommand(projectId, 'ship')
+        .reduce((m, r) => Math.max(m, r.sortOrder ?? 0), 0) + 1
+
     // Gate: Prevent shipping from main/master
     workflowRuleStorage.addRule(projectId, {
       type: 'gate',

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -1,32 +1,47 @@
 /**
- * Shipping Commands: ship and related helpers
- * Write-Through Architecture: JSON → MD → Event
+ * Shipping Commands — workflow-first dispatcher.
+ *
+ * ship() has no hardcoded "code pipeline". Version bump, changelog,
+ * git commit/push all live as rules in the workflow table (seeded
+ * per-project at init based on stack detection). Non-code projects
+ * get no rules and ship just records a shipped_features row.
+ *
+ * If no step rules exist and the project doesn't auto-seed as code,
+ * we return a `clarification` instead of acting — the agent is
+ * expected to ask the user and re-invoke with an explicit intent.
  */
 
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 import configManager from '../infrastructure/config-manager'
-import { ChangelogService } from '../services/changelog-service'
 import { syncService } from '../services/sync-service'
-import { VersionService } from '../services/version-service'
 import { shippedStorage } from '../storage/shipped-storage'
 import { stateStorage } from '../storage/state-storage'
-import type { CommandResult } from '../types/commands'
-import { getErrorMessage, isNotFoundError } from '../types/fs'
+import { workflowRuleStorage } from '../storage/workflow-rule-storage'
+import type { CommandClarification, CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import type { WorkflowRule } from '../types/storage.js'
+import type { WorkflowRunContext } from '../types/workflow.js'
 import * as dateHelper from '../utils/date-helper'
-import { execFileAsync } from '../utils/exec'
 import { mdDone, mdList, mdNextSteps, mdOutput, mdSection } from '../utils/md-formatter'
 import { getNextSteps, showNextSteps } from '../utils/next-steps'
 import out from '../utils/output'
 import { executeWorkflowRules } from '../workflow/workflow-engine'
 import { PrjctCommandsBase } from './base'
 
+type ShipIntent = 'register-only' | 'seed-code-workflow' | 'proceed'
+
+interface ShipOptions {
+  skipHooks?: boolean
+  md?: boolean
+  intent?: ShipIntent
+}
+
 export class ShippingCommands extends PrjctCommandsBase {
-  /**
-   * /p:ship - Ship feature with complete automated workflow
-   */
   async ship(
     feature: string | null,
     projectPath: string = process.cwd(),
-    options: { skipHooks?: boolean; md?: boolean } = {}
+    options: ShipOptions = {}
   ): Promise<CommandResult> {
     try {
       const initResult = await this.ensureProjectInit(projectPath)
@@ -40,47 +55,64 @@ export class ShippingCommands extends PrjctCommandsBase {
 
       let featureName = feature
 
-      // Complete current task implicitly before shipping
       const currentTask = await stateStorage.getCurrentTask(projectId)
       if (currentTask) {
         if (!featureName) featureName = currentTask.description || 'current work'
         await stateStorage.completeTask(projectId)
       }
-
       if (!featureName) featureName = 'current work'
 
-      // Execute before_ship workflow (gates + steps from DB)
+      let rules = workflowRuleStorage.getRulesForCommand(projectId, 'ship')
+
+      // If the caller explicitly asked to seed, do it up front and continue.
+      if (options.intent === 'seed-code-workflow') {
+        const seeded = await seedCodeShipRules(projectId, projectPath)
+        if (!seeded) {
+          return {
+            success: false,
+            error:
+              'seed-code-workflow requested but this project does not look like code (no package.json / Cargo.toml / pyproject.toml / VERSION). Add rules manually with `prjct workflow add`.',
+          }
+        }
+        rules = workflowRuleStorage.getRulesForCommand(projectId, 'ship')
+      }
+
+      // Migration path: first ship on an existing code project that
+      // predates workflow-first seeding. Silent — log a one-liner so
+      // users see what happened.
+      const hasSteps = rules.some((r) => r.type === 'step' && r.position === 'before')
+      if (!hasSteps && options.intent !== 'register-only') {
+        const seeded = await seedCodeShipRules(projectId, projectPath)
+        if (seeded) {
+          console.log('ℹ️  Auto-seeded code ship workflow (one-time migration)')
+          rules = workflowRuleStorage.getRulesForCommand(projectId, 'ship')
+        }
+      }
+
+      // Ambiguity gate. Only triggers when the caller did NOT pass an
+      // explicit intent — callers that have already asked the user
+      // (e.g. re-invocation with --intent) skip the gate.
+      const clarification = await buildClarification(projectId, projectPath, rules, options)
+      if (clarification) {
+        renderClarification(clarification, options.md === true)
+        return { success: false, clarification }
+      }
+
+      const runCtx: WorkflowRunContext = { feature: featureName }
+
       const beforeResult = await executeWorkflowRules(projectId, 'ship', 'before', {
         projectPath,
         skipRules: options.skipHooks,
+        runContext: runCtx,
       })
       if (!beforeResult.success) {
-        const msg =
-          beforeResult.gatesFailed.length > 0
-            ? `Blocked: ${beforeResult.gatesFailed.join(', ')}`
-            : `Step failed: ${beforeResult.gatesFailed.join(', ')}`
-        return { success: false, error: msg }
+        const failedList =
+          beforeResult.gatesFailed.length > 0 ? beforeResult.gatesFailed.join(', ') : 'unknown step'
+        return { success: false, error: `Ship blocked: ${failedList}` }
       }
 
-      // SHIP CORE (universal, stack-aware)
-      if (!options.md) out.step(1, 4, 'Bumping version...')
-      const versionService = new VersionService(projectPath)
-      const newVersion = await versionService.bump()
+      const newVersion = typeof runCtx.version === 'string' ? runCtx.version : 'unversioned'
 
-      if (!options.md) out.step(2, 4, 'Updating changelog...')
-      const changelogService = new ChangelogService(projectPath)
-      await changelogService.addFeature(newVersion, featureName)
-
-      if (!options.md) out.step(3, 4, 'Committing...')
-      const commitResult = await this._createShipCommit(featureName, projectPath)
-
-      let pushStatus = 'skipped'
-      if (commitResult.success) {
-        const pushResult = await this._gitPush(projectPath)
-        pushStatus = pushResult.success ? 'pushed' : pushResult.message
-      }
-
-      // Write-through: Record shipped feature (JSON → MD → Event)
       await shippedStorage.addShipped(projectId, {
         name: featureName,
         version: newVersion,
@@ -92,46 +124,28 @@ export class ShippingCommands extends PrjctCommandsBase {
         timestamp: dateHelper.getTimestamp(),
       })
 
-      // Ship is already recorded in `shipped_features` by
-      // shippedStorage.addShipped above, which is what project-memory
-      // reads as `type=shipped`. The old `learnDecision` /
-      // `recordWorkflow` calls wrote into the pre-v2 memory-system
-      // (deleted in Phase C) — redundant with shipped_features.
-
-      // Run after_ship rules
       const afterResult = await executeWorkflowRules(projectId, 'ship', 'after', {
         projectPath,
         skipRules: options.skipHooks,
+        runContext: runCtx,
       })
 
-      // Collect instructions from both phases
       const allInstructions = [...beforeResult.instructions, ...afterResult.instructions]
 
-      // Auto-sync AI context after shipping to ensure agents have latest state
       try {
-        if (!options.md) {
-          out.step(4, 4, 'Updating AI context...')
-        }
-
         await syncService.sync(projectPath)
-
-        if (!options.md) {
-          out.done('✓ AI context updated')
-        }
       } catch (syncError) {
-        // Log but don't fail the ship — context sync is nice-to-have
         console.warn('⚠️  Failed to sync AI context after shipping:', getErrorMessage(syncError))
       }
 
-      // Regenerate the agent-crawlable wiki so subagents can read the latest
-      // ship + memory snapshot with plain Read/Glob. Incremental + deferred
-      // under daemon so the ship response isn't held up.
       try {
         const { regenerateWikiDeferred } = await import('../services/wiki-generator')
         await regenerateWikiDeferred(projectPath, projectId)
       } catch (wikiError) {
         console.warn('⚠️  Wiki regeneration failed (non-blocking):', getErrorMessage(wikiError))
       }
+
+      const stepsRun = beforeResult.stepsRun.length + afterResult.stepsRun.length
 
       if (options.md) {
         const steps = getNextSteps('ship', true)
@@ -141,9 +155,8 @@ export class ShippingCommands extends PrjctCommandsBase {
             'Results',
             mdList([
               `Version: ${newVersion}`,
-              `Commit: ${commitResult.success ? 'created' : commitResult.message}`,
-              `Push: ${pushStatus}`,
-              `Workflow steps: ${beforeResult.stepsRun.length > 0 ? beforeResult.stepsRun.join(', ') : 'none'}`,
+              `Workflow steps run: ${stepsRun > 0 ? [...beforeResult.stepsRun, ...afterResult.stepsRun].join(', ') : 'none'}`,
+              `Hooks failed (non-blocking): ${beforeResult.hooksFailed.length + afterResult.hooksFailed.length}`,
             ])
           ),
           allInstructions.length > 0
@@ -163,42 +176,171 @@ export class ShippingCommands extends PrjctCommandsBase {
       return { success: false, error: getErrorMessage(error) }
     }
   }
+}
 
-  /**
-   * Create git commit for ship
-   */
-  async _createShipCommit(
-    feature: string,
-    projectPath: string
-  ): Promise<{ success: boolean; message: string }> {
-    try {
-      await execFileAsync('git', ['add', '.'], { cwd: projectPath })
+function isCodeProject(projectPath: string): boolean {
+  const markers = [
+    'package.json',
+    'Cargo.toml',
+    'pyproject.toml',
+    'go.mod',
+    'Gemfile',
+    'pom.xml',
+    'build.gradle',
+    'VERSION',
+  ]
+  return markers.some((m) => existsSync(path.join(projectPath, m)))
+}
 
-      const commitMsg = `feat: ${feature}\n\nGenerated with [p/](https://www.prjct.app/)`
+function isGitRepo(projectPath: string): boolean {
+  return existsSync(path.join(projectPath, '.git'))
+}
 
-      await execFileAsync('git', ['commit', '-m', commitMsg], { cwd: projectPath })
+/**
+ * Seed the 4 code-default ship steps (version:bump, changelog:add,
+ * git:commit, git:push) if this project looks like code. Returns true
+ * when rules were added.
+ *
+ * Delegates the "does this look like code?" check to isCodeProject
+ * here (instead of detectProjectCommands) because we want ship's
+ * migration path to stay decoupled from planning.ts internals.
+ */
+export async function seedCodeShipRules(projectId: string, projectPath: string): Promise<boolean> {
+  if (!isCodeProject(projectPath)) return false
 
-      return { success: true, message: 'Committed' }
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        return { success: false, message: 'Git not found' }
-      }
-      return { success: false, message: `Commit failed: ${getErrorMessage(error)}` }
+  const now = new Date().toISOString()
+  const existing = workflowRuleStorage.getRulesForCommand(projectId, 'ship')
+  const existingActions = new Set(existing.map((r) => r.action))
+  // Seeded rules are sorted after any user-authored rules. Start from
+  // max(existing) + 1 so we don't collide.
+  const maxSort = existing.reduce((m, r) => Math.max(m, r.sortOrder ?? 0), 0)
+  let sort = maxSort + 1
+
+  const rules: Array<{ action: string; description: string; timeoutMs: number }> = [
+    { action: 'version:bump', description: 'Bump version (stack-aware)', timeoutMs: 10000 },
+    { action: 'changelog:add', description: 'Append CHANGELOG entry', timeoutMs: 10000 },
+  ]
+  if (isGitRepo(projectPath)) {
+    rules.push({ action: 'git:commit', description: 'Commit ship', timeoutMs: 15000 })
+    rules.push({ action: 'git:push', description: 'Push to origin', timeoutMs: 30000 })
+  }
+
+  let added = 0
+  for (const r of rules) {
+    if (existingActions.has(r.action)) continue
+    workflowRuleStorage.addRule(projectId, {
+      type: 'step',
+      command: 'ship',
+      position: 'before',
+      action: r.action,
+      description: r.description,
+      enabled: true,
+      timeoutMs: r.timeoutMs,
+      sortOrder: sort++,
+      createdAt: now,
+    })
+    added++
+  }
+
+  return added > 0
+}
+
+/**
+ * Inspect state and decide whether ship can proceed autonomously. When
+ * we're unsure, return a clarification object; the dispatcher lifts it
+ * into CommandResult.clarification and the agent surfaces the question
+ * to the user.
+ */
+async function buildClarification(
+  projectId: string,
+  projectPath: string,
+  rules: WorkflowRule[],
+  options: ShipOptions
+): Promise<CommandClarification | null> {
+  // If caller already expressed intent, trust them.
+  if (options.intent === 'proceed' || options.intent === 'register-only') return null
+
+  const hasSteps = rules.some((r) => r.type === 'step' && r.position === 'before')
+
+  // Case 1 — no steps configured at all. Auto-seed already ran, so
+  // arriving here means the project isn't code (or migration failed).
+  if (!hasSteps) {
+    return {
+      question: 'No `ship` workflow steps are configured for this project. What should ship do?',
+      options: ['register-only', 'seed-code-workflow', 'abort'],
+      state: {
+        rulesCount: rules.length,
+        looksLikeCode: isCodeProject(projectPath),
+      },
     }
   }
 
-  /**
-   * Push to remote
-   */
-  async _gitPush(projectPath: string): Promise<{ success: boolean; message: string }> {
-    try {
-      await execFileAsync('git', ['push'], { cwd: projectPath })
-      return { success: true, message: 'Pushed to remote' }
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        return { success: false, message: 'Git not found' }
-      }
-      return { success: false, message: `Push failed: ${getErrorMessage(error)}` }
+  // Case 2 — steps are defined AND there's an active task → proceed.
+  const activeTask = await stateStorage.getCurrentTask(projectId)
+  if (activeTask) return null
+
+  // Case 3 — no active task but steps exist. Dangerous when there's a
+  // PR already open for this branch: we don't know whether the user
+  // wants another commit on top or to start fresh. Ask.
+  const pr = await findOpenPrForBranch(projectPath)
+  if (pr) {
+    return {
+      question: `No active task, and PR #${pr.number} ("${pr.title}") is OPEN for this branch. Continue ship anyway?`,
+      options: ['proceed', 'abort'],
+      state: { openPr: pr.number, branch: pr.branch },
     }
+  }
+
+  // Case 4 — steps exist, no task, no PR. Nothing obviously wrong;
+  // proceed. The configured gate step (e.g. "not on main") handles the
+  // rest.
+  return null
+}
+
+function renderClarification(c: CommandClarification, md: boolean): void {
+  if (md) {
+    const body = mdOutput(
+      mdSection(`Clarification needed`, c.question),
+      mdSection('Options', mdList(c.options.map((o) => `\`prjct ship --intent=${o}\``))),
+      c.state
+        ? mdSection(
+            'State',
+            mdList(Object.entries(c.state).map(([k, v]) => `${k}: ${JSON.stringify(v)}`))
+          )
+        : null
+    )
+    console.log(body)
+    return
+  }
+  console.log(`\n⚠️  ${c.question}`)
+  console.log('\nOptions:')
+  for (const o of c.options) {
+    console.log(`  prjct ship --intent=${o}`)
+  }
+}
+
+async function findOpenPrForBranch(
+  projectPath: string
+): Promise<{ number: number; title: string; branch: string } | null> {
+  if (!isGitRepo(projectPath)) return null
+  try {
+    const { execFileAsync } = await import('../utils/exec')
+    const { stdout: branch } = await execFileAsync('git', ['branch', '--show-current'], {
+      cwd: projectPath,
+      timeout: 3000,
+    })
+    const head = branch.toString().trim()
+    if (!head) return null
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'list', '--head', head, '--state', 'open', '--json', 'number,title', '--limit', '1'],
+      { cwd: projectPath, timeout: 5000 }
+    )
+    const parsed = JSON.parse(stdout.toString()) as Array<{ number: number; title: string }>
+    if (parsed.length === 0) return null
+    return { number: parsed[0].number, title: parsed[0].title, branch: head }
+  } catch {
+    // gh missing, no auth, or non-github remote — treat as "no PR".
+    return null
   }
 }

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -358,8 +358,14 @@ async function executeCommand(
       })
     case 'task':
       return commands!.task(param, request.cwd, { md })
-    case 'ship':
-      return commands!.ship(param, request.cwd, { md })
+    case 'ship': {
+      const intent = typeof opts.intent === 'string' ? (opts.intent as string) : undefined
+      return commands!.ship(param, request.cwd, {
+        md,
+        intent: intent as 'register-only' | 'seed-code-workflow' | 'proceed' | undefined,
+        skipHooks: opts['skip-hooks'] === true,
+      })
+    }
     case 'workflow':
       return commands!.workflowPrefs(param, request.cwd, { md })
     case 'analyze':

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -8,6 +8,17 @@
 // ============================================
 
 /**
+ * Structured clarification surfaced when a command can't proceed
+ * autonomously — the agent is expected to ask the user and re-invoke
+ * with `--intent=<option>`.
+ */
+export interface CommandClarification {
+  question: string
+  options: string[]
+  state?: Record<string, unknown>
+}
+
+/**
  * Command execution result with optional extra data.
  * This is the EXTENDED version with command-specific fields.
  */
@@ -23,6 +34,8 @@ export interface CommandResult {
   feature?: string
   /** Files that were modified */
   filesModified?: string[]
+  /** Command declined to proceed; agent should ask the user. */
+  clarification?: CommandClarification
   /** Allow any additional properties for command-specific data */
   [key: string]: unknown
 }

--- a/core/types/workflow.ts
+++ b/core/types/workflow.ts
@@ -47,3 +47,11 @@ export interface WorkflowExecutionResult {
   instructions: string[]
   output: string
 }
+
+/**
+ * Shared state threaded through a single `executeWorkflowRules` call (and
+ * optionally across the before/after pair in the same command run).
+ * Handlers for action prefixes like `version:bump` write into it so
+ * downstream steps (`changelog:add`, `git:commit`) can read the values.
+ */
+export type WorkflowRunContext = Record<string, unknown>

--- a/core/workflow/workflow-engine.ts
+++ b/core/workflow/workflow-engine.ts
@@ -25,7 +25,9 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import chalk from 'chalk'
 import { STATUS_CHANGE_ACTION, TAG_EVENT_TYPE } from '../memory/events'
+import { ChangelogService } from '../services/changelog-service'
 import { memoryService } from '../services/memory-service'
+import { VersionService } from '../services/version-service'
 import { getGitBranch } from '../session/git-helpers'
 import prjctDb from '../storage/database'
 import { stateStorage } from '../storage/state-storage'
@@ -33,14 +35,18 @@ import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { LocalConfig, ProjectPersona } from '../types/config'
 import { getErrorMessage } from '../types/fs'
 import type { WorkflowRule } from '../types/storage.js'
-import type { WorkflowExecutionResult } from '../types/workflow.js'
-import { execAsync } from '../utils/exec'
+import type { WorkflowExecutionResult, WorkflowRunContext } from '../types/workflow.js'
+import { execAsync, execFileAsync } from '../utils/exec'
 import { evaluateWhen, type WhenContext } from './when-evaluator'
 
 const STATUS_ACTION_PREFIX = 'status:'
 const SCRIPT_ACTION_PREFIX = 'script:'
 const MCP_ACTION_PREFIX = 'mcp:'
 const PERSONA_CONTEXT_ACTION = 'persona:context'
+const VERSION_BUMP_PREFIX = 'version:bump'
+const CHANGELOG_ADD_ACTION = 'changelog:add'
+const GIT_COMMIT_PREFIX = 'git:commit'
+const GIT_PUSH_ACTION = 'git:push'
 
 async function runStatusTransition(
   projectId: string,
@@ -178,12 +184,61 @@ async function buildPersonaInstruction(projectPath: string): Promise<string> {
   }
 }
 
+async function runVersionBump(projectPath: string, runCtx: WorkflowRunContext): Promise<void> {
+  const service = new VersionService(projectPath)
+  const next = await service.bump()
+  runCtx.version = next
+}
+
+async function runChangelogAdd(projectPath: string, runCtx: WorkflowRunContext): Promise<void> {
+  const version = typeof runCtx.version === 'string' ? runCtx.version : null
+  const feature = typeof runCtx.feature === 'string' ? runCtx.feature : null
+  if (!version) {
+    throw new Error('changelog:add requires a prior version:bump step (no version in runContext)')
+  }
+  if (!feature) {
+    throw new Error(
+      'changelog:add requires a feature name in runContext (set by ship before rules run)'
+    )
+  }
+  const service = new ChangelogService(projectPath)
+  await service.addFeature(version, feature)
+}
+
+function expandTemplate(template: string, runCtx: WorkflowRunContext): string {
+  return template.replace(/\$([A-Z_]+)/g, (_match, name: string) => {
+    const key = name.toLowerCase()
+    const value = runCtx[key]
+    return typeof value === 'string' ? value : ''
+  })
+}
+
+async function runGitCommit(
+  action: string,
+  projectPath: string,
+  runCtx: WorkflowRunContext
+): Promise<void> {
+  // Accept optional `git:commit:<template>` suffix. Default template uses
+  // the feature (and version, if set) from runContext.
+  const rawTemplate = action.slice(GIT_COMMIT_PREFIX.length).replace(/^:/, '').trim()
+  const template = rawTemplate || (runCtx.version ? 'feat: $FEATURE (v$VERSION)' : 'feat: $FEATURE')
+  const msg = `${expandTemplate(template, runCtx)}\n\nGenerated with [p/](https://www.prjct.app/)`
+
+  await execFileAsync('git', ['add', '.'], { cwd: projectPath })
+  await execFileAsync('git', ['commit', '-m', msg], { cwd: projectPath })
+}
+
+async function runGitPush(projectPath: string): Promise<void> {
+  await execFileAsync('git', ['push'], { cwd: projectPath })
+}
+
 async function runRuleAction(
   rule: WorkflowRule,
   projectId: string,
   projectPath: string,
   whenCtx: WhenContext,
-  result: WorkflowExecutionResult
+  result: WorkflowExecutionResult,
+  runCtx: WorkflowRunContext
 ): Promise<void> {
   const action = rule.action
 
@@ -208,6 +263,26 @@ async function runRuleAction(
 
   if (action === PERSONA_CONTEXT_ACTION) {
     result.instructions.push(await buildPersonaInstruction(projectPath))
+    return
+  }
+
+  if (action === VERSION_BUMP_PREFIX || action.startsWith(`${VERSION_BUMP_PREFIX}:`)) {
+    await runVersionBump(projectPath, runCtx)
+    return
+  }
+
+  if (action === CHANGELOG_ADD_ACTION) {
+    await runChangelogAdd(projectPath, runCtx)
+    return
+  }
+
+  if (action === GIT_COMMIT_PREFIX || action.startsWith(`${GIT_COMMIT_PREFIX}:`)) {
+    await runGitCommit(action, projectPath, runCtx)
+    return
+  }
+
+  if (action === GIT_PUSH_ACTION) {
+    await runGitPush(projectPath)
     return
   }
 
@@ -287,7 +362,11 @@ export async function executeWorkflowRules(
   projectId: string,
   command: string,
   phase: 'before' | 'after',
-  options: { projectPath?: string; skipRules?: boolean } = {}
+  options: {
+    projectPath?: string
+    skipRules?: boolean
+    runContext?: WorkflowRunContext
+  } = {}
 ): Promise<WorkflowExecutionResult> {
   const result: WorkflowExecutionResult = {
     success: true,
@@ -300,6 +379,7 @@ export async function executeWorkflowRules(
 
   if (options.skipRules) return result
 
+  const runCtx: WorkflowRunContext = options.runContext ?? {}
   const allRules = workflowRuleStorage.getRulesForCommand(projectId, command)
   const phased = allRules.filter((r) => r.position === phase)
   const projectPath = options.projectPath || process.cwd()
@@ -327,7 +407,7 @@ export async function executeWorkflowRules(
     console.log(`\n${chalk.dim(`[gate] ${phase}-${command}: ${gate.action}`)}`)
     try {
       const startTime = Date.now()
-      await runRuleAction(gate, projectId, projectPath, whenCtx, result)
+      await runRuleAction(gate, projectId, projectPath, whenCtx, result, runCtx)
       const elapsed = Date.now() - startTime
       const timeStr = elapsed > 1000 ? `${(elapsed / 1000).toFixed(1)}s` : `${elapsed}ms`
       console.log(`${chalk.green('✓')} ${chalk.dim(`gate passed (${timeStr})`)}`)
@@ -359,7 +439,7 @@ export async function executeWorkflowRules(
     console.log(`\n${chalk.dim(`[hook] ${phase}-${command}: ${hook.action}`)}`)
     try {
       const startTime = Date.now()
-      await runRuleAction(hook, projectId, projectPath, whenCtx, result)
+      await runRuleAction(hook, projectId, projectPath, whenCtx, result, runCtx)
       const elapsed = Date.now() - startTime
       const timeStr = elapsed > 1000 ? `${(elapsed / 1000).toFixed(1)}s` : `${elapsed}ms`
       console.log(`${chalk.green('✓')} ${chalk.dim(`(${timeStr})`)}`)
@@ -384,7 +464,7 @@ export async function executeWorkflowRules(
     console.log(`\n${chalk.dim(`[step] ${command}: ${step.action}`)}`)
     try {
       const startTime = Date.now()
-      await runRuleAction(step, projectId, projectPath, whenCtx, result)
+      await runRuleAction(step, projectId, projectPath, whenCtx, result, runCtx)
       const elapsed = Date.now() - startTime
       const timeStr = elapsed > 1000 ? `${(elapsed / 1000).toFixed(1)}s` : `${elapsed}ms`
       console.log(`${chalk.green('✓')} ${chalk.dim(`step passed (${timeStr})`)}`)


### PR DESCRIPTION
## Summary
- `ship()` is now a dispatcher. No more hardcoded `version bump → changelog → git add . → commit → push` core. Every one of those steps is a workflow rule the user (or `prjct init`) decides to seed.
- New action prefixes in the workflow engine: `version:bump`, `changelog:add`, `git:commit[:<template>]`, `git:push`. Handlers share a `WorkflowRunContext` so `version:bump` can feed the new version to `changelog:add` / `git:commit`.
- Ambiguity gate: if no `step` rules are configured for `ship`, we return a structured `CommandClarification` instead of assuming anything. The agent surfaces it to the user and re-invokes with `--intent=<option>`.
- Code projects (package.json, Cargo.toml, pyproject.toml, VERSION, etc.) auto-seed the 4 default code steps — on `prjct init` going forward, and on first ship of existing projects as a one-time migration (logged as such).
- Non-code projects get zero rules. Ship on them is a no-op that records a `shipped_features` row (with `--intent=register-only`), or asks for intent otherwise.

## Why
Two failure modes surfaced this week:

1. **prjct is expanding past code.** `pm`, `founder`, `research`, `daily` packs already declare non-code memory types. For those personas "ship" isn't `git push` — it could be sending an update to investors, closing a sprint, publishing a piece. Ship's hardcoded core was incompatible with any of that.
2. **Ship assumed without asking.** The previous core would run `git add .` + `git commit` + `git push` even with no active task, 14 uncommitted files across mixed scopes, and an already-open PR for the branch. Combined with the daemon-cwd bug (fixed separately in #252 as `d9ccb84`), that silently pushed commits with `feat: current work` messages into unrelated repos.

## Test plan
- [x] 829 existing unit tests pass
- [x] 10 new unit tests (action prefixes + ship dispatcher) pass
- [x] Smoke on non-code tmpdir: `prjct ship` returns clarification, no files touched
- [x] Smoke on code tmpdir: auto-seed fires, version bumps 1.0.0→1.0.1 in the correct `projectPath`, commit lands in the correct git repo
- [ ] Manual: exercise `--intent=register-only` on a non-code project
- [ ] Manual: exercise `--intent=seed-code-workflow` to recover after an accidental abort

## Follow-ups (not in this PR)
- Audit other `execAsync` call-sites in `core/services/*` and `core/domain/*` for the same missing-`cwd` bug pattern.
- Memory-type installer via seed (infrastructure already accepts any string; no UI yet).
- Persona-conditional command templates (`~/.claude/commands/p/*.md`).
- Cleanup of the polluted `feat: current work` commits in `/Users/jj/Apps/avo/alliance-redesign` origin/develop (user decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)