### PR TITLE
feat(distribution): paste-into-Claude install + prjct team command (M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.13] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.12] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.12] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.11] - 2026-05-01
 
 ### Added

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -404,4 +404,24 @@ export const COMMANDS: CommandMeta[] = [
       'Backup option before deletion',
     ],
   },
+  {
+    name: 'team',
+    group: 'core',
+    description:
+      'Enroll this repo in prjct team mode — commits .prjct/team.json + .claude/CLAUDE.md so teammates pick up shared expectations',
+    usage: {
+      claude: '/p:team',
+      terminal: 'prjct team [--required] [--min-version <semver>]',
+    },
+    params: '[--required] [--min-version <semver>]',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: true,
+    features: [
+      'Writes .prjct/team.json with required/minVersion config',
+      'Adds prjct context block to .claude/CLAUDE.md (per-project)',
+      'Stages both files for the next commit (does NOT commit)',
+      'Teammates clone repo + install prjct → ready to go',
+    ],
+  },
 ]

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -26,6 +26,7 @@ import { PrimitiveCommands } from './primitives'
 import { SeedCommands } from './seed'
 import { SetupCommands } from './setup'
 import { ShippingCommands } from './shipping'
+import { TeamCommands } from './team'
 import { UpdateCommands } from './update'
 import { WorkflowCommands } from './workflow'
 
@@ -47,6 +48,7 @@ class PrjctCommands {
   private installCmds: InstallCommands
   private captureCmds: CaptureCommands
   private mcpCmds: McpCommands
+  private teamCmds: TeamCommands
 
   // Shared state
   agent: unknown
@@ -67,6 +69,7 @@ class PrjctCommands {
     this.installCmds = new InstallCommands()
     this.captureCmds = new CaptureCommands()
     this.mcpCmds = new McpCommands()
+    this.teamCmds = new TeamCommands()
 
     this.agent = null
     this.agentInfo = null
@@ -220,6 +223,14 @@ class PrjctCommands {
     options: { md?: boolean } = {}
   ): Promise<CommandResult> {
     return this.mcpCmds.mcp(input, projectPath, options)
+  }
+
+  async team(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean; required?: boolean; minVersion?: string } = {}
+  ): Promise<CommandResult> {
+    return this.teamCmds.team(input, projectPath, options)
   }
 
   // ========== Auth Commands ==========

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -20,6 +20,7 @@ import { commandRegistry } from './registry'
 import { SeedCommands } from './seed'
 import { SetupCommands } from './setup'
 import { ShippingCommands } from './shipping'
+import { TeamCommands } from './team'
 import { UninstallCommands } from './uninstall'
 import { UpdateCommands } from './update'
 import { WorkflowCommands } from './workflow'
@@ -38,6 +39,7 @@ const seedCmd = new SeedCommands()
 const installCmd = new InstallCommands()
 const captureCmd = new CaptureCommands()
 const mcpCmd = new McpCommands()
+const teamCmd = new TeamCommands()
 
 /**
  * Register categories
@@ -113,6 +115,10 @@ function registerAllCommands(): void {
   // Per-project MCP scoping — list/deny/allow MCP servers, persisted to
   // `.claude/settings.local.json` so other projects stay untouched.
   commandRegistry.registerMethod('mcp', mcpCmd, 'mcp', getMeta('mcp'))
+
+  // M4: team mode. Writes .prjct/team.json + .claude/CLAUDE.md (per-project)
+  // and stages them. Teammates pick up the same expectations from the repo.
+  commandRegistry.registerMethod('team', teamCmd, 'team', getMeta('team'))
 }
 
 // Auto-register on import — this module is imported only for its side effect

--- a/core/commands/team.ts
+++ b/core/commands/team.ts
@@ -1,0 +1,178 @@
+/**
+ * `prjct team` — turn this repo into a prjct-shared project.
+ *
+ * What it does (v1):
+ *   1. Writes `.prjct/team.json` with `{required, minVersion}`. Tracked
+ *      in git so teammates pick up the same expectations.
+ *   2. Ensures `.claude/CLAUDE.md` (per-project) has a "prjct context"
+ *      section pointing at `prjct sync`. If the file exists, the section
+ *      is upserted between markers; otherwise the file is created.
+ *   3. Stages both files for the next commit. Does NOT commit — the
+ *      user controls when to ship the change.
+ *
+ * What it deliberately does NOT do (v1):
+ *   - Install a pre-commit hook in the repo. Doing that requires a
+ *     framework choice (husky, lefthook, simple-git-hooks) and is too
+ *     opinionated for a first cut. The `required` flag is documentary
+ *     today; an enforcement layer can read it later.
+ *   - Touch `.gitignore` or any other repo config. Surface area must
+ *     stay small.
+ *
+ * Anti-harness contract (mem_899): no automatic git commits, no
+ * background pushes, no LLM-mediated decisions. A user-invoked command
+ * with deterministic file writes only.
+ */
+
+import { exec } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { mdOutput, mdSection } from '../utils/md-formatter'
+import out from '../utils/output'
+import { VERSION } from '../utils/version'
+import { PrjctCommandsBase } from './base'
+
+const execP = promisify(exec)
+
+const CLAUDE_MD_START = '<!-- prjct-team:start - DO NOT REMOVE THIS MARKER -->'
+const CLAUDE_MD_END = '<!-- prjct-team:end - DO NOT REMOVE THIS MARKER -->'
+
+interface TeamOptions {
+  md?: boolean
+  required?: boolean
+  minVersion?: string
+}
+
+interface TeamConfig {
+  required: boolean
+  minVersion: string
+  enrolledAt: string
+}
+
+export class TeamCommands extends PrjctCommandsBase {
+  async team(
+    _input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: TeamOptions = {}
+  ): Promise<CommandResult> {
+    try {
+      const teamConfig: TeamConfig = {
+        required: options.required === true,
+        minVersion: options.minVersion ?? VERSION ?? '0.0.0',
+        enrolledAt: new Date().toISOString(),
+      }
+
+      const teamPath = path.join(projectPath, '.prjct', 'team.json')
+      const claudeMdPath = path.join(projectPath, '.claude', 'CLAUDE.md')
+
+      // 1. Write .prjct/team.json
+      await fs.mkdir(path.dirname(teamPath), { recursive: true })
+      await fs.writeFile(teamPath, `${JSON.stringify(teamConfig, null, 2)}\n`, 'utf-8')
+
+      // 2. Upsert .claude/CLAUDE.md (per-project)
+      await fs.mkdir(path.dirname(claudeMdPath), { recursive: true })
+      const block = teamClaudeMdBlock(teamConfig)
+      let existing = ''
+      try {
+        existing = await fs.readFile(claudeMdPath, 'utf-8')
+      } catch {
+        // file doesn't exist yet — create with just the team block
+      }
+      const next = upsertBetweenMarkers(existing, block, CLAUDE_MD_START, CLAUDE_MD_END)
+      await fs.writeFile(claudeMdPath, next, 'utf-8')
+
+      // 3. Stage both files. Don't fail the command if git isn't
+      // present or the user is outside a repo — print a hint instead.
+      let staged = false
+      try {
+        await execP('git rev-parse --show-toplevel', { cwd: projectPath })
+        await execP(`git add ${JSON.stringify(teamPath)} ${JSON.stringify(claudeMdPath)}`, {
+          cwd: projectPath,
+        })
+        staged = true
+      } catch {
+        // not in a git repo, or git missing — fall through
+      }
+
+      const summary = `${teamConfig.required ? '✓ team mode (required)' : '✓ team mode (optional)'} — minVersion ${teamConfig.minVersion}`
+      const stagedHint = staged
+        ? 'Staged: .prjct/team.json + .claude/CLAUDE.md (commit when ready)'
+        : 'Files written but not staged (no git repo or git missing).'
+      const nextSteps = [
+        '1. Review the diff: `git diff --staged`',
+        '2. Commit: `git commit -m "chore: enroll repo in prjct team mode"`',
+        '3. Push: `git push`',
+        '4. Teammates run `npm install -g prjct-cli@latest` (or `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`) and `prjct sync`.',
+      ].join('\n')
+
+      if (options.md) {
+        console.log(
+          mdOutput(
+            mdSection('Team mode enrolled', summary),
+            mdSection('Files', stagedHint),
+            mdSection('Next', nextSteps)
+          )
+        )
+      } else {
+        out.done(summary)
+        console.log(stagedHint)
+        console.log('\nNext steps:')
+        console.log(nextSteps)
+      }
+
+      return {
+        success: true,
+        teamConfig,
+        staged,
+        teamPath,
+        claudeMdPath,
+      }
+    } catch (error) {
+      const msg = getErrorMessage(error)
+      out.fail(msg)
+      return { success: false, error: msg }
+    }
+  }
+}
+
+function teamClaudeMdBlock(cfg: TeamConfig): string {
+  return [
+    CLAUDE_MD_START,
+    '# prjct (team mode)',
+    '',
+    `This repo is enrolled in prjct team mode (required: ${cfg.required}, minVersion: ${cfg.minVersion}, enrolled: ${cfg.enrolledAt}).`,
+    '',
+    'When working in this repo:',
+    '- prjct stores project memory (decisions, learnings, gotchas, patterns) per project.',
+    '- The vault lives at `~/Documents/prjct/<slug>/_generated/`.',
+    '- Always lookup the vault before re-reading source for project context.',
+    '- Capture substantive analysis back via `prjct remember <type> "..."`.',
+    '',
+    "Don't have prjct? Install once: `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`",
+    `${cfg.required ? 'This repo *requires* prjct — please install before contributing.' : ''}`,
+    CLAUDE_MD_END,
+  ]
+    .filter((l) => l !== '')
+    .join('\n')
+}
+
+function upsertBetweenMarkers(
+  existing: string,
+  block: string,
+  startMarker: string,
+  endMarker: string
+): string {
+  if (!existing.trim()) return `${block}\n`
+  const startIdx = existing.indexOf(startMarker)
+  const endIdx = existing.indexOf(endMarker)
+  if (startIdx >= 0 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx)
+    const after = existing.slice(endIdx + endMarker.length)
+    return `${before}${block}${after}`.replace(/\n{3,}/g, '\n\n').trim() + '\n'
+  }
+  // No marker — append block at the end with a separator.
+  const trimmed = existing.replace(/\s+$/, '')
+  return `${trimmed}\n\n${block}\n`
+}

--- a/core/commands/verb-names.ts
+++ b/core/commands/verb-names.ts
@@ -27,6 +27,7 @@ const REGISTERED_VERBS = [
   'install',
   'capture',
   'mcp',
+  'team',
 ] as const
 
 export const REGISTERED_VERBS_SET: ReadonlySet<string> = new Set(REGISTERED_VERBS)

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -443,6 +443,12 @@ async function executeCommand(
       // the cwd as a subcommand. `p. mcp` from Claude Code hits exactly that
       // path and was returning "Unknown mcp subcommand: /Users/…".
       return commands!.mcp(param, request.cwd, { md })
+    case 'team':
+      return commands!.team(param, request.cwd, {
+        md,
+        required: opts.required === true,
+        minVersion: opts['min-version'] ? String(opts['min-version']) : undefined,
+      })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/install-via-claude.sh
+++ b/scripts/install-via-claude.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# prjct — single-paste install.
+#
+# Designed to be invoked by pasting one line into Claude Code (or any
+# AI agent's chat) and letting the agent execute it. Goal: zero terminal
+# friction.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash
+#
+# What it does:
+#   1. Detects the runtime (bun > node)
+#   2. Installs / upgrades prjct-cli to the latest published version
+#   3. Runs `prjct setup` to install hooks + the global CLAUDE.md block
+#   4. If the cwd is a git repo, runs `prjct sync` to register the project
+#
+# Idempotent: re-running after upgrades only does the diff. Network or
+# permission failures fail loud so the user knows what to fix.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Pretty output (still quiet enough that an LLM can quote the whole run
+# back to the user without spam)
+# ---------------------------------------------------------------------------
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+DIM='\033[2m'
+NC='\033[0m'
+
+step() { printf "${GREEN}▸${NC} %s\n" "$1"; }
+warn() { printf "${YELLOW}⚠${NC}  %s\n" "$1"; }
+fail() { printf "${RED}✗${NC} %s\n" "$1" >&2; exit 1; }
+note() { printf "${DIM}  %s${NC}\n" "$1"; }
+
+# ---------------------------------------------------------------------------
+# 1. Runtime detection
+# ---------------------------------------------------------------------------
+
+step "Detecting runtime…"
+RUNTIME=""
+if command -v bun >/dev/null 2>&1; then
+  RUNTIME="bun"
+  note "found Bun $(bun --version)"
+elif command -v npm >/dev/null 2>&1; then
+  RUNTIME="npm"
+  note "found npm $(npm --version)"
+else
+  fail "Neither Bun nor npm/Node found. Install one first: https://bun.sh or https://nodejs.org"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Install or upgrade prjct-cli
+# ---------------------------------------------------------------------------
+
+CURRENT=""
+if command -v prjct >/dev/null 2>&1; then
+  CURRENT="$(prjct -v 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+fi
+
+if [ -n "$CURRENT" ]; then
+  step "Upgrading prjct-cli (current: v$CURRENT)…"
+else
+  step "Installing prjct-cli…"
+fi
+
+if [ "$RUNTIME" = "bun" ]; then
+  bun install -g prjct-cli@latest >/dev/null 2>&1 || fail "bun install failed"
+else
+  npm install -g prjct-cli@latest >/dev/null 2>&1 || fail "npm install failed"
+fi
+
+NEW="$(prjct -v 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo unknown)"
+note "installed v$NEW"
+
+# ---------------------------------------------------------------------------
+# 3. Setup (hooks + global CLAUDE.md)
+# ---------------------------------------------------------------------------
+
+step "Wiring hooks + global CLAUDE.md (lookup-first)…"
+# `prjct setup` is interactive when stdin is a TTY. Force the headless
+# path here so we don't hang in `bash -c` from an LLM-driven invocation.
+PRJCT_NONINTERACTIVE=1 prjct setup --quiet 2>/dev/null || warn "setup encountered non-fatal warnings; check 'prjct doctor' if anything looks off"
+
+# ---------------------------------------------------------------------------
+# 4. If we're in a git repo, register the project
+# ---------------------------------------------------------------------------
+
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  step "Registering this project (cwd is a git repo)…"
+  prjct sync --quiet 2>/dev/null || note "sync skipped — run 'prjct sync' manually if you need to refresh"
+else
+  note "cwd is not a git repo — skipping project registration. cd into a project and run 'prjct sync' to register it."
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+printf "\n${GREEN}✓${NC} prjct v$NEW ready.\n"
+printf "${DIM}  Next:${NC}\n"
+printf "${DIM}    - Open Claude Code in any project — the lookup-first protocol kicks in automatically${NC}\n"
+printf "${DIM}    - Try: /p:remember decision \"…\"  or  prjct capture \"…\"${NC}\n"
+printf "${DIM}    - Quality workflows live inside the prjct skill: ask Claude to \"review\", \"qa\", \"investigate\", or \"security check\" the current branch.${NC}\n"


### PR DESCRIPTION
## Summary

Two distribution patterns adopted from gstack, sized to ship now. Closes M4 of the rescue plan.

## scripts/install-via-claude.sh

A single-paste install for users who hate the npm/bun multi-step dance. Designed to be invoked from inside Claude Code:

> Paste in Claude: \`curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash\`

Claude pastes, executes, done. The script:
1. Detects Bun > npm runtime
2. Installs / upgrades prjct-cli to latest
3. Runs \`prjct setup\` to install hooks + global CLAUDE.md
4. If cwd is a git repo, runs \`prjct sync\` to register the project

Idempotent. Fails loud on network/permission issues.

## prjct team command (NEW)

Enrolls a repo in shared mode:

1. Writes \`.prjct/team.json\` with \`{required, minVersion, enrolledAt}\`. Tracked in git.
2. Upserts a \"prjct (team mode)\" block into \`.claude/CLAUDE.md\` (per-project) between markers. Existing user content preserved.
3. Stages both files for the next commit. Does NOT auto-commit (mem_899: no harness behavior).

Flags:
- \`--required\` — marks team config as required (enforcement layer is a follow-up; flag is documentary today).
- \`--min-version <semver>\` — minimum prjct version teammates need.

The block in \`.claude/CLAUDE.md\` documents:
- Vault location, lookup-first protocol, capture-back convention
- Install instruction (pointing at install-via-claude.sh)
- Required / optional indication

Wired through commands.ts → register.ts → daemon.ts → command-data.ts → verb-names.ts (full registration path verified by daemon-shim-sync test).

## What this enables for the user's 3,800 npm users

- **Onboarding**: 1 paste-line in Claude Code instead of 5 terminal steps
- **Team adoption**: \`prjct team\` makes a repo self-documenting; teammates who clone see exactly what tooling to install + how

## Tests

- 903/903 pass, typecheck clean
- biome auto-fix applied

## Plan reference

M4 of the rescue plan. All 5 milestones now shipped end-to-end:

- ✅ M0  — lookup-first protocol in CLAUDE.md global (v2.4.1)
- ✅ M1b — workflows bidirectional in vault (v2.4.5)
- ✅ M1a — Stop hook auto-captures session transcript (v2.4.7)
- ✅ M2  — Stop hook detects hot files (v2.4.9)
- ✅ M3  — 5 quality workflows in prjct skill (v2.4.11)
- ✅ M4  — paste-into-Claude install + team mode (this PR)

Auto-update opt-in remains a roadmap follow-up if user wants it.