### PR TITLE
feat(health): prjct health — composite quality dashboard (gstack Fase C/5)

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -70,6 +70,7 @@ const _binCommands = new Set([
   'mcp',
   'prefs',
   'retro',
+  'health',
 ])
 
 // v2 verbs registered in the command registry — imported from the single
@@ -516,6 +517,14 @@ async function main(): Promise<void> {
     else {
       console.error(`Unknown seed subcommand: ${sub}. Use: add, remove, list, suggest.`)
     }
+    process.exitCode = result.success ? 0 : 1
+  } else if (args[0] === 'health') {
+    // `prjct health [--md]` — composite quality dashboard. Wraps
+    // typecheck / lint / tests / knip and reports a weighted score.
+    const mdMode = args.includes('--md')
+    const { HealthCommands } = await import('../core/commands/health')
+    const cmd = new HealthCommands()
+    const result = await cmd.health(null, process.cwd(), { md: mdMode })
     process.exitCode = result.success ? 0 : 1
   } else if (args[0] === 'retro') {
     // `prjct retro [window]` — gstack-style weekly engineering retro.

--- a/core/__tests__/commands/health.test.ts
+++ b/core/__tests__/commands/health.test.ts
@@ -1,0 +1,71 @@
+/**
+ * HealthCommands — `prjct health` smoke tests.
+ *
+ * Runs against tmpdir projects with controllable script outcomes.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { HealthCommands } from '../../commands/health'
+
+let dir: string
+const cmd = new HealthCommands()
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-health-test-'))
+  await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+  await fs.writeFile(
+    path.join(dir, '.prjct/prjct.config.json'),
+    JSON.stringify({ projectId: `health-test-${Date.now()}` })
+  )
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+async function writePkg(scripts: Record<string, string>): Promise<void> {
+  await fs.writeFile(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'tmp', version: '0.0.1', scripts })
+  )
+}
+
+describe('prjct health', () => {
+  it('reports zero dimensions when package.json is missing', async () => {
+    const r = await cmd.health(null, dir, { md: false })
+    expect(r.success).toBe(true)
+    expect(r.results).toBe(0)
+  })
+
+  it('reports zero dimensions when no quality scripts exist', async () => {
+    await writePkg({ build: 'echo build' })
+    const r = await cmd.health(null, dir, { md: true })
+    expect(r.success).toBe(true)
+    expect(r.results).toBe(0)
+  })
+
+  it('runs the typecheck dimension and scores 100 when it exits 0', async () => {
+    await writePkg({ typecheck: 'true' }) // `true` exits 0
+    const r = await cmd.health(null, dir, { md: false })
+    expect(r.success).toBe(true)
+    expect(r.score).toBe(100)
+  })
+
+  it('exits non-zero and lowers the score when a dimension fails', async () => {
+    await writePkg({ typecheck: 'false' }) // `false` exits 1
+    const r = await cmd.health(null, dir, { md: false })
+    expect(r.success).toBe(false)
+    expect(r.score).toBe(0)
+  })
+
+  it('partial pass — typecheck pass + lint fail = 25/45 ≈ 56', async () => {
+    await writePkg({ typecheck: 'true', lint: 'false' })
+    const r = await cmd.health(null, dir, { md: false })
+    expect(r.success).toBe(false)
+    // typecheck weight=25, lint weight=20; pass=25 / total=45 → 56
+    expect(r.score).toBe(56)
+  })
+})

--- a/core/commands/health.ts
+++ b/core/commands/health.ts
@@ -1,0 +1,199 @@
+/**
+ * Health Command — `prjct health`
+ *
+ * Composite quality dashboard. Wraps the project's existing tools
+ * (typecheck, lint, tests, dead-code) and reports a per-dimension
+ * pass/fail with a weighted overall score. Inspired by gstack's
+ * `/health` SKILL.md (garrytan/gstack/health).
+ *
+ * Distinct from `prjct doctor` — doctor checks the *system* state
+ * (binaries, configs, staleness). Health checks *code* quality.
+ */
+
+import path from 'node:path'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { execAsync } from '../utils/exec'
+import { fileExists, readJson } from '../utils/file-helper'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+interface HealthDimension {
+  name: string
+  /** The script name in package.json — e.g. `typecheck`, `lint`, `test`. */
+  scriptName: string
+  command: string | null
+  /** ISO-ish narrative description shown to the user. */
+  description: string
+  weight: number
+}
+
+interface HealthResult {
+  dimension: HealthDimension
+  status: 'pass' | 'fail' | 'skipped'
+  durationMs: number
+  /** Captured first error line / diagnostic when status=fail. */
+  diagnostic?: string
+}
+
+/**
+ * The known dimensions and their package.json script names. The
+ * runtime resolves a runner (bun preferred when available) and writes
+ * the final command at detection time.
+ */
+const KNOWN_DIMENSIONS: ReadonlyArray<Omit<HealthDimension, 'command'>> = [
+  { name: 'typecheck', scriptName: 'typecheck', description: 'TypeScript types', weight: 25 },
+  { name: 'lint', scriptName: 'lint', description: 'Lint rules', weight: 20 },
+  { name: 'tests', scriptName: 'test', description: 'Test suite', weight: 35 },
+  { name: 'dead-code', scriptName: 'knip', description: 'Dead-code scan', weight: 20 },
+]
+
+export class HealthCommands extends PrjctCommandsBase {
+  async health(
+    _arg: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean } = {}
+  ): Promise<CommandResult> {
+    try {
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+
+      const dimensions = await detectDimensions(projectPath)
+      const results: HealthResult[] = []
+      for (const dim of dimensions) {
+        results.push(await runDimension(projectPath, dim))
+      }
+      const score = computeScore(results)
+
+      if (options.md) {
+        console.log(formatMarkdown(score, results))
+      } else {
+        console.log(formatText(score, results))
+      }
+
+      // Exit non-zero on any FAIL so CI can gate on `prjct health`.
+      const allPass = results.every((r) => r.status !== 'fail')
+      return { success: allPass, score, results: results.length }
+    } catch (error) {
+      const msg = getErrorMessage(error)
+      out.fail(msg)
+      return { success: false, error: msg }
+    }
+  }
+}
+
+// ============================================================================
+// Detection
+// ============================================================================
+
+async function detectDimensions(projectPath: string): Promise<HealthDimension[]> {
+  const pkgPath = path.join(projectPath, 'package.json')
+  if (!(await fileExists(pkgPath))) {
+    return []
+  }
+  const pkg = await readJson<{ scripts?: Record<string, string> }>(pkgPath, null)
+  const scripts = pkg?.scripts ?? {}
+
+  // Pick the runner. We resolve to the script value DIRECTLY (sh -c
+  // <script>) rather than `bun run <name>` / `npm run <name>` so the
+  // health command works regardless of which package manager is on PATH.
+  // This also dodges the "global npm not installed" failure mode in CI
+  // / sandboxed test environments.
+  return KNOWN_DIMENSIONS.filter((d) => Boolean(scripts[d.scriptName])).map((d) => ({
+    ...d,
+    command: scripts[d.scriptName] ?? null,
+  }))
+}
+
+// ============================================================================
+// Dimension execution
+// ============================================================================
+
+async function runDimension(projectPath: string, dim: HealthDimension): Promise<HealthResult> {
+  if (!dim.command) {
+    return { dimension: dim, status: 'skipped', durationMs: 0 }
+  }
+  const start = Date.now()
+  try {
+    await execAsync(dim.command, {
+      cwd: projectPath,
+      timeout: 5 * 60 * 1000,
+      maxBuffer: 16 * 1024 * 1024,
+    })
+    return { dimension: dim, status: 'pass', durationMs: Date.now() - start }
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const firstNonEmpty = (stderr + '\n' + stdout)
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.length > 0)
+    return {
+      dimension: dim,
+      status: 'fail',
+      durationMs: Date.now() - start,
+      diagnostic: firstNonEmpty ?? getErrorMessage(error),
+    }
+  }
+}
+
+// ============================================================================
+// Scoring
+// ============================================================================
+
+function computeScore(results: HealthResult[]): number {
+  if (results.length === 0) return 0
+  // Weighted: each pass contributes its full weight, fails contribute 0,
+  // skipped don't change the denominator (we only count present dimensions).
+  let pts = 0
+  let denom = 0
+  for (const r of results) {
+    if (r.status === 'skipped') continue
+    denom += r.dimension.weight
+    if (r.status === 'pass') pts += r.dimension.weight
+  }
+  if (denom === 0) return 0
+  return Math.round((pts / denom) * 100)
+}
+
+// ============================================================================
+// Output
+// ============================================================================
+
+function statusIcon(status: HealthResult['status']): string {
+  if (status === 'pass') return '✓'
+  if (status === 'fail') return '✗'
+  return '·'
+}
+
+function formatText(score: number, results: HealthResult[]): string {
+  if (results.length === 0) {
+    return 'health: no quality dimensions detected (add typecheck/lint/test/knip scripts to package.json)'
+  }
+  const lines: string[] = []
+  lines.push(`health: ${score}/100`)
+  for (const r of results) {
+    const dur = r.durationMs > 1000 ? `${(r.durationMs / 1000).toFixed(1)}s` : `${r.durationMs}ms`
+    const tail = r.status === 'fail' && r.diagnostic ? ` — ${r.diagnostic.slice(0, 80)}` : ''
+    lines.push(`  ${statusIcon(r.status)} ${r.dimension.name.padEnd(10)} ${dur}${tail}`)
+  }
+  return lines.join('\n')
+}
+
+function formatMarkdown(score: number, results: HealthResult[]): string {
+  if (results.length === 0) {
+    return `## Health\n\n_No quality dimensions detected. Add \`typecheck\`, \`lint\`, \`test\`, or \`knip\` scripts to \`package.json\`._\n`
+  }
+  const lines: string[] = []
+  lines.push(`## Health — ${score}/100`)
+  lines.push('')
+  lines.push('| Dimension | Status | Duration | Notes |')
+  lines.push('|---|---|---|---|')
+  for (const r of results) {
+    const dur = r.durationMs > 1000 ? `${(r.durationMs / 1000).toFixed(1)}s` : `${r.durationMs}ms`
+    const note =
+      r.status === 'fail' && r.diagnostic ? r.diagnostic.slice(0, 100).replaceAll('|', '\\|') : ''
+    lines.push(`| ${r.dimension.name} | ${r.status} | ${dur} | ${note} |`)
+  }
+  return lines.join('\n')
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -172,7 +172,7 @@ import{connect}from"node:net";import{existsSync}from"node:fs";import{randomUUID}
 const sockPath=homedir()+"/.prjct-cli/run/daemon.sock";
 const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
-const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro"]);
+const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health"]);
 if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
   const cArgs=[],cOpts={};
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}


### PR DESCRIPTION
Adopts gstack's `/health`. Runs typecheck/lint/tests/knip from package.json scripts, reports weighted score. 5 tests. 985/985 pass.