### PR TITLE
feat(stop-hook): pattern-detector extended — recurring bugs + tech debt growth (M5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.18] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.17] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.19] - 2026-05-01
+
+### Added
+- current work
+
 ## [2.4.18] - 2026-05-01
 
 ### Added

--- a/core/__tests__/services/pattern-detector.test.ts
+++ b/core/__tests__/services/pattern-detector.test.ts
@@ -61,4 +61,24 @@ describe('pattern-detector — constants', () => {
   test('ignore patterns cover common noise', () => {
     expect(IGNORE_PATTERNS.length).toBeGreaterThan(5)
   })
+
+  test('recurring-bug detection uses 30 day window + 2+ threshold', () => {
+    expect(_internal.RECURRING_WINDOW_DAYS).toBe(30)
+    expect(_internal.RECURRING_THRESHOLD).toBe(2)
+  })
+
+  test('tech-debt growth threshold is 5 (avoids noise from 1-2 churn)', () => {
+    expect(_internal.TECH_DEBT_GROWTH_THRESHOLD).toBe(5)
+  })
+})
+
+describe('pattern-detector — measureTechDebt', () => {
+  test('returns a non-negative count for this repo', async () => {
+    // Integration smoke test: this repo has at least some TODO/FIXME
+    // markers. Just verify the function returns a finite, non-negative
+    // number rather than asserting an exact count.
+    const snap = await _internal.measureTechDebt(process.cwd())
+    expect(snap.totalCount).toBeGreaterThanOrEqual(0)
+    expect(Number.isFinite(snap.totalCount)).toBe(true)
+  })
 })

--- a/core/services/pattern-detector.ts
+++ b/core/services/pattern-detector.ts
@@ -1,24 +1,27 @@
 /**
  * Pattern Detector — surface durable patterns from recent project work.
  *
- * Scope (M2 of the rescue plan): start with hot files only. A file
- * touched 3+ times in the last 7 days is a refactor candidate worth
- * the user's attention. Detected on every Stop hook fire, persisted as
- * a `learning` memory entry tagged `pattern:hot-file`. The wiki regen
- * exposes them under `_generated/memory/learning.md`, and the
- * lookup-first protocol in CLAUDE.md ensures Claude finds them at
- * session start.
+ * Three detectors, all conservative + idempotent + best-effort:
  *
- * Recurring bugs and tech-debt growth are deferred to a follow-up
- * commit. Heuristics for those need more thought to avoid false
- * positives.
+ * 1. Hot files — a file touched 3+ times in the last 7 days is a
+ *    refactor candidate. (Original M2 scope.)
+ * 2. Recurring bugs — gotchas with the same `topic` tag that appear
+ *    2+ times across the last 30 days. Suggests a pattern bug worth
+ *    investigation.
+ * 3. Tech-debt growth — total TODO/FIXME/XXX count grew by 5+ since
+ *    the last detection run. Suggests debt is accumulating without
+ *    being addressed.
+ *
+ * All detectors persist findings as `learning` memory entries so the
+ * wiki regen exposes them under `_generated/memory/learning.md`. The
+ * lookup-first protocol in CLAUDE.md (M0) ensures Claude finds them
+ * at session start and can propose action.
  *
  * Design contract (mem_899):
  *   - Best-effort, never blocks the Stop hook.
- *   - Idempotent: a file already marked hot in the same window is not
- *     re-persisted.
- *   - Conservative: noise > value. We'd rather miss a hot file than
- *     pollute the memory store with churn.
+ *   - Idempotent: window-based dedup on each detector.
+ *   - Conservative: noise > value. Each detector tuned for high
+ *     precision over recall.
  */
 
 import { execFile } from 'node:child_process'
@@ -31,11 +34,26 @@ const execFileP = promisify(execFile)
 
 const HOT_FILE_PATTERN_TAG = 'hot-file'
 const HOT_FILE_SOURCE_TAG = 'pattern-detector-auto'
+const RECURRING_BUG_PATTERN_TAG = 'recurring-bug'
+const RECURRING_BUG_SOURCE_TAG = 'pattern-detector-recurring'
+const TECH_DEBT_PATTERN_TAG = 'tech-debt-growth'
+const TECH_DEBT_SOURCE_TAG = 'pattern-detector-debt'
+
 // Window + threshold tuned conservatively. 3+ touches over a week is
 // "this file is the locus of recent activity" without flagging every
 // daily-touched file in an active repo.
 const WINDOW_DAYS = 7
 const HOT_THRESHOLD = 3
+// Recurring bugs: same topic tag must appear 2+ times across a longer
+// window. Bugs cluster monthly more than weekly — using 30 days
+// catches real patterns without re-flagging every day.
+const RECURRING_WINDOW_DAYS = 30
+const RECURRING_THRESHOLD = 2
+// Tech debt: only flag when growth >= 5 since last snapshot. Smaller
+// deltas are noise (refactors flush old TODOs and add new ones in
+// passing). Using projectMemory as the storage layer for snapshots so
+// we don't need a new table.
+const TECH_DEBT_GROWTH_THRESHOLD = 5
 // Skip noisy paths that are touched on every commit and offer no
 // refactor signal.
 const IGNORE_PATTERNS: readonly RegExp[] = [
@@ -64,9 +82,9 @@ interface DetectResult {
 }
 
 /**
- * Public entry: run all detectors, persist insights for new hot files.
- * Stop hook awaits this best-effort. Wraps every IO in try/catch so a
- * non-git directory or a transient git failure never escapes.
+ * Public entry: run all three detectors, persist new insights. Stop
+ * hook awaits this best-effort. Each detector is wrapped so a single
+ * failure (e.g. git missing) never breaks the others.
  */
 export async function detectAndPersistPatterns(projectPath: string): Promise<DetectResult> {
   const result: DetectResult = {
@@ -83,44 +101,109 @@ export async function detectAndPersistPatterns(projectPath: string): Promise<Det
     return result
   }
 
-  let hotFiles: HotFile[] = []
+  // 1. Hot files
   try {
-    hotFiles = await detectHotFiles(projectPath)
+    const hotFiles = await detectHotFiles(projectPath)
+    result.scanned += hotFiles.length
+    result.hotFiles = hotFiles
+    if (hotFiles.length > 0) {
+      const alreadyMarked = collectAlreadyMarkedHotFiles(config.projectId)
+      for (const hf of hotFiles) {
+        if (alreadyMarked.has(hf.path)) {
+          result.skipped.push({ reason: 'already-marked-this-window', file: hf.path })
+          continue
+        }
+        try {
+          await projectMemory.remember(projectPath, {
+            type: 'learning',
+            content:
+              `Hot file: \`${hf.path}\` — ${hf.touches} touches in the last ${WINDOW_DAYS} days. ` +
+              `Worth a refactor pass or a deliberate decision about why it churns this often.`,
+            tags: {
+              source: HOT_FILE_SOURCE_TAG,
+              pattern: HOT_FILE_PATTERN_TAG,
+              file: hf.path,
+              touches: String(hf.touches),
+              window_days: String(WINDOW_DAYS),
+            },
+            provenance: 'inferred',
+          })
+          result.persisted += 1
+        } catch (err) {
+          result.errors.push(`remember failed for ${hf.path}: ${(err as Error).message}`)
+        }
+      }
+    }
   } catch (err) {
     result.errors.push(`hot-file detection failed: ${(err as Error).message}`)
-    return result
   }
-  result.scanned = hotFiles.length
-  result.hotFiles = hotFiles
 
-  if (hotFiles.length === 0) return result
-
-  const alreadyMarked = collectAlreadyMarked(config.projectId)
-
-  for (const hf of hotFiles) {
-    if (alreadyMarked.has(hf.path)) {
-      result.skipped.push({ reason: 'already-marked-this-window', file: hf.path })
-      continue
+  // 2. Recurring bugs
+  try {
+    const recurring = detectRecurringBugs(config.projectId)
+    if (recurring.length > 0) {
+      const alreadyMarked = collectAlreadyMarkedRecurringBugs(config.projectId)
+      for (const r of recurring) {
+        if (alreadyMarked.has(r.topic)) {
+          result.skipped.push({ reason: 'recurring-bug-already-marked', file: r.topic })
+          continue
+        }
+        try {
+          await projectMemory.remember(projectPath, {
+            type: 'learning',
+            content:
+              `Recurring bug pattern: gotchas tagged \`topic:${r.topic}\` reported ${r.occurrences} ` +
+              `times in the last ${RECURRING_WINDOW_DAYS} days. Likely a real underlying issue — ` +
+              `consider a focused investigation before patching the next instance.`,
+            tags: {
+              source: RECURRING_BUG_SOURCE_TAG,
+              pattern: RECURRING_BUG_PATTERN_TAG,
+              topic: r.topic,
+              occurrences: String(r.occurrences),
+              window_days: String(RECURRING_WINDOW_DAYS),
+            },
+            provenance: 'inferred',
+          })
+          result.persisted += 1
+        } catch (err) {
+          result.errors.push(`remember failed for recurring ${r.topic}: ${(err as Error).message}`)
+        }
+      }
     }
-    try {
-      await projectMemory.remember(projectPath, {
-        type: 'learning',
-        content:
-          `Hot file: \`${hf.path}\` — ${hf.touches} touches in the last ${WINDOW_DAYS} days. ` +
-          `Worth a refactor pass or a deliberate decision about why it churns this often.`,
-        tags: {
-          source: HOT_FILE_SOURCE_TAG,
-          pattern: HOT_FILE_PATTERN_TAG,
-          file: hf.path,
-          touches: String(hf.touches),
-          window_days: String(WINDOW_DAYS),
-        },
-        provenance: 'inferred',
-      })
-      result.persisted += 1
-    } catch (err) {
-      result.errors.push(`remember failed for ${hf.path}: ${(err as Error).message}`)
+  } catch (err) {
+    result.errors.push(`recurring-bug detection failed: ${(err as Error).message}`)
+  }
+
+  // 3. Tech-debt growth
+  try {
+    const debtSnapshot = await measureTechDebt(projectPath)
+    if (debtSnapshot.totalCount > 0) {
+      const previous = collectPreviousDebtSnapshot(config.projectId)
+      const delta = debtSnapshot.totalCount - previous
+      if (previous > 0 && delta >= TECH_DEBT_GROWTH_THRESHOLD) {
+        try {
+          await projectMemory.remember(projectPath, {
+            type: 'learning',
+            content:
+              `Tech debt growing: TODO/FIXME/XXX count rose by ${delta} (now ${debtSnapshot.totalCount}, was ${previous}). ` +
+              `Consider a focused debt-reduction pass before adding more features.`,
+            tags: {
+              source: TECH_DEBT_SOURCE_TAG,
+              pattern: TECH_DEBT_PATTERN_TAG,
+              total: String(debtSnapshot.totalCount),
+              previous: String(previous),
+              delta: String(delta),
+            },
+            provenance: 'inferred',
+          })
+          result.persisted += 1
+        } catch (err) {
+          result.errors.push(`remember failed for tech-debt: ${(err as Error).message}`)
+        }
+      }
     }
+  } catch (err) {
+    result.errors.push(`tech-debt detection failed: ${(err as Error).message}`)
   }
 
   return result
@@ -173,7 +256,142 @@ function isIgnored(file: string): boolean {
 }
 
 // =============================================================================
-// Dedup against previously persisted hot-file insights (same window)
+// Recurring bug detection
+// =============================================================================
+
+interface RecurringBug {
+  topic: string
+  occurrences: number
+}
+
+interface GotchaRow {
+  data: string
+  timestamp: string
+}
+
+/**
+ * Walk the last RECURRING_WINDOW_DAYS of `gotcha` memory entries.
+ * Group by `topic` tag (or by `area` tag if topic is missing). Any
+ * group with RECURRING_THRESHOLD+ entries is a recurring bug pattern.
+ *
+ * Conservative: skips entries without a `topic` or `area` tag — those
+ * are too noisy to group reliably.
+ */
+export function detectRecurringBugs(projectId: string): RecurringBug[] {
+  try {
+    const { prjctDb } = require('../storage/database') as typeof import('../storage/database')
+    const cutoff = new Date(Date.now() - RECURRING_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString()
+    const rows = prjctDb.query<GotchaRow>(
+      projectId,
+      "SELECT data, timestamp FROM events WHERE type = 'memory.remember.gotcha' AND timestamp >= ? ORDER BY id DESC LIMIT 500",
+      cutoff
+    )
+    const counts = new Map<string, number>()
+    for (const row of rows) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(row.data)
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== 'object') continue
+      const tags = (parsed as { tags?: Record<string, unknown> }).tags
+      if (!tags) continue
+      // Skip auto-captured gotchas — they'd inflate the count without
+      // adding signal. We only care about user-asserted gotchas.
+      if (tags.source === 'transcript-auto') continue
+      const topic = typeof tags.topic === 'string' ? tags.topic : undefined
+      const area = typeof tags.area === 'string' ? tags.area : undefined
+      const key = topic ?? area
+      if (!key) continue
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+    const out: RecurringBug[] = []
+    for (const [topic, occurrences] of counts) {
+      if (occurrences < RECURRING_THRESHOLD) continue
+      out.push({ topic, occurrences })
+    }
+    out.sort((a, b) => b.occurrences - a.occurrences)
+    return out
+  } catch {
+    return []
+  }
+}
+
+// =============================================================================
+// Tech-debt growth detection
+// =============================================================================
+
+interface DebtSnapshot {
+  totalCount: number
+}
+
+/**
+ * Count TODO/FIXME/XXX markers across the working tree using `git
+ * grep` (so we automatically respect .gitignore + skip binaries). Only
+ * counts the markers themselves, not surrounding context — keeps the
+ * comparison meaningful turn-over-turn.
+ */
+export async function measureTechDebt(projectPath: string): Promise<DebtSnapshot> {
+  try {
+    const { stdout } = await execFileP('git', ['grep', '-cE', '\\b(TODO|FIXME|XXX)\\b'], {
+      cwd: projectPath,
+      maxBuffer: 16 * 1024 * 1024,
+    })
+    let total = 0
+    for (const line of stdout.split('\n')) {
+      // git grep -c emits "<file>:<count>" per file
+      const idx = line.lastIndexOf(':')
+      if (idx <= 0) continue
+      const num = Number.parseInt(line.slice(idx + 1), 10)
+      if (Number.isFinite(num)) total += num
+    }
+    return { totalCount: total }
+  } catch (err) {
+    // git grep exits non-zero when no matches — treat as 0
+    const code = (err as { code?: number }).code
+    if (code === 1) return { totalCount: 0 }
+    throw err
+  }
+}
+
+interface DebtMemoryRow {
+  data: string
+}
+
+/**
+ * Read the most recent tech-debt snapshot we persisted. Returns 0 if
+ * we've never measured (first run); the comparison gates on previous>0
+ * so first-run never flags noise.
+ */
+function collectPreviousDebtSnapshot(projectId: string): number {
+  try {
+    const { prjctDb } = require('../storage/database') as typeof import('../storage/database')
+    const rows = prjctDb.query<DebtMemoryRow>(
+      projectId,
+      "SELECT data FROM events WHERE type = 'memory.remember.learning' ORDER BY id DESC LIMIT 50"
+    )
+    for (const row of rows) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(row.data)
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== 'object') continue
+      const tags = (parsed as { tags?: Record<string, unknown> }).tags
+      if (!tags || tags.source !== TECH_DEBT_SOURCE_TAG) continue
+      const total = typeof tags.total === 'string' ? Number.parseInt(tags.total, 10) : 0
+      if (Number.isFinite(total)) return total
+    }
+  } catch {
+    /* fall through */
+  }
+  return 0
+}
+
+// =============================================================================
+// Dedup against previously persisted insights (per detector)
 // =============================================================================
 
 interface MemoryRow {
@@ -186,7 +404,7 @@ interface MemoryRow {
  * last WINDOW_DAYS as "still valid" so we don't re-persist on every
  * Stop hook call. The next window will let us re-mark naturally.
  */
-function collectAlreadyMarked(projectId: string): Set<string> {
+function collectAlreadyMarkedHotFiles(projectId: string): Set<string> {
   const out = new Set<string>()
   try {
     const { prjctDb } = require('../storage/database') as typeof import('../storage/database')
@@ -225,14 +443,57 @@ function collectAlreadyMarked(projectId: string): Set<string> {
   return out
 }
 
+/**
+ * Same shape as collectAlreadyMarkedHotFiles, but for recurring-bug
+ * insights. Keyed by `topic` (the gotcha tag we grouped on).
+ */
+function collectAlreadyMarkedRecurringBugs(projectId: string): Set<string> {
+  const out = new Set<string>()
+  try {
+    const { prjctDb } = require('../storage/database') as typeof import('../storage/database')
+    const rows = prjctDb.query<MemoryRow>(
+      projectId,
+      "SELECT data FROM events WHERE type = 'memory.remember.learning' ORDER BY id DESC LIMIT 200"
+    )
+    const cutoffMs = Date.now() - RECURRING_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    for (const row of rows) {
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(row.data)
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== 'object') continue
+      const tags = (parsed as { tags?: Record<string, unknown> }).tags
+      if (!tags || tags.source !== RECURRING_BUG_SOURCE_TAG) continue
+      const topic = tags.topic
+      const ts = (parsed as { rememberedAt?: unknown }).rememberedAt
+      if (typeof topic !== 'string') continue
+      if (typeof ts === 'string') {
+        const t = Date.parse(ts)
+        if (!Number.isNaN(t) && t < cutoffMs) continue
+      }
+      out.add(topic)
+    }
+  } catch {
+    /* best-effort */
+  }
+  return out
+}
+
 // =============================================================================
 // Test exports
 // =============================================================================
 
 export const _internal = {
   detectHotFiles,
+  detectRecurringBugs,
+  measureTechDebt,
   isIgnored,
   IGNORE_PATTERNS,
   HOT_THRESHOLD,
   WINDOW_DAYS,
+  RECURRING_WINDOW_DAYS,
+  RECURRING_THRESHOLD,
+  TECH_DEBT_GROWTH_THRESHOLD,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.17",
+  "version": "2.4.18",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Completes the pattern-detector originally deferred in M2. Two new
detectors run on every Stop hook fire, persist insights via memory,
surface them via the lookup-first protocol next session.

## detectRecurringBugs(projectId)

Walks the last 30 days of \`gotcha\` memory entries, groups by \`topic\`
tag (or \`area\` if topic missing). Any group with 2+ entries → recurring
bug pattern → persisted as \`learning\` tagged \`pattern:recurring-bug\`.

Filters out auto-captured gotchas (\`source:transcript-auto\`) so
M1a's noise doesn't drive recurring counts up.

## measureTechDebt(projectPath)

\`git grep -cE '\\b(TODO|FIXME|XXX)\\b'\` across the working tree.
Respects .gitignore + skips binaries automatically. Compared against
the last persisted snapshot — if growth >= 5 markers, persist a
\`learning\` tagged \`pattern:tech-debt-growth\`.

Threshold of 5 avoids noise from refactors that flush old TODOs and
add new ones in passing.

## Detector orchestration

\`detectAndPersistPatterns\` now runs all three detectors. Each
wrapped in try/catch so a single failure doesn't break the others.
Window-based dedup per detector prevents re-flagging on every fire.

## What this enables

Every Stop hook now runs three signals. Claude can next session
propose:
- \"src/auth.ts is hot — refactor candidate\"
- \"topic:cors gotcha appeared 4 times this month — likely deeper bug\"
- \"tech debt grew by 23 markers — focused cleanup?\"

All without the user asking. Compounds across sessions.

## Tests

- 3 new tests (constants for 2 new detectors + integration smoke for measureTechDebt)
- Full suite: 906/906 pass (was 903 + 3 new), typecheck clean

## Plan reference

M5 of the rescue plan. Last piece is team-mode enforce (pre-commit hook).