### PR TITLE
feat(harness): opt-in multi-agent harness mode

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -35,6 +35,7 @@ const _binCommands = new Set([
   'hook',
   'seed',
   'install',
+  'harness',
   'watch',
   'help',
   '-h',
@@ -558,6 +559,26 @@ async function main(): Promise<void> {
       process.stdout.write('{}\n')
       process.exitCode = 0
     }
+  } else if (args[0] === 'harness') {
+    // `prjct harness install|uninstall|status` — manage the multi-agent
+    // harness bundle (leader/implementer/reviewer + CHECKPOINTS + CLAUDE.md
+    // snippet). Strictly opt-in.
+    const subcommand = args[1] ?? 'status'
+    const { HarnessCommands } = await import('../core/commands/harness')
+    const cmd = new HarnessCommands()
+    const mdMode = args.includes('--md')
+    let result: Awaited<ReturnType<typeof cmd.install>>
+    if (subcommand === 'install') {
+      result = await cmd.install(null, process.cwd(), { md: mdMode })
+    } else if (subcommand === 'uninstall') {
+      result = await cmd.uninstall(null, process.cwd(), { md: mdMode })
+    } else if (subcommand === 'status') {
+      result = await cmd.status(null, process.cwd(), { md: mdMode })
+    } else {
+      console.error(`Unknown harness subcommand: ${subcommand}. Use: install, uninstall, status.`)
+      result = { success: false, error: `unknown subcommand: ${subcommand}` }
+    }
+    process.exitCode = result.success ? 0 : 1
   } else if (args[0] === 'doctor') {
     const done = await trackSession('doctor')
     const { doctorService } = await import('../core/services/doctor-service')

--- a/core/__tests__/commands/harness.test.ts
+++ b/core/__tests__/commands/harness.test.ts
@@ -1,0 +1,159 @@
+/**
+ * `prjct harness` install/uninstall/status.
+ *
+ * Behavior-focused: each test runs the command against a real tmp project
+ * and asserts on the resulting filesystem state. No mocks for fs.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { HarnessCommands } from '../../commands/harness'
+
+async function freshProject(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'prjct-harness-test-'))
+}
+
+const SNIPPET_START = '<!-- prjct:harness:start - DO NOT REMOVE THIS MARKER -->'
+const SNIPPET_END = '<!-- prjct:harness:end - DO NOT REMOVE THIS MARKER -->'
+
+describe('prjct harness', () => {
+  let projectPath: string
+  let cmd: HarnessCommands
+
+  beforeEach(async () => {
+    projectPath = await freshProject()
+    cmd = new HarnessCommands()
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('install creates the trio + CHECKPOINTS + appends snippet', async () => {
+    const result = await cmd.install(null, projectPath, { md: true })
+    expect(result.success).toBe(true)
+
+    for (const f of [
+      '.claude/agents/leader.md',
+      '.claude/agents/implementer.md',
+      '.claude/agents/reviewer.md',
+      '.prjct/CHECKPOINTS.md',
+      'CLAUDE.md',
+    ]) {
+      const content = await fs.readFile(path.join(projectPath, f), 'utf-8')
+      expect(content.length).toBeGreaterThan(0)
+    }
+
+    const claudeMd = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).toContain(SNIPPET_START)
+    expect(claudeMd).toContain(SNIPPET_END)
+    expect(claudeMd).toContain('Harness leader mode')
+  })
+
+  test('install preserves existing CLAUDE.md content', async () => {
+    const original = '# My project\n\nSome existing instructions.\n'
+    await fs.writeFile(path.join(projectPath, 'CLAUDE.md'), original, 'utf-8')
+
+    await cmd.install(null, projectPath, { md: true })
+
+    const claudeMd = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).toContain('# My project')
+    expect(claudeMd).toContain('Some existing instructions.')
+    expect(claudeMd).toContain(SNIPPET_START)
+  })
+
+  test('install is idempotent — does not duplicate the snippet', async () => {
+    await cmd.install(null, projectPath, { md: true })
+    await cmd.install(null, projectPath, { md: true })
+
+    const claudeMd = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    const startMatches = claudeMd.match(/prjct:harness:start/g) ?? []
+    const endMatches = claudeMd.match(/prjct:harness:end/g) ?? []
+    expect(startMatches.length).toBe(1)
+    expect(endMatches.length).toBe(1)
+  })
+
+  test('install does not overwrite an existing CHECKPOINTS.md', async () => {
+    const existingPath = path.join(projectPath, '.prjct/CHECKPOINTS.md')
+    await fs.mkdir(path.dirname(existingPath), { recursive: true })
+    await fs.writeFile(existingPath, '# my custom checkpoints\n', 'utf-8')
+
+    await cmd.install(null, projectPath, { md: true })
+
+    const content = await fs.readFile(existingPath, 'utf-8')
+    expect(content).toBe('# my custom checkpoints\n')
+  })
+
+  test('uninstall removes the trio + CHECKPOINTS + strips snippet', async () => {
+    await cmd.install(null, projectPath, { md: true })
+    const result = await cmd.uninstall(null, projectPath, { md: true })
+    expect(result.success).toBe(true)
+
+    for (const f of [
+      '.claude/agents/leader.md',
+      '.claude/agents/implementer.md',
+      '.claude/agents/reviewer.md',
+      '.prjct/CHECKPOINTS.md',
+    ]) {
+      const exists = await fs
+        .access(path.join(projectPath, f))
+        .then(() => true)
+        .catch(() => false)
+      expect(exists).toBe(false)
+    }
+
+    const claudeMd = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).not.toContain(SNIPPET_START)
+    expect(claudeMd).not.toContain(SNIPPET_END)
+  })
+
+  test('uninstall preserves non-harness content in CLAUDE.md', async () => {
+    const original = '# My project\n\nSome existing instructions.\n'
+    await fs.writeFile(path.join(projectPath, 'CLAUDE.md'), original, 'utf-8')
+
+    await cmd.install(null, projectPath, { md: true })
+    await cmd.uninstall(null, projectPath, { md: true })
+
+    const claudeMd = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    expect(claudeMd).toContain('# My project')
+    expect(claudeMd).toContain('Some existing instructions.')
+    expect(claudeMd).not.toContain('prjct:harness')
+  })
+
+  test('uninstall preserves unrelated agents in .claude/agents/', async () => {
+    const userAgent = path.join(projectPath, '.claude/agents/my-agent.md')
+    await fs.mkdir(path.dirname(userAgent), { recursive: true })
+    await fs.writeFile(userAgent, '# my agent\n', 'utf-8')
+
+    await cmd.install(null, projectPath, { md: true })
+    await cmd.uninstall(null, projectPath, { md: true })
+
+    const stillExists = await fs
+      .access(userAgent)
+      .then(() => true)
+      .catch(() => false)
+    expect(stillExists).toBe(true)
+  })
+
+  test('status reports complete=false on a fresh project', async () => {
+    const result = await cmd.status(null, projectPath, { md: true })
+    expect(result.success).toBe(true)
+    expect(result.complete).toBe(false)
+  })
+
+  test('status reports complete=true after install', async () => {
+    await cmd.install(null, projectPath, { md: true })
+    const result = await cmd.status(null, projectPath, { md: true })
+    expect(result.success).toBe(true)
+    expect(result.complete).toBe(true)
+  })
+
+  test('status reports complete=false if any piece is missing', async () => {
+    await cmd.install(null, projectPath, { md: true })
+    await fs.rm(path.join(projectPath, '.claude/agents/leader.md'))
+    const result = await cmd.status(null, projectPath, { md: true })
+    expect(result.complete).toBe(false)
+  })
+})

--- a/core/commands/harness.ts
+++ b/core/commands/harness.ts
@@ -1,0 +1,319 @@
+/**
+ * prjct harness — install/uninstall/status the harness-mode bundle.
+ *
+ * Harness mode is an opinionated multi-agent setup: a leader/implementer/reviewer
+ * trio in `.claude/agents/`, a project-level `CHECKPOINTS.md`, and a CLAUDE.md
+ * snippet that locks the main session into leader role. Strictly opt-in.
+ *
+ * Inspired by https://github.com/betta-tech/ejemplo-harness-subagentes
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { getTemplateContent } from '../agentic/template-loader'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { fileExists } from '../utils/file-helper'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+const SNIPPET_START = '<!-- prjct:harness:start - DO NOT REMOVE THIS MARKER -->'
+const SNIPPET_END = '<!-- prjct:harness:end - DO NOT REMOVE THIS MARKER -->'
+
+interface HarnessFile {
+  /** Path inside the templates/harness/ tree */
+  templateKey: string
+  /** Destination relative to the project root */
+  destRelative: string
+}
+
+const AGENT_FILES: HarnessFile[] = [
+  { templateKey: 'harness/agents/leader.md', destRelative: '.claude/agents/leader.md' },
+  { templateKey: 'harness/agents/implementer.md', destRelative: '.claude/agents/implementer.md' },
+  { templateKey: 'harness/agents/reviewer.md', destRelative: '.claude/agents/reviewer.md' },
+]
+
+const CHECKPOINTS_FILE: HarnessFile = {
+  templateKey: 'harness/CHECKPOINTS.md',
+  destRelative: '.prjct/CHECKPOINTS.md',
+}
+
+const CLAUDE_SNIPPET_TEMPLATE = 'harness/CLAUDE-leader-mode.md'
+const CLAUDE_FILE = 'CLAUDE.md'
+
+interface PieceStatus {
+  path: string
+  installed: boolean
+}
+
+interface HarnessStatus {
+  agents: PieceStatus[]
+  checkpoints: PieceStatus
+  claudeSnippet: PieceStatus
+  complete: boolean
+}
+
+async function readSnippet(): Promise<string> {
+  const content = getTemplateContent(CLAUDE_SNIPPET_TEMPLATE)
+  if (!content) {
+    throw new Error(`Missing harness template: ${CLAUDE_SNIPPET_TEMPLATE}`)
+  }
+  return content.trim()
+}
+
+async function readTemplate(key: string): Promise<string> {
+  const content = getTemplateContent(key)
+  if (!content) {
+    throw new Error(`Missing harness template: ${key}`)
+  }
+  return content
+}
+
+async function writeFileEnsureDir(absPath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(absPath), { recursive: true })
+  await fs.writeFile(absPath, content, 'utf-8')
+}
+
+function snippetPresent(claudeContent: string): boolean {
+  return claudeContent.includes(SNIPPET_START) && claudeContent.includes(SNIPPET_END)
+}
+
+function appendSnippet(claudeContent: string, snippet: string): string {
+  // Idempotent: if markers exist, replace the block; otherwise append.
+  if (snippetPresent(claudeContent)) {
+    const startIdx = claudeContent.indexOf(SNIPPET_START)
+    const endIdx = claudeContent.indexOf(SNIPPET_END) + SNIPPET_END.length
+    return `${claudeContent.slice(0, startIdx)}${snippet}${claudeContent.slice(endIdx)}`
+  }
+  const sep = claudeContent.length > 0 && !claudeContent.endsWith('\n') ? '\n\n' : '\n'
+  return `${claudeContent}${sep}${snippet}\n`
+}
+
+function stripSnippet(claudeContent: string): string {
+  if (!snippetPresent(claudeContent)) return claudeContent
+  const startIdx = claudeContent.indexOf(SNIPPET_START)
+  const endIdx = claudeContent.indexOf(SNIPPET_END) + SNIPPET_END.length
+  let result = `${claudeContent.slice(0, startIdx)}${claudeContent.slice(endIdx)}`
+  // Trim leading whitespace gap left by the removal.
+  result = result.replace(/\n{3,}/g, '\n\n').trimEnd()
+  return result.length > 0 ? `${result}\n` : ''
+}
+
+async function readClaudeMd(projectPath: string): Promise<string | null> {
+  const claudePath = path.join(projectPath, CLAUDE_FILE)
+  try {
+    return await fs.readFile(claudePath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+async function getStatus(projectPath: string): Promise<HarnessStatus> {
+  const agents = await Promise.all(
+    AGENT_FILES.map(async (f) => ({
+      path: f.destRelative,
+      installed: await fileExists(path.join(projectPath, f.destRelative)),
+    }))
+  )
+
+  const checkpoints: PieceStatus = {
+    path: CHECKPOINTS_FILE.destRelative,
+    installed: await fileExists(path.join(projectPath, CHECKPOINTS_FILE.destRelative)),
+  }
+
+  const claudeContent = await readClaudeMd(projectPath)
+  const claudeSnippet: PieceStatus = {
+    path: CLAUDE_FILE,
+    installed: claudeContent !== null && snippetPresent(claudeContent),
+  }
+
+  const complete =
+    agents.every((a) => a.installed) && checkpoints.installed && claudeSnippet.installed
+
+  return { agents, checkpoints, claudeSnippet, complete }
+}
+
+export class HarnessCommands extends PrjctCommandsBase {
+  /**
+   * `prjct harness install` — copy the trio + CHECKPOINTS into the project,
+   * append the leader-mode snippet to CLAUDE.md (idempotent).
+   */
+  async install(
+    _arg: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean } = {}
+  ): Promise<CommandResult> {
+    try {
+      const written: string[] = []
+      const skipped: string[] = []
+
+      // 1. Agents
+      for (const f of AGENT_FILES) {
+        const dest = path.join(projectPath, f.destRelative)
+        const content = await readTemplate(f.templateKey)
+        const exists = await fileExists(dest)
+        await writeFileEnsureDir(dest, content)
+        if (exists) skipped.push(`${f.destRelative} (overwritten)`)
+        else written.push(f.destRelative)
+      }
+
+      // 2. CHECKPOINTS — never overwrite if user has customised it
+      const checkpointsDest = path.join(projectPath, CHECKPOINTS_FILE.destRelative)
+      if (await fileExists(checkpointsDest)) {
+        skipped.push(`${CHECKPOINTS_FILE.destRelative} (kept existing)`)
+      } else {
+        const content = await readTemplate(CHECKPOINTS_FILE.templateKey)
+        await writeFileEnsureDir(checkpointsDest, content)
+        written.push(CHECKPOINTS_FILE.destRelative)
+      }
+
+      // 3. CLAUDE.md snippet — append/replace marker block, idempotent
+      const snippet = await readSnippet()
+      const claudePath = path.join(projectPath, CLAUDE_FILE)
+      const existingClaude = (await readClaudeMd(projectPath)) ?? ''
+      const wasPresent = snippetPresent(existingClaude)
+      const nextClaude = appendSnippet(existingClaude, snippet)
+      if (nextClaude !== existingClaude) {
+        await fs.writeFile(claudePath, nextClaude, 'utf-8')
+        written.push(`${CLAUDE_FILE} (${wasPresent ? 'snippet refreshed' : 'snippet appended'})`)
+      } else {
+        skipped.push(`${CLAUDE_FILE} (snippet already current)`)
+      }
+
+      const summary = `harness installed (${written.length} written, ${skipped.length} kept)`
+      const hookHint = [
+        'Suggested next step — wire verification hooks into .claude/settings.json:',
+        '  PostToolUse(Edit|Write) → run your test command',
+        '  Stop → run `prjct check` (when available) or your project test command',
+        'Use the /update-config skill or edit settings.json manually.',
+      ].join('\n')
+
+      if (options.md) {
+        const lines = [
+          '# prjct harness installed',
+          '',
+          `Wrote to \`${projectPath}\`.`,
+          '',
+          '## Files',
+        ]
+        for (const f of written) lines.push(`- written: \`${f}\``)
+        for (const f of skipped) lines.push(`- kept: \`${f}\``)
+        lines.push('', '## Next step', '', hookHint)
+        console.log(lines.join('\n'))
+      } else {
+        out.done(summary)
+        for (const f of written) out.info(`written: ${f}`)
+        for (const f of skipped) out.info(`kept:    ${f}`)
+        console.log('')
+        console.log(hookHint)
+      }
+
+      return { success: true, written, skipped }
+    } catch (error) {
+      const msg = getErrorMessage(error)
+      out.fail(msg)
+      return { success: false, error: msg }
+    }
+  }
+
+  /**
+   * `prjct harness uninstall` — remove the trio + CHECKPOINTS,
+   * strip the leader-mode snippet from CLAUDE.md.
+   */
+  async uninstall(
+    _arg: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean } = {}
+  ): Promise<CommandResult> {
+    try {
+      const removed: string[] = []
+      const missing: string[] = []
+
+      for (const f of [...AGENT_FILES, CHECKPOINTS_FILE]) {
+        const dest = path.join(projectPath, f.destRelative)
+        if (await fileExists(dest)) {
+          await fs.rm(dest)
+          removed.push(f.destRelative)
+        } else {
+          missing.push(f.destRelative)
+        }
+      }
+
+      // Clean up empty .claude/agents (only if it ended up empty after removal)
+      const agentsDir = path.join(projectPath, '.claude/agents')
+      try {
+        const entries = await fs.readdir(agentsDir)
+        if (entries.length === 0) await fs.rmdir(agentsDir)
+      } catch {
+        // Either doesn't exist or not empty — leave it.
+      }
+
+      // Strip CLAUDE.md snippet if present
+      const claudePath = path.join(projectPath, CLAUDE_FILE)
+      const existingClaude = await readClaudeMd(projectPath)
+      if (existingClaude !== null && snippetPresent(existingClaude)) {
+        const next = stripSnippet(existingClaude)
+        await fs.writeFile(claudePath, next, 'utf-8')
+        removed.push(`${CLAUDE_FILE} (snippet stripped)`)
+      }
+
+      const summary = `harness uninstalled (${removed.length} removed)`
+      if (options.md) {
+        const lines = ['# prjct harness uninstalled', '']
+        for (const f of removed) lines.push(`- removed: \`${f}\``)
+        for (const f of missing) lines.push(`- not present: \`${f}\``)
+        console.log(lines.join('\n'))
+      } else {
+        out.done(summary)
+        for (const f of removed) out.info(`removed: ${f}`)
+      }
+
+      return { success: true, removed, missing }
+    } catch (error) {
+      const msg = getErrorMessage(error)
+      out.fail(msg)
+      return { success: false, error: msg }
+    }
+  }
+
+  /**
+   * `prjct harness status` — report which pieces of the bundle are installed.
+   */
+  async status(
+    _arg: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean } = {}
+  ): Promise<CommandResult> {
+    try {
+      const status = await getStatus(projectPath)
+      const tag = (s: PieceStatus) => (s.installed ? 'installed' : 'missing')
+
+      if (options.md) {
+        const lines = [
+          '# prjct harness status',
+          '',
+          `Project: \`${projectPath}\``,
+          `Complete: **${status.complete ? 'yes' : 'no'}**`,
+          '',
+          '## Pieces',
+        ]
+        for (const a of status.agents) lines.push(`- ${tag(a)}: \`${a.path}\``)
+        lines.push(`- ${tag(status.checkpoints)}: \`${status.checkpoints.path}\``)
+        lines.push(`- ${tag(status.claudeSnippet)}: \`${status.claudeSnippet.path}\` (snippet)`)
+        console.log(lines.join('\n'))
+      } else {
+        const label = status.complete ? 'complete' : 'partial'
+        out.info(`harness: ${label}`)
+        for (const a of status.agents) out.info(`  ${tag(a)}: ${a.path}`)
+        out.info(`  ${tag(status.checkpoints)}: ${status.checkpoints.path}`)
+        out.info(`  ${tag(status.claudeSnippet)}: ${status.claudeSnippet.path} (snippet)`)
+      }
+
+      return { success: true, complete: status.complete, status }
+    } catch (error) {
+      const msg = getErrorMessage(error)
+      out.fail(msg)
+      return { success: false, error: msg }
+    }
+  }
+}

--- a/templates/agents/AGENTS.md
+++ b/templates/agents/AGENTS.md
@@ -65,3 +65,7 @@ agents/    # domain specialists
 - Atomic operations via `prjct` CLI
 - CLI handles all state persistence (SQLite)
 - Handle missing config gracefully
+
+## Harness mode (opt-in)
+
+Projects that want a multi-agent workflow can run `prjct harness install` to drop a leader/implementer/reviewer trio into `.claude/agents/`, a project `CHECKPOINTS.md`, and a CLAUDE.md snippet that locks the main session into orchestrator role. Templates live in `templates/harness/`. Uninstall with `prjct harness uninstall`. Strictly opt-in — not invoked by `init`/`sync`.

--- a/templates/harness/CHECKPOINTS.md
+++ b/templates/harness/CHECKPOINTS.md
@@ -1,0 +1,51 @@
+# CHECKPOINTS — End-state criteria
+
+> In multi-agent systems you don't evaluate the path, you evaluate the destination.
+> These are the objective checkboxes a reviewer (human or AI) walks through to decide
+> whether the project is healthy after a session.
+
+> **Customise this file for your project.** The defaults below cover the generic
+> harness invariants. Add project-specific items (lint rules, build commands,
+> deployment gates) under the matching section.
+
+## C1 — The harness is wired
+
+- [ ] `.prjct/prjct.config.json` exists and points to a valid project ID.
+- [ ] `.prjct/CHECKPOINTS.md` exists (this file).
+- [ ] `.claude/agents/leader.md`, `implementer.md`, `reviewer.md` are present.
+- [ ] Project `CLAUDE.md` (or equivalent) contains the harness leader-mode block.
+
+## C2 — State is coherent
+
+- [ ] At most **one** task is in `active` status (`prjct status --md`).
+- [ ] No task in `active` is older than the current session without a captured blocker note.
+- [ ] Every task marked `done` has at least one paired test file (or a justified exception in the implementer report).
+
+## C3 — The code respects the architecture
+
+- [ ] Modified files follow the conventions of their neighbouring files (style, naming, imports).
+- [ ] No new runtime dependencies were added without a `prjct capture --tags dep-add` note.
+- [ ] No debug noise: no `console.log` / `print()` / `dbg!` left in source.
+- [ ] No `TODO` without a captured follow-up in `prjct capture`.
+
+## C4 — Verification is real
+
+- [ ] The project's test command was run for this session and exited cleanly.
+- [ ] Every new public function has at least one test covering the happy path.
+- [ ] Every new error path has at least one test asserting the error is raised/returned.
+- [ ] Tests use real temp dirs / real fixtures, not blanket mocks of the filesystem or DB.
+
+## C5 — The session closed cleanly
+
+- [ ] No untracked junk in the worktree (`*.tmp`, scratch logs, accidental binaries).
+- [ ] The implementer's report exists at `.prjct/sessions/<task-slug>/impl.md`.
+- [ ] The reviewer's verdict exists at `.prjct/sessions/<task-slug>/review.md` and is `APPROVED`.
+- [ ] The task's status was advanced (`prjct status done` for completed work, `prjct status paused` if intentionally paused).
+
+---
+
+**How to use this file:**
+
+The `reviewer` subagent reads every checkbox, marks `[x]` for met and `[ ]` for missed,
+and refuses to approve session close if any C1-C5 box remains unchecked. Customise the
+list with project-specific gates (lint, typecheck, build, deploy preview, etc.).

--- a/templates/harness/CLAUDE-leader-mode.md
+++ b/templates/harness/CLAUDE-leader-mode.md
@@ -1,0 +1,23 @@
+<!-- prjct:harness:start - DO NOT REMOVE THIS MARKER -->
+## Harness leader mode
+
+This project is in **harness mode**. The main session always acts as the `leader` subagent (see `.claude/agents/leader.md`). The leader **decomposes and coordinates** — it does not implement.
+
+### Hard rules for the main session
+
+- ❌ Do not edit application source or test files directly (no Edit, no Write, no Bash that writes to those paths).
+- ❌ Do not run `prjct status done` yourself — the implementer does that, but only after the reviewer approves.
+- ✅ For any code task, launch the appropriate subagent via the `Agent` tool:
+  - `subagent_type: "implementer"` → writes code and tests for one prjct task.
+  - `subagent_type: "reviewer"` → validates the implementer's work against `.prjct/CHECKPOINTS.md` before close.
+  - For up-front investigation, launch 2-3 `Explore` (or `general-purpose`) subagents in parallel, each with a narrow question.
+
+### Anti-broken-telephone
+
+When you launch any subagent, instruct it to **write its results to a file** (e.g. `.prjct/sessions/<task-slug>/<role>.md`) and reply to you with **only the path reference**. You read the file from disk if you need detail. Never accept full diffs or long outputs in chat.
+
+### When this role does NOT apply
+
+- Pure exploratory / read-only questions about the repo → answer directly.
+- Edits to `.prjct/`, docs, configuration, or this file → you may edit directly.
+<!-- prjct:harness:end - DO NOT REMOVE THIS MARKER -->

--- a/templates/harness/agents/implementer.md
+++ b/templates/harness/agents/implementer.md
@@ -1,0 +1,37 @@
+---
+name: implementer
+description: Worker. Implements exactly ONE prjct task end-to-end. Writes code, writes tests, self-verifies. Never approves its own work.
+tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Implementer
+
+You are an implementer. Your job is to take **one** prjct task from active to ready-for-review.
+
+## Protocol
+
+1. **Orient.** Read `.prjct/CHECKPOINTS.md` and run `prjct context --md` to understand task and recent decisions.
+2. **Confirm scope.** Run `prjct status --md` — there must be exactly one active task. If not, stop and report `blocked -> no single active task`.
+3. **Plan.** Write a 3-5 bullet plan to `.prjct/sessions/<task-slug>/impl.md` (create the directory). Include: files you will touch, tests you will add, verification command.
+4. **Implement.** Follow the project's existing conventions (read neighboring files first; do not invent style). Stay within the task scope — if you discover the change touches a separate concern, stop and capture it: `prjct capture "<text>" --tags scope-creep`.
+5. **Test.** Every code change is paired with a test before moving on. Use the project's existing test runner.
+6. **Self-verify.** Run the project's tests. If they fail, return to step 4. If they pass, run `prjct check --md` if available; otherwise note the verification command you ran in `.prjct/sessions/<task-slug>/impl.md`.
+7. **Do not mark `done`.** Append a final summary block to `.prjct/sessions/<task-slug>/impl.md` listing every file touched and the verification command output.
+8. **Hand off.** Reply to the leader with **one line**:
+
+   ```
+   done -> .prjct/sessions/<task-slug>/impl.md
+   ```
+
+   The leader will launch a `reviewer` next. Only after the reviewer approves does the implementer (in a follow-up turn) run `prjct status done`.
+
+## Hard rules
+
+- One task per session. If a tool fails unexpectedly, **do not improvise a workaround** — capture the blocker (`prjct capture "<blocker>" --tags blocker`) and stop.
+- Every code edit must be accompanied by its test before the next edit.
+- Never declare a task `done` without the reviewer's explicit `APPROVED`.
+- Never write debug `console.log` / `print` / scratch files into source. Clean up before handing off.
+
+## Anti-broken-telephone
+
+Your reply to the leader is **one line** with a file reference. Never paste diffs or large outputs into chat — write them to `.prjct/sessions/<task-slug>/impl.md`.

--- a/templates/harness/agents/leader.md
+++ b/templates/harness/agents/leader.md
@@ -1,0 +1,55 @@
+---
+name: leader
+description: Orchestrator. Decomposes the user's request, delegates work to implementer/reviewer subagents, and never edits application code directly.
+tools: Read, Glob, Grep, Bash, Agent
+---
+
+# Leader (Orchestrator)
+
+You are the leader of this repository. Your only job is to **decompose and coordinate**, never to implement.
+
+## Boot protocol (run on first request of the session)
+
+1. Read `.prjct/CHECKPOINTS.md` to know what "done" looks like in this project.
+2. Run `prjct context --md` to load current task, recent memory, and project state.
+3. Run `prjct status --md` to confirm whether there is an active task.
+4. If there is no active task and the user asked you to work on one, register it with `prjct task "<description>"` before delegating.
+
+## How to break work down
+
+For each request:
+
+1. Identify whether the work fits in **one** task or needs to be split.
+   - If split, register subtasks with `prjct task` and tackle one at a time.
+2. Trivial change (1 file, no design surface) → 1 `implementer` subagent.
+3. Standard change (2-3 files) → 1 `implementer` then 1 `reviewer`.
+4. Investigation needed first → 2-3 `Explore` subagents in parallel, each with a narrow question, **then** 1 `implementer`, **then** 1 `reviewer`.
+5. Refactor / architectural change → split into subtasks and apply this table again per subtask.
+
+## Anti-broken-telephone rule
+
+When you launch subagents, instruct them to **write their results to a file** under `.prjct/sessions/<task-slug>/<role>.md` and return only that path. Never accept their full output in chat — read the file from disk if you need details.
+
+Example correct prompt to a subagent:
+
+> "Investigate how `notes.py` serializes IDs. Write findings to `.prjct/sessions/cli-edit/explore_ids.md`. Reply to me with only `done -> .prjct/sessions/cli-edit/explore_ids.md` or a blocker message."
+
+## Effort scaling
+
+| Complexity                 | Subagents                                         |
+|----------------------------|---------------------------------------------------|
+| Trivial (1 file)           | 1 implementer                                     |
+| Standard (2-3 files)       | 1 implementer + 1 reviewer                        |
+| Refactor / cross-cutting   | 2-3 explorers → 1 implementer → 1 reviewer        |
+| Very complex               | Split into prjct subtasks; recurse per subtask    |
+
+## What you do NOT do
+
+- Do not edit files in the application's source/test directories directly.
+- Do not mark a task as `done` yourself — the implementer does that after the reviewer approves.
+- Do not accept subagent results delivered in chat without a file reference.
+
+## When this role does NOT apply
+
+- Pure exploration / read-only questions about the repo → answer directly, no subagents.
+- Edits to `.prjct/`, docs, configuration, or this file itself → you may edit directly.

--- a/templates/harness/agents/reviewer.md
+++ b/templates/harness/agents/reviewer.md
@@ -1,0 +1,59 @@
+---
+name: reviewer
+description: Strict reviewer. Approves or rejects an implementer's work against .prjct/CHECKPOINTS.md and project conventions. Never edits code.
+tools: Read, Glob, Grep, Bash
+---
+
+# Reviewer
+
+You are a strict reviewer. Your only function is to **approve or reject** changes. You never edit code.
+
+## Protocol
+
+1. Read `.prjct/CHECKPOINTS.md` and the implementer's report at `.prjct/sessions/<task-slug>/impl.md`.
+2. Identify the modified files (use `git status --porcelain` and `git diff --stat`). Cross-reference with the implementer's stated file list — flag any discrepancy.
+3. For each modified file, verify:
+   - It respects the project's conventions (style of neighboring files).
+   - Test coverage exists for the new behavior (find the corresponding test file).
+   - No debug noise was left behind (`console.log`, `print`, `TODO` without a captured note).
+4. Run the project's test command. Tests must pass — if any test is red, that is an automatic rejection.
+5. Walk every checkbox in `.prjct/CHECKPOINTS.md`. Mark `[x]` for items met, `[ ]` for items missed.
+6. Emit verdict.
+
+## Verdict format
+
+Write your verdict to `.prjct/sessions/<task-slug>/review.md`:
+
+```markdown
+# Review — <task title>
+
+**Verdict:** APPROVED | CHANGES_REQUESTED
+
+## Checkpoints
+- C1: [x]
+- C2: [x]
+- C3: [ ]  ← Reason: src/foo.ts imports `lodash`; the project disallows new runtime deps without prior capture
+- C4: [x]
+- C5: [x]
+
+## Required changes (if any)
+1. Remove `import lodash from 'lodash'` from src/foo.ts.
+2. ...
+```
+
+Reply to the leader with **one line**:
+
+```
+APPROVED -> .prjct/sessions/<task-slug>/review.md
+```
+or
+```
+CHANGES_REQUESTED -> .prjct/sessions/<task-slug>/review.md
+```
+
+## Hard rules
+
+- Never approve with red tests.
+- Never approve with empty checkboxes in C1-C5.
+- Never edit the implementer's code. Your job is to say what fails — not to fix it.
+- Be concrete: cite file paths and line numbers. No generic feedback.


### PR DESCRIPTION
## Summary

- New `prjct harness install/uninstall/status` command — opt-in installer for a multi-agent harness pattern adapted from [betta-tech/ejemplo-harness-subagentes](https://github.com/betta-tech/ejemplo-harness-subagentes).
- Drops a `leader / implementer / reviewer` trio into `.claude/agents/`, a project `CHECKPOINTS.md`, and a marker-fenced snippet into `CLAUDE.md` that locks the main session to orchestrator role (no editing application code directly).
- Tasks and state continue to live in SQLite (`prjct task/status/context`); no `feature_list.json` introduced.
- Strictly opt-in — not invoked by `init` or `sync`.

## What's not included (follow-up)

- `prjct check` (init.sh-equivalent verification gate)
- Bundled `PostToolUse` / `Stop` hooks that auto-policy the harness

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test core/__tests__/commands/harness.test.ts` — 10/10 pass
- [x] Full suite: 863 pass / 5 pre-existing `DependencyValidator` fails on main (unrelated)
- [x] `bun run build` — templates bundled in `dist/templates.json`
- [x] E2E smoke: install → status → re-install (idempotent) → uninstall, with pre-existing `CLAUDE.md` content preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)