### PR TITLE
fix(install): runtime self-heal of hooks + global CLAUDE.md (no postinstall dependency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.15] - 2026-04-25
+
+### Added
+- current work
+
 ## [2.2.14] - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.16] - 2026-04-25
+
+### Added
+- current work
+
 ## [2.2.15] - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.14] - 2026-04-25
+
+### Added
+- current work
+
 ## [2.2.13] - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.13] - 2026-04-25
+
+### Added
+- current work
+
 ## [2.2.12] - 2026-04-26
 
 ### Performance

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -101,6 +101,34 @@ if (
   }
 }
 
+// === SELF-HEAL ===
+// Re-install hooks + global CLAUDE.md when the binary version has moved
+// past the last successful sync. Replaces postinstall (which is disabled
+// by --ignore-scripts and corporate security policies on many client
+// machines). Hot path is a single fs read of the stamp file; the slow
+// path (a few writes to settings.json + CLAUDE.md) only fires once per
+// version bump per machine.
+//
+// Skipped for:
+//   - `daemon`/`update`/`version` (would deadlock the upgrade flow)
+//   - `hook` (session-start fires its own self-heal; other hook events
+//     fire too often to pay even the fs-read cost)
+//   - PRJCT_NO_SELF_SYNC=1 (escape hatch)
+const _selfHealSkip = new Set(['daemon', 'update', 'version', '-v', '--version', 'hook'])
+if (_fastCommand && !_selfHealSkip.has(_fastCommand) && process.env.PRJCT_NO_SELF_SYNC !== '1') {
+  try {
+    const { VERSION } = await import('../core/utils/version')
+    if (VERSION) {
+      const { isSyncCurrent, runSelfHeal } = await import('../core/infrastructure/self-heal')
+      if (!isSyncCurrent(VERSION)) {
+        await runSelfHeal(VERSION)
+      }
+    }
+  } catch {
+    // best-effort — never block the user's command on self-heal
+  }
+}
+
 // v2 auto-route: if the first positional isn't a known verb, treat the
 // whole argv as GTD-style inbox capture → `prjct capture "<argv>"`.
 // Explicit verbs still win. Capture is zero-ceremony; if the user

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -101,6 +101,22 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
     restartPending: false,
   }
 
+  // Self-heal hooks + global CLAUDE.md when the binary moved past the
+  // last sync. Runs once per fresh daemon spawn — combined with the
+  // version-drift auto-suicide below, every npm upgrade re-syncs the
+  // user's config the first time the next command spawns a new daemon.
+  // Best-effort: failures must never block daemon startup.
+  if (ownVersion) {
+    try {
+      const { isSyncCurrent, runSelfHeal } = await import('../infrastructure/self-heal')
+      if (!isSyncCurrent(ownVersion)) {
+        await runSelfHeal(ownVersion)
+      }
+    } catch {
+      // never block daemon startup
+    }
+  }
+
   // Pre-load modules (this is the whole point — do it once)
   commands = new PrjctCommands()
 

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -31,8 +31,10 @@
  */
 
 import configManager from '../infrastructure/config-manager'
+import { isSyncCurrent, runSelfHeal } from '../infrastructure/self-heal'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import type { LocalConfig, ProjectPersona } from '../types/config'
+import { VERSION } from '../utils/version'
 import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
 
 interface HookInput {
@@ -97,6 +99,13 @@ export async function runSessionStartHook(projectPath: string = process.cwd()): 
     // reflect current project state. Best-effort; errors are swallowed.
     if (config?.projectId) {
       await regenerateWikiDeferred(projectPath, config.projectId).catch(() => undefined)
+    }
+
+    // Self-heal hooks + global CLAUDE.md when the binary moved past the
+    // last sync. Catches machines where postinstall is disabled by
+    // security policy. Hot path is one fs read of the stamp file.
+    if (!isSyncCurrent(VERSION)) {
+      await runSelfHeal(VERSION).catch(() => undefined)
     }
   })
 }

--- a/core/infrastructure/self-heal.ts
+++ b/core/infrastructure/self-heal.ts
@@ -1,0 +1,98 @@
+/**
+ * Self-heal — re-installs hooks + global CLAUDE.md when the running
+ * binary's version differs from the last successful sync.
+ *
+ * Why this exists: `npm install -g prjct-cli` only updates the binary.
+ * `scripts/postinstall.js` is best-effort and disabled on many client
+ * machines by `--ignore-scripts` or corporate security policies, so we
+ * cannot rely on it to refresh `~/.claude/settings.json` hooks or the
+ * `<!-- prjct:start -->` block in `~/.claude/CLAUDE.md` after an upgrade.
+ *
+ * The fix is runtime: every prjct invocation reads a tiny stamp file at
+ * `~/.prjct-cli/state/installed-version`. If it matches the bundled
+ * version → fast no-op (one fs read, microseconds). If it differs →
+ * re-run `installGlobalConfig()` + `settings-installer.install()` and
+ * rewrite the stamp.
+ *
+ * Idempotency comes from the installers themselves:
+ *   - settings-installer: every entry tagged `_prjctManaged: true`,
+ *     dedupes on re-run.
+ *   - command-installer: rewrites the `<!-- prjct:start -->` block
+ *     between markers; user content outside the markers is preserved.
+ *
+ * Failure mode: every step is wrapped — a self-heal failure must NEVER
+ * block the user's command. Worst case the user keeps the stale config
+ * until the next invocation.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const STAMP_DIR = path.join(os.homedir(), '.prjct-cli', 'state')
+const STAMP_PATH = path.join(STAMP_DIR, 'installed-version')
+
+function readStamp(): string | null {
+  try {
+    return fs.readFileSync(STAMP_PATH, 'utf-8').trim()
+  } catch {
+    return null
+  }
+}
+
+function writeStamp(version: string): void {
+  try {
+    fs.mkdirSync(STAMP_DIR, { recursive: true })
+    fs.writeFileSync(STAMP_PATH, version, 'utf-8')
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Cheap check — single fs read. Use this to gate the slow path.
+ * Returns true when the stamp matches the running version (no work needed).
+ */
+export function isSyncCurrent(currentVersion: string): boolean {
+  if (!currentVersion) return true
+  return readStamp() === currentVersion
+}
+
+/**
+ * Run the actual re-sync. Caller is expected to have checked
+ * `isSyncCurrent` first; calling this on the hot path is wasteful but
+ * not incorrect — the underlying installers are idempotent.
+ *
+ * Errors are swallowed by design.
+ */
+export async function runSelfHeal(currentVersion: string): Promise<void> {
+  if (!currentVersion) return
+  if (process.env.PRJCT_NO_SELF_SYNC === '1') return
+
+  try {
+    const { installGlobalConfig } = await import('./command-installer')
+    await installGlobalConfig()
+  } catch {
+    // best-effort
+  }
+
+  try {
+    const settingsInstaller = await import('../services/settings-installer')
+    await settingsInstaller.install()
+  } catch {
+    // best-effort
+  }
+
+  writeStamp(currentVersion)
+}
+
+/**
+ * One-shot helper: cheap-check + slow-path. Safe to call from hot paths
+ * — when the stamp matches the running version this returns
+ * immediately after a single fs read.
+ */
+export async function selfHealIfStale(currentVersion: string): Promise<void> {
+  if (process.env.PRJCT_NO_SELF_SYNC === '1') return
+  if (isSyncCurrent(currentVersion)) return
+  await runSelfHeal(currentVersion)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- Many client machines disable npm postinstall scripts (`--ignore-scripts`, corporate security policies), so `npm install -g prjct-cli@latest` only refreshes the binary while `~/.claude/settings.json` hooks and the `<!-- prjct:start -->` block in `~/.claude/CLAUDE.md` stay frozen at whatever the first install wrote.
- Adds a runtime self-heal: a tiny stamp file at `~/.prjct-cli/state/installed-version` is compared against the running binary's version on every CLI invocation, on every fresh daemon spawn, and at the end of `SessionStart` hook. On mismatch, `installGlobalConfig()` + `settings-installer.install()` re-apply the contract; the hot path is a single fs read.
- Best-effort + idempotent: failures never block the user's command, and the existing `_prjctManaged: true` / `<!-- prjct:start -->` markers prevent duplicates.

## Why this respects the harness boundary

The self-heal only re-syncs config artifacts the user already opted into via `prjct install` (hooks list, global CLAUDE.md block). It does not inject new prompts, prescribe behavior, or write to `_generated/`. SessionStart hook self-heal runs **after** `emit()`, so `additionalContext` stays byte-identical and the prompt-cache prefix is preserved.

## Test plan

- [x] `npm test` — 858/858 pass
- [x] Direct path: `PRJCT_NO_DAEMON=1 prjct status` writes stamp from missing
- [x] Stale-stamp path: writing `0.0.0` to stamp triggers re-sync to current version
- [x] Daemon path: stopped daemon → next command spawns fresh daemon → daemon self-heals
- [x] `~/.claude/settings.json` ends with all 7 PRJCT_HOOKS events merged
- [ ] Verify on a client machine where `--ignore-scripts` is in effect (post-merge npm publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)