### PR TITLE
feat: lookup-first protocol — Claude reads vault before source (M0 of rescue plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.13] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.3.11] - 2026-05-02
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.14] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.3.13] - 2026-05-01
 
 ### Added

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -43,6 +43,10 @@ const _binCommands = new Set([
   'version',
   '-v',
   '--version',
+  // mcp's interactive multi-select needs TTY on stdin/stdout. Daemon runs
+  // detached with no TTY, so routing through it falls back to plain `list`
+  // output. Always execute mcp in the client process so prompts work.
+  'mcp',
 ])
 
 // v2 verbs registered in the command registry — imported from the single

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -198,19 +198,21 @@ export const COMMANDS: CommandMeta[] = [
   {
     name: 'mcp',
     group: 'core',
-    description: 'List / deny / allow MCP servers per-project (~/.claude/settings.local.json)',
+    description:
+      'Toggle MCP servers per-project — interactive multi-select in your terminal, list/deny/allow for scripts',
     usage: {
       claude: '/p:mcp list',
-      terminal: 'prjct mcp deny claude_ai_PostHog',
+      terminal: 'prjct mcp',
     },
     params: '[list|status|deny|allow] [serverName]',
     implemented: true,
     hasTemplate: false,
     requiresProject: false,
     features: [
-      'Project-local — never touches your other projects',
+      'Interactive multi-select with live tool-cost delta (default UX in TTY)',
+      'Project-local — writes only to .claude/settings.local.json',
       'Knows the well-known cloud MCPs from claude.ai (PostHog, Atlassian, etc.)',
-      'Tells you exactly what to do next (Claude Code restart) — no guessing',
+      'Headless list/deny/allow for LLM agents and scripts (--md flag)',
     ],
   },
   {

--- a/core/commands/mcp.ts
+++ b/core/commands/mcp.ts
@@ -17,6 +17,8 @@
  * user never has to guess.
  */
 
+import * as p from '@clack/prompts'
+import chalk from 'chalk'
 import { type McpServerInfo, mcpService } from '../services/mcp-service'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
@@ -39,8 +41,18 @@ export class McpCommands extends PrjctCommandsBase {
     options: McpOptions = {}
   ): Promise<CommandResult> {
     const parts = (input ?? '').trim().split(/\s+/).filter(Boolean)
-    const sub = parts[0] ?? 'list'
+    const sub = parts[0] ?? null
     const arg = parts[1] ?? null
+
+    // Default (no subcommand) → interactive multi-select in TTY, headless
+    // list output everywhere else (LLM/--md/piped). Keeps `p. mcp` from
+    // Claude/Cursor working as a structured query while making `prjct mcp`
+    // in the user's terminal a real toggle UI.
+    if (sub === null) {
+      const interactive =
+        !options.md && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY)
+      return interactive ? this.interactive(projectPath) : this.list(projectPath, options)
+    }
 
     switch (sub) {
       case 'list':
@@ -55,6 +67,119 @@ export class McpCommands extends PrjctCommandsBase {
         out.fail(`Unknown mcp subcommand: ${sub}. Use: list, status, deny <name>, allow <name>.`)
         return { success: false, error: 'Unknown mcp subcommand' }
     }
+  }
+
+  /**
+   * Interactive multi-select — the primary UX. Shows every MCP prjct knows
+   * about with its tool-cost estimate, lets the user toggle which ones stay
+   * enabled in this project, then writes a single diff to
+   * `.claude/settings.local.json` and prints the restart hint.
+   */
+  private async interactive(projectPath: string): Promise<CommandResult> {
+    try {
+      const servers = await mcpService.list(projectPath)
+      if (servers.length === 0) {
+        out.info('No MCP servers detected for this project.')
+        return { success: true, servers: [] }
+      }
+
+      const sumTools = (list: McpServerInfo[]) => list.reduce((n, s) => n + s.estimatedTools, 0)
+      const beforeActive = servers.filter((s) => !s.denied)
+      const beforeTools = sumTools(beforeActive)
+      const totalTools = sumTools(servers)
+
+      const projectName = projectPath.split('/').pop() ?? 'this project'
+      p.intro(chalk.cyan.bold(`MCP servers — ${projectName}`))
+      p.note(
+        [
+          `${beforeActive.length}/${servers.length} active · ~${beforeTools} of ~${totalTools} tools loaded`,
+          chalk.dim('Space toggles · Enter applies · Esc cancels'),
+        ].join('\n'),
+        'Context cost'
+      )
+
+      const sourceLabel: Record<McpServerInfo['source'], string> = {
+        cloud: 'cloud',
+        project: 'project',
+        global: 'global',
+      }
+
+      const sorted = [...servers].sort((a, b) => {
+        if (a.source !== b.source) {
+          const order: McpServerInfo['source'][] = ['cloud', 'project', 'global']
+          return order.indexOf(a.source) - order.indexOf(b.source)
+        }
+        return b.estimatedTools - a.estimatedTools
+      })
+
+      const selected = await p.multiselect({
+        message: 'Keep enabled in this project:',
+        options: sorted.map((s) => ({
+          value: s.name,
+          label: this.optionLabel(s, sourceLabel[s.source]),
+          hint: s.description,
+        })),
+        initialValues: sorted.filter((s) => !s.denied).map((s) => s.name),
+        required: false,
+      })
+
+      if (p.isCancel(selected)) {
+        p.cancel('No changes.')
+        return { success: true, cancelled: true }
+      }
+
+      const enabledNames = selected as string[]
+      const result = await mcpService.setEnabled(
+        projectPath,
+        enabledNames,
+        servers.map((s) => s.name)
+      )
+
+      const afterTools = sumTools(servers.filter((s) => enabledNames.includes(s.name)))
+      const delta = afterTools - beforeTools
+
+      if (result.nowDenied.length === 0 && result.nowAllowed.length === 0) {
+        p.outro(chalk.dim('No changes.'))
+        return { success: true, unchanged: true }
+      }
+
+      const diffLines: string[] = []
+      if (result.nowDenied.length > 0) {
+        diffLines.push(
+          chalk.red(`✗ denied (${result.nowDenied.length}): ${result.nowDenied.join(', ')}`)
+        )
+      }
+      if (result.nowAllowed.length > 0) {
+        diffLines.push(
+          chalk.green(`✓ allowed (${result.nowAllowed.length}): ${result.nowAllowed.join(', ')}`)
+        )
+      }
+      const sign = delta > 0 ? '+' : ''
+      diffLines.push('')
+      diffLines.push(
+        `Tools loaded: ${beforeTools} → ${afterTools} (${chalk.bold(`${sign}${delta}`)})`
+      )
+      p.note(
+        diffLines.join('\n'),
+        `Wrote ${this.relativeSettingsPath(result.settingsPath, projectPath)}`
+      )
+
+      p.outro(chalk.yellow('Restart Claude Code to apply (MCP config is cached at session start).'))
+      return { success: true, ...result, beforeTools, afterTools }
+    } catch (error) {
+      const msg = getErrorMessage(error)
+      out.fail(msg)
+      return { success: false, error: msg }
+    }
+  }
+
+  private optionLabel(s: McpServerInfo, source: string): string {
+    const cost = s.estimatedTools > 0 ? chalk.dim(` ~${s.estimatedTools} tools`) : ''
+    return `${chalk.dim(`[${source}]`)} ${s.displayName}${cost}`
+  }
+
+  private relativeSettingsPath(abs: string, projectPath: string): string {
+    return abs.startsWith(projectPath) ? abs.slice(projectPath.length + 1) : abs
   }
 
   private async list(projectPath: string, options: McpOptions): Promise<CommandResult> {

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -437,6 +437,12 @@ async function executeCommand(
         md,
         tags: opts.tags ? String(opts.tags) : undefined,
       })
+    case 'mcp':
+      // Explicit case (not registry.execute) because the registry wrapper
+      // calls `mcp(projectPath)` when param is null — which makes `mcp` parse
+      // the cwd as a subcommand. `p. mcp` from Claude Code hits exactly that
+      // path and was returning "Unknown mcp subcommand: /Users/…".
+      return commands!.mcp(param, request.cwd, { md })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/core/infrastructure/command-installer.ts
+++ b/core/infrastructure/command-installer.ts
@@ -28,26 +28,49 @@ import { mergeWithMarkers } from './ide-project-installer'
 // =============================================================================
 
 const GLOBAL_CLAUDE_MD_CONTENT = `<!-- prjct:start - DO NOT REMOVE THIS MARKER -->
-# p/ — Context layer for AI agents
+# p/ — Project knowledge layer
 
-Skills auto-activate for: task, ship, status, tag, remember, capture, sync, workflow, seed, install, context
-Other commands: run \`prjct <command> --md\` and follow CLI output
+prjct stores project memory (decisions, learnings, gotchas, patterns, ships, analyses) per project and regenerates a readable Markdown vault. **Use it — don't re-read source from scratch.**
 
-Task lifecycle (v2): \`prjct task "<desc>"\` → work → \`prjct status done\` → \`prjct ship\`
-- Pause: \`prjct status paused\`  |  Resume: \`prjct status active\`  |  Reopen: \`prjct status active\` (on completed task)
-- Capture to inbox (bugs, ideas, anything): \`prjct capture "<text>" --tags bug|idea|…\`
+You are in a prjct project when any of these signs are present: \`~/Documents/prjct/<slug>/_generated/\` exists, OR \`.prjct/\` is in cwd, OR \`~/.prjct-cli/projects/\` has an entry for the current path.
 
-Data:
-- prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
-- Commit footer: \`Generated with [p/](https://www.prjct.app/)\`
-- Path resolution: \`.prjct/prjct.config.json\` → \`~/.prjct-cli/projects/{projectId}\`
-- Storage: \`prjct\` CLI (SQLite internally)
+## Lookup FIRST, source LAST
 
-Memory (project RAG):
-- Save with \`prjct remember <type> "<content>"\` or \`prjct capture "<text>"\` — these write to SQLite and hooks regenerate the Obsidian vault.
-- Recall via the SessionStart / UserPromptSubmit hook context that prjct injects, or \`prjct context memory [topic]\`.
-- Do **not** write to \`~/.claude/projects/<slug>/memory/\` — that is Claude Code auto-memory, disjoint from this project's RAG and invisible to other tools (Cursor, Gemini, web dashboard). In a prjct project, project memory is prjct.
-- The vault at \`~/Documents/prjct/<slug>/_generated/\` is a read-only snapshot regenerated from DB. Do not hand-edit it — fix the pipeline instead.
+Before reading source code or running broad searches for ANY question about the project (architecture, conventions, decisions, recent ships, bugs, patterns, tech debt, past analyses), READ these vault files first using Read/Glob — no CLI round-trip:
+
+- \`~/Documents/prjct/<slug>/_generated/index.md\` — overview, ships, memory counts, patterns count
+- \`~/Documents/prjct/<slug>/_generated/architecture.md\` — domains, conventions, key insights
+- \`~/Documents/prjct/<slug>/_generated/{patterns,insights,tech-debt}.md\` — inferred state of the project
+- \`~/Documents/prjct/<slug>/_generated/memory/{decision,gotcha,learning,fact,inbox}.md\` — captured knowledge
+- \`~/Documents/prjct/<slug>/_generated/analysis/{anti-patterns,insights,patterns,refactors,risk-areas,tech-debt}/\` — past analyses by category
+- \`~/Documents/prjct/<slug>/_generated/{ships,releases,tags}/\` — history & taxonomy
+
+Only fall through to source/repo reading when the vault does not contain the answer.
+
+## Capture analyses BACK to prjct
+
+When you complete substantive work — analysis, decision, learning, gotcha discovered — persist it so the next session benefits:
+
+- \`prjct remember decision "<choice + why>"\` — choices made, with rationale
+- \`prjct remember learning "<insight>"\` — non-obvious insights gained
+- \`prjct remember gotcha "<trap + how to avoid>"\` — bugs/traps found
+- \`prjct remember fact "<verifiable claim>"\` — project facts (paths, conventions, IDs)
+- \`prjct capture "<text>" --tags type:analysis,topic:<x>\` — analytical dumps & inbox items
+
+Tag with \`--tags k:v,k:v\` for searchability. Memory persists to SQLite; vault auto-regenerates. **Default to capturing — under-capture is the failure mode that makes prjct useless.**
+
+## Workflow
+
+\`prjct task "<desc>"\` → work → \`prjct status done\` → \`prjct ship\`
+Pause/resume: \`prjct status paused\` | \`prjct status active\` (also reopens completed tasks)
+
+## Where things live
+
+- Source of truth: SQLite at \`~/.prjct-cli/projects/<id>/\` (don't read directly — use \`prjct\` CLI)
+- Read snapshot: vault at \`~/Documents/prjct/<slug>/_generated/\` (Read/Glob freely; never hand-edit — fix the pipeline)
+- Project config: \`.prjct/prjct.config.json\` in repo root
+
+The vault regenerates automatically on \`remember\`, \`capture\`, \`ship\`, \`sync\`, and the SessionStart/Stop hooks.
 
 **Auto-managed by prjct-cli** | https://prjct.app
 <!-- prjct:end - DO NOT REMOVE THIS MARKER -->

--- a/core/services/mcp-service.ts
+++ b/core/services/mcp-service.ts
@@ -207,6 +207,56 @@ class McpService {
     return { wasDenied: true, settingsPath }
   }
 
+  /**
+   * Atomically reconcile the denylist with a desired set of *enabled* server
+   * names. Returns which names changed sides so callers can show a diff.
+   * Used by the interactive multi-select — single file write instead of N.
+   */
+  async setEnabled(
+    projectPath: string,
+    enabledNames: string[],
+    knownNames: string[]
+  ): Promise<{
+    nowDenied: string[]
+    nowAllowed: string[]
+    settingsPath: string
+  }> {
+    const settingsPath = this.localSettingsPath(projectPath)
+    const settings = this.readJson<LocalSettings>(settingsPath) ?? {}
+    const previous = new Set((settings.deniedMcpServers ?? []).map((e) => e.serverName))
+    const enabled = new Set(enabledNames)
+
+    // Desired denylist = (previous denylist ∪ known names) − enabled names.
+    // Preserves entries we don't recognize (user may hand-edit denylist for
+    // servers prjct doesn't catalog yet).
+    const desired = new Set<string>(previous)
+    for (const name of knownNames) {
+      if (enabled.has(name)) desired.delete(name)
+      else desired.add(name)
+    }
+
+    const nowDenied: string[] = []
+    const nowAllowed: string[] = []
+    for (const name of knownNames) {
+      const wasDenied = previous.has(name)
+      const isDenied = desired.has(name)
+      if (!wasDenied && isDenied) nowDenied.push(name)
+      else if (wasDenied && !isDenied) nowAllowed.push(name)
+    }
+
+    if (nowDenied.length === 0 && nowAllowed.length === 0) {
+      return { nowDenied, nowAllowed, settingsPath }
+    }
+
+    if (desired.size === 0) {
+      delete settings.deniedMcpServers
+    } else {
+      settings.deniedMcpServers = Array.from(desired).map((serverName) => ({ serverName }))
+    }
+    this.writeJson(settingsPath, settings)
+    return { nowDenied, nowAllowed, settingsPath }
+  }
+
   // ---------------------------------------------------------------------
 
   private localSettingsPath(projectPath: string): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prjct-cli",
-  "version": "2.3.10",
+  "version": "2.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prjct-cli",
-      "version": "2.3.10",
+      "version": "2.3.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.3.11",
+  "version": "2.3.12",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- **MCP TTY fix**: route `prjct mcp` through client process so the interactive multi-select picker actually fires (daemon has no TTY)
- **M0 of rescue plan**: rewrite global CLAUDE.md from informative to imperative — Claude now reads the vault FIRST and falls through to source LAST, plus explicit auto-capture instructions
- Versions bumped to v2.3.14 (cumulative across both ship runs)

## Why this matters (M0)

3,800 npm users were hitting prjct as overhead, not value. Root cause: prjct produces the vault but the global CLAUDE.md mentioned it only informatively (\"don't hand-edit it\"). Claude ignored the vault entirely and burned ~10K tokens per session re-exploring source from scratch.

The new CLAUDE.md content:

- **Lookup FIRST, source LAST**: explicit list of 6 vault paths Claude must read before falling through to source (architecture, patterns, insights, memory by type, analysis subcategories, ships/releases/tags)
- **Capture analyses BACK to prjct**: explicit \`prjct remember <type>\` and \`prjct capture --tags\` patterns for decision/learning/gotcha/fact/analysis dumps. Punchline: *\"Default to capturing — under-capture is the failure mode that makes prjct useless.\"*
- Concrete project-detection signs

Existing users get this on next prjct invocation via the existing self-heal mechanism (no manual reinstall needed).

## Test plan

- [ ] `prjct sync` on a fresh machine triggers self-heal and rewrites the \`<!-- prjct:start -->\` block in \`~/.claude/CLAUDE.md\`
- [ ] Open Claude Code in any prjct project → ask about architecture → Claude reads \`_generated/architecture.md\`, NOT \`grep -r\` in source
- [ ] Ask Claude to do an analysis → Claude ends with \`prjct remember <type>\` spontaneously
- [ ] \`prjct mcp\` (no args) opens the multi-select picker in TTY (was falling to headless \`list\`)
- [ ] Existing CHANGELOG entries and version bump look correct in releases

## Plan reference

Full rescue plan: \`~/.claude/plans/por-que-estas-herramientas-partitioned-jellyfish.md\` (M0 done, M1-M4 next).