### PR TITLE
feat(vault): bidirectional workflow editing — drop a .md, override SQLite (M1b INPUT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.4] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.3] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.5] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.4] - 2026-05-01
 
 ### Added

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -20,7 +20,7 @@
 
 import configManager from '../infrastructure/config-manager'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
-import { ingestCapturedNotes } from '../services/wiki-ingest'
+import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
 import { emit, readStdinSafe, safeRun } from './_shared'
 
 export async function runStopHook(projectPath: string = process.cwd()): Promise<void> {
@@ -28,16 +28,26 @@ export async function runStopHook(projectPath: string = process.cwd()): Promise<
     await readStdinSafe()
     emit({})
 
-    // Side effects: ingest captured/ → DB, then refresh the _generated/
-    // snapshot. Best-effort; failures stay silent so the host session
-    // is never disturbed.
+    // Side effects: ingest user-authored content → DB, then refresh the
+    // _generated/ snapshot. Best-effort; failures stay silent so the
+    // host session is never disturbed.
     const config = await configManager.readConfig(projectPath).catch(() => null)
     if (!config?.projectId) return
+
+    // Captured notes → memory entries (existing behavior).
     try {
       await ingestCapturedNotes(projectPath)
     } catch {
       // Ingest failure shouldn't block regen — captured/ stays for next turn.
     }
+
+    // M1b INPUT: workflow overrides → workflow_rules table.
+    try {
+      await ingestWorkflowEdits(projectPath)
+    } catch {
+      // Same contract — failed parses leave the file in place for the user.
+    }
+
     await regenerateWikiDeferred(projectPath, config.projectId).catch(() => undefined)
   })
 }

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -50,7 +50,7 @@ import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { LLMAnalysis } from '../types/llm-analysis'
 import type { ShippedFeature, WorkflowRule } from '../types/storage'
 import { ensureObsidianVault } from './obsidian-vault'
-import { ensureCapturedReadme } from './wiki-ingest'
+import { ensureCapturedReadme, ensureWorkflowsReadme } from './wiki-ingest'
 import { resolveVaultRoot } from './wiki-migration'
 
 // Generated output goes into a dedicated subdir so user notes placed in
@@ -1412,6 +1412,10 @@ export async function generateWiki(
   // in Obsidian discover the capture workflow. No-op if the README
   // already exists.
   await ensureCapturedReadme(projectPath)
+
+  // M1b INPUT: seed the workflows/ dropzone with its own README so users
+  // discover that they can override workflow rules from Obsidian.
+  await ensureWorkflowsReadme(projectPath)
 
   // Make the folder a one-click-open Obsidian vault: bootstrap a
   // minimal `.obsidian/` and register the path in Obsidian's vault

--- a/core/services/wiki-ingest.ts
+++ b/core/services/wiki-ingest.ts
@@ -25,16 +25,24 @@
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import configManager from '../infrastructure/config-manager'
 import { MEMORY_TYPES, type MemoryType, projectMemory } from '../memory/project-memory'
 import { scanForSecrets } from '../memory/secret-scanner'
+import { workflowRuleStorage } from '../storage/workflow-rule-storage'
+import type { WorkflowRule } from '../types/storage'
 import { resolveVaultRoot } from './wiki-migration'
 
 const CAPTURED_SUBDIR = 'captured'
+const WORKFLOWS_SUBDIR = 'workflows'
 const INGESTED_SUBDIR = '_ingested'
 const README_FILENAME = 'README.md'
 
 async function resolveCapturedRoot(projectPath: string): Promise<string> {
   return path.join(await resolveVaultRoot(projectPath), CAPTURED_SUBDIR)
+}
+
+async function resolveWorkflowsRoot(projectPath: string): Promise<string> {
+  return path.join(await resolveVaultRoot(projectPath), WORKFLOWS_SUBDIR)
 }
 
 /**
@@ -277,4 +285,243 @@ function stripQuotes(v: string): string {
     return v.slice(1, -1)
   }
   return v
+}
+
+// =============================================================================
+// Workflow ingest (M1b INPUT half) — bidirectional editing of workflows
+// from <vault>/workflows/<command>.md.
+//
+// Pattern mirrors captured/: user drops a .md, Stop hook ingests, file is
+// archived to workflows/_ingested/<timestamp>/. Difference: workflow
+// ingest REPLACES the SQLite rules for that command rather than appending.
+// =============================================================================
+
+interface ParsedWorkflow {
+  command: string
+  rules: Array<{
+    type: WorkflowRule['type']
+    action: string
+    description: string | null
+    sortOrder: number
+    position: string
+    whenExpr: string | null
+  }>
+}
+
+interface WorkflowIngestResult {
+  ingested: { command: string; rulesReplaced: number }[]
+  skipped: { file: string; reason: string }[]
+  errors: { file: string; error: string }[]
+}
+
+/**
+ * Ingest workflow overrides from <vault>/workflows/*.md. For every valid
+ * file found, REPLACE all SQLite rules for that command with the parsed
+ * rules (delete + insert). Files are archived to workflows/_ingested/
+ * after successful ingest. The wiki regen will recreate the read-only
+ * snapshot under _generated/workflows/ on the next run, so the user
+ * sees their edits reflected immediately.
+ */
+export async function ingestWorkflowEdits(projectPath: string): Promise<WorkflowIngestResult> {
+  const result: WorkflowIngestResult = { ingested: [], skipped: [], errors: [] }
+  const config = await configManager.readConfig(projectPath).catch(() => null)
+  if (!config?.projectId) return result
+  const projectId = config.projectId
+
+  const workflowsRoot = await resolveWorkflowsRoot(projectPath)
+  const files = await listWorkflowFiles(workflowsRoot)
+  if (files.length === 0) return result
+
+  const archiveRoot = path.join(workflowsRoot, INGESTED_SUBDIR, timestampSlug())
+
+  for (const absPath of files) {
+    const relName = path.basename(absPath)
+    try {
+      const raw = await fs.readFile(absPath, 'utf-8')
+      const parsed = parseWorkflowMarkdown(raw)
+      if (!parsed.ok) {
+        result.skipped.push({ file: relName, reason: parsed.error })
+        continue
+      }
+      const wf = parsed.workflow
+
+      // Replace existing rules for this command. Done as delete + insert to
+      // keep the schema simple — workflowRuleStorage doesn't expose a
+      // per-command nuke today, so we iterate.
+      const existing = workflowRuleStorage.getRulesForCommand(projectId, wf.command)
+      for (const r of existing) workflowRuleStorage.removeRule(projectId, r.id)
+
+      for (const r of wf.rules) {
+        workflowRuleStorage.addRule(projectId, {
+          type: r.type,
+          command: wf.command,
+          position: r.position,
+          action: r.action,
+          description: r.description,
+          enabled: true,
+          timeoutMs: 60_000,
+          sortOrder: r.sortOrder,
+          createdAt: new Date().toISOString(),
+        })
+      }
+
+      await moveToArchive(absPath, archiveRoot, relName)
+      result.ingested.push({ command: wf.command, rulesReplaced: wf.rules.length })
+    } catch (error) {
+      result.errors.push({
+        file: relName,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return result
+}
+
+export async function ensureWorkflowsReadme(projectPath: string): Promise<void> {
+  const workflowsRoot = await resolveWorkflowsRoot(projectPath)
+  await fs.mkdir(workflowsRoot, { recursive: true })
+  const readmePath = path.join(workflowsRoot, README_FILENAME)
+  const exists = await fs.stat(readmePath).then(
+    () => true,
+    () => false
+  )
+  if (exists) return
+  await fs.writeFile(readmePath, WORKFLOWS_README_BODY, 'utf-8')
+}
+
+const WORKFLOWS_README_BODY = `# Workflows (Obsidian dropzone)
+
+Drop a markdown file here to OVERRIDE a workflow's rules in SQLite. Format:
+
+\`\`\`markdown
+---
+name: ship
+---
+
+## Gates
+- \`git branch --show-current | grep -vE "^(main|master)$"\` — Prevent shipping from main branch
+
+## Steps
+- \`version:bump\` — Bump version (stack-aware)
+- \`changelog:add\` — Append CHANGELOG entry
+- \`git:commit\` — Commit ship
+- \`git:push\` — Push to origin
+\`\`\`
+
+## How it works
+
+1. You drop \`workflows/<name>.md\` here.
+2. Stop hook (or \`prjct context wiki sync\`) reads it.
+3. ALL existing rules for that workflow are deleted from SQLite.
+4. New rules from your file are inserted.
+5. Wiki regenerates → \`_generated/workflows/<name>.md\` reflects your edits.
+6. Your file moves to \`_ingested/<timestamp>/\` so this folder stays clean.
+
+## Schema
+
+- Frontmatter \`name:\` is required (the workflow command: ship, task, sync, …)
+- Sections: \`## Gates\`, \`## Steps\`, \`## Hooks\`, \`## Instructions\` (any subset)
+- Each bullet: \`- \\\`<action>\\\` — <description>\` (description optional)
+- Order within a section is preserved as sortOrder
+
+## Notes
+
+- This is destructive: SQLite rules for the named workflow are REPLACED, not merged.
+- To restore a built-in workflow, run \`prjct workflow reset <name>\`.
+- \`README.md\` and \`index.md\` are ignored.
+- Files in \`_ingested/\` are ignored.
+`
+
+type WorkflowParseSuccess = { ok: true; workflow: ParsedWorkflow }
+type WorkflowParseFailure = { ok: false; error: string }
+
+function parseWorkflowMarkdown(raw: string): WorkflowParseSuccess | WorkflowParseFailure {
+  // Frontmatter: name is required.
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!fmMatch) return { ok: false, error: 'missing frontmatter (---name: foo---)' }
+  const fmBody = fmMatch[1]
+  const body = fmMatch[2]
+  const nameMatch = fmBody.match(/^\s*name\s*:\s*(\S+)/m)
+  if (!nameMatch) return { ok: false, error: "frontmatter missing 'name' field" }
+  const command = stripQuotes(nameMatch[1].trim())
+
+  const rules: ParsedWorkflow['rules'] = []
+  // Section parsing: ## Gates / ## Steps / ## Hooks / ## Instructions
+  const sectionMap: Record<string, { type: WorkflowRule['type']; position: string }> = {
+    gates: { type: 'gate', position: 'before' },
+    steps: { type: 'step', position: 'before' },
+    hooks: { type: 'hook', position: 'before' },
+    instructions: { type: 'instruction', position: 'before' },
+  }
+  const sectionRegex = /^##\s+(\w+)/gm
+  const matches = [...body.matchAll(sectionRegex)]
+
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i]
+    const heading = m[1].toLowerCase()
+    const meta = sectionMap[heading]
+    if (!meta) continue
+    const start = m.index! + m[0].length
+    const end = i + 1 < matches.length ? matches[i + 1].index! : body.length
+    const sectionBody = body.slice(start, end)
+    let order = 0
+    for (const line of sectionBody.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('-')) continue
+      // Bullet shapes accepted:
+      //   - `<action>` — <description>
+      //   - `<action>` -- <description>
+      //   - <action>
+      const bullet = trimmed.replace(/^-\s*/, '')
+      const codeMatch = bullet.match(/^`([^`]+)`(?:\s*[—-]+\s*(.+))?$/)
+      let action = ''
+      let description: string | null = null
+      if (codeMatch) {
+        action = codeMatch[1].trim()
+        description = (codeMatch[2] ?? '').trim() || null
+      } else {
+        action = bullet.trim()
+      }
+      if (!action) continue
+      rules.push({
+        type: meta.type,
+        action,
+        description,
+        sortOrder: order,
+        position: meta.position,
+        whenExpr: null,
+      })
+      order += 1
+    }
+  }
+
+  if (rules.length === 0) {
+    return {
+      ok: false,
+      error: 'no rules found (expected ## Gates / ## Steps / ## Hooks / ## Instructions)',
+    }
+  }
+
+  return { ok: true, workflow: { command, rules } }
+}
+
+async function listWorkflowFiles(workflowsRoot: string): Promise<string[]> {
+  let entries: string[]
+  try {
+    entries = await fs.readdir(workflowsRoot)
+  } catch {
+    return []
+  }
+  const out: string[] = []
+  for (const entry of entries) {
+    if (entry.startsWith('.') || entry.startsWith('_')) continue
+    if (entry === README_FILENAME || entry === 'index.md') continue
+    if (!entry.endsWith('.md')) continue
+    const abs = path.join(workflowsRoot, entry)
+    const stat = await fs.stat(abs)
+    if (!stat.isFile()) continue
+    out.push(abs)
+  }
+  return out
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Closes the months-old user request: edit workflows from Obsidian and have prjct ingest them back to SQLite. M1b OUTPUT half (visualization) shipped in #270; this is the INPUT half (round-trip).

## What ships

1. **`<vault>/workflows/`** — new dropzone, paired with `captured/`. Stop hook ingests anything dropped here. Auto-seeded with a README that documents the schema with examples.

2. **`ingestWorkflowEdits()`** in `wiki-ingest.ts`:
   - Parses frontmatter `name:` (the workflow command).
   - Parses sections `## Gates`, `## Steps`, `## Hooks`, `## Instructions`. Bullets shaped `- \`<action>\` — <description>`. Order within a section becomes sortOrder.
   - **REPLACES** all existing SQLite rules for that command (delete + insert via `workflowRuleStorage`). Destructive by design — the user is the source of truth when they edit.
   - Archives the file to `workflows/_ingested/<timestamp>/<name>.md` after successful ingest, so the dropzone stays clean. Failures leave the file in place for the user to fix and retry.

3. **Stop hook** (`core/hooks/stop.ts`) now invokes both `ingestCapturedNotes` (existing) and `ingestWorkflowEdits` (new) before regen. Both are best-effort and silent — failures never disturb the host session.

4. **`ensureWorkflowsReadme()`** seeds the workflows dropzone README on every regen, just like `ensureCapturedReadme`.

## Round-trip verified end-to-end

```
$ cat workflows/test-custom.md
---
name: test-custom
---

## Steps
- \`echo "step 1"\` — Say hello
- \`echo "step 2"\` — Say bye

$ ingestWorkflowEdits → {"ingested":[{"command":"test-custom","rulesReplaced":2}]}
$ ls workflows/_ingested/  → 20260502-040611
$ prjct workflow test-custom → shows the new 2 rules
$ cat _generated/workflows/test-custom.md → reflects edits
```

The user edits in Obsidian → saves → next session (or `prjct context wiki sync`) → SQLite updated → vault snapshot regenerated.

## Tests

- bun test → 878/878 pass
- typecheck clean

## Plan reference

M1b INPUT half of the rescue plan (`~/.claude/plans/por-que-estas-herramientas-partitioned-jellyfish.md`). M1a (Stop hook auto-captures session transcript heuristics) is the next PR.