### PR TITLE
fix(ship): seed main-branch gate + trailing newline in writeJson

### DIFF
--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -216,26 +216,54 @@ export async function seedCodeShipRules(projectId: string, projectPath: string):
   const maxSort = existing.reduce((m, r) => Math.max(m, r.sortOrder ?? 0), 0)
   let sort = maxSort + 1
 
-  const rules: Array<{ action: string; description: string; timeoutMs: number }> = [
+  // Gate: refuse to ship from main/master. Auto-seed used to skip this
+  // and only add the 4 steps, so projects that predated workflow-first
+  // would happily bump + commit + push from main. Seed it here too so
+  // the migration and fresh-init paths produce the same rule set.
+  const gates: Array<{ action: string; description: string; timeoutMs: number }> = []
+  if (isGitRepo(projectPath)) {
+    gates.push({
+      action: 'git branch --show-current | grep -vE "^(main|master)$"',
+      description: 'Prevent shipping from main branch',
+      timeoutMs: 5000,
+    })
+  }
+
+  const steps: Array<{ action: string; description: string; timeoutMs: number }> = [
     { action: 'version:bump', description: 'Bump version (stack-aware)', timeoutMs: 10000 },
     { action: 'changelog:add', description: 'Append CHANGELOG entry', timeoutMs: 10000 },
   ]
   if (isGitRepo(projectPath)) {
-    rules.push({ action: 'git:commit', description: 'Commit ship', timeoutMs: 15000 })
-    rules.push({ action: 'git:push', description: 'Push to origin', timeoutMs: 30000 })
+    steps.push({ action: 'git:commit', description: 'Commit ship', timeoutMs: 15000 })
+    steps.push({ action: 'git:push', description: 'Push to origin', timeoutMs: 30000 })
   }
 
   let added = 0
-  for (const r of rules) {
-    if (existingActions.has(r.action)) continue
+  for (const g of gates) {
+    if (existingActions.has(g.action)) continue
+    workflowRuleStorage.addRule(projectId, {
+      type: 'gate',
+      command: 'ship',
+      position: 'before',
+      action: g.action,
+      description: g.description,
+      enabled: true,
+      timeoutMs: g.timeoutMs,
+      sortOrder: sort++,
+      createdAt: now,
+    })
+    added++
+  }
+  for (const s of steps) {
+    if (existingActions.has(s.action)) continue
     workflowRuleStorage.addRule(projectId, {
       type: 'step',
       command: 'ship',
       position: 'before',
-      action: r.action,
-      description: r.description,
+      action: s.action,
+      description: s.description,
       enabled: true,
-      timeoutMs: r.timeoutMs,
+      timeoutMs: s.timeoutMs,
       sortOrder: sort++,
       createdAt: now,
     })

--- a/core/utils/file-helper.ts
+++ b/core/utils/file-helper.ts
@@ -124,7 +124,7 @@ export async function readJson<T = unknown>(
 export async function writeJson(filePath: string, data: unknown, indent = 2): Promise<void> {
   const dir = path.dirname(filePath)
   await fs.mkdir(dir, { recursive: true })
-  const content = JSON.stringify(data, null, indent)
+  const content = `${JSON.stringify(data, null, indent)}\n`
   await fs.writeFile(filePath, content, 'utf-8')
 }
 


### PR DESCRIPTION
## Summary
Two small regressions that surfaced running \`prjct ship\` on a migrated project:

1. **Auto-seed missed the gate.** \`seedCodeShipRules\` was adding the 4 steps (\`version:bump\`, \`changelog:add\`, \`git:commit\`, \`git:push\`) but not the "refuse to ship from main/master" gate that \`prjct init\` has always seeded. Projects whose rules came from the one-time migration would happily bump + commit + push from main.
2. **\`writeJson\` didn't emit a trailing newline.** After \`version:bump\` rewrote \`package.json\`, the lefthook pre-commit biome check failed with a \`noNewlineAtEndOfFile\` format error — and \`git:commit\` would fail, leaving \`package.json\` and \`CHANGELOG.md\` dirty.

## Fix
- \`seedCodeShipRules\` now also adds the gate rule (sorted ahead of the steps).
- \`writeJson\` appends \`\\n\` once. POSIX-clean file, no caller has to remember.

🤖 Generated with [Claude Code](https://claude.com/claude-code)