### PR TITLE
fix(daemon): replicate bare-verb auto-route to capture

### DIFF
--- a/core/commands/closest-command.ts
+++ b/core/commands/closest-command.ts
@@ -1,0 +1,47 @@
+/**
+ * Find the closest registered command to a user-entered name.
+ *
+ * Used by:
+ *   - core/index.ts → "Did you mean…" hint when an unknown command is run.
+ *   - core/index.ts + core/daemon/daemon.ts → typo guard on the bare-verb
+ *     auto-route to capture (a single-word near-typo of a real command
+ *     should surface as "unknown" instead of being silently captured).
+ *
+ * Levenshtein distance ≤ 2 is the suggestion threshold — close enough to
+ * catch fat-finger typos, far enough to not match unrelated short words.
+ */
+
+import { commandRegistry } from './registry'
+
+export function findClosestCommand(input: string): string | null {
+  const allNames = commandRegistry.getAll().map((c) => c.name)
+  let best: string | null = null
+  let bestDist = Infinity
+
+  for (const name of allNames) {
+    const dist = editDistance(input.toLowerCase(), name.toLowerCase())
+    if (dist < bestDist) {
+      bestDist = dist
+      best = name
+    }
+  }
+
+  return bestDist <= 2 ? best : null
+}
+
+function editDistance(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0))
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+    }
+  }
+  return dp[m][n]
+}

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -14,6 +14,7 @@
 import fs from 'node:fs'
 import type { Server, Socket } from 'node:net'
 import { createServer as createNetServer } from 'node:net'
+import { findClosestCommand } from '../commands/closest-command'
 import { PrjctCommands } from '../commands/commands'
 import { commandRegistry } from '../commands/registry'
 import '../commands/register'
@@ -343,6 +344,27 @@ async function executeCommand(
   if (isRemovedVerb(request.command) && !commandRegistry.getByName(request.command)) {
     const msg = migrationMessage(request.command) ?? `'${request.command}' was removed in v2.`
     return { success: false, error: msg }
+  }
+
+  // Mirror the v2 GTD auto-route from core/index.ts: an unknown verb
+  // becomes `prjct capture "<verb plus args>"` so dumps without ceremony
+  // land in the inbox. Single-word near-typos of a real verb still bubble
+  // up as "Command not found" (handled by the default switch case below)
+  // so users don't silently capture e.g. "shipp".
+  if (
+    request.command &&
+    !commandRegistry.getByName(request.command) &&
+    !(request.args.length === 0 && findClosestCommand(request.command) !== null)
+  ) {
+    const fullDescription = [
+      request.command,
+      ...request.args.filter((a) => !a.startsWith('-')),
+    ].join(' ')
+    return commands!.capture(fullDescription, request.cwd, {
+      md,
+      tags: opts.tags ? String(opts.tags) : undefined,
+      force: opts.force === true,
+    })
   }
 
   // Commands that need options routed through PrjctCommands

--- a/core/index.ts
+++ b/core/index.ts
@@ -4,6 +4,7 @@
  * This file is required by bin/prjct after setup verification
  */
 
+import { findClosestCommand } from './commands/closest-command'
 import { PrjctCommands } from './commands/commands'
 import { commandRegistry } from './commands/registry'
 import './commands/register' // Ensure commands are registered
@@ -324,44 +325,6 @@ function validateCommandParams(
   }
 
   return null
-}
-
-/**
- * Find closest matching command name for did-you-mean suggestions
- * Uses Levenshtein edit distance — suggests if distance <= 2
- */
-function findClosestCommand(input: string): string | null {
-  const allNames = commandRegistry.getAll().map((c) => c.name)
-  let best: string | null = null
-  let bestDist = Infinity
-
-  for (const name of allNames) {
-    const dist = editDistance(input.toLowerCase(), name.toLowerCase())
-    if (dist < bestDist) {
-      bestDist = dist
-      best = name
-    }
-  }
-
-  // Only suggest if edit distance is at most 2
-  return bestDist <= 2 ? best : null
-}
-
-function editDistance(a: string, b: string): number {
-  const m = a.length
-  const n = b.length
-  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0))
-  for (let i = 0; i <= m; i++) dp[i][0] = i
-  for (let j = 0; j <= n; j++) dp[0][j] = j
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      dp[i][j] =
-        a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
-    }
-  }
-  return dp[m][n]
 }
 
 /**


### PR DESCRIPTION
## Summary

Daemon's command dispatcher was missing the GTD auto-route from \`core/index.ts:79-87\`. Unknown verbs fell through to the registry's \"Command not found\" instead of routing to \`prjct capture\`.

Pre-fix:
\`\`\`
$ prjct \"random thought i want to remember later\"
Command not found: random
\`\`\`

(Worked only with \`PRJCT_NO_DAEMON=1\`.)

## Fix

- Extracted \`findClosestCommand\` + \`editDistance\` from core/index.ts → new \`core/commands/closest-command.ts\` so both entry points share the typo guard without duplicating Levenshtein.
- Daemon \`executeCommand()\` now mirrors the index.ts auto-route: unknown verb + not a single-word near-typo → \`commands.capture(...)\`.

## Test plan

- [x] \`bun test\` → 866 pass / 0 fail
- [x] \`bun run typecheck\` → exit 0
- [x] \`bun run check\` → 0 warnings
- [x] \`bun run build\` → 1203 KB
- [ ] After install: \`prjct \"random thought\"\` (with daemon active) → captured to inbox

## Origin

Detected during the post-#256/#257 end-to-end sweep on v2.2.8. Pre-existing bug, not a regression from #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)