### PR TITLE
feat(stop-hook): detect hot files automatically (M2 — pattern detection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.8] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.7] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.9] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.8] - 2026-05-01
 
 ### Added

--- a/core/__tests__/services/pattern-detector.test.ts
+++ b/core/__tests__/services/pattern-detector.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Pattern Detector — hot file detection tests.
+ *
+ * Covers the ignore-pattern filter and detect-on-empty behavior. The
+ * full detectHotFiles() flow needs a real git repo and is integration
+ * tested via Stop hook in production sessions.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { _internal } from '../../services/pattern-detector'
+
+const { isIgnored, IGNORE_PATTERNS, HOT_THRESHOLD, WINDOW_DAYS } = _internal
+
+describe('pattern-detector — isIgnored', () => {
+  test('ignores lock files', () => {
+    expect(isIgnored('package.json')).toBe(true)
+    expect(isIgnored('package-lock.json')).toBe(true)
+    expect(isIgnored('bun.lock')).toBe(true)
+    expect(isIgnored('bun.lockb')).toBe(true)
+    expect(isIgnored('pnpm-lock.yaml')).toBe(true)
+    expect(isIgnored('yarn.lock')).toBe(true)
+  })
+
+  test('ignores changelog and gitignore', () => {
+    expect(isIgnored('CHANGELOG.md')).toBe(true)
+    expect(isIgnored('.gitignore')).toBe(true)
+  })
+
+  test('ignores snapshot tests', () => {
+    expect(isIgnored('__tests__/foo.test.ts.snap')).toBe(true)
+  })
+
+  test('ignores generated dirs', () => {
+    expect(isIgnored('dist/index.js')).toBe(true)
+    expect(isIgnored('node_modules/react/index.js')).toBe(true)
+  })
+
+  test('does not ignore source files', () => {
+    expect(isIgnored('src/index.ts')).toBe(false)
+    expect(isIgnored('core/services/wiki-generator.ts')).toBe(false)
+    expect(isIgnored('README.md')).toBe(false)
+  })
+
+  test('matches against basename, not just path', () => {
+    expect(isIgnored('subdir/package.json')).toBe(true)
+    expect(isIgnored('vendor/foo/bun.lockb')).toBe(true)
+  })
+})
+
+describe('pattern-detector — constants', () => {
+  test('HOT_THRESHOLD is conservative', () => {
+    // 3+ touches over a week is the documented contract. Lowering this
+    // would flood memory with churn from any active repo.
+    expect(HOT_THRESHOLD).toBe(3)
+  })
+
+  test('WINDOW_DAYS is 7', () => {
+    expect(WINDOW_DAYS).toBe(7)
+  })
+
+  test('ignore patterns cover common noise', () => {
+    expect(IGNORE_PATTERNS.length).toBeGreaterThan(5)
+  })
+})

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -19,6 +19,7 @@
  */
 
 import configManager from '../infrastructure/config-manager'
+import { detectAndPersistPatterns } from '../services/pattern-detector'
 import { ingestTranscript } from '../services/transcript-learner'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
@@ -63,6 +64,15 @@ export async function runStopHook(projectPath: string = process.cwd()): Promise<
         // Failed parse / unexpected format → swallow. The user can
         // always run `prjct remember` explicitly.
       }
+    }
+
+    // M2: detect durable patterns (hot files for now) and persist them
+    // as learning memory entries. Lookup-first protocol means Claude
+    // finds them on next session start without inflating context.
+    try {
+      await detectAndPersistPatterns(projectPath)
+    } catch {
+      // Git failure / non-repo → swallow; nothing to do here.
     }
 
     await regenerateWikiDeferred(projectPath, config.projectId).catch(() => undefined)

--- a/core/services/pattern-detector.ts
+++ b/core/services/pattern-detector.ts
@@ -1,0 +1,238 @@
+/**
+ * Pattern Detector — surface durable patterns from recent project work.
+ *
+ * Scope (M2 of the rescue plan): start with hot files only. A file
+ * touched 3+ times in the last 7 days is a refactor candidate worth
+ * the user's attention. Detected on every Stop hook fire, persisted as
+ * a `learning` memory entry tagged `pattern:hot-file`. The wiki regen
+ * exposes them under `_generated/memory/learning.md`, and the
+ * lookup-first protocol in CLAUDE.md ensures Claude finds them at
+ * session start.
+ *
+ * Recurring bugs and tech-debt growth are deferred to a follow-up
+ * commit. Heuristics for those need more thought to avoid false
+ * positives.
+ *
+ * Design contract (mem_899):
+ *   - Best-effort, never blocks the Stop hook.
+ *   - Idempotent: a file already marked hot in the same window is not
+ *     re-persisted.
+ *   - Conservative: noise > value. We'd rather miss a hot file than
+ *     pollute the memory store with churn.
+ */
+
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import configManager from '../infrastructure/config-manager'
+import { projectMemory } from '../memory/project-memory'
+
+const execFileP = promisify(execFile)
+
+const HOT_FILE_PATTERN_TAG = 'hot-file'
+const HOT_FILE_SOURCE_TAG = 'pattern-detector-auto'
+// Window + threshold tuned conservatively. 3+ touches over a week is
+// "this file is the locus of recent activity" without flagging every
+// daily-touched file in an active repo.
+const WINDOW_DAYS = 7
+const HOT_THRESHOLD = 3
+// Skip noisy paths that are touched on every commit and offer no
+// refactor signal.
+const IGNORE_PATTERNS: readonly RegExp[] = [
+  /^package(-lock)?\.json$/,
+  /^bun\.lock(b)?$/,
+  /^pnpm-lock\.yaml$/,
+  /^yarn\.lock$/,
+  /^CHANGELOG\.md$/,
+  /^\.gitignore$/,
+  /\.snap$/,
+  /^dist\//,
+  /^node_modules\//,
+]
+
+interface HotFile {
+  path: string
+  touches: number
+}
+
+interface DetectResult {
+  scanned: number
+  hotFiles: HotFile[]
+  persisted: number
+  skipped: { reason: string; file?: string }[]
+  errors: string[]
+}
+
+/**
+ * Public entry: run all detectors, persist insights for new hot files.
+ * Stop hook awaits this best-effort. Wraps every IO in try/catch so a
+ * non-git directory or a transient git failure never escapes.
+ */
+export async function detectAndPersistPatterns(projectPath: string): Promise<DetectResult> {
+  const result: DetectResult = {
+    scanned: 0,
+    hotFiles: [],
+    persisted: 0,
+    skipped: [],
+    errors: [],
+  }
+
+  const config = await configManager.readConfig(projectPath).catch(() => null)
+  if (!config?.projectId) {
+    result.errors.push('no project config')
+    return result
+  }
+
+  let hotFiles: HotFile[] = []
+  try {
+    hotFiles = await detectHotFiles(projectPath)
+  } catch (err) {
+    result.errors.push(`hot-file detection failed: ${(err as Error).message}`)
+    return result
+  }
+  result.scanned = hotFiles.length
+  result.hotFiles = hotFiles
+
+  if (hotFiles.length === 0) return result
+
+  const alreadyMarked = collectAlreadyMarked(config.projectId)
+
+  for (const hf of hotFiles) {
+    if (alreadyMarked.has(hf.path)) {
+      result.skipped.push({ reason: 'already-marked-this-window', file: hf.path })
+      continue
+    }
+    try {
+      await projectMemory.remember(projectPath, {
+        type: 'learning',
+        content:
+          `Hot file: \`${hf.path}\` — ${hf.touches} touches in the last ${WINDOW_DAYS} days. ` +
+          `Worth a refactor pass or a deliberate decision about why it churns this often.`,
+        tags: {
+          source: HOT_FILE_SOURCE_TAG,
+          pattern: HOT_FILE_PATTERN_TAG,
+          file: hf.path,
+          touches: String(hf.touches),
+          window_days: String(WINDOW_DAYS),
+        },
+        provenance: 'inferred',
+      })
+      result.persisted += 1
+    } catch (err) {
+      result.errors.push(`remember failed for ${hf.path}: ${(err as Error).message}`)
+    }
+  }
+
+  return result
+}
+
+// =============================================================================
+// Hot file detection
+// =============================================================================
+
+/**
+ * Walk `git log --name-only` for the last WINDOW_DAYS, count touches per
+ * path, drop ignore-listed paths, return ones over HOT_THRESHOLD.
+ *
+ * Uses `git log -z` so paths with newlines or quotes don't fragment the
+ * parse. Returns sorted by touch count desc.
+ */
+export async function detectHotFiles(projectPath: string): Promise<HotFile[]> {
+  // -z: NUL-separate paths inside each commit; --name-only without
+  //   --diff-filter so we count any change (add/modify/rename).
+  // --pretty=format:: empty so each commit emits only its file list.
+  const { stdout } = await execFileP(
+    'git',
+    ['log', `--since=${WINDOW_DAYS}.days.ago`, '--name-only', '--pretty=format:', '-z'],
+    { cwd: projectPath, maxBuffer: 16 * 1024 * 1024 }
+  )
+
+  const counts = new Map<string, number>()
+  for (const raw of stdout.split('\0')) {
+    const file = raw.trim()
+    if (!file) continue
+    if (isIgnored(file)) continue
+    counts.set(file, (counts.get(file) ?? 0) + 1)
+  }
+
+  const hot: HotFile[] = []
+  for (const [file, touches] of counts) {
+    if (touches < HOT_THRESHOLD) continue
+    hot.push({ path: file, touches })
+  }
+  hot.sort((a, b) => b.touches - a.touches)
+  return hot
+}
+
+function isIgnored(file: string): boolean {
+  const base = path.basename(file)
+  for (const re of IGNORE_PATTERNS) {
+    if (re.test(file) || re.test(base)) return true
+  }
+  return false
+}
+
+// =============================================================================
+// Dedup against previously persisted hot-file insights (same window)
+// =============================================================================
+
+interface MemoryRow {
+  data: string
+}
+
+/**
+ * Pull recent auto-persisted hot-file insights and return the set of
+ * file paths already marked. Window dedup: we treat any insight in the
+ * last WINDOW_DAYS as "still valid" so we don't re-persist on every
+ * Stop hook call. The next window will let us re-mark naturally.
+ */
+function collectAlreadyMarked(projectId: string): Set<string> {
+  const out = new Set<string>()
+  try {
+    const { prjctDb } = require('../storage/database') as typeof import('../storage/database')
+    const rows = prjctDb.query<MemoryRow>(
+      projectId,
+      "SELECT data FROM events WHERE type = 'memory.remember.learning' ORDER BY id DESC LIMIT 200"
+    )
+    const cutoffMs = Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000
+    for (const row of rows) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(row.data)
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== 'object') continue
+      const tags = (parsed as { tags?: Record<string, unknown> }).tags
+      if (!tags || tags.source !== HOT_FILE_SOURCE_TAG) continue
+      // Tags carry the marker; the row's timestamp is the event's
+      // outer field, not in `data`. Conservative: if we have a hit on
+      // source+pattern+file, treat as marked regardless of age and let
+      // the LIMIT 200 window handle staleness.
+      const file = tags.file
+      const ts = (parsed as { rememberedAt?: unknown }).rememberedAt
+      if (typeof file !== 'string') continue
+      if (typeof ts === 'string') {
+        const t = Date.parse(ts)
+        if (!Number.isNaN(t) && t < cutoffMs) continue
+      }
+      out.add(file)
+    }
+  } catch {
+    // Best-effort: a missing dedup index just means a duplicate this
+    // turn. The user can prune.
+  }
+  return out
+}
+
+// =============================================================================
+// Test exports
+// =============================================================================
+
+export const _internal = {
+  detectHotFiles,
+  isIgnored,
+  IGNORE_PATTERNS,
+  HOT_THRESHOLD,
+  WINDOW_DAYS,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Surfaces durable patterns from recent project work without the user having to ask. M2 of the rescue plan; recurring-bug + tech-debt detectors deferred to follow-up.

## How it works

**`core/services/pattern-detector.ts`** (NEW):
1. `detectHotFiles(projectPath)` walks `git log --since=7.days.ago --name-only -z` and counts touches per file, dropping noisy paths (lock files, CHANGELOG, dist/, node_modules/, .snap).
2. **Threshold**: 3+ touches in 7 days = hot.
3. For each hot file, persists a `learning` memory entry tagged `source:pattern-detector-auto`, `pattern:hot-file`, `file:<path>`, `touches:<n>`, provenance:`'inferred'`.
4. **Window dedup**: a file already marked in the last 7 days is skipped.
5. Wiki regen exposes them under `_generated/memory/learning.md`. The lookup-first protocol in CLAUDE.md (M0) ensures Claude finds them on next session and can propose refactors.

**`core/hooks/stop.ts`**: invokes `detectAndPersistPatterns` after `ingestTranscript` and before `regenerateWikiDeferred`. Best-effort; git failures or non-repo dirs swallow.

## Verified in this repo

`detectHotFiles(prjct-cli)` returned 6 hot files this week:
- `core/daemon/daemon.ts` (6 touches)
- `core/hooks/stop.ts` (4 touches)
- `core/services/wiki-generator.ts` (3 touches)
- `core/__tests__/services/wiki-incremental.test.ts` (3 touches)
- `.github/workflows/release.yml` (3 touches)
- `core/hooks/session-start.ts` (3 touches)

Lock files / dist / CHANGELOG correctly filtered out by IGNORE_PATTERNS.

## Why hot files first (and not recurring bugs / tech-debt growth)

mem_899 / conservative heuristics: hot files have a clean signal (git history) and a clear action (refactor candidate). Recurring bugs need fuzzy matching across gotcha entries; tech-debt growth needs a running TODO/FIXME count diff. Both can produce false positives that pollute memory. Defer until we have better signals.

## Tests

- 9 new tests in pattern-detector.test.ts (ignore-list shape, threshold values, basename matching)
- Full suite: 903/903 pass, typecheck clean

## End-to-end after publish

1. User updates to vNext via the standard `npm install -g prjct-cli@latest` (banner shows automatically).
2. Self-heal already updated CLAUDE.md (M0). 
3. Their next Stop hook (every Claude Code turn end) detects hot files in their repo.
4. Wiki regenerates `_generated/memory/learning.md` with the new entries.
5. Their next Claude session reads the vault per the lookup-first protocol → proposes refactors / investigations / decisions about the hot files.

## Plan reference

M2 of the rescue plan. Next: M3 (5 quality workflows gstack-style — review/qa/security/investigate/ship endurecido) and M4 (distribution).