### PR TITLE
fix(deps): clean install — bump zod, MCP SDK, better-sqlite3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.17] - 2026-04-25
+
+### Added
+- current work
+
 ## [2.2.16] - 2026-04-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.18] - 2026-04-25
+
+### Added
+- current work
+
 ## [2.2.17] - 2026-04-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.0",
-        "@modelcontextprotocol/sdk": "1.28.0",
-        "better-sqlite3": "12.6.2",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "better-sqlite3": "12.9.0",
         "chalk": "4.1.2",
         "chokidar": "5.0.0",
         "date-fns": "4.1.0",
         "glob": "13.0.1",
         "jsonc-parser": "3.3.1",
-        "zod": "3.24.1"
+        "zod": "3.25.76"
       },
       "bin": {
         "prjct": "bin/prjct"
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1587,9 +1587,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3897,9 +3897,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "1.0.0",
-    "@modelcontextprotocol/sdk": "1.28.0",
-    "better-sqlite3": "12.6.2",
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "better-sqlite3": "12.9.0",
     "chalk": "4.1.2",
     "chokidar": "5.0.0",
     "date-fns": "4.1.0",
     "glob": "13.0.1",
     "jsonc-parser": "3.3.1",
-    "zod": "3.24.1"
+    "zod": "3.25.76"
   },
   "overrides": {
     "path-to-regexp": "8.4.0",


### PR DESCRIPTION
## Summary

Clients on 2.2.16 install saw two warnings:
\`\`\`
WARN  unmet peer zod@\"^3.25 || ^4.0\": found 3.24.1
WARN  unmet peer zod@\"^3.25.28 || ^4\": found 3.24.1
WARN  1 deprecated subdependencies found: prebuild-install@7.1.3
\`\`\`

## Changes

- **zod** 3.24.1 → 3.25.76 — fixes both peer warnings (\`@modelcontextprotocol/sdk\` and \`zod-to-json-schema\` both required \`^3.25\`). Minor bump on the same major; verified zero behavioral change via typecheck + 858 tests passing.
- **@modelcontextprotocol/sdk** 1.28.0 → 1.29.0 — released 2026-03-30, past the 48h supply-chain rule.
- **better-sqlite3** 12.6.2 → 12.9.0 — released 2026-04-12, past the 48h rule.

## Lingering warning we cannot fix here

\`prebuild-install@7.1.3\` is a transitive dep of \`better-sqlite3\` and is officially deprecated upstream (\"No longer maintained. Please contact the author of the relevant native addon\"). The fix has to land in better-sqlite3 itself — bumping to 12.9.0 already; nothing more we can do without dropping the SQLite engine.

## Test plan

- [x] \`npm install\` — zero peer warnings
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 858/858 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)