### PR TITLE
fix(build): unblock CI Release — sync mcp into daemon shim skip set

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -19,7 +19,15 @@
 let _fastArgs = process.argv.slice(2)
 let _fastCommand = _fastArgs.find((a) => !a.startsWith('--') && !a.startsWith('-'))
 
-// Commands that bin/prjct.ts handles directly (NOT routed through daemon)
+// Commands that bin/prjct.ts handles directly (NOT routed through daemon).
+// Note: mcp must stay here because its interactive multi-select needs TTY on
+// stdin/stdout — the detached daemon process has no TTY and would silently
+// fall back to plain list output.
+//
+// IMPORTANT: when adding a command to this set, ALSO add it to the shim skip
+// set in scripts/build.js (~line 175). The daemon-shim-sync test enforces it,
+// and CI Release will fail otherwise. The test parses string literals from
+// this array, so keep entries on bare lines without inline comments.
 const _binCommands = new Set([
   'daemon',
   'stop',
@@ -43,9 +51,6 @@ const _binCommands = new Set([
   'version',
   '-v',
   '--version',
-  // mcp's interactive multi-select needs TTY on stdin/stdout. Daemon runs
-  // detached with no TTY, so routing through it falls back to plain `list`
-  // output. Always execute mcp in the client process so prompts work.
   'mcp',
 ])
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -172,7 +172,7 @@ import{connect}from"node:net";import{existsSync}from"node:fs";import{randomUUID}
 const sockPath=homedir()+"/.prjct-cli/run/daemon.sock";
 const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
-const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew"]);
+const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp"]);
 if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
   const cArgs=[],cOpts={};
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}


### PR DESCRIPTION
## Summary

Hot-fix for the CI Release failure on PR #268 (M0 lookup-first ship).

The daemon-shim-sync test caught two issues my M0 ship missed:

1. **`scripts/build.js` shim skip Set** missing `'mcp'` — same regression class as `crew` in 2.3.5 → 2.3.6. Any command in `_binCommands` not also in the shim skip Set gets swallowed by the daemon.

2. **`bin/prjct.ts` inline comment** had apostrophes/backticks that the test's regex string-extractor falsely captured as a (corrupt) array entry. Moved comment above the array, added explicit warning for next person who touches `_binCommands`.

## Verification

- `bun test core/__tests__/infrastructure/daemon-shim-sync.test.ts` → 2 pass, 0 fail
- Full suite: 878/878 pass

## Captured to prjct

The gotcha + workflow learning are in the vault now (`prjct remember gotcha` + `prjct remember learning`) so the next time someone touches `_binCommands` the lookup-first protocol surfaces the warning.

## Why this slipped through

I should have run `bun test` locally before opening PR #268. Captured the workflow learning to prevent repeat.