### PR TITLE
fix: install prompt + script must DETECT package manager, not assume npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.38] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.37] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.37] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.36] - 2026-05-02
 
 ### Added

--- a/INSTALL_PROMPT.md
+++ b/INSTALL_PROMPT.md
@@ -6,30 +6,44 @@ Three paths, each smaller than the last. Pick the one your audience can follow.
 
 ---
 
-## Path 1 — One paste in Claude Code (recommended, harness-friendly)
+## Path 1 — One paste in Claude Code (recommended, harness-friendly + package-manager-aware)
 
-Copy the prompt below and paste it into the Claude Code chat. Claude runs `npm` directly — no sandbox restrictions, ~30 seconds end-to-end:
+Copy the prompt below and paste it into the Claude Code chat. Claude detects YOUR package manager and uses it — does NOT force npm:
 
 ```text
-Install or upgrade prjct (project memory + quality workflows for AI coding agents) on this machine:
+Install or upgrade prjct (project memory + quality workflows for AI coding agents) on this machine.
 
-1. Run `npm install -g prjct-cli@latest`
-2. Run `prjct setup` to install Claude Code hooks + the global CLAUDE.md lookup-first block
-3. If the cwd is a git repo, run `prjct sync` to register it
-4. Verify with `prjct -v` and confirm the version
+1. Detect which package manager I use globally. Check `command -v pnpm`, `command -v bun`, `command -v yarn`, `command -v npm` in that order. ALSO check `command -v prjct` — if there's an existing install, identify which package manager owns it (pnpm path, bun path, etc.) and use the SAME one to upgrade in-place. This is critical: using a different package manager creates a parallel install that shadows the existing one and breaks PATH resolution.
+
+2. Run the install with the detected package manager:
+   - pnpm: `pnpm install -g prjct-cli@latest`
+   - bun:  `bun install -g prjct-cli@latest`
+   - yarn: `yarn global add prjct-cli@latest`
+   - npm:  `npm install -g prjct-cli@latest`
+   - homebrew: `brew upgrade prjct-cli` (or `brew install prjct-cli`)
+
+3. Run `prjct setup` to install Claude Code hooks + the global CLAUDE.md lookup-first block.
+4. If the cwd is a git repo, run `prjct sync` to register it.
+5. Verify with `prjct -v` and tell me which package manager you used.
 
 After install, the prjct skill activates on requests like "review this branch", "qa the UI", "security check", or "investigate this bug" — each with a named methodology (Production Bug Hunt, OWASP+STRIDE, Iron Law, Coverage Gate). Stop hook auto-captures decisions/learnings/gotchas + detects hot files, recurring bugs, and tech-debt growth so the next session compounds.
 ```
 
-### Shorter version (if you want a one-liner prompt)
+### Shorter version (one-liner)
 
 ```text
-Install or upgrade prjct on this machine: run `npm install -g prjct-cli@latest`, then `prjct setup`, then `prjct sync` if cwd is a git repo. Verify with `prjct -v`.
+Install or upgrade prjct: detect my package manager (pnpm > bun > yarn > npm in preference order; reuse the one that owns any existing prjct install), run the matching `<pm> install -g prjct-cli@latest` (or `yarn global add` / `brew upgrade prjct-cli`), then `prjct setup`, then `prjct sync` if cwd is git. Verify with `prjct -v`.
 ```
 
-### Why npm and not the standalone binary?
+### Why detection matters
 
-The standalone binary install (`curl | bash`) is faster and Node-free, but **Claude Code's harness intentionally blocks remote `curl | bash` execution for safety** — that's a sandbox policy, not something a prompt can or should bypass. The npm path runs through Claude Code's allowed tool surface.
+If Claude assumes one package manager (say, npm) and you actually use pnpm, the install creates a SECOND prjct in your nvm bin dir while your existing pnpm install stays in `~/Library/pnpm/`. PATH resolution picks one — usually whichever is earlier — and you see a stale version. Aggressive cleanup of duplicates can leave your shell with NO working prjct.
+
+The detection-first prompt avoids this entirely. It's also why the standalone-binary script (Path 2) detects existing installs and upgrades in-place rather than blindly creating new ones.
+
+### Why detection in the prompt and not via npm?
+
+The standalone binary install (`curl | bash`) is the cleanest no-package-manager path, but **Claude Code's harness intentionally blocks remote `curl | bash` execution for safety** — that's a sandbox policy, not something a prompt can or should bypass. The package-manager path runs through Claude Code's allowed tool surface.
 
 If you want the standalone binary, see Path 2 (run yourself in a terminal).
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,21 @@
 
 ## Install / upgrade — one paste
 
-Copy this prompt and paste it in Claude Code (works for fresh install AND upgrade):
+Copy this prompt and paste it in Claude Code (works for fresh install AND upgrade — Claude picks YOUR package manager, doesn't force npm):
 
 ```text
-Install or upgrade prjct on this machine: run `npm install -g prjct-cli@latest`, then `prjct setup` to wire hooks, and `prjct sync` if the cwd is a git repo. Verify the version with `prjct -v`.
+Install or upgrade prjct on this machine. First detect which package manager I use globally (check `command -v pnpm`, `command -v bun`, `command -v yarn`, `command -v npm` in that order; also check where any existing `prjct` install lives via `command -v prjct` and use the SAME package manager so we don't create parallel installs). Then run the matching install:
+- pnpm: `pnpm install -g prjct-cli@latest`
+- bun:  `bun install -g prjct-cli@latest`
+- yarn: `yarn global add prjct-cli@latest`
+- npm:  `npm install -g prjct-cli@latest`
+
+After install, run `prjct setup` to wire hooks, then `prjct sync` if the cwd is a git repo. Verify with `prjct -v` and tell me which package manager you used.
 ```
 
-~30 seconds. Claude runs npm directly (no harness restrictions), wires the SessionStart/Stop hooks + the lookup-first CLAUDE.md block, and registers the project. Re-pasting upgrades to the latest published version.
+~30 seconds. Claude detects YOUR package manager (pnpm, bun, yarn, npm) and uses it — critical so we don't end up with parallel installs in different package managers' bin dirs. Re-pasting upgrades to the latest published version.
+
+> **Why detection matters:** if you have `pnpm` globally and Claude runs `npm install -g prjct-cli@latest`, you end up with TWO installs in PATH. The earlier one wins, `prjct -v` reports the wrong version, and aggressive cleanup risks bricking your shell. The detection-first prompt avoids this entirely.
 
 ### Prefer no Node/npm? (run in your own terminal)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.37",
+  "version": "2.4.38",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.36",
+  "version": "2.4.37",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/install-via-claude.sh
+++ b/scripts/install-via-claude.sh
@@ -94,21 +94,60 @@ if [ -n "$ASSET" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 2b. Package manager fallback
+# 2b. Package manager fallback — pnpm / bun / yarn / npm
+#
+# Detection order is critical to avoid creating PARALLEL installs:
+#   1. If prjct is already installed via a known package manager,
+#      use the SAME one to upgrade. Otherwise we end up with multiple
+#      copies of prjct in PATH (the user's reality on 2026-05-02 had
+#      5 concurrent installs from pnpm/bun/homebrew/npm/standalone).
+#   2. If no existing install, prefer pnpm > bun > yarn > npm in that
+#      order. Reasons: pnpm + bun are what most modern setups use; npm
+#      is the universal fallback.
 # ---------------------------------------------------------------------------
 
 if [ "$DOWNLOAD_OK" = false ]; then
   INSTALLED_VIA="pkg-manager"
   step "Falling back to package manager…"
-  if command -v bun >/dev/null 2>&1; then
-    note "using Bun $(bun --version)"
-    bun install -g prjct-cli@latest >/dev/null 2>&1 || fail "bun install failed"
-  elif command -v npm >/dev/null 2>&1; then
-    note "using npm $(npm --version)"
-    npm install -g prjct-cli@latest >/dev/null 2>&1 || fail "npm install failed"
-  else
-    fail "Neither standalone binary nor a runtime (Bun/npm) is available. Install Bun: https://bun.sh"
+
+  # Detect which package manager (if any) owns the existing prjct install
+  EXISTING_PRJCT="$(command -v prjct 2>/dev/null || true)"
+  PM=""
+  if [ -n "$EXISTING_PRJCT" ]; then
+    case "$EXISTING_PRJCT" in
+      */pnpm/*)        PM="pnpm" ;;
+      */bun/*)         PM="bun" ;;
+      */yarn/*)        PM="yarn" ;;
+      */homebrew/*|*/Cellar/*) PM="brew" ;;
+      */npm/*|*/.nvm/*|*/n/*)  PM="npm" ;;
+    esac
+    [ -n "$PM" ] && note "existing install via $PM ($EXISTING_PRJCT) — upgrading in-place"
   fi
+
+  # No existing install (or unknown PM) — pick the user's preferred one
+  if [ -z "$PM" ]; then
+    if command -v pnpm >/dev/null 2>&1; then
+      PM="pnpm"
+    elif command -v bun >/dev/null 2>&1; then
+      PM="bun"
+    elif command -v yarn >/dev/null 2>&1; then
+      PM="yarn"
+    elif command -v npm >/dev/null 2>&1; then
+      PM="npm"
+    else
+      fail "No package manager found (pnpm, bun, yarn, npm). Install one or use the standalone binary path: https://github.com/jlopezlira/prjct-cli#install"
+    fi
+    note "no existing install — using $PM (first available in pnpm > bun > yarn > npm preference order)"
+  fi
+
+  case "$PM" in
+    pnpm) pnpm install -g prjct-cli@latest >/dev/null 2>&1 || fail "pnpm install failed" ;;
+    bun)  bun install -g prjct-cli@latest >/dev/null 2>&1 || fail "bun install failed" ;;
+    yarn) yarn global add prjct-cli@latest >/dev/null 2>&1 || fail "yarn global add failed" ;;
+    npm)  npm install -g prjct-cli@latest >/dev/null 2>&1 || fail "npm install failed" ;;
+    brew) brew upgrade prjct-cli >/dev/null 2>&1 || brew install prjct-cli >/dev/null 2>&1 || fail "brew install failed" ;;
+    *)    fail "Unknown package manager: $PM" ;;
+  esac
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

User's nightmare scenario tonight (chained from #283 #285 #286 #287):

1. Pasted the install prompt that said \"run \`npm install -g prjct-cli@latest\`.\"
2. User actually uses **pnpm**, not npm.
3. \`npm install\` created a SECOND prjct in \`~/.nvm/.../bin/\` (v2.4.34).
4. Existing pnpm install stayed in \`~/Library/pnpm/\` (v2.4.0).
5. pnpm path was earlier in \$PATH → \`prjct -v\` returned 2.4.0.
6. Aggressive cleanup of duplicates ended with NO prjct on PATH and the Stop hook spamming \"command not found.\"

Root cause: forcing one package manager when the user has another. Painful chain reaction.

## Fix #1 — install-via-claude.sh detects pnpm/bun/yarn/npm/brew

Two-step detection in the package-manager fallback:

1. **If \`prjct\` is already installed**, identify which package manager owns the binary (path matches \`/pnpm/\`, \`/bun/\`, \`/yarn/\`, \`/Cellar/\`, \`/npm/\`, \`/.nvm/\`) and upgrade IN-PLACE with the same one. No more parallel installs.
2. **If no existing install**, prefer pnpm > bun > yarn > npm in that order.

Each PM gets its native install command:
- \`pnpm install -g prjct-cli@latest\`
- \`bun install -g prjct-cli@latest\`
- \`yarn global add prjct-cli@latest\`
- \`npm install -g prjct-cli@latest\`
- \`brew upgrade prjct-cli\` (or install if absent)

## Fix #2 — README + INSTALL_PROMPT.md prompt is detection-first

Prompt rewritten to instruct Claude:
1. Check \`command -v pnpm/bun/yarn/npm\` in preference order
2. ALSO check \`command -v prjct\` to detect existing install's PM and reuse it
3. Run the matching install command
4. Tell the user which PM was used

Plus a \"Why detection matters\" callout so users + future Claude sessions understand the failure mode.

## Tests

bun test → 942/942 pass (no logic changed in tested code paths).

Captured to memory (gotcha): install prompts must NEVER hardcode a package manager.