### PR TITLE
docs: harness-aware install prompt (npm primary, binary as user-run option)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.34] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.33] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.33] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.32] - 2026-05-02
 
 ### Added

--- a/INSTALL_PROMPT.md
+++ b/INSTALL_PROMPT.md
@@ -6,36 +6,44 @@ Three paths, each smaller than the last. Pick the one your audience can follow.
 
 ---
 
-## Path 1 — One paste in Claude Code (recommended, install + upgrade)
+## Path 1 — One paste in Claude Code (recommended, harness-friendly)
 
-Copy the prompt below (use the GitHub copy button on the code block) and paste it into the Claude Code chat. Claude executes it and you're done in ~30 seconds:
+Copy the prompt below and paste it into the Claude Code chat. Claude runs `npm` directly — no sandbox restrictions, ~30 seconds end-to-end:
 
 ```text
 Install or upgrade prjct (project memory + quality workflows for AI coding agents) on this machine:
 
-1. Run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`
-2. Verify with `prjct -v` (should print the latest v2.4.x)
+1. Run `npm install -g prjct-cli@latest`
+2. Run `prjct setup` to install Claude Code hooks + the global CLAUDE.md lookup-first block
 3. If the cwd is a git repo, run `prjct sync` to register it
-4. Show me the install output and confirm the version (note: it'll say "upgraded X → vY" if I had a previous version, or "installed" if fresh)
+4. Verify with `prjct -v` and confirm the version
 
-The script downloads the standalone binary for my platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades. After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
+After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
 ```
 
 ### Shorter version (if you want a one-liner prompt)
 
 ```text
-Install or upgrade prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
+Install or upgrade prjct on this machine: run `npm install -g prjct-cli@latest`, then `prjct setup`, then `prjct sync` if cwd is a git repo. Verify with `prjct -v`.
 ```
+
+### Why npm and not the standalone binary?
+
+The standalone binary install (`curl | bash`) is faster and Node-free, but **Claude Code's harness intentionally blocks remote `curl | bash` execution for safety** — that's a sandbox policy, not something a prompt can or should bypass. The npm path runs through Claude Code's allowed tool surface.
+
+If you want the standalone binary, see Path 2 (run yourself in a terminal).
 
 ---
 
-## Path 2 — One terminal line
+## Path 2 — Standalone binary, run in your own terminal (no Node/npm needed)
 
-For users who prefer a terminal:
+If you'd rather have the standalone binary (Bun runtime embedded), open your own terminal and run:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash
 ```
+
+> **Note:** This is a `curl | bash` install. Run it from your own terminal, not via Claude Code — the Claude Code harness blocks remote `curl | bash` for safety, and that's the right call. Trust comes from you reading the script before running it. The script is here: [scripts/install-via-claude.sh](./scripts/install-via-claude.sh).
 
 The script:
 1. Detects platform (macOS arm64/intel + Linux x64)
@@ -43,6 +51,7 @@ The script:
 3. Symlinks `~/.prjct-cli/bin/prjct` → `~/.local/bin/prjct` (added to `$PATH`)
 4. Falls back to `npm install -g prjct-cli@latest` if binary download fails
 5. Runs `prjct setup` (hooks + global CLAUDE.md) and `prjct sync` (if cwd is git repo)
+6. Warns if a stale package-manager install (pnpm / yarn / brew / bun) is shadowing the new binary on PATH
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,29 +12,26 @@
 Copy this prompt and paste it in Claude Code (works for fresh install AND upgrade):
 
 ```text
-Install or upgrade prjct on this machine: run `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash` and verify with `prjct -v`. If the cwd is a git repo, also run `prjct sync` to register it.
+Install or upgrade prjct on this machine: run `npm install -g prjct-cli@latest`, then `prjct setup` to wire hooks, and `prjct sync` if the cwd is a git repo. Verify the version with `prjct -v`.
 ```
 
-~30 seconds. The script downloads the standalone binary for your platform from GitHub Releases (no Node/npm needed), wires hooks + the lookup-first CLAUDE.md block, and registers the project. Re-running is safe — the script detects existing installs and upgrades to the latest published version.
+~30 seconds. Claude runs npm directly (no harness restrictions), wires the SessionStart/Stop hooks + the lookup-first CLAUDE.md block, and registers the project. Re-pasting upgrades to the latest published version.
 
-Prefer terminal? Same effect:
+### Prefer no Node/npm? (run in your own terminal)
+
+If you'd rather have the standalone binary (Bun runtime embedded, no Node ecosystem needed), run this **yourself in a terminal** — it's a `curl | bash` install which Claude Code's harness intentionally blocks for safety:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash
 ```
 
-Or via package manager:
-
-```bash
-npm install -g prjct-cli@latest
-# or: bun install -g prjct-cli@latest
-```
+The script auto-detects platform (mac arm64/intel + linux x64), downloads the right binary from GitHub Releases, sets up `~/.local/bin/prjct` on your PATH, runs `prjct setup` + `prjct sync`, and warns you if a stale package-manager install is shadowing the new binary.
 
 ### After install — three upgrade paths
 
 | Method | Command | When |
 |---|---|---|
-| Same prompt | re-paste the install prompt | Default. Works whether installed or not. |
+| Re-paste the install prompt | (same prompt above) | Default. Claude re-runs `npm install -g prjct-cli@latest` and re-verifies. |
 | CLI shortcut | `prjct update` | Already in a terminal. Auto-detects npm/pnpm/bun/yarn/homebrew. |
 | Silent (set once) | `prjct config set auto-update on` | Background check 1/hour throttled, logs to `~/.prjct-cli/state/auto-update.log`. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.32",
+  "version": "2.4.33",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.33",
+  "version": "2.4.34",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

User pasted the install prompt into Claude Code. The harness blocked \`curl | bash\` (correct sandbox policy — that's exactly what should be blocked by default) and Claude responded with a workaround (\`!\` prefix). User flagged: *\"cuidado por que no podemos ir en contra de lo que dicen los ToS de claude.\"*

So the prompt now uses npm as the primary path. Claude can run \`npm install -g prjct-cli@latest\` directly without harness friction or \`!\` prefix elevation. The standalone-binary path stays available but is documented as a thing the user runs THEMSELVES in a terminal — not via Claude.

## Why this is the right framing

- We don't ask Claude to circumvent its own sandbox.
- We don't ask the user to use \`!\` prefix as a workaround (also circumvention-adjacent).
- npm is a standard tool already in the harness allow-set on most setups.
- The standalone binary remains the recommended path for users who don't want Node — they just run it in a real terminal where they own the trust decision.

## Changes

### README.md

Old install snippet led with \`curl | bash\` paste-into-Claude. New leads with:

\`\`\`text
Install or upgrade prjct on this machine: run \`npm install -g prjct-cli@latest\`, then \`prjct setup\` to wire hooks, and \`prjct sync\` if the cwd is a git repo. Verify the version with \`prjct -v\`.
\`\`\`

Plus a \"Prefer no Node/npm? (run in your own terminal)\" subsection that explains the binary path, why Claude can't run it (without dressing it up), and the curl command for the user's own terminal.

### INSTALL_PROMPT.md

Path 1 rewritten to use npm. Includes a \"Why npm and not the standalone binary?\" callout that explains the harness restriction honestly + points at Path 2 for users who want the binary.

Path 2 rewritten with \"Standalone binary, run in your own terminal\" framing — explicitly NOT for Claude. Adds a security note: trust comes from reading the script before running it.

## Tests

bun test → 939/939 pass (docs-only).