### PR TITLE
feat(distribution): opt-in silent auto-update + global config (M5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.16] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.15] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.17] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.16] - 2026-05-01
 
 ### Added

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -19,6 +19,22 @@
 let _fastArgs = process.argv.slice(2)
 let _fastCommand = _fastArgs.find((a) => !a.startsWith('--') && !a.startsWith('-'))
 
+// M5: internal hook — `prjct __internal-auto-update <currentVersion>`
+// is invoked by the SessionStart hook as a detached child to perform a
+// silent update. Handled here BEFORE the heavy imports so the rest of
+// the CLI plumbing never loads in this child.
+if (_fastCommand === '__internal-auto-update') {
+  const currentVersion = _fastArgs[1] ?? ''
+  try {
+    const { runBackgroundCheck } = await import('../core/services/auto-updater')
+    await runBackgroundCheck(currentVersion)
+  } catch {
+    // Detached child — never crash visibly. Errors are logged to
+    // ~/.prjct-cli/state/auto-update.log inside runBackgroundCheck.
+  }
+  process.exit(0)
+}
+
 // Commands that bin/prjct.ts handles directly (NOT routed through daemon).
 // Note: mcp must stay here because its interactive multi-select needs TTY on
 // stdin/stdout — the detached daemon process has no TTY and would silently

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -424,4 +424,23 @@ export const COMMANDS: CommandMeta[] = [
       'Teammates clone repo + install prjct → ready to go',
     ],
   },
+  {
+    name: 'config',
+    group: 'core',
+    description: 'Read/write global prjct config — auto-update opt-in, suggestions toggle, etc.',
+    usage: {
+      claude: '/p:config list',
+      terminal: 'prjct config <list|get|set|unset> [key] [value]',
+    },
+    params: '<list|get|set|unset> [key] [value]',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: false,
+    features: [
+      'Stored at ~/.prjct-cli/config/global.json',
+      'Opt into silent auto-update: prjct config set auto-update on',
+      'Toggle proactive suggestions: prjct config set suggestions off',
+      'Booleans accept on/off/true/false; numbers parsed automatically',
+    ],
+  },
 ]

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -18,6 +18,7 @@ import type { AgentInfo } from '../types/agents'
 import type { AnalyzeOptions, Author, CommandResult, SetupOptions } from '../types/commands'
 import { AnalysisCommands } from './analysis'
 import { CaptureCommands } from './capture'
+import { ConfigCommands } from './config'
 import { ContextCommands } from './context'
 import { InstallCommands } from './install'
 import { McpCommands } from './mcp'
@@ -49,6 +50,7 @@ class PrjctCommands {
   private captureCmds: CaptureCommands
   private mcpCmds: McpCommands
   private teamCmds: TeamCommands
+  private configCmds: ConfigCommands
 
   // Shared state
   agent: unknown
@@ -70,6 +72,7 @@ class PrjctCommands {
     this.captureCmds = new CaptureCommands()
     this.mcpCmds = new McpCommands()
     this.teamCmds = new TeamCommands()
+    this.configCmds = new ConfigCommands()
 
     this.agent = null
     this.agentInfo = null
@@ -231,6 +234,14 @@ class PrjctCommands {
     options: { md?: boolean; required?: boolean; minVersion?: string } = {}
   ): Promise<CommandResult> {
     return this.teamCmds.team(input, projectPath, options)
+  }
+
+  async config(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean } = {}
+  ): Promise<CommandResult> {
+    return this.configCmds.config(input, projectPath, options)
   }
 
   // ========== Auth Commands ==========

--- a/core/commands/config.ts
+++ b/core/commands/config.ts
@@ -1,0 +1,133 @@
+/**
+ * `prjct config` — read/write the global config at
+ * `~/.prjct-cli/config/global.json`.
+ *
+ * Subcommands:
+ *   list                Show all keys + values
+ *   get <key>           Read one value
+ *   set <key> <value>   Write one value (booleans as 'on'/'off',
+ *                       numbers parsed automatically)
+ *   unset <key>         Remove a key
+ *
+ * Anti-harness contract: this is a deterministic file editor, no
+ * network, no LLM mediation, no auto-updates triggered as a side
+ * effect.
+ */
+
+import { configPath, getAll, getConfig, setConfig, unsetConfig } from '../services/global-config'
+import type { CommandResult } from '../types/commands'
+import { mdOutput, mdSection } from '../utils/md-formatter'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+interface ConfigOptions {
+  md?: boolean
+}
+
+export class ConfigCommands extends PrjctCommandsBase {
+  async config(
+    input: string | null = null,
+    _projectPath: string = process.cwd(),
+    options: ConfigOptions = {}
+  ): Promise<CommandResult> {
+    const parts = (input ?? '').trim().split(/\s+/).filter(Boolean)
+    const sub = parts[0] ?? 'list'
+
+    switch (sub) {
+      case 'list':
+        return this.list(options)
+      case 'get':
+        return this.get(parts[1], options)
+      case 'set':
+        return this.set(parts[1], parts.slice(2).join(' '), options)
+      case 'unset':
+        return this.unset(parts[1], options)
+      default:
+        out.fail(`Unknown config subcommand: ${sub}. Use: list, get <k>, set <k> <v>, unset <k>.`)
+        return { success: false, error: 'Unknown config subcommand' }
+    }
+  }
+
+  private list(options: ConfigOptions): CommandResult {
+    const all = getAll()
+    const keys = Object.keys(all).sort()
+    if (options.md) {
+      const body =
+        keys.length === 0
+          ? '_No global config set._'
+          : keys.map((k) => `- \`${k}\`: \`${JSON.stringify(all[k])}\``).join('\n')
+      console.log(
+        mdOutput(mdSection('Global config', body), mdSection('Path', `\`${configPath()}\``))
+      )
+    } else {
+      if (keys.length === 0) {
+        out.info('No global config set.')
+      } else {
+        for (const k of keys) console.log(`  ${k} = ${JSON.stringify(all[k])}`)
+      }
+    }
+    return { success: true, config: all }
+  }
+
+  private get(key: string | undefined, options: ConfigOptions): CommandResult {
+    if (!key) {
+      out.fail('Usage: prjct config get <key>')
+      return { success: false, error: 'Missing key' }
+    }
+    const value = getConfig(key as never)
+    if (options.md) {
+      console.log(
+        mdOutput(mdSection(key, value === undefined ? '_(unset)_' : `\`${JSON.stringify(value)}\``))
+      )
+    } else if (value === undefined) {
+      out.info(`(unset)`)
+    } else {
+      console.log(JSON.stringify(value))
+    }
+    return { success: true, key, value }
+  }
+
+  private set(
+    key: string | undefined,
+    rawValue: string | undefined,
+    options: ConfigOptions
+  ): CommandResult {
+    if (!key || rawValue === undefined || rawValue === '') {
+      out.fail('Usage: prjct config set <key> <value>')
+      return { success: false, error: 'Missing key or value' }
+    }
+    const parsed = parseValue(rawValue)
+    setConfig(key as never, parsed as never)
+    const msg = `${key} = ${JSON.stringify(parsed)}`
+    if (options.md) {
+      console.log(mdOutput(mdSection('Set', msg)))
+    } else {
+      out.done(msg)
+    }
+    return { success: true, key, value: parsed }
+  }
+
+  private unset(key: string | undefined, options: ConfigOptions): CommandResult {
+    if (!key) {
+      out.fail('Usage: prjct config unset <key>')
+      return { success: false, error: 'Missing key' }
+    }
+    unsetConfig(key as never)
+    const msg = `Removed ${key}`
+    if (options.md) {
+      console.log(mdOutput(mdSection('Unset', msg)))
+    } else {
+      out.done(msg)
+    }
+    return { success: true, key }
+  }
+}
+
+function parseValue(raw: string): string | number | boolean {
+  const lower = raw.toLowerCase()
+  if (lower === 'true' || lower === 'on') return 'on'
+  if (lower === 'false' || lower === 'off') return 'off'
+  const num = Number(raw)
+  if (!Number.isNaN(num) && /^-?\d+(\.\d+)?$/.test(raw)) return num
+  return raw
+}

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -11,6 +11,7 @@
 import { AnalysisCommands } from './analysis'
 import { CaptureCommands } from './capture'
 import { CATEGORIES, COMMANDS } from './command-data'
+import { ConfigCommands } from './config'
 import { ContextCommands } from './context'
 import { InstallCommands } from './install'
 import { McpCommands } from './mcp'
@@ -40,6 +41,7 @@ const installCmd = new InstallCommands()
 const captureCmd = new CaptureCommands()
 const mcpCmd = new McpCommands()
 const teamCmd = new TeamCommands()
+const configCmd = new ConfigCommands()
 
 /**
  * Register categories
@@ -119,6 +121,9 @@ function registerAllCommands(): void {
   // M4: team mode. Writes .prjct/team.json + .claude/CLAUDE.md (per-project)
   // and stages them. Teammates pick up the same expectations from the repo.
   commandRegistry.registerMethod('team', teamCmd, 'team', getMeta('team'))
+
+  // M5: global config (auto-update opt-in, suggestions toggle, …).
+  commandRegistry.registerMethod('config', configCmd, 'config', getMeta('config'))
 }
 
 // Auto-register on import — this module is imported only for its side effect

--- a/core/commands/verb-names.ts
+++ b/core/commands/verb-names.ts
@@ -28,6 +28,7 @@ const REGISTERED_VERBS = [
   'capture',
   'mcp',
   'team',
+  'config',
 ] as const
 
 export const REGISTERED_VERBS_SET: ReadonlySet<string> = new Set(REGISTERED_VERBS)

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -449,6 +449,8 @@ async function executeCommand(
         required: opts.required === true,
         minVersion: opts['min-version'] ? String(opts['min-version']) : undefined,
       })
+    case 'config':
+      return commands!.config(param, request.cwd, { md })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -107,5 +107,15 @@ export async function runSessionStartHook(projectPath: string = process.cwd()): 
     if (!isSyncCurrent(VERSION)) {
       await runSelfHeal(VERSION).catch(() => undefined)
     }
+
+    // M5: opt-in silent auto-update. No-op unless the user has opted
+    // in via `prjct config set auto-update on`. Throttled to 1/hour
+    // and runs detached so the session never waits.
+    try {
+      const { maybeAutoUpdate } = await import('../services/auto-updater')
+      maybeAutoUpdate(VERSION)
+    } catch {
+      // never block the session on update mechanics
+    }
   })
 }

--- a/core/services/auto-updater.ts
+++ b/core/services/auto-updater.ts
@@ -1,0 +1,190 @@
+/**
+ * Auto-Updater — opt-in silent self-update for prjct.
+ *
+ * Why: even after a release ships and the banner shows up, users have
+ * to remember to run `npm install -g prjct-cli@latest`. The banner
+ * solves discovery; this solves laziness. Both are bypassable.
+ *
+ * Design constraints (mem_899: efficiency contract + don't-be-creepy):
+ *   - OPT-IN. Default off. User runs `prjct config set auto-update on`
+ *     to turn it on. We never auto-modify someone's binary without
+ *     consent.
+ *   - Throttled to once/hour via a timestamp in global config so we
+ *     don't hit the npm registry on every Claude turn.
+ *   - Background spawn via detached child process. The Claude session
+ *     never waits for the install to finish.
+ *   - Network-failure-safe. Any error → swallow + log to update.log.
+ *   - Detects how prjct was installed (binary in ~/.prjct-cli/bin/ vs
+ *     npm global) and uses the right upgrade path:
+ *       - Binary install → re-run install-via-claude.sh (handles
+ *         platform detection + download)
+ *       - npm install → `npm install -g prjct-cli@latest`
+ *       - bun install → `bun install -g prjct-cli@latest`
+ */
+
+import { execFile, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { getConfig, setConfig } from './global-config'
+
+const execFileP = promisify(execFile)
+
+const STATE_DIR = path.join(os.homedir(), '.prjct-cli', 'state')
+const LOG_PATH = path.join(STATE_DIR, 'auto-update.log')
+const THROTTLE_MS = 60 * 60 * 1000 // 1 hour
+const NPM_REGISTRY = 'https://registry.npmjs.org/prjct-cli/latest'
+
+type InstallSource = 'binary' | 'npm' | 'bun' | 'unknown'
+
+/**
+ * Public entry: call from SessionStart hook. Returns immediately;
+ * the actual update (if any) runs detached in the background.
+ */
+export function maybeAutoUpdate(currentVersion: string | undefined): void {
+  if (!currentVersion) return
+  if (process.env.PRJCT_NO_AUTO_UPDATE === '1') return
+  if (getConfig('auto-update') !== 'on') return
+
+  const last = getConfig('auto-update-last-check')
+  if (last && Date.now() - Date.parse(last) < THROTTLE_MS) return
+
+  // Stamp the check timestamp NOW so concurrent SessionStart hooks
+  // (parallel Claude windows) don't all race to fetch.
+  setConfig('auto-update-last-check', new Date().toISOString())
+
+  // Detached fire-and-forget. Stop hook doesn't await this; the
+  // session never waits.
+  const child = spawn(
+    process.execPath,
+    [process.argv[1], '__internal-auto-update', currentVersion],
+    { detached: true, stdio: 'ignore' }
+  )
+  child.unref()
+}
+
+/**
+ * Background entry — invoked by the spawned child process. Does the
+ * actual fetch + apply. Errors land in update.log.
+ */
+export async function runBackgroundCheck(currentVersion: string): Promise<void> {
+  try {
+    const latest = await fetchLatestVersion()
+    if (!latest) return
+    if (compareSemver(latest, currentVersion) <= 0) {
+      log(`current ${currentVersion} >= latest ${latest}, no-op`)
+      return
+    }
+
+    const source = detectInstallSource()
+    log(`upgrade available: ${currentVersion} → ${latest} (source: ${source})`)
+    await applyUpgrade(source, latest)
+    log(`upgrade complete: ${currentVersion} → ${latest}`)
+  } catch (err) {
+    log(`auto-update failed: ${(err as Error).message}`)
+  }
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    // 6s timeout — npm registry should answer fast or not at all
+    const ac = new AbortController()
+    const timer = setTimeout(() => ac.abort(), 6000)
+    const res = await fetch(NPM_REGISTRY, { signal: ac.signal })
+    clearTimeout(timer)
+    if (!res.ok) return null
+    const json = (await res.json()) as { version?: string }
+    return typeof json.version === 'string' ? json.version : null
+  } catch {
+    return null
+  }
+}
+
+function detectInstallSource(): InstallSource {
+  // 1. Binary install lives at ~/.prjct-cli/bin/prjct
+  const binaryPath = path.join(os.homedir(), '.prjct-cli', 'bin', 'prjct')
+  if (fs.existsSync(binaryPath)) {
+    try {
+      const stat = fs.statSync(binaryPath)
+      // Standalone binary is ~60MB; the bun-shim wrapper is <5KB. If
+      // it's the big one, that's the standalone install path.
+      if (stat.size > 1024 * 1024) return 'binary'
+    } catch {
+      /* fall through */
+    }
+  }
+  // 2. Try `npm root -g` / `bun pm bin` to find the install dir.
+  // We don't need certainty — if both fail, default to npm which is
+  // most common.
+  try {
+    const npmGlobal = String(require('node:child_process').execSync('npm root -g')).trim()
+    if (npmGlobal && fs.existsSync(path.join(npmGlobal, 'prjct-cli'))) return 'npm'
+  } catch {
+    /* ignore */
+  }
+  try {
+    const bunBin = String(require('node:child_process').execSync('bun pm bin -g')).trim()
+    if (bunBin && fs.existsSync(path.join(bunBin, 'prjct'))) return 'bun'
+  } catch {
+    /* ignore */
+  }
+  return 'unknown'
+}
+
+async function applyUpgrade(source: InstallSource, _targetVersion: string): Promise<void> {
+  if (source === 'binary') {
+    // Re-run install-via-claude.sh — it handles platform detection,
+    // checksum, atomic swap. Fetch over curl since we know git might
+    // not be present on the user's box.
+    const url =
+      'https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh'
+    await execFileP('bash', ['-c', `curl -sSL '${url}' | bash`], {
+      timeout: 120_000,
+      maxBuffer: 4 * 1024 * 1024,
+    })
+    return
+  }
+  if (source === 'bun') {
+    await execFileP('bun', ['install', '-g', 'prjct-cli@latest'], {
+      timeout: 120_000,
+    })
+    return
+  }
+  if (source === 'npm' || source === 'unknown') {
+    await execFileP('npm', ['install', '-g', 'prjct-cli@latest'], {
+      timeout: 120_000,
+    })
+    return
+  }
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map((n) => Number.parseInt(n, 10) || 0)
+  const pb = b.split('.').map((n) => Number.parseInt(n, 10) || 0)
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return 1
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return -1
+  }
+  return 0
+}
+
+function log(line: string): void {
+  try {
+    fs.mkdirSync(STATE_DIR, { recursive: true })
+    fs.appendFileSync(LOG_PATH, `${new Date().toISOString()} ${line}\n`)
+  } catch {
+    /* best-effort */
+  }
+}
+
+export const _internal = {
+  fetchLatestVersion,
+  detectInstallSource,
+  compareSemver,
+  THROTTLE_MS,
+}

--- a/core/services/global-config.ts
+++ b/core/services/global-config.ts
@@ -1,0 +1,69 @@
+/**
+ * Global config — small typed key/value store at
+ * `~/.prjct-cli/config/global.json`. Lets users opt into behaviors
+ * (e.g. auto-update) without per-project state.
+ *
+ * Design: deliberately minimal. No schema versioning, no migrations.
+ * Unknown keys are preserved on round-trip so newer/older versions of
+ * prjct don't trample each other's settings.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const CONFIG_DIR = path.join(os.homedir(), '.prjct-cli', 'config')
+const CONFIG_PATH = path.join(CONFIG_DIR, 'global.json')
+
+export type GlobalConfigValue = string | number | boolean
+
+export interface GlobalConfig {
+  /** Opt into silent self-update (1/hour throttled). Default: false. */
+  'auto-update'?: 'on' | 'off'
+  /** ISO timestamp of last update check. Internal — set by auto-updater. */
+  'auto-update-last-check'?: string
+  /** Suppress proactive workflow suggestions in the prompt hook. */
+  suggestions?: 'on' | 'off'
+  // Free-form bag for forward compat — readers preserve unknown keys.
+  [key: string]: GlobalConfigValue | undefined
+}
+
+function readRaw(): GlobalConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+      return parsed as GlobalConfig
+  } catch {
+    // missing or malformed → start fresh
+  }
+  return {}
+}
+
+function writeRaw(cfg: GlobalConfig): void {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true })
+  fs.writeFileSync(CONFIG_PATH, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+}
+
+export function getConfig<K extends keyof GlobalConfig>(key: K): GlobalConfig[K] {
+  return readRaw()[key]
+}
+
+export function getAll(): GlobalConfig {
+  return readRaw()
+}
+
+export function setConfig<K extends keyof GlobalConfig>(key: K, value: GlobalConfig[K]): void {
+  const cfg = readRaw()
+  if (value === undefined) delete cfg[key]
+  else cfg[key] = value
+  writeRaw(cfg)
+}
+
+export function unsetConfig(key: keyof GlobalConfig): void {
+  setConfig(key, undefined as GlobalConfig[typeof key])
+}
+
+export function configPath(): string {
+  return CONFIG_PATH
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Closes the manual-install loop. Banner already nags every run; this gives users who want zero maintenance a single command to enroll, then prjct updates itself silently without ever blocking a session.

## What ships

### prjct config <list|get|set|unset>

NEW command. Read/write \`~/.prjct-cli/config/global.json\`:

\`\`\`
prjct config set auto-update on
prjct config set suggestions off
prjct config list
\`\`\`

Numbers parsed automatically; on/off/true/false normalize to on/off. Forward-compatible — unknown keys preserved on round-trip.

### core/services/auto-updater.ts

- \`maybeAutoUpdate()\` — called from SessionStart. Default no-op unless user opted in. Throttled 1/hour. Spawns detached child with \`__internal-auto-update <version>\`.
- \`runBackgroundCheck()\` — the child's body. Fetches npm registry latest (6s timeout), compares semver, applies via the right path:
  - **Binary install** (~/.prjct-cli/bin/prjct >1MB) → re-runs install-via-claude.sh
  - **bun install** → \`bun install -g prjct-cli@latest\`
  - **npm or unknown** → \`npm install -g prjct-cli@latest\`

All steps log to \`~/.prjct-cli/state/auto-update.log\`. Network/permission failures swallow.

### bin/prjct.ts early-return

\`__internal-auto-update\` handled BEFORE heavy imports — child stays tiny, exits immediately when done.

### core/hooks/session-start.ts wires \`maybeAutoUpdate\`

After \`runSelfHeal\`. Both best-effort. Try/catch: never blocks the session.

## Anti-harness contract (mem_899)

- OPT-IN. Default off. We never modify someone's binary without consent.
- \`PRJCT_NO_AUTO_UPDATE=1\` env override.
- Throttled (1/hr) so we don't hammer npm registry.
- Detached child — zero added latency to SessionStart hot path.
- Best-effort detection: if we can't tell what install path, default to npm.

## Tests

- bun test → 903/903 pass, typecheck clean
- biome check fix applied

## Plan reference

M5 of the rescue plan (\"lo más verga del mundo\"). Pattern detector
extended (recurring bugs, tech-debt growth) and team enforce ship next.