### PR TITLE
feat(distribution): standalone binary install — no npm/Node needed (M5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,6 +345,24 @@ jobs:
             . || true
           sha256sum prjct-cli-$VERSION.tar.gz > checksums.txt
 
+      # M5: standalone binaries via `bun build --compile`. Embeds the bun
+      # runtime so users can install prjct without npm/node/bun. The
+      # install-via-claude.sh script auto-detects platform and downloads
+      # the right asset; npm install -g remains the documented fallback.
+      - name: Build standalone binaries
+        if: ${{ !inputs.dry_run }}
+        run: |
+          mkdir -p dist-binaries
+          # Mac arm64 + intel + Linux x64. Add windows-x64 / linux-arm64
+          # if there's demand — bun supports both.
+          for target in bun-darwin-arm64 bun-darwin-x64 bun-linux-x64; do
+            out="dist-binaries/prjct-${target#bun-}"
+            echo "Compiling $out…"
+            bun build --compile --target=$target ./bin/prjct.ts --outfile "$out"
+          done
+          (cd dist-binaries && sha256sum prjct-* >> ../checksums.txt)
+          ls -lh dist-binaries
+
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
         uses: softprops/action-gh-release@v2
@@ -354,16 +372,30 @@ jobs:
           files: |
             prjct-cli-${{ steps.version.outputs.new }}.tar.gz
             checksums.txt
+            dist-binaries/prjct-darwin-arm64
+            dist-binaries/prjct-darwin-x64
+            dist-binaries/prjct-linux-x64
           body: |
             ${{ steps.changelog.outputs.ENTRY }}
 
             ## Installation
 
-            ```bash
-            # Bun (recommended)
-            bun install -g prjct-cli@${{ steps.version.outputs.new }}
+            ### One-paste (no npm needed)
 
-            # npm
+            Paste this into Claude Code (or any AI agent):
+
+            ```bash
+            curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash
+            ```
+
+            The script downloads the standalone binary for your platform
+            from this release — no Node, no npm, no Bun required at install time.
+
+            ### Package manager (fallback)
+
+            ```bash
+            bun install -g prjct-cli@${{ steps.version.outputs.new }}
+            # or
             npm install -g prjct-cli@${{ steps.version.outputs.new }}
             ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.15] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.14] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.14] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.13] - 2026-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/install-via-claude.sh
+++ b/scripts/install-via-claude.sh
@@ -4,19 +4,19 @@
 #
 # Designed to be invoked by pasting one line into Claude Code (or any
 # AI agent's chat) and letting the agent execute it. Goal: zero terminal
-# friction.
+# friction AND zero npm/Node dependency at install time.
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash
 #
 # What it does:
-#   1. Detects the runtime (bun > node)
-#   2. Installs / upgrades prjct-cli to the latest published version
-#   3. Runs `prjct setup` to install hooks + the global CLAUDE.md block
-#   4. If the cwd is a git repo, runs `prjct sync` to register the project
-#
-# Idempotent: re-running after upgrades only does the diff. Network or
-# permission failures fail loud so the user knows what to fix.
+#   1. Detects platform (mac arm64/intel + linux x64)
+#   2. Tries to download the standalone binary from the latest GitHub
+#      release (no npm needed). Falls through to npm/bun on failure.
+#   3. Installs to ~/.prjct-cli/bin/prjct, symlinks to ~/.local/bin/prjct
+#      (or /usr/local/bin/prjct as fallback)
+#   4. Runs `prjct setup` to install hooks + the global CLAUDE.md block
+#   5. If the cwd is a git repo, runs `prjct sync` to register the project
 
 set -euo pipefail
 
@@ -36,57 +36,118 @@ warn() { printf "${YELLOW}⚠${NC}  %s\n" "$1"; }
 fail() { printf "${RED}✗${NC} %s\n" "$1" >&2; exit 1; }
 note() { printf "${DIM}  %s${NC}\n" "$1"; }
 
+PRJCT_DIR="${PRJCT_DIR:-$HOME/.prjct-cli}"
+BIN_DIR="$PRJCT_DIR/bin"
+LOCAL_BIN="$HOME/.local/bin"
+
 # ---------------------------------------------------------------------------
-# 1. Runtime detection
+# 1. Platform detection
 # ---------------------------------------------------------------------------
 
-step "Detecting runtime…"
-RUNTIME=""
-if command -v bun >/dev/null 2>&1; then
-  RUNTIME="bun"
-  note "found Bun $(bun --version)"
-elif command -v npm >/dev/null 2>&1; then
-  RUNTIME="npm"
-  note "found npm $(npm --version)"
-else
-  fail "Neither Bun nor npm/Node found. Install one first: https://bun.sh or https://nodejs.org"
+step "Detecting platform…"
+KERNEL="$(uname -s | tr '[:upper:]' '[:lower:]')"
+MACHINE="$(uname -m)"
+ASSET=""
+case "$KERNEL/$MACHINE" in
+  darwin/arm64|darwin/aarch64) ASSET="prjct-darwin-arm64" ;;
+  darwin/x86_64)               ASSET="prjct-darwin-x64" ;;
+  linux/x86_64)                ASSET="prjct-linux-x64" ;;
+  *) note "no standalone binary for $KERNEL/$MACHINE — will try package manager fallback" ;;
+esac
+[ -n "$ASSET" ] && note "platform: $ASSET"
+
+# ---------------------------------------------------------------------------
+# 2a. Try standalone binary first (the user's preferred path — no npm)
+# ---------------------------------------------------------------------------
+
+INSTALLED_VIA="binary"
+DOWNLOAD_OK=false
+
+if [ -n "$ASSET" ]; then
+  step "Fetching latest release metadata…"
+  LATEST_TAG="$(curl -sSL --fail https://api.github.com/repos/jlopezlira/prjct-cli/releases/latest \
+    | grep -oE '"tag_name":\s*"[^"]+"' | head -1 | cut -d '"' -f4 || true)"
+
+  if [ -n "$LATEST_TAG" ]; then
+    URL="https://github.com/jlopezlira/prjct-cli/releases/download/$LATEST_TAG/$ASSET"
+    note "downloading $LATEST_TAG → $URL"
+    mkdir -p "$BIN_DIR"
+    if curl -sSL --fail -o "$BIN_DIR/prjct.new" "$URL"; then
+      chmod +x "$BIN_DIR/prjct.new"
+      mv "$BIN_DIR/prjct.new" "$BIN_DIR/prjct"
+      DOWNLOAD_OK=true
+    else
+      warn "binary download failed (release asset may not exist yet for this version) — falling back to package manager"
+      rm -f "$BIN_DIR/prjct.new"
+    fi
+  else
+    warn "could not query GitHub releases — falling back to package manager"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
-# 2. Install or upgrade prjct-cli
+# 2b. Package manager fallback
 # ---------------------------------------------------------------------------
 
-CURRENT=""
-if command -v prjct >/dev/null 2>&1; then
-  CURRENT="$(prjct -v 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+if [ "$DOWNLOAD_OK" = false ]; then
+  INSTALLED_VIA="pkg-manager"
+  step "Falling back to package manager…"
+  if command -v bun >/dev/null 2>&1; then
+    note "using Bun $(bun --version)"
+    bun install -g prjct-cli@latest >/dev/null 2>&1 || fail "bun install failed"
+  elif command -v npm >/dev/null 2>&1; then
+    note "using npm $(npm --version)"
+    npm install -g prjct-cli@latest >/dev/null 2>&1 || fail "npm install failed"
+  else
+    fail "Neither standalone binary nor a runtime (Bun/npm) is available. Install Bun: https://bun.sh"
+  fi
 fi
 
-if [ -n "$CURRENT" ]; then
-  step "Upgrading prjct-cli (current: v$CURRENT)…"
-else
-  step "Installing prjct-cli…"
+# ---------------------------------------------------------------------------
+# 3. Symlink so `prjct` is on PATH
+# ---------------------------------------------------------------------------
+
+if [ "$INSTALLED_VIA" = "binary" ]; then
+  step "Adding prjct to PATH…"
+  mkdir -p "$LOCAL_BIN"
+  ln -sf "$BIN_DIR/prjct" "$LOCAL_BIN/prjct"
+  if ! echo "$PATH" | tr ':' '\n' | grep -qx "$LOCAL_BIN"; then
+    # Append PATH export to the user's shell rc, with a guard comment.
+    SHELL_RC=""
+    case "${SHELL:-}" in
+      */zsh)  SHELL_RC="$HOME/.zshrc" ;;
+      */bash) SHELL_RC="$HOME/.bashrc" ;;
+    esac
+    if [ -n "$SHELL_RC" ]; then
+      if ! grep -qF "# prjct: add ~/.local/bin to PATH" "$SHELL_RC" 2>/dev/null; then
+        printf "\n# prjct: add ~/.local/bin to PATH\nexport PATH=\"\$HOME/.local/bin:\$PATH\"\n" >> "$SHELL_RC"
+        note "appended PATH export to $SHELL_RC — open a new shell or run 'source $SHELL_RC'"
+      fi
+    else
+      warn "couldn't detect your shell rc — add this to your shell config: export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+  fi
+  # Make `prjct` resolvable in this script run too.
+  export PATH="$LOCAL_BIN:$PATH"
 fi
 
-if [ "$RUNTIME" = "bun" ]; then
-  bun install -g prjct-cli@latest >/dev/null 2>&1 || fail "bun install failed"
-else
-  npm install -g prjct-cli@latest >/dev/null 2>&1 || fail "npm install failed"
+# Verify install
+if ! command -v prjct >/dev/null 2>&1; then
+  fail "prjct didn't end up on PATH — please add $LOCAL_BIN to your PATH manually"
 fi
 
 NEW="$(prjct -v 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo unknown)"
-note "installed v$NEW"
+note "installed v$NEW (via $INSTALLED_VIA)"
 
 # ---------------------------------------------------------------------------
-# 3. Setup (hooks + global CLAUDE.md)
+# 4. Setup (hooks + global CLAUDE.md)
 # ---------------------------------------------------------------------------
 
 step "Wiring hooks + global CLAUDE.md (lookup-first)…"
-# `prjct setup` is interactive when stdin is a TTY. Force the headless
-# path here so we don't hang in `bash -c` from an LLM-driven invocation.
 PRJCT_NONINTERACTIVE=1 prjct setup --quiet 2>/dev/null || warn "setup encountered non-fatal warnings; check 'prjct doctor' if anything looks off"
 
 # ---------------------------------------------------------------------------
-# 4. If we're in a git repo, register the project
+# 5. Register cwd if it's a git repo
 # ---------------------------------------------------------------------------
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
@@ -100,8 +161,8 @@ fi
 # Done
 # ---------------------------------------------------------------------------
 
-printf "\n${GREEN}✓${NC} prjct v$NEW ready.\n"
+printf "\n${GREEN}✓${NC} prjct v$NEW ready (installed via $INSTALLED_VIA).\n"
 printf "${DIM}  Next:${NC}\n"
 printf "${DIM}    - Open Claude Code in any project — the lookup-first protocol kicks in automatically${NC}\n"
-printf "${DIM}    - Try: /p:remember decision \"…\"  or  prjct capture \"…\"${NC}\n"
-printf "${DIM}    - Quality workflows live inside the prjct skill: ask Claude to \"review\", \"qa\", \"investigate\", or \"security check\" the current branch.${NC}\n"
+printf "${DIM}    - Try: prjct capture \"a thought\"  or  prjct task \"the thing I'm working on\"${NC}\n"
+printf "${DIM}    - Quality workflows: ask Claude to \"review\", \"qa\", \"investigate\", or \"security check\" the current branch.${NC}\n"


### PR DESCRIPTION
## Summary

Closes the user's months-old preference: \"a mí no me gusta instalar por medio de npm, pnpm o bun o lo que sea.\" Ships true standalone binaries via \`bun build --compile\`, embedded runtime included. Install path drops the package-manager dependency.

## Release pipeline

\`.github/workflows/release.yml\` now also runs:

\`\`\`bash
bun build --compile --target=bun-darwin-arm64 ./bin/prjct.ts \\
  --outfile dist-binaries/prjct-darwin-arm64
# + bun-darwin-x64 + bun-linux-x64
\`\`\`

Verified locally: 63MB single-file executable runs \`prjct -v\` correctly with NO bun/node installed at runtime (it embeds them). Each upload is checksummed and attached to the GitHub release.

## install-via-claude.sh (rewritten)

The one-paste script:

1. \`uname -sm\` → picks asset (mac arm64/intel + linux x64)
2. Queries latest release JSON via GitHub API
3. \`curl\`s the right binary to \`~/.prjct-cli/bin/prjct\`
4. Symlinks into \`~/.local/bin/prjct\`, appends PATH export to \`.zshrc\`/\`.bashrc\` if missing (with guard comment so re-runs are idempotent)
5. Falls back to bun-or-npm install if the binary download fails
6. Runs \`prjct setup\` (hooks + global CLAUDE.md) and \`prjct sync\` (if cwd is git repo)

## Release notes

The release body now leads with the no-npm path. Bun/npm install kept as fallback.

## Tests

- bun test → 903/903 pass, typecheck clean
- Local compile verified: 63MB binary runs standalone

## Plan reference

M5 of the rescue plan (\"lo más verga del mundo\" follow-up).
Auto-update, extended pattern detector, and team-mode enforce ship in
subsequent PRs.