### PR TITLE
docs+script: install-via-claude.sh distinguishes install vs upgrade + UPGRADE docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.28] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.27] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.27] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.26] - 2026-05-02
 
 ### Added

--- a/INSTALL_PROMPT.md
+++ b/INSTALL_PROMPT.md
@@ -1,21 +1,23 @@
-# Install prjct via prompt (paste into Claude Code or any AI agent)
+# Install / Upgrade prjct via prompt (paste into Claude Code or any AI agent)
 
-Three install paths, each smaller than the last. Pick the one your audience can follow.
+**The same prompt installs AND upgrades.** The script detects whether prjct is already on this machine and either does a fresh install or upgrades to the latest published version. Re-running is always safe.
+
+Three paths, each smaller than the last. Pick the one your audience can follow.
 
 ---
 
-## Path 1 — One paste in Claude Code (recommended)
+## Path 1 — One paste in Claude Code (recommended, install + upgrade)
 
 Paste this into the Claude Code chat. Claude executes it and you're done in ~30 seconds:
 
-> Install prjct (project memory + quality workflows for AI coding agents) on this machine:
+> Install or upgrade prjct (project memory + quality workflows for AI coding agents) on this machine:
 >
 > 1. Run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`
-> 2. Verify with `prjct -v` (should print v2.4.x or higher)
+> 2. Verify with `prjct -v` (should print the latest v2.4.x)
 > 3. If the cwd is a git repo, run `prjct sync` to register it
-> 4. Show me the install output and confirm the version
+> 4. Show me the install output and confirm the version (note: it'll say "upgraded X → vY" if I had a previous version, or "installed" if fresh)
 >
-> The script downloads the standalone binary for my platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
+> The script downloads the standalone binary for my platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades. After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
 
 ---
 
@@ -56,6 +58,20 @@ prjct config set auto-update on    # silent self-update, throttled 1/hour
 prjct config set suggestions off   # mute proactive workflow nudges
 prjct team --enforce               # require prjct in this repo (pre-commit hook)
 ```
+
+## Upgrade (3 ways, all equivalent)
+
+| Method | Command | When to use |
+|---|---|---|
+| **Same paste prompt** | re-run Path 1 above | The default. Works whether prjct is installed or not. |
+| **CLI shortcut** | `prjct update` | If you're already in a terminal with prjct installed. Auto-detects npm/pnpm/bun/yarn/homebrew and upgrades. |
+| **Silent auto-update** | `prjct config set auto-update on` (one time) | Set and forget. Hook checks 1/hour throttled, upgrades in background, logs to `~/.prjct-cli/state/auto-update.log`. |
+
+The `install-via-claude.sh` script's output explicitly distinguishes the path:
+
+- `✓ prjct installed (via binary)` — fresh install
+- `✓ prjct upgraded 2.4.20 → v2.4.26 (via binary)` — actual upgrade
+- `✓ prjct re-verified at v2.4.26 (already current) (via binary)` — no-op (already latest)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@
 [![Gemini CLI](https://img.shields.io/badge/Gemini%20CLI-Ready-4285F4)]()
 [![Cursor IDE](https://img.shields.io/badge/Cursor%20IDE-Ready-00D4AA)]()
 
-## Install — one paste
+## Install / upgrade — one paste
 
-Paste this into Claude Code:
+Paste this into Claude Code (works for fresh install AND upgrade):
 
-> Install prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
+> Install or upgrade prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
 
-That's it. ~30 seconds. The script downloads the standalone binary for your platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Full install paths (terminal one-liner, npm fallback, follow-up config) are documented in [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
+That's it. ~30 seconds. The script downloads the standalone binary for your platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades to the latest published version.
+
+Three additional upgrade paths once installed:
+- **CLI**: `prjct update` (auto-detects npm/pnpm/bun/yarn/homebrew)
+- **Silent**: `prjct config set auto-update on` (background check 1/hour throttled)
+- **Manual**: `npm install -g prjct-cli@latest` (or your package manager equivalent)
+
+Full install + upgrade paths in [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
 
 ## What you get
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.26",
+  "version": "2.4.27",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.27",
+  "version": "2.4.28",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/install-via-claude.sh
+++ b/scripts/install-via-claude.sh
@@ -161,8 +161,16 @@ fi
 # Done
 # ---------------------------------------------------------------------------
 
-printf "\n${GREEN}✓${NC} prjct v$NEW ready (installed via $INSTALLED_VIA).\n"
+VERB="installed"
+if [ -n "$CURRENT" ] && [ "$CURRENT" != "$NEW" ]; then
+  VERB="upgraded $CURRENT → v$NEW"
+elif [ -n "$CURRENT" ] && [ "$CURRENT" = "$NEW" ]; then
+  VERB="re-verified at v$NEW (already current)"
+fi
+
+printf "\n${GREEN}✓${NC} prjct %s (via $INSTALLED_VIA).\n" "$VERB"
 printf "${DIM}  Next:${NC}\n"
 printf "${DIM}    - Open Claude Code in any project — the lookup-first protocol kicks in automatically${NC}\n"
 printf "${DIM}    - Try: prjct capture \"a thought\"  or  prjct task \"the thing I'm working on\"${NC}\n"
 printf "${DIM}    - Quality workflows: ask Claude to \"review\", \"qa\", \"investigate\", or \"security check\" the current branch.${NC}\n"
+printf "${DIM}    - Re-run this same command anytime to upgrade to the latest version.${NC}\n"


### PR DESCRIPTION
## Summary

User asked for "actualizar con un solo script" — same script as install. The script already handled upgrades (npm install -g + symlink swap is idempotent), but the UX didn't make that obvious. Now the output is explicit:

\`\`\`
✓ prjct installed (via binary)
✓ prjct upgraded 2.4.20 → v2.4.26 (via binary)
✓ prjct re-verified at v2.4.26 (already current) (via binary)
\`\`\`

Plus a "Re-run this same command anytime to upgrade" hint in the post-install footer.

## Doc updates

INSTALL_PROMPT.md leads with a one-line clarification: same prompt installs AND upgrades. Added a dedicated "Upgrade (3 ways, all equivalent)" table:
- Same paste prompt → re-run Path 1
- \`prjct update\` → CLI shortcut, auto-detects npm/pnpm/bun/yarn/homebrew
- \`prjct config set auto-update on\` → set-and-forget silent updates

README "Install" section becomes "Install / upgrade — one paste" with the same single-prompt-for-both framing + the 3 alternative upgrade paths inline.

## Note on recent build status

User said "el build falló nuevamente" — verified all recent runs:
- Last 3 Release runs (#280, #281, #282 corresponding to v2.4.22, v2.4.24, v2.4.26): all ✅ success
- npm latest: v2.4.26 published
- GitHub Release v2.4.26 has all 3 standalone binaries (darwin-arm64, darwin-x64, linux-x64)

The failures user may have seen were from v2.4.15-v2.4.21 (pre-#280, the Setup Bun fix). Those are stale; everything since v2.4.22 builds clean.

## Tests

bun test → 935/935 pass (docs + script-only change).