### PR TITLE
fix(release): Setup Bun in release job — unblocks Build standalone binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,11 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Install dependencies
         run: npm install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.22] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.21] - 2026-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.21",
+  "version": "2.4.22",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

The M5 standalone-binary step (added in #276) calls \`bun build --compile\` inside the \`release\` job, but only the \`ci\` job had Setup Bun. Result: every release since v2.4.15 has failed at the binary-build step:

\`\`\`
/home/runner/.../sh: line 7: bun: command not found
##[error]Process completed with exit code 127
\`\`\`

This blocked GitHub release asset upload (the binaries for \`install-via-claude.sh\` to download) for v2.4.15 through v2.4.21. The npm publish itself still worked because that step ran earlier (it just needs Node), but no GitHub Releases were created.

## Fix

Adds Setup Bun action to the release job before \`Install dependencies\` so it's available when the \`Build standalone binaries\` step runs.

## After merge

The next push to main will:
1. Trigger Release workflow
2. Bump to v2.4.22 (via \`prjct ship\` — already done in this branch)
3. npm publish v2.4.22
4. **Build standalone binaries** (now works) — uploads prjct-darwin-arm64, prjct-darwin-x64, prjct-linux-x64 to the GitHub Release
5. Create the GitHub Release with the binary assets

Once that's done, \`install-via-claude.sh\` actually has binaries to download (today it would fall through to npm fallback because the release assets don't exist).

## Captured to memory

- gotcha: \"Adding a step to release.yml that uses Bun → also add Setup Bun action to the release job. The release and ci jobs are separate setups; copying steps doesn't carry the toolchain.\"