### PR TITLE
fix(hooks): stop hook counts ships/captures/tags as checkpoints

### DIFF
--- a/core/__tests__/hooks/stop-checkpoint.test.ts
+++ b/core/__tests__/hooks/stop-checkpoint.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Stop hook capture-checkpoint rule.
+ *
+ * Regression: the hook used to match only `memory.remember.%`, which
+ * meant shipping a feature, capturing to inbox, or closing a task
+ * still left the nag firing. Now ANY `memory.*` event that isn't
+ * `memory.post_edit` counts as a checkpoint.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildStopContext } from '../../hooks/stop'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+
+async function freshProject(): Promise<{ projectPath: string; projectId: string }> {
+  const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-stop-test-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  const projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  })
+  await pathManager.ensureProjectStructure(projectId)
+  return { projectPath, projectId }
+}
+
+function insertEvent(projectId: string, type: string, offsetMinutes = 0): void {
+  const ts = new Date(Date.now() - offsetMinutes * 60 * 1000).toISOString()
+  prjctDb.run(projectId, "INSERT INTO events (type, data, timestamp) VALUES (?, '{}', ?)", type, ts)
+}
+
+describe('Stop hook capture checkpoint', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    ;({ projectPath, projectId } = await freshProject())
+  })
+
+  afterEach(async () => {
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('returns null when no edits fired', async () => {
+    const context = await buildStopContext(projectPath)
+    expect(context).toBeNull()
+  })
+
+  test('nags when edits fired and nothing durable landed', async () => {
+    for (let i = 0; i < 5; i++) insertEvent(projectId, 'memory.post_edit')
+    const context = await buildStopContext(projectPath)
+    expect(context).not.toBeNull()
+    expect(context).toContain('5 file edits')
+    expect(context).toContain('capture checkpoint')
+  })
+
+  test('stays silent when a ship happened alongside edits', async () => {
+    for (let i = 0; i < 20; i++) insertEvent(projectId, 'memory.post_edit')
+    insertEvent(projectId, 'memory.feature_shipped')
+    const context = await buildStopContext(projectPath)
+    expect(context).toBeNull()
+  })
+
+  test('stays silent when a capture (remember.inbox) happened', async () => {
+    for (let i = 0; i < 10; i++) insertEvent(projectId, 'memory.post_edit')
+    insertEvent(projectId, 'memory.remember.inbox')
+    const context = await buildStopContext(projectPath)
+    expect(context).toBeNull()
+  })
+
+  test('stays silent when only a task.tagged event fired', async () => {
+    for (let i = 0; i < 7; i++) insertEvent(projectId, 'memory.post_edit')
+    insertEvent(projectId, 'memory.task.tagged')
+    const context = await buildStopContext(projectPath)
+    expect(context).toBeNull()
+  })
+
+  test('stays silent for status.changed', async () => {
+    for (let i = 0; i < 3; i++) insertEvent(projectId, 'memory.post_edit')
+    insertEvent(projectId, 'memory.status.changed')
+    const context = await buildStopContext(projectPath)
+    expect(context).toBeNull()
+  })
+
+  test('ignores checkpoints older than the 30-minute window', async () => {
+    for (let i = 0; i < 4; i++) insertEvent(projectId, 'memory.post_edit', 5) // 5m ago
+    insertEvent(projectId, 'memory.feature_shipped', 120) // 2h ago
+    const context = await buildStopContext(projectPath)
+    expect(context).not.toBeNull()
+    expect(context).toContain('4 file edits')
+  })
+})

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -1,15 +1,16 @@
 /**
  * Stop hook — fires when Claude finishes a turn.
  *
- * Nudges Claude to capture a learning if the turn produced work
- * (files edited) and no recent `remember` / `capture` fired. Pure
- * nudge: `additionalContext` only, never `decision: "block"`. Claude
- * decides whether to save anything.
+ * Nudges Claude to capture a learning if the turn produced raw edits
+ * but nothing durable got written anywhere — no ship, no capture, no
+ * remember, no status change, no tag. Pure nudge: `additionalContext`
+ * only, never `decision: "block"`.
  *
- * We skip the nudge when:
- *   - No project config.
- *   - No post_edit events recorded this session.
- *   - A recent `remember.*` event already fired in the last 30 min.
+ * We treat every `memory.*` event EXCEPT `memory.post_edit` as a
+ * checkpoint (ships, captures, remembers, tagged tasks, status
+ * transitions, bug reports, llm analysis saves…). The hook used to
+ * only look at `memory.remember.%`, which meant shipping a feature,
+ * capturing to inbox, or closing a task still left the nag firing.
  */
 
 import configManager from '../infrastructure/config-manager'
@@ -19,42 +20,47 @@ import prjctDb from '../storage/database'
 import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
 
 const RECENT_REMEMBER_WINDOW_MS = 30 * 60 * 1000
+const POST_EDIT_EVENT = 'memory.post_edit'
 
 export async function buildStopContext(projectPath: string): Promise<string | null> {
   const config = await configManager.readConfig(projectPath)
   if (!config?.projectId) return null
 
   const projectId = config.projectId
-
-  // Did Claude actually touch files this session? If not, nothing to
-  // reflect on.
   const sinceIso = new Date(Date.now() - RECENT_REMEMBER_WINDOW_MS).toISOString()
-  let edits: Array<{ count: number }>
-  try {
-    edits = prjctDb.query<{ count: number }>(
-      projectId,
-      'SELECT COUNT(*) as count FROM events WHERE type = ? AND timestamp > ?',
-      'memory.post_edit',
-      sinceIso
-    )
-  } catch {
-    return null
-  }
-  const editCount = edits[0]?.count ?? 0
-  if (editCount === 0) return null
 
-  // If a remember already fired in the window, don't nag.
-  let remembers: Array<{ count: number }>
+  // Single pass over the events table: count edits vs. everything else
+  // in the memory namespace. Avoids two round-trips and keeps the two
+  // counts on a consistent snapshot.
+  let rows: Array<{ type: string; count: number }>
   try {
-    remembers = prjctDb.query<{ count: number }>(
+    rows = prjctDb.query<{ type: string; count: number }>(
       projectId,
-      "SELECT COUNT(*) as count FROM events WHERE type LIKE 'memory.remember.%' AND timestamp > ?",
+      `SELECT
+         CASE WHEN type = ? THEN 'edit' ELSE 'checkpoint' END AS type,
+         COUNT(*) AS count
+       FROM events
+       WHERE type LIKE 'memory.%' AND timestamp > ?
+       GROUP BY 1`,
+      POST_EDIT_EVENT,
       sinceIso
     )
   } catch {
     return null
   }
-  if ((remembers[0]?.count ?? 0) > 0) return null
+
+  let editCount = 0
+  let checkpointCount = 0
+  for (const r of rows) {
+    if (r.type === 'edit') editCount = r.count
+    else checkpointCount = r.count
+  }
+
+  // No edits → nothing to reflect on.
+  if (editCount === 0) return null
+  // Anything durable already landed (ship, capture, remember, tag,
+  // status change…) → don't nag.
+  if (checkpointCount > 0) return null
 
   return [
     '# prjct: capture checkpoint',


### PR DESCRIPTION
## Summary
The Stop hook's capture-checkpoint nudge ignored every save path except \`prjct remember\`. After a productive turn that shipped a PR, captured inbox items, tagged a task, or changed status, the hook still printed \`"N file edits this session without a memory entry"\` and told the agent to call \`prjct remember\` — even though durable events had already landed.

## Fix
One GROUP BY over \`memory.%\`:
- \`memory.post_edit\` → counted as edits
- anything else in the memory namespace → counted as a checkpoint

Nag fires only when edits > 0 AND checkpoints = 0. The 30-min window is unchanged.

## Test plan
- [x] 7 new tests (\`core/__tests__/hooks/stop-checkpoint.test.ts\`) covering ship / capture / remember / tag / status-changed / window-expiry / no-edit early-out
- [x] 836/836 in the full suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)