### PR TITLE
feat(stop-hook): auto-capture substantive insights from transcript (M1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.7] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.6] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.6] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.5] - 2026-05-01
 
 ### Added

--- a/core/__tests__/services/transcript-learner.test.ts
+++ b/core/__tests__/services/transcript-learner.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Transcript Learner — extraction + dedup tests.
+ *
+ * Covers parser, candidate extraction with phrase heuristics, hash
+ * dedup, paragraph length floor, and per-session candidate cap. Does
+ * not exercise the full ingestTranscript() path since that needs a real
+ * project DB; that is integration-tested via the Stop hook in
+ * production sessions.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { _internal } from '../../services/transcript-learner'
+
+const { parseTranscript, extractCandidates, hashContent, PHRASE_TYPE_MAP } = _internal
+
+function transcriptLine(role: string, text: string): string {
+  return JSON.stringify({ role, content: text })
+}
+
+describe('transcript-learner — parseTranscript', () => {
+  test('skips non-assistant roles', () => {
+    const raw = [
+      transcriptLine('user', 'a'.repeat(200)),
+      transcriptLine('assistant', 'b'.repeat(200)),
+      transcriptLine('system', 'c'.repeat(200)),
+    ].join('\n')
+    const out = parseTranscript(raw)
+    expect(out).toHaveLength(1)
+    expect(out[0].role).toBe('assistant')
+  })
+
+  test('skips messages shorter than the paragraph floor', () => {
+    const raw = [
+      transcriptLine('assistant', 'short answer'),
+      transcriptLine('assistant', 'long answer '.repeat(50)),
+    ].join('\n')
+    const out = parseTranscript(raw)
+    expect(out).toHaveLength(1)
+  })
+
+  test('handles content as text-block array shape', () => {
+    const raw = JSON.stringify({
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'a'.repeat(100) },
+        { type: 'tool_use', id: 'x', name: 'Bash', input: {} },
+      ],
+    })
+    const out = parseTranscript(raw)
+    expect(out).toHaveLength(1)
+    expect(out[0].text).toMatch(/^a{100}$/)
+  })
+
+  test('survives malformed JSONL lines', () => {
+    const raw = ['not json', '', transcriptLine('assistant', 'x'.repeat(200))].join('\n')
+    const out = parseTranscript(raw)
+    expect(out).toHaveLength(1)
+  })
+
+  test('handles nested message.content shape', () => {
+    const raw = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: 'y'.repeat(100) },
+    })
+    const out = parseTranscript(raw)
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe('transcript-learner — extractCandidates', () => {
+  test('extracts decision phrases as type=decision', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        text: `We considered three approaches and decided to go with option B because it has the simplest invariants and the lowest blast radius if it fails.`,
+      },
+    ]
+    const out = extractCandidates(messages)
+    expect(out).toHaveLength(1)
+    expect(out[0].type).toBe('decision')
+    expect(out[0].matchedPhrase).toBe('decided to')
+  })
+
+  test('extracts learning phrases as type=learning', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        text: `Turns out that the daemon was caching the rules per-process — which is why a restart was needed before the change took effect.`,
+      },
+    ]
+    const out = extractCandidates(messages)
+    expect(out).toHaveLength(1)
+    expect(out[0].type).toBe('learning')
+  })
+
+  test('extracts gotcha phrases as type=gotcha', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        text: `Gotcha: the path resolver fails when the project root is a symlink — we hit this on macOS with /tmp pointing into /private/tmp.`,
+      },
+    ]
+    const out = extractCandidates(messages)
+    expect(out).toHaveLength(1)
+    expect(out[0].type).toBe('gotcha')
+  })
+
+  test('skips paragraphs without recognized phrases', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        text: 'This is a long paragraph with no high-signal phrase, just normal prose talking about something. '.repeat(
+          2
+        ),
+      },
+    ]
+    const out = extractCandidates(messages)
+    expect(out).toHaveLength(0)
+  })
+
+  test('skips paragraphs shorter than the floor', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        text: 'I decided to go.',
+      },
+    ]
+    const out = extractCandidates(messages)
+    expect(out).toHaveLength(0)
+  })
+
+  test('dedups by content hash within a single run', () => {
+    const para = `The right call here was to keep the daemon and just make it invisible to the user — every alternative had worse trade-offs around latency and routing.`
+    const messages = [
+      { role: 'assistant' as const, text: para },
+      { role: 'assistant' as const, text: para },
+    ]
+    const out = extractCandidates(messages)
+    expect(out).toHaveLength(1)
+  })
+
+  test('caps at MAX_CANDIDATES_PER_SESSION', () => {
+    const decisions: { role: 'assistant'; text: string }[] = []
+    for (let i = 0; i < 50; i++) {
+      decisions.push({
+        role: 'assistant',
+        text: `Decided to take action ${i} because of the unique reasoning ${i} that supports this choice in context ${i}.`,
+      })
+    }
+    const out = extractCandidates(decisions)
+    expect(out.length).toBeLessThanOrEqual(12)
+    expect(out.length).toBe(12)
+  })
+})
+
+describe('transcript-learner — hashContent', () => {
+  test('returns a 16-char lowercase hex prefix', () => {
+    const h = hashContent('Hello World')
+    expect(h).toHaveLength(16)
+    expect(h).toMatch(/^[0-9a-f]{16}$/)
+  })
+
+  test('case- and whitespace-insensitive', () => {
+    expect(hashContent('  Hello World  ')).toBe(hashContent('hello world'))
+    expect(hashContent('HELLO WORLD')).toBe(hashContent('hello world'))
+  })
+})
+
+describe('transcript-learner — PHRASE_TYPE_MAP', () => {
+  test('every phrase maps to one of the known memory types', () => {
+    const validTypes = new Set(['decision', 'learning', 'gotcha', 'fact'])
+    for (const entry of PHRASE_TYPE_MAP) {
+      expect(validTypes.has(entry.type)).toBe(true)
+    }
+  })
+
+  test('phrases are lowercase (extractor lowercases the haystack)', () => {
+    for (const entry of PHRASE_TYPE_MAP) {
+      expect(entry.phrase).toBe(entry.phrase.toLowerCase())
+    }
+  })
+})

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -19,13 +19,19 @@
  */
 
 import configManager from '../infrastructure/config-manager'
+import { ingestTranscript } from '../services/transcript-learner'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
 import { emit, readStdinSafe, safeRun } from './_shared'
 
+interface HookInput {
+  transcript_path?: string
+  session_id?: string
+}
+
 export async function runStopHook(projectPath: string = process.cwd()): Promise<void> {
   await safeRun(async () => {
-    await readStdinSafe()
+    const input = await readStdinSafe<HookInput>()
     emit({})
 
     // Side effects: ingest user-authored content → DB, then refresh the
@@ -46,6 +52,17 @@ export async function runStopHook(projectPath: string = process.cwd()): Promise<
       await ingestWorkflowEdits(projectPath)
     } catch {
       // Same contract — failed parses leave the file in place for the user.
+    }
+
+    // M1a: auto-capture substantive insights from the assistant's
+    // transcript. Conservative heuristics, hashed-dedup, never blocks.
+    if (input.transcript_path) {
+      try {
+        await ingestTranscript(projectPath, input.transcript_path, input.session_id ?? null)
+      } catch {
+        // Failed parse / unexpected format → swallow. The user can
+        // always run `prjct remember` explicitly.
+      }
     }
 
     await regenerateWikiDeferred(projectPath, config.projectId).catch(() => undefined)

--- a/core/services/transcript-learner.ts
+++ b/core/services/transcript-learner.ts
@@ -1,0 +1,327 @@
+/**
+ * Transcript Learner — extract durable insights from a Claude Code
+ * session transcript and persist them as project memory.
+ *
+ * Why this exists: even when prjct is installed, Claude routinely does
+ * substantive analysis during a turn (decisions, root-cause findings,
+ * gotchas discovered) without explicitly calling `prjct remember`. The
+ * next session has to re-derive the same insights from source. This
+ * service is the safety net: at session end, scan what the assistant
+ * said, lift the substantive bits into SQLite as memory entries, and
+ * the wiki regen exposes them under `_generated/memory/<type>.md`.
+ *
+ * Design constraints (from mem_899: efficiency contract):
+ *   - Asynchronous, best-effort, never blocks session close
+ *   - Idempotent: hash-based dedup, re-running on the same transcript
+ *     never doubles entries
+ *   - Conservative heuristics: high precision, low recall. False
+ *     positives are worse than misses — the user can always call
+ *     `prjct remember` explicitly. Noise erodes trust in the vault.
+ *   - Tag entries with `source:transcript-auto` so the user can filter,
+ *     audit, or `prjct memory prune --auto` if it gets noisy.
+ */
+
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import configManager from '../infrastructure/config-manager'
+import { type MemoryType, projectMemory } from '../memory/project-memory'
+
+const SOURCE_TAG = 'transcript-auto'
+const MIN_PARAGRAPH_CHARS = 80
+const MAX_CONTENT_CHARS = 1500
+const MAX_CANDIDATES_PER_SESSION = 12
+
+interface Candidate {
+  type: MemoryType
+  content: string
+  hash: string
+  matchedPhrase: string
+}
+
+interface IngestResult {
+  scanned: number
+  ingested: number
+  skipped: { reason: string; phrase?: string }[]
+  errors: string[]
+}
+
+/**
+ * Phrases that signal the assistant was making a durable claim. Each
+ * phrase maps to a memory type. Match is case-insensitive on word
+ * boundaries — we check `\bphrase\b` against the line's lowercase form.
+ *
+ * Keep this list short and high-signal. Each addition risks false
+ * positives that pollute memory.
+ */
+const PHRASE_TYPE_MAP: Array<{ phrase: string; type: MemoryType }> = [
+  // Decisions: explicit choice or recommendation that should outlive the turn
+  { phrase: 'decided to', type: 'decision' },
+  { phrase: 'we chose', type: 'decision' },
+  { phrase: 'going with', type: 'decision' },
+  { phrase: 'the right call', type: 'decision' },
+  { phrase: 'best approach is', type: 'decision' },
+  // Learnings: non-obvious insights gained during the work
+  { phrase: 'turns out that', type: 'learning' },
+  { phrase: 'now i understand', type: 'learning' },
+  { phrase: 'the key insight', type: 'learning' },
+  { phrase: 'i learned that', type: 'learning' },
+  { phrase: 'discovered that', type: 'learning' },
+  // Gotchas: traps, bugs, or surprising failure modes
+  { phrase: 'gotcha:', type: 'gotcha' },
+  { phrase: 'bug:', type: 'gotcha' },
+  { phrase: 'fails when', type: 'gotcha' },
+  { phrase: 'breaks when', type: 'gotcha' },
+  { phrase: 'be careful', type: 'gotcha' },
+]
+
+/**
+ * Public entry: read a Claude Code transcript JSONL, extract durable
+ * candidates, persist them as memory, return a report.
+ *
+ * Caller (Stop hook) wraps in try/catch and discards errors. We surface
+ * `errors` on the result for tests + future telemetry.
+ */
+export async function ingestTranscript(
+  projectPath: string,
+  transcriptPath: string,
+  sessionId: string | null
+): Promise<IngestResult> {
+  const result: IngestResult = { scanned: 0, ingested: 0, skipped: [], errors: [] }
+
+  const config = await configManager.readConfig(projectPath).catch(() => null)
+  if (!config?.projectId) {
+    result.errors.push('no project config')
+    return result
+  }
+
+  let raw: string
+  try {
+    raw = await fs.readFile(transcriptPath, 'utf-8')
+  } catch (err) {
+    result.errors.push(`transcript read failed: ${(err as Error).message}`)
+    return result
+  }
+
+  const messages = parseTranscript(raw)
+  result.scanned = messages.length
+  if (messages.length === 0) return result
+
+  const candidates = extractCandidates(messages)
+  if (candidates.length === 0) return result
+
+  // Dedup against memory we already wrote from previous transcript
+  // ingests. We tag every auto-captured entry with `source:transcript-auto`
+  // and embed the content hash in the tags as `hash:<first16>` so this
+  // check is one query + a Set lookup.
+  const existingHashes = collectExistingAutoHashes(config.projectId)
+
+  const sessionTag = sessionId ? sessionId.slice(0, 12) : 'unknown'
+  for (const cand of candidates) {
+    if (existingHashes.has(cand.hash)) {
+      result.skipped.push({ reason: 'duplicate', phrase: cand.matchedPhrase })
+      continue
+    }
+    try {
+      await projectMemory.remember(projectPath, {
+        type: cand.type,
+        content: cand.content,
+        tags: {
+          source: SOURCE_TAG,
+          session: sessionTag,
+          hash: cand.hash,
+          phrase: cand.matchedPhrase,
+        },
+        provenance: 'inferred',
+      })
+      result.ingested += 1
+    } catch (err) {
+      result.errors.push(`remember failed: ${(err as Error).message}`)
+    }
+  }
+
+  return result
+}
+
+// =============================================================================
+// Transcript parsing
+// =============================================================================
+
+interface TranscriptMessage {
+  role: 'assistant' | 'user' | 'system'
+  text: string
+}
+
+/**
+ * Best-effort JSONL parser. Claude Code's transcript shape varies by
+ * version, but the contract we depend on is minimal: each line is JSON
+ * with a recognizable role + extractable text content.
+ *
+ * We only care about `assistant` messages with substantive text. Tool
+ * calls, tool results, and user turns are skipped.
+ */
+function parseTranscript(raw: string): TranscriptMessage[] {
+  const out: TranscriptMessage[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(trimmed) as Record<string, unknown>
+    } catch {
+      continue
+    }
+    const role = inferRole(parsed)
+    if (role !== 'assistant') continue
+    const text = extractText(parsed)
+    if (!text || text.length < MIN_PARAGRAPH_CHARS) continue
+    out.push({ role, text })
+  }
+  return out
+}
+
+function inferRole(msg: Record<string, unknown>): TranscriptMessage['role'] | null {
+  // Try common shapes: top-level `role`, nested `message.role`, or
+  // `type` field. Fall through quietly if unrecognized.
+  const direct = msg.role
+  if (typeof direct === 'string') return normalizeRole(direct)
+  const nested = msg.message
+  if (nested && typeof nested === 'object' && 'role' in nested) {
+    const r = (nested as Record<string, unknown>).role
+    if (typeof r === 'string') return normalizeRole(r)
+  }
+  const type = msg.type
+  if (type === 'assistant' || type === 'user' || type === 'system') return type
+  return null
+}
+
+function normalizeRole(r: string): TranscriptMessage['role'] | null {
+  const lower = r.toLowerCase()
+  if (lower === 'assistant' || lower === 'user' || lower === 'system') {
+    return lower as TranscriptMessage['role']
+  }
+  return null
+}
+
+/**
+ * Pull the assistant's textual output from whatever shape the line
+ * uses. Claude Code emits content as either a string or an array of
+ * `{type:'text', text:'...'}` blocks. Tool-use blocks are dropped.
+ */
+function extractText(msg: Record<string, unknown>): string {
+  // Some shapes nest under message.content
+  let content: unknown = msg.content
+  if (content === undefined && msg.message && typeof msg.message === 'object') {
+    content = (msg.message as Record<string, unknown>).content
+  }
+  if (typeof content === 'string') return content.trim()
+  if (Array.isArray(content)) {
+    const parts: string[] = []
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue
+      const b = block as Record<string, unknown>
+      if (b.type === 'text' && typeof b.text === 'string') parts.push(b.text)
+    }
+    return parts.join('\n').trim()
+  }
+  return ''
+}
+
+// =============================================================================
+// Candidate extraction
+// =============================================================================
+
+/**
+ * Walk assistant messages, return the substantive paragraphs that
+ * trigger one of the recognized phrases. Capped at
+ * MAX_CANDIDATES_PER_SESSION so a chatty session doesn't flood the
+ * memory store.
+ */
+function extractCandidates(messages: TranscriptMessage[]): Candidate[] {
+  const candidates: Candidate[] = []
+  const seen = new Set<string>()
+
+  for (const msg of messages) {
+    const paragraphs = splitParagraphs(msg.text)
+    for (const para of paragraphs) {
+      if (candidates.length >= MAX_CANDIDATES_PER_SESSION) return candidates
+      if (para.length < MIN_PARAGRAPH_CHARS) continue
+      const lower = para.toLowerCase()
+      const match = PHRASE_TYPE_MAP.find((m) => lower.includes(m.phrase))
+      if (!match) continue
+      const trimmed =
+        para.length > MAX_CONTENT_CHARS ? `${para.slice(0, MAX_CONTENT_CHARS)}…` : para
+      const hash = hashContent(trimmed)
+      if (seen.has(hash)) continue
+      seen.add(hash)
+      candidates.push({
+        type: match.type,
+        content: trimmed,
+        hash,
+        matchedPhrase: match.phrase,
+      })
+    }
+  }
+
+  return candidates
+}
+
+function splitParagraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+}
+
+function hashContent(content: string): string {
+  return crypto.createHash('sha256').update(content.toLowerCase().trim()).digest('hex').slice(0, 16)
+}
+
+// =============================================================================
+// Dedup against previously ingested entries
+// =============================================================================
+
+interface AutoMemoryRow {
+  data: string
+}
+
+function collectExistingAutoHashes(projectId: string): Set<string> {
+  const out = new Set<string>()
+  try {
+    // We tag every auto-captured entry with `source:transcript-auto` and
+    // embed the hash in `tags.hash`. Pull recent events and parse out
+    // the hashes — same pattern projectMemory.recall uses.
+    const { prjctDb } = require('../storage/database') as typeof import('../storage/database')
+    const rows = prjctDb.query<AutoMemoryRow>(
+      projectId,
+      "SELECT data FROM events WHERE type LIKE 'memory.remember.%' ORDER BY id DESC LIMIT 500"
+    )
+    for (const row of rows) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(row.data)
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== 'object') continue
+      const tags = (parsed as { tags?: Record<string, unknown> }).tags
+      if (!tags || tags.source !== SOURCE_TAG) continue
+      const h = tags.hash
+      if (typeof h === 'string') out.add(h)
+    }
+  } catch {
+    // Best-effort: a missing dedup index just means we may write a
+    // duplicate this turn; the user can prune.
+  }
+  return out
+}
+
+// =============================================================================
+// Test exports
+// =============================================================================
+
+export const _internal = {
+  parseTranscript,
+  extractCandidates,
+  hashContent,
+  PHRASE_TYPE_MAP,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Closes the gap surfaced in the gstack analysis: even when prjct is installed, Claude routinely makes durable decisions/findings during a turn without calling `prjct remember`. Next session has to re-derive everything from source.

## How it works

**`core/services/transcript-learner.ts`** (NEW):
1. Parses the JSONL transcript Claude Code writes per session
2. Filters to assistant messages with paragraphs ≥80 chars
3. Scans each paragraph for one of 15 high-signal phrases mapped to a memory type:
   - **decision**: \"decided to\", \"we chose\", \"going with\", \"the right call\", \"best approach is\"
   - **learning**: \"turns out that\", \"now i understand\", \"the key insight\", \"i learned that\", \"discovered that\"
   - **gotcha**: \"gotcha:\", \"bug:\", \"fails when\", \"breaks when\", \"be careful\"
4. Persists each match as `prjct remember <type>` with tags `source:transcript-auto`, `session:<id>`, `hash:<sha>`, `phrase:<matched>`, provenance:`'inferred'`
5. **Hash dedup** against previous auto-captured entries — re-running on same transcript never doubles
6. Capped at 12 candidates/session so chatty turns don't flood memory

**`core/hooks/stop.ts`** (CHANGED):
- Now reads `transcript_path` + `session_id` from stdin
- Invokes `ingestTranscript` between `ingestWorkflowEdits` and `regenerateWikiDeferred`
- Best-effort: parse failures swallowed, host session never disturbed

## Why phrase heuristics, not LLM classification

mem_899 (efficiency contract): prjct never spends tokens/latency on the user's behalf without clear value. Phrase matching is O(n) regex. False positives erode trust in the vault — high precision > high recall. Missed captures are recoverable via explicit `prjct remember`; spurious entries pollute search.

## Verifying after merge

After publishing to npm + reinstall:
1. Have a session where Claude says \"I decided to use approach X because Y\"
2. Close Claude Code
3. Check `~/Documents/prjct/<slug>/_generated/memory/decision.md` — the entry appears, tagged `source:transcript-auto`
4. Re-open and run another session: hash dedup prevents the same paragraph entering twice

## Tests

- 16 new tests in transcript-learner.test.ts (parser shapes, candidate extraction by type, length floor, hash dedup, per-session cap)
- Full suite: 894/894 pass, typecheck clean

## Plan reference

M1a of the rescue plan. M2 (Stop hook detects hot files / recurring bugs / tech debt growth) is the next PR.