### PR TITLE
fix(ai-provider): re-export getActiveProvider (regression from #256)

### DIFF
--- a/core/infrastructure/ai-provider.ts
+++ b/core/infrastructure/ai-provider.ts
@@ -335,7 +335,9 @@ export async function detectAllProviders(refresh = false): Promise<{
  * 2. Auto-detect single installed provider
  * 3. Default to Claude if both installed
  */
-async function _getActiveProvider(projectProvider?: AIProviderName): Promise<AIProviderConfig> {
+export async function getActiveProvider(
+  projectProvider?: AIProviderName
+): Promise<AIProviderConfig> {
   // If project has a saved preference, use it
   if (projectProvider && Providers[projectProvider]) {
     return Providers[projectProvider]


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #256.

\`getActiveProvider\` was demoted to non-exported and then renamed to \`_getActiveProvider\` by biome's --unsafe lint pass — knip flagged the named export as unused, which was wrong: it's consumed via dynamic \`require('./ai-provider').getActiveProvider()\` from \`path-manager.ts\` and \`command-installer.ts\`, plus 8 other call sites. Knip can't track those.

Symptom on v2.2.7 install:

\`\`\`
$ prjct sync --md
n.getActiveProvider is not a function. (In 'n.getActiveProvider()', 'n.getActiveProvider' is undefined)
\`\`\`

## Fix

Single-line: restore \`export async function getActiveProvider(...)\`.

## Test plan

- [x] \`bun test\` → 866 pass
- [x] \`bun run typecheck\` → exit 0
- [x] \`bun run check\` → 0 warnings (lint+format)
- [x] \`bun run build\` → 1202 KB
- [x] After install: \`prjct sync --md\` returns OK (regression confirmed gone)

## Lessons

The \`namespace import + dynamic require()\` pattern is invisible to knip. For future cleanup sweeps, grep for \`require('...').<symbol>\` and \`import * as X\` BEFORE bulk-demoting named exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)