### PR TITLE
feat(init): project CLAUDE.md routing + onboarding rewrite (UX phase 4+5)

### DIFF
--- a/core/__tests__/services/project-claude-md.test.ts
+++ b/core/__tests__/services/project-claude-md.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Project CLAUDE.md routing block — written by `prjct init`.
+ *
+ * Pins the contract:
+ *   1. Missing CLAUDE.md → file is created with the block.
+ *   2. Existing CLAUDE.md without markers → block appended,
+ *      user content preserved.
+ *   3. Existing CLAUDE.md with stale markers → block content refreshed,
+ *      user content outside markers preserved.
+ *   4. Re-running on already-current file → action='unchanged'
+ *      (idempotent — `prjct init` is safe to re-run).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { _routing, writeProjectClaudeMd } from '../../services/project-claude-md'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-claude-md-test-'))
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+async function readClaudeMd(): Promise<string> {
+  return fs.readFile(path.join(dir, 'CLAUDE.md'), 'utf-8')
+}
+
+describe('writeProjectClaudeMd', () => {
+  it('creates CLAUDE.md when none exists', async () => {
+    const r = await writeProjectClaudeMd(dir)
+    expect(r.action).toBe('created')
+    const body = await readClaudeMd()
+    expect(body).toContain(_routing.START_MARKER)
+    expect(body).toContain(_routing.END_MARKER)
+    expect(body).toContain('## prjct usage')
+    expect(body).toContain('Do not ask the\nuser to run prjct commands')
+  })
+
+  it('appends the block to an existing CLAUDE.md without markers', async () => {
+    await fs.writeFile(path.join(dir, 'CLAUDE.md'), '# My Project\n\nExisting notes.\n')
+    const r = await writeProjectClaudeMd(dir)
+    expect(r.action).toBe('updated')
+    const body = await readClaudeMd()
+    expect(body).toContain('# My Project')
+    expect(body).toContain('Existing notes.')
+    expect(body).toContain(_routing.START_MARKER)
+    // Original content survives.
+    expect(body.indexOf('Existing notes.')).toBeLessThan(body.indexOf(_routing.START_MARKER))
+  })
+
+  it('replaces stale block content while preserving the user content outside markers', async () => {
+    const initialBody = `# My Project
+
+Custom rules.
+
+${_routing.START_MARKER}
+old stale routing instructions
+${_routing.END_MARKER}
+
+## More user content
+trailing notes here
+`
+    await fs.writeFile(path.join(dir, 'CLAUDE.md'), initialBody)
+    const r = await writeProjectClaudeMd(dir)
+    expect(r.action).toBe('updated')
+    const body = await readClaudeMd()
+    // The user-authored content survives unchanged.
+    expect(body).toContain('Custom rules.')
+    expect(body).toContain('trailing notes here')
+    // Old stale content is gone.
+    expect(body).not.toContain('old stale routing instructions')
+    // New block is in place.
+    expect(body).toContain('Do not ask the\nuser to run prjct commands')
+  })
+
+  it('is idempotent — second run on a current file reports unchanged', async () => {
+    await writeProjectClaudeMd(dir)
+    const second = await writeProjectClaudeMd(dir)
+    expect(second.action).toBe('unchanged')
+  })
+})

--- a/core/commands/planning.ts
+++ b/core/commands/planning.ts
@@ -9,6 +9,7 @@ import * as authorDetector from '../infrastructure/author-detector'
 import commandInstaller from '../infrastructure/command-installer'
 import configManager from '../infrastructure/config-manager'
 import pathManager from '../infrastructure/path-manager'
+import { writeProjectClaudeMd } from '../services/project-claude-md'
 import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { CommandResult, InitOptions } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
@@ -183,6 +184,10 @@ export class PlanningCommands extends PrjctCommandsBase {
       }
 
       await commandInstaller.installGlobalConfig()
+      // Write the per-project CLAUDE.md routing block so Claude Code
+      // sessions in this directory pick up the prjct contract on cwd
+      // entry. Best-effort — a missing/locked file degrades silently.
+      await writeProjectClaudeMd(projectPath).catch(() => {})
 
       out.done('initialized')
       this._printNextSteps(wizardResult)
@@ -198,10 +203,20 @@ export class PlanningCommands extends PrjctCommandsBase {
    */
   private _printNextSteps(wizardResult: import('../types/workflows').WizardResult | null): void {
     console.log('')
-    console.log('  Quick start:')
-    console.log('    prjct sync     Update context after changes')
-    console.log('    prjct task     Start working on a task')
-    console.log('    prjct hooks    Auto-sync on commit/checkout')
+    console.log('  ✓ skill installed at ~/.claude/skills/prjct/')
+    console.log('  ✓ project CLAUDE.md updated with routing block')
+    console.log('')
+    console.log("  You don't run prjct commands. Claude does.")
+    console.log('')
+    console.log("  Just describe what you're doing — Claude reads the intent and")
+    console.log('  runs the right verb. Routine captures (decision, learning,')
+    console.log('  gotcha, idea) save automatically; ship and other destructive')
+    console.log('  verbs surface a one-line plan and wait for your OK.')
+    console.log('')
+    console.log('  If you want to drive manually:')
+    console.log('    prjct sync       Refresh context + skill body')
+    console.log('    prjct task       Start a task')
+    console.log('    prjct hooks      Auto-sync on commit/checkout')
     console.log('')
 
     if (wizardResult) {

--- a/core/services/project-claude-md.ts
+++ b/core/services/project-claude-md.ts
@@ -1,0 +1,81 @@
+/**
+ * Project CLAUDE.md — routing block writer.
+ *
+ * Writes (or refreshes between markers) a small block at the project's
+ * `CLAUDE.md` that tells Claude "this project uses prjct — refer to
+ * the global skill, don't make the user type commands". Idempotent
+ * via the same `mergeWithMarkers` helper used by the global config.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { mergeWithMarkers } from '../infrastructure/ide-project-installer'
+import { getErrorMessage, isNotFoundError } from '../types/fs'
+
+const START_MARKER = '<!-- prjct:routing - do not edit between markers -->'
+const END_MARKER = '<!-- /prjct:routing - managed by prjct -->'
+
+const ROUTING_BODY = `## prjct usage
+
+This project uses prjct for memory + workflow tracking. **Do not ask the
+user to run prjct commands** — recognize their intent and run the right
+verb yourself.
+
+The full verb intent map and the suggest-vs-auto-execute protocol live
+in the global skill at \`~/.claude/skills/prjct/SKILL.md\`. Two reminders
+that travel with this project:
+
+- **Routine captures auto-execute, no permission.** When the user mentions
+  a decision, learning, gotcha, or random thought, save it via
+  \`prjct remember <type>\` or \`prjct capture\` immediately and confirm in
+  one line. Asking "want me to save that?" is the failure mode.
+- **Destructive verbs suggest first.** \`ship\`, \`status done\`, \`prefs set\`,
+  and the audit/security/investigate workflows surface a one-line plan
+  ("I'll run \`prjct ship\` — bumps version, opens PR. Ok?") and wait for
+  green light.
+
+When in doubt: capture is always safe; ship is never silent.`
+
+const FULL_BLOCK = `${START_MARKER}
+${ROUTING_BODY}
+${END_MARKER}
+`
+
+/**
+ * Write or refresh the prjct routing block at `<projectPath>/CLAUDE.md`.
+ *
+ * - File missing → create with just the block + trailing newline.
+ * - File present without markers → append (with separator).
+ * - File present with markers → replace block content; user content
+ *   outside markers is preserved.
+ */
+export async function writeProjectClaudeMd(
+  projectPath: string
+): Promise<{ action: 'created' | 'updated' | 'unchanged'; path: string }> {
+  const file = path.join(projectPath, 'CLAUDE.md')
+  let existing = ''
+  let fileExists = true
+  try {
+    existing = await fs.readFile(file, 'utf-8')
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw new Error(`Could not read ${file}: ${getErrorMessage(error)}`)
+    }
+    fileExists = false
+  }
+
+  const merged = mergeWithMarkers(fileExists ? existing : '', FULL_BLOCK, START_MARKER, END_MARKER)
+
+  if (fileExists && merged.content === existing) {
+    return { action: 'unchanged', path: file }
+  }
+
+  await fs.writeFile(file, merged.content, 'utf-8')
+  return {
+    action: fileExists ? 'updated' : 'created',
+    path: file,
+  }
+}
+
+// Exposed for test-only assertions on the exact block shape.
+export const _routing = { START_MARKER, END_MARKER, FULL_BLOCK }


### PR DESCRIPTION
Closes the UX adoption plan. `prjct init` writes a per-project routing block (idempotent, marker-anchored), and the post-init output leads with 'You don't run prjct commands. Claude does.' 4 new tests. 1006/1006 pass.