### PR TITLE
fix(analyze): write report to vault, stop clobbering global CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.39] - 2026-05-02
+
+### Added
+- current work
+
 ## [2.4.38] - 2026-05-02
 
 ### Added

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -4,7 +4,6 @@
 
 import fs from 'node:fs/promises'
 import analyzer from '../domain/analyzer'
-import commandInstaller from '../infrastructure/command-installer'
 import configManager from '../infrastructure/config-manager'
 import pathManager from '../infrastructure/path-manager'
 import { formatCost } from '../schemas/metrics'
@@ -94,9 +93,11 @@ export class AnalysisCommands extends PrjctCommandsBase {
 
       const summary = generateAnalysisSummary(analysisData, projectPath)
 
-      const projectId = await configManager.getProjectId(projectPath)
-      const summaryPath = pathManager.getFilePath(projectId!, 'analysis', 'repo-summary.md')
+      const config = await configManager.readConfig(projectPath).catch(() => null)
+      const wikiRoot = await pathManager.getWikiPath(projectPath, config?.vaultPath)
+      const summaryPath = `${wikiRoot}/_generated/analysis/repo-summary.md`
 
+      await fs.mkdir(`${wikiRoot}/_generated/analysis`, { recursive: true })
       await fs.writeFile(summaryPath, summary, 'utf-8')
 
       await this.logToMemory(projectPath, 'repository_analyzed', {
@@ -105,17 +106,8 @@ export class AnalysisCommands extends PrjctCommandsBase {
         gitCommits: analysisData.gitStats.totalCommits,
       })
 
-      const aiProvider = require('../infrastructure/ai-provider')
-      const activeProvider = await aiProvider.getActiveProvider()
-
-      const globalConfigResult = await commandInstaller.installGlobalConfig()
-      if (globalConfigResult.success) {
-        console.log(`📝 Updated ${pathManager.getDisplayPath(globalConfigResult.path!)}`)
-      }
-
       console.log('✅ Analysis complete!\n')
-      console.log(`📄 Full report: ${pathManager.getDisplayPath(summaryPath)}`)
-      console.log(`📝 Context: ~/.prjct-cli/projects/${projectId}/${activeProvider.contextFile}\n`)
+      console.log(`📄 Full report: ${pathManager.getDisplayPath(summaryPath)}\n`)
       console.log('Next steps:')
       console.log('• /p:sync → Generate agents based on stack')
       console.log('• /p:feature → Add a new feature')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.4.38",
+  "version": "2.4.39",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- `prjct analyze` now writes `repo-summary.md` into the vault (`~/Documents/prjct/<slug>/_generated/analysis/`) via `pathManager.getWikiPath()`, matching `regenVault` and the v2.2.0+ vault location convention. Previously it wrote to `~/.prjct-cli/projects/<id>/analysis/`, which is SQLite-side global storage, not user-facing.
- Removed the `commandInstaller.installGlobalConfig()` call from `analyze`. That was overwriting the user's global `~/.claude/CLAUDE.md` on every analysis run; global-config installation belongs in `setup`/`install`, not per-analyze.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run check` clean (no new findings)
- [x] `./bin/prjct analyze` reports `~/Documents/prjct/prjct-cli/_generated/analysis/repo-summary.md`
- [x] No `Updated ~/.claude/CLAUDE.md` line in output
- [x] File confirmed at the new path with full contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)