### PR TITLE
fix: 3 install bugs caught by user testing v2.4.28 (binary v0.0.0 + script crash + PATH shadow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,19 +354,30 @@ jobs:
       # runtime so users can install prjct without npm/node/bun. The
       # install-via-claude.sh script auto-detects platform and downloads
       # the right asset; npm install -g remains the documented fallback.
+      #
+      # The --define for process.env.PRJCT_VERSION is critical: at
+      # runtime in the standalone binary, __dirname points at the CI
+      # runner's filesystem which doesn't exist on the user's box, so
+      # version.ts can't read package.json from disk. Baking the version
+      # in at build time solves this. Without --define every binary
+      # reports v0.0.0 with a noisy ENOENT log on first invocation.
       - name: Build standalone binaries
         if: ${{ !inputs.dry_run }}
         run: |
           mkdir -p dist-binaries
-          # Mac arm64 + intel + Linux x64. Add windows-x64 / linux-arm64
-          # if there's demand — bun supports both.
+          VERSION=${{ steps.version.outputs.new }}
           for target in bun-darwin-arm64 bun-darwin-x64 bun-linux-x64; do
             out="dist-binaries/prjct-${target#bun-}"
-            echo "Compiling $out…"
-            bun build --compile --target=$target ./bin/prjct.ts --outfile "$out"
+            echo "Compiling $out (PRJCT_VERSION=$VERSION)…"
+            bun build --compile --target=$target \
+              --define='process.env.PRJCT_VERSION="'"$VERSION"'"' \
+              ./bin/prjct.ts --outfile "$out"
           done
           (cd dist-binaries && sha256sum prjct-* >> ../checksums.txt)
           ls -lh dist-binaries
+          # Smoke check — the just-built linux binary should report the
+          # right version (we run it on the CI runner which is linux x64).
+          ./dist-binaries/prjct-linux-x64 -v | head -1
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.31] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.30] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.32] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.31] - 2026-05-02
 
 ### Added

--- a/core/__tests__/utils/version.test.ts
+++ b/core/__tests__/utils/version.test.ts
@@ -1,0 +1,61 @@
+/**
+ * version — env-var first, package.json fallback.
+ *
+ * Critical regression coverage: standalone binaries built via
+ * `bun build --compile` cannot read package.json at runtime
+ * (the baked-in __dirname points at the CI runner's filesystem).
+ * The PRJCT_VERSION env-var path is the only thing that makes those
+ * binaries report the right version. Without this test, the
+ * regression is silent until a user installs the binary and gets
+ * v0.0.0 with a noisy ENOENT log.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+let originalEnv: string | undefined
+
+beforeEach(() => {
+  originalEnv = process.env.PRJCT_VERSION
+})
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env.PRJCT_VERSION
+  } else {
+    process.env.PRJCT_VERSION = originalEnv
+  }
+})
+
+async function freshImport(): Promise<typeof import('../../utils/version')> {
+  return import(`../../utils/version?t=${Date.now()}`)
+}
+
+describe('version — env-var bake', () => {
+  test('PRJCT_VERSION env var wins over package.json read', async () => {
+    process.env.PRJCT_VERSION = '99.99.99'
+    const m = await freshImport()
+    expect(m.getVersion()).toBe('99.99.99')
+  })
+
+  test('rejects malformed env-var values (falls through to filesystem)', async () => {
+    process.env.PRJCT_VERSION = 'not-a-version'
+    const m = await freshImport()
+    // Falls through to package.json — should yield a real semver
+    const v = m.getVersion()
+    expect(v).toMatch(/^\d+\.\d+\.\d+/)
+    expect(v).not.toBe('not-a-version')
+  })
+
+  test('reads package.json when env-var is absent', async () => {
+    delete process.env.PRJCT_VERSION
+    const m = await freshImport()
+    const v = m.getVersion()
+    expect(v).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  test('VERSION constant matches getVersion()', async () => {
+    delete process.env.PRJCT_VERSION
+    const m = await freshImport()
+    expect(m.VERSION).toBe(m.getVersion())
+  })
+})

--- a/core/utils/version.ts
+++ b/core/utils/version.ts
@@ -56,10 +56,25 @@ export function getPackageRoot(): string {
 }
 
 /**
- * Get the current application version from package.json
+ * Get the current application version.
+ *
+ * Resolution order:
+ *   1. `process.env.PRJCT_VERSION` — baked in at build time via
+ *      `bun build --compile --define`. Standalone binaries MUST
+ *      use this path because their compiled __dirname points at the
+ *      CI runner's filesystem (which doesn't exist on the user's box).
+ *   2. `package.json` walked up from __dirname — works for source +
+ *      dist runs where the package is installed normally.
+ *   3. `'0.0.0'` — last-resort fallback so the binary still functions.
  */
 export function getVersion(): string {
   if (cachedVersion) {
+    return cachedVersion
+  }
+
+  const baked = process.env.PRJCT_VERSION
+  if (baked && /^\d+\.\d+\.\d+/.test(baked)) {
+    cachedVersion = baked
     return cachedVersion
   }
 
@@ -69,7 +84,12 @@ export function getVersion(): string {
     cachedVersion = packageJson.version
     return cachedVersion
   } catch (error) {
-    console.error('Failed to read version from package.json:', getErrorMessage(error))
+    // Stay silent in standalone binaries — the env-var fallback above
+    // covered the expected path. Logging here would surface the
+    // internal "looking for /home/runner/..." path to the user.
+    if (process.env.PRJCT_DEBUG === '1') {
+      console.error('Failed to read version from package.json:', getErrorMessage(error))
+    }
     return '0.0.0'
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.30",
+  "version": "2.4.31",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.31",
+  "version": "2.4.32",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/install-via-claude.sh
+++ b/scripts/install-via-claude.sh
@@ -40,6 +40,14 @@ PRJCT_DIR="${PRJCT_DIR:-$HOME/.prjct-cli}"
 BIN_DIR="$PRJCT_DIR/bin"
 LOCAL_BIN="$HOME/.local/bin"
 
+# Defaults for variables we read after `set -u` is in effect. Never
+# remove these — see fix line ~165 (CURRENT unbound) regression in
+# v2.4.28.
+CURRENT=""
+NEW="unknown"
+INSTALLED_VIA="unknown"
+DOWNLOAD_OK=false
+
 # ---------------------------------------------------------------------------
 # 1. Platform detection
 # ---------------------------------------------------------------------------
@@ -163,9 +171,36 @@ fi
 
 VERB="installed"
 if [ -n "$CURRENT" ] && [ "$CURRENT" != "$NEW" ]; then
-  VERB="upgraded $CURRENT → v$NEW"
+  VERB="upgraded v$CURRENT → v$NEW"
 elif [ -n "$CURRENT" ] && [ "$CURRENT" = "$NEW" ]; then
   VERB="re-verified at v$NEW (already current)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. PATH shadow detection — warn if an older `prjct` (e.g. from a stale
+#    pnpm/yarn/homebrew install) is winning the PATH lookup over the
+#    binary we just put in $LOCAL_BIN. Without this the user sees the
+#    OLD version on `prjct -v` and assumes the install failed.
+# ---------------------------------------------------------------------------
+
+ACTIVE_PRJCT="$(command -v prjct 2>/dev/null || true)"
+EXPECTED_PRJCT_BINARY="$BIN_DIR/prjct"
+EXPECTED_PRJCT_SYMLINK="$LOCAL_BIN/prjct"
+
+if [ -n "$ACTIVE_PRJCT" ] && [ "$ACTIVE_PRJCT" != "$EXPECTED_PRJCT_BINARY" ] && [ "$ACTIVE_PRJCT" != "$EXPECTED_PRJCT_SYMLINK" ]; then
+  warn "PATH shadow detected: 'prjct' resolves to $ACTIVE_PRJCT (not the install we just placed at $EXPECTED_PRJCT_SYMLINK)."
+  ACTIVE_VERSION="$($ACTIVE_PRJCT -v 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo unknown)"
+  printf "${DIM}    Active path version: %s — expected: v%s${NC}\n" "$ACTIVE_VERSION" "$NEW"
+  printf "${DIM}    Likely a stale pnpm / yarn / homebrew install. Remove it:${NC}\n"
+  case "$ACTIVE_PRJCT" in
+    */pnpm/*)        printf "${DIM}      pnpm rm -g prjct-cli${NC}\n" ;;
+    */yarn/*)        printf "${DIM}      yarn global remove prjct-cli${NC}\n" ;;
+    */homebrew/*|*/Cellar/*)
+                     printf "${DIM}      brew uninstall prjct-cli${NC}\n" ;;
+    */bun/*)         printf "${DIM}      bun remove -g prjct-cli${NC}\n" ;;
+    *)               printf "${DIM}      (manually remove %s)${NC}\n" "$ACTIVE_PRJCT" ;;
+  esac
+  printf "${DIM}    Then start a new shell (or 'hash -r') and re-run this install command.${NC}\n"
 fi
 
 printf "\n${GREEN}✓${NC} prjct %s (via $INSTALLED_VIA).\n" "$VERB"


### PR DESCRIPTION
## Summary

User pasted the install prompt into Claude and reported 3 real bugs. All fixed.

## Bug 1 — Standalone binary reports v0.0.0

**Cause:** \`getVersion()\` reads package.json at runtime via __dirname. In the bun-compiled standalone binary, __dirname points at the CI runner's filesystem (\`/home/runner/work/prjct-cli/...\`) — that path doesn't exist on the user's machine. ENOENT → \"Failed to read version\" log → fall through to '0.0.0'.

**Fix:** Bake the version in at build time via Bun's \`--define\` flag, read \`process.env.PRJCT_VERSION\` first in \`getVersion()\` before falling through to filesystem.

\`\`\`yaml
bun build --compile --target=bun-darwin-arm64 \\
  --define='process.env.PRJCT_VERSION=\"2.4.30\"' \\
  ./bin/prjct.ts --outfile prjct-darwin-arm64
\`\`\`

Verified locally: standalone binary now reports the build-time version. Smoke check added to release workflow runs the linux binary's \`-v\` immediately after compile so future regressions fail CI loud.

Plus: silenced the noisy ENOENT log unless \`PRJCT_DEBUG=1\` — surfacing the internal CI runner path to users was the visible symptom.

## Bug 2 — Install script crashes with \"CURRENT: unbound variable\"

**Cause:** Script uses \`set -u\`. Footer reads \`\$CURRENT\` to print install/upgrade verb. Variable was only set inside the upgrade branch — fresh installs reached the footer with CURRENT unbound → exit 1 right at the success message.

**Fix:** Declare \`CURRENT=\"\"\`, \`NEW=\"unknown\"\`, \`INSTALLED_VIA=\"unknown\"\`, \`DOWNLOAD_OK=false\` at the top of the script (before \`set -u\` takes effect). Comment notes the regression so the next refactor doesn't drop the defaults.

## Bug 3 — PATH shadowing detection (silent failure)

**Cause:** User had a stale pnpm install at \`/Users/jj/Library/pnpm/prjct\` (v2.4.0) earlier in PATH than \`~/.local/bin\`. New binary went to the right place but \`prjct -v\` returned the OLD shadowed version. User sees same version, assumes install failed.

**Fix:** End-of-script check: \`command -v prjct\` vs the path we just placed. If different, warn explicitly:
- Naming the active path + version
- Naming the package manager (pnpm/yarn/homebrew/bun) detected from the path
- Printing the right uninstall command for that package manager
- Reminding to start a new shell + re-run

## Tests

- 4 new tests in \`core/__tests__/utils/version.test.ts\` covering env-var precedence, malformed env-var fallthrough, package.json fallback, VERSION constant consistency
- Full suite: 939/939 pass (was 935 + 4 new), typecheck clean
- Local smoke: \`bun build --compile --define\` produces a binary that reports the right version

## Captured to memory (dogfood)

3 gotchas via \`prjct remember gotcha\` tagged with severity + area so the next session lookup-first finds them:
- Bun --compile binaries can't read filesystem-relative paths at runtime → bake values via --define
- Install scripts with \`set -u\` must default all variables before first use
- PATH shadowing detection is a must when binary install can be preempted by package manager installs

## Release timing

The next release (v2.4.30+) will ship binaries that report the right version. Versions v2.4.22-v2.4.28 currently on GitHub Releases continue to report v0.0.0 — fix lands when this PR merges + the next ship cycle runs.