### PR TITLE
docs(readme): copy-friendly install prompt as fenced code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.30] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.29] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.29] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.28] - 2026-05-02
 
 ### Added

--- a/INSTALL_PROMPT.md
+++ b/INSTALL_PROMPT.md
@@ -8,16 +8,24 @@ Three paths, each smaller than the last. Pick the one your audience can follow.
 
 ## Path 1 — One paste in Claude Code (recommended, install + upgrade)
 
-Paste this into the Claude Code chat. Claude executes it and you're done in ~30 seconds:
+Copy the prompt below (use the GitHub copy button on the code block) and paste it into the Claude Code chat. Claude executes it and you're done in ~30 seconds:
 
-> Install or upgrade prjct (project memory + quality workflows for AI coding agents) on this machine:
->
-> 1. Run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`
-> 2. Verify with `prjct -v` (should print the latest v2.4.x)
-> 3. If the cwd is a git repo, run `prjct sync` to register it
-> 4. Show me the install output and confirm the version (note: it'll say "upgraded X → vY" if I had a previous version, or "installed" if fresh)
->
-> The script downloads the standalone binary for my platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades. After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
+```text
+Install or upgrade prjct (project memory + quality workflows for AI coding agents) on this machine:
+
+1. Run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`
+2. Verify with `prjct -v` (should print the latest v2.4.x)
+3. If the cwd is a git repo, run `prjct sync` to register it
+4. Show me the install output and confirm the version (note: it'll say "upgraded X → vY" if I had a previous version, or "installed" if fresh)
+
+The script downloads the standalone binary for my platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades. After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
+```
+
+### Shorter version (if you want a one-liner prompt)
+
+```text
+Install or upgrade prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,36 @@
 
 ## Install / upgrade — one paste
 
-Paste this into Claude Code (works for fresh install AND upgrade):
+Copy this prompt and paste it in Claude Code (works for fresh install AND upgrade):
 
-> Install or upgrade prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
+```text
+Install or upgrade prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
+```
 
-That's it. ~30 seconds. The script downloads the standalone binary for your platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades to the latest published version.
+~30 seconds. The script downloads the standalone binary for your platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades to the latest published version.
 
-Three additional upgrade paths once installed:
-- **CLI**: `prjct update` (auto-detects npm/pnpm/bun/yarn/homebrew)
-- **Silent**: `prjct config set auto-update on` (background check 1/hour throttled)
-- **Manual**: `npm install -g prjct-cli@latest` (or your package manager equivalent)
+Prefer terminal? Same effect:
 
-Full install + upgrade paths in [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
+```bash
+curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash
+```
+
+Or via package manager:
+
+```bash
+npm install -g prjct-cli@latest
+# or: bun install -g prjct-cli@latest
+```
+
+### After install — three upgrade paths
+
+| Method | Command | When |
+|---|---|---|
+| Same prompt | re-paste the install prompt | Default. Works whether installed or not. |
+| CLI shortcut | `prjct update` | Already in a terminal. Auto-detects npm/pnpm/bun/yarn/homebrew. |
+| Silent (set once) | `prjct config set auto-update on` | Background check 1/hour throttled, logs to `~/.prjct-cli/state/auto-update.log`. |
+
+Full install + upgrade paths documented in [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
 
 ## What you get
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.29",
+  "version": "2.4.30",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

User feedback: *\"quiero en el readme el prompt de instalación con un copy CTA de md, solo quiero copiarlo y pegarlo, no como ese paste.\"*

Wraps the paste-into-Claude prompt in a \`\`\`text fenced block so GitHub renders it with a copy button. Same treatment for INSTALL_PROMPT.md Path 1 (long form + a shorter one-liner alternative).

## Side-effect

The README install section is shorter and more scan-friendly:

1. Prompt (with copy button)
2. Terminal one-liner (alternative for shell users)
3. npm fallback
4. Upgrade table (3 paths)

Old prose framing (\"Paste this in Claude Code\") was friction the user explicitly rejected.

## Tests

bun test → 935/935 pass (docs-only).