### PR TITLE
refactor(hooks): introduce runHook<I> runner — DRY the hook quartet

### DIFF
--- a/core/hooks/_runner.ts
+++ b/core/hooks/_runner.ts
@@ -1,0 +1,47 @@
+/**
+ * Hook lifecycle runner. Replaces the boilerplate quartet
+ * `safeRun + readStdinSafe + buildHookOutput + emit` that every hook
+ * entry-point used to repeat verbatim.
+ *
+ * A hook now declares only what makes IT distinctive:
+ *   - the Claude Code event name (so the output schema is correct)
+ *   - an optional `build` that produces the additionalContext / null
+ *   - an optional `afterEmit` for side-effects that must not block the
+ *     host (DB writes, vault regen, self-heal, etc.)
+ *
+ * The runner guarantees:
+ *   1. Never throws past the harness — `safeRun` swallows all errors.
+ *   2. stdin is read with the standard 200ms timeout.
+ *   3. Output is JSON-validated against the event's schema by
+ *      `buildHookOutput` (e.g. SessionStart accepts hookSpecificOutput,
+ *      Stop only accepts systemMessage).
+ *   4. After-effects run AFTER `emit` so the host parser doesn't wait
+ *      on side-effect work.
+ */
+
+import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
+
+export interface RunHookOptions<I> {
+  /** Claude Code event name (SessionStart, UserPromptSubmit, etc.). */
+  event: string
+  /** Project path; defaults to process.cwd(). */
+  projectPath?: string
+  /** Build the additionalContext / systemMessage body. Return null to
+   *  inject nothing (the runner emits `{}` instead). Omit for hooks
+   *  that are purely side-effect driven. */
+  build?: (input: I, projectPath: string) => Promise<string | null>
+  /** Optional side-effects that run AFTER emit. The runner already
+   *  swallows errors thrown here via safeRun; explicit try/catch is
+   *  only needed when you want to keep going after a sub-step fails. */
+  afterEmit?: (input: I, projectPath: string) => Promise<void>
+}
+
+export async function runHook<I = Record<string, unknown>>(opts: RunHookOptions<I>): Promise<void> {
+  const projectPath = opts.projectPath ?? process.cwd()
+  await safeRun(async () => {
+    const input = await readStdinSafe<I>()
+    const context = opts.build ? await opts.build(input, projectPath) : null
+    emit(buildHookOutput(opts.event, context))
+    if (opts.afterEmit) await opts.afterEmit(input, projectPath)
+  })
+}

--- a/core/hooks/cwd-changed.ts
+++ b/core/hooks/cwd-changed.ts
@@ -9,18 +9,20 @@
  * If the new cwd has no prjct project, we emit `{}` — no noise.
  */
 
-import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
 import { buildSessionContext } from './session-start'
 
 interface HookInput {
   cwd?: string
 }
 
-export async function runCwdChangedHook(fallbackCwd: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    const input = await readStdinSafe<HookInput>()
-    const cwd = input.cwd || fallbackCwd
-    const context = await buildSessionContext(cwd)
-    emit(buildHookOutput('CwdChanged', context))
+export function runCwdChangedHook(fallbackCwd: string = process.cwd()): Promise<void> {
+  return runHook<HookInput>({
+    event: 'CwdChanged',
+    projectPath: fallbackCwd,
+    build: async (input, fallback) => {
+      const cwd = input.cwd || fallback
+      return buildSessionContext(cwd)
+    },
   })
 }

--- a/core/hooks/post-edit.ts
+++ b/core/hooks/post-edit.ts
@@ -10,45 +10,37 @@
 
 import configManager from '../infrastructure/config-manager'
 import { memoryService } from '../services/memory-service'
-import { emit, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
 
-interface EditToolInput {
-  file_path?: string
-}
-
-interface WriteToolInput {
+interface EditOrWriteToolInput {
   file_path?: string
 }
 
 interface HookInput {
   tool_name?: string
-  tool_input?: EditToolInput | WriteToolInput
+  tool_input?: EditOrWriteToolInput
 }
 
-export async function runPostEditHook(projectPath: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    const input = await readStdinSafe<HookInput>()
-    const file = input.tool_input?.file_path
-    if (!file) {
-      emit({})
-      return
-    }
-    const config = await configManager.readConfig(projectPath)
-    if (!config?.projectId) {
-      emit({})
-      return
-    }
-    // Event-sourced — downstream hooks/workflows can query via
-    // `memoryService.getRecent()` filtering on `post_edit`. Fire and
-    // forget; any failure is non-critical.
-    try {
-      await memoryService.log(projectPath, 'post_edit', {
-        file,
-        tool: input.tool_name ?? 'unknown',
-      })
-    } catch {
-      // swallow — hook must never surface errors
-    }
-    emit({})
+export function runPostEditHook(projectPath: string = process.cwd()): Promise<void> {
+  return runHook<HookInput>({
+    event: 'PostToolUse',
+    projectPath,
+    afterEmit: async (input, p) => {
+      const file = input.tool_input?.file_path
+      if (!file) return
+      const config = await configManager.readConfig(p)
+      if (!config?.projectId) return
+      // Event-sourced — downstream hooks/workflows can query via
+      // `memoryService.getRecent()` filtering on `post_edit`. Fire and
+      // forget; any failure is non-critical.
+      try {
+        await memoryService.log(p, 'post_edit', {
+          file,
+          tool: input.tool_name ?? 'unknown',
+        })
+      } catch {
+        /* swallow — hook must never surface errors */
+      }
+    },
   })
 }

--- a/core/hooks/pre-commit.ts
+++ b/core/hooks/pre-commit.ts
@@ -15,7 +15,7 @@
 import { execSync } from 'node:child_process'
 import configManager from '../infrastructure/config-manager'
 import { formatMemoryMd, type MemoryEntry, projectMemory } from '../memory/project-memory'
-import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
 
 const MAX_CHARS = 1200
 const MAX_ENTRIES = 3
@@ -103,18 +103,17 @@ async function buildPreCommitContext(projectPath: string): Promise<string | null
   return body.length > MAX_CHARS ? `${body.slice(0, MAX_CHARS - 20)}\n… [truncated]` : body
 }
 
-export async function runPreCommitHook(projectPath: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    const input = await readStdinSafe<HookInput>()
-    // Only fire for `git commit` invocations — the matcher in
-    // settings.json already narrows to Bash, but the `if:` clause
-    // is pattern-based and the host may pass us other Bash calls.
-    const command = input.tool_input?.command ?? ''
-    if (!/\bgit\s+commit\b/.test(command)) {
-      emit({})
-      return
-    }
-    const context = await buildPreCommitContext(projectPath)
-    emit(buildHookOutput('PreToolUse', context))
+export function runPreCommitHook(projectPath: string = process.cwd()): Promise<void> {
+  return runHook<HookInput>({
+    event: 'PreToolUse',
+    projectPath,
+    build: async (input, p) => {
+      // Only fire for `git commit` invocations — the matcher in
+      // settings.json already narrows to Bash, but the `if:` clause
+      // is pattern-based and the host may pass us other Bash calls.
+      const command = input.tool_input?.command ?? ''
+      if (!/\bgit\s+commit\b/.test(command)) return null
+      return buildPreCommitContext(p)
+    },
   })
 }

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -21,7 +21,8 @@ import { shippedStorage } from '../storage/shipped-storage'
 import { stateStorage } from '../storage/state-storage'
 import { execFileAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
-import { buildHookOutput, emit, extractKeywords, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
+import { extractKeywords } from './_shared'
 
 const MAX_CHARS = 1800
 const MAX_ENTRIES = 4
@@ -263,31 +264,27 @@ function formatRelative(isoTimestamp: string): string {
   return `${Math.floor(days / 30)}mo ago`
 }
 
-export async function runPromptHook(projectPath: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    const input = await readStdinSafe<HookInput>()
-    const prompt = (input.prompt ?? '').trim()
-    if (!prompt) {
-      emit({})
-      return
-    }
-    // Three pass: state (for intent disambiguation) + memory (for topical
-    // recall) + improvement signals (proactive UX nudges from prior
-    // sessions). All independent, each silently null'd on failure.
-    const [state, memory, signals] = await Promise.all([
-      buildProjectState(projectPath),
-      buildPromptContext(projectPath, prompt),
-      buildImprovementSignals(projectPath),
-    ])
-    const blocks = [state, signals, memory].filter((b): b is string => Boolean(b))
-    if (blocks.length === 0) {
-      emit(buildHookOutput('UserPromptSubmit', null))
-      return
-    }
-    let context = blocks.join('\n\n')
-    if (context.length > MAX_CHARS) {
-      context = `${context.slice(0, MAX_CHARS - 20)}\n… [truncated]`
-    }
-    emit(buildHookOutput('UserPromptSubmit', context))
+export function runPromptHook(projectPath: string = process.cwd()): Promise<void> {
+  return runHook<HookInput>({
+    event: 'UserPromptSubmit',
+    projectPath,
+    build: async (input, p) => {
+      const prompt = (input.prompt ?? '').trim()
+      if (!prompt) return null
+      // Three pass: state (for intent disambiguation) + memory (for topical
+      // recall) + improvement signals (proactive UX nudges from prior
+      // sessions). All independent, each silently null'd on failure.
+      const [state, memory, signals] = await Promise.all([
+        buildProjectState(p),
+        buildPromptContext(p, prompt),
+        buildImprovementSignals(p),
+      ])
+      const blocks = [state, signals, memory].filter((b): b is string => Boolean(b))
+      if (blocks.length === 0) return null
+      const context = blocks.join('\n\n')
+      return context.length > MAX_CHARS
+        ? `${context.slice(0, MAX_CHARS - 20)}\n… [truncated]`
+        : context
+    },
   })
 }

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -35,7 +35,7 @@ import { isSyncCurrent, runSelfHeal } from '../infrastructure/self-heal'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import type { LocalConfig, ProjectPersona } from '../types/config'
 import { VERSION } from '../utils/version'
-import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
 
 interface HookInput {
   source?: 'startup' | 'resume' | 'clear' | 'compact'
@@ -85,37 +85,41 @@ function formatPersona(persona: ProjectPersona): string {
  * Top-level entry — read stdin, emit JSON, exit.
  * Never throws; hook failures must not break the host session.
  */
-export async function runSessionStartHook(projectPath: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    await readStdinSafe<HookInput>()
-    // Read once; pass to both the context builder and the regen call so
-    // we're not doing two disk reads on a hot path that fires on every
-    // session start.
-    const config = await configManager.readConfig(projectPath).catch(() => null)
-    const context = await buildSessionContext(projectPath, config)
-    emit(buildHookOutput('SessionStart', context))
+export function runSessionStartHook(projectPath: string = process.cwd()): Promise<void> {
+  // Captured by the build closure so afterEmit can reuse it without a
+  // second disk read on the hot path that fires on every session start.
+  let cachedConfig: LocalConfig | null = null
 
-    // Refresh the Obsidian vault from DB so the files Claude may Read
-    // reflect current project state. Best-effort; errors are swallowed.
-    if (config?.projectId) {
-      await regenerateWikiDeferred(projectPath, config.projectId).catch(() => undefined)
-    }
+  return runHook<HookInput>({
+    event: 'SessionStart',
+    projectPath,
+    build: async (_input, p) => {
+      cachedConfig = await configManager.readConfig(p).catch(() => null)
+      return buildSessionContext(p, cachedConfig)
+    },
+    afterEmit: async (_input, p) => {
+      // Refresh the Obsidian vault from DB so the files Claude may Read
+      // reflect current project state. Best-effort; errors are swallowed.
+      if (cachedConfig?.projectId) {
+        await regenerateWikiDeferred(p, cachedConfig.projectId).catch(() => undefined)
+      }
 
-    // Self-heal hooks + global CLAUDE.md when the binary moved past the
-    // last sync. Catches machines where postinstall is disabled by
-    // security policy. Hot path is one fs read of the stamp file.
-    if (!isSyncCurrent(VERSION)) {
-      await runSelfHeal(VERSION).catch(() => undefined)
-    }
+      // Self-heal hooks + global CLAUDE.md when the binary moved past the
+      // last sync. Catches machines where postinstall is disabled by
+      // security policy. Hot path is one fs read of the stamp file.
+      if (!isSyncCurrent(VERSION)) {
+        await runSelfHeal(VERSION).catch(() => undefined)
+      }
 
-    // M5: opt-in silent auto-update. No-op unless the user has opted
-    // in via `prjct config set auto-update on`. Throttled to 1/hour
-    // and runs detached so the session never waits.
-    try {
-      const { maybeAutoUpdate } = await import('../services/auto-updater')
-      maybeAutoUpdate(VERSION)
-    } catch {
-      // never block the session on update mechanics
-    }
+      // M5: opt-in silent auto-update. No-op unless the user has opted
+      // in via `prjct config set auto-update on`. Throttled to 1/hour
+      // and runs detached so the session never waits.
+      try {
+        const { maybeAutoUpdate } = await import('../services/auto-updater')
+        maybeAutoUpdate(VERSION)
+      } catch {
+        // never block the session on update mechanics
+      }
+    },
   })
 }

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -1,21 +1,20 @@
 /**
  * Stop hook — fires when Claude finishes a turn.
  *
- * Silent by contract. The hook does two useful things:
- *   1. Ingests any markdown notes the user dropped into the vault's
- *      `captured/` directory into SQLite.
- *   2. Regenerates the `_generated/` vault snapshot so the on-disk
- *      files reflect current DB state.
+ * Silent by contract. The hook does several useful things, all in
+ * `afterEmit` so the host parser doesn't wait on housekeeping:
+ *   1. Ingest captured/ notes + workflow edits → SQLite.
+ *   2. Mine the assistant transcript for substantive captures.
+ *   3. Detect durable patterns (hot files, debt growth).
+ *   4. Run session-end housekeeping (inbox age-out, archive prune).
+ *   5. Detect friction signals from user pushback in the transcript.
+ *   6. Regenerate the `_generated/` vault snapshot.
  *
- * It deliberately injects no user-visible message. An earlier version
- * nagged Claude with "N file edits this session without a memory
- * entry" when it counted raw `memory.post_edit` events but no
- * checkpoint events. That nag violated prjct's anti-harness contract:
- * memory capture flows through the explicit primitives (`remember`,
- * `capture`, `ship`) — telling the model "you forgot to capture" is
- * exactly the kind of harness behavior the project rejects (mem_220).
- * If prjct wants implicit checkpointing, it has to do it itself, not
- * delegate the chore to Claude.
+ * Each step internally swallows its own failures, so the rest of
+ * cleanup still runs even if one step trips. The hook deliberately
+ * injects no user-visible message — see mem_220 for the anti-harness
+ * rationale (we used to nag "N edits without a memory entry"; that
+ * delegated capture to Claude instead of doing it ourselves).
  */
 
 import configManager from '../infrastructure/config-manager'
@@ -25,83 +24,81 @@ import { recordCleanupReport, runSessionCleanup } from '../services/session-clea
 import { ingestTranscript } from '../services/transcript-learner'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
-import { emit, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
 
 interface HookInput {
   transcript_path?: string
   session_id?: string
 }
 
-export async function runStopHook(projectPath: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    const input = await readStdinSafe<HookInput>()
-    emit({})
+export function runStopHook(projectPath: string = process.cwd()): Promise<void> {
+  return runHook<HookInput>({
+    event: 'Stop',
+    projectPath,
+    afterEmit: async (input, p) => {
+      const config = await configManager.readConfig(p).catch(() => null)
+      if (!config?.projectId) return
 
-    // Side effects: ingest user-authored content → DB, then refresh the
-    // _generated/ snapshot. Best-effort; failures stay silent so the
-    // host session is never disturbed.
-    const config = await configManager.readConfig(projectPath).catch(() => null)
-    if (!config?.projectId) return
-
-    // Captured notes → memory entries (existing behavior).
-    try {
-      await ingestCapturedNotes(projectPath)
-    } catch {
-      // Ingest failure shouldn't block regen — captured/ stays for next turn.
-    }
-
-    // M1b INPUT: workflow overrides → workflow_rules table.
-    try {
-      await ingestWorkflowEdits(projectPath)
-    } catch {
-      // Same contract — failed parses leave the file in place for the user.
-    }
-
-    // M1a: auto-capture substantive insights from the assistant's
-    // transcript. Conservative heuristics, hashed-dedup, never blocks.
-    if (input.transcript_path) {
+      // Captured notes → memory entries (existing behavior).
       try {
-        await ingestTranscript(projectPath, input.transcript_path, input.session_id ?? null)
+        await ingestCapturedNotes(p)
       } catch {
-        // Failed parse / unexpected format → swallow. The user can
-        // always run `prjct remember` explicitly.
+        // Ingest failure shouldn't block regen — captured/ stays for next turn.
       }
-    }
 
-    // M2: detect durable patterns (hot files for now) and persist them
-    // as learning memory entries. Lookup-first protocol means Claude
-    // finds them on next session start without inflating context.
-    try {
-      await detectAndPersistPatterns(projectPath)
-    } catch {
-      // Git failure / non-repo → swallow; nothing to do here.
-    }
-
-    // Session-end housekeeping (Phase A): age-out inbox, prune archives
-    // and old checkpoints, rotate stale on-disk caches. Best-effort —
-    // each step internally swallows its own failures, so the rest of
-    // the cleanup still runs even if one step trips.
-    try {
-      const cleanup = await runSessionCleanup(config.projectId)
-      await recordCleanupReport(config.projectId, cleanup)
-    } catch {
-      /* never block session end on cleanup */
-    }
-
-    // Session-end friction capture (Phase B): scan the transcript for
-    // user-pushback moments (negation, correction, complaint markers)
-    // and persist them as `improvement-signal` memory entries. The
-    // next session's Claude reads them via topical recall and
-    // synthesises improvement ideas — no regex-based classification
-    // here, only signal extraction.
-    if (input.transcript_path) {
+      // M1b INPUT: workflow overrides → workflow_rules table.
       try {
-        await detectFriction(projectPath, input.transcript_path, input.session_id ?? null)
+        await ingestWorkflowEdits(p)
       } catch {
-        /* same contract as transcript-learner — silent best-effort */
+        // Same contract — failed parses leave the file in place for the user.
       }
-    }
 
-    await regenerateWikiDeferred(projectPath, config.projectId).catch(() => undefined)
+      // M1a: auto-capture substantive insights from the assistant's
+      // transcript. Conservative heuristics, hashed-dedup, never blocks.
+      if (input.transcript_path) {
+        try {
+          await ingestTranscript(p, input.transcript_path, input.session_id ?? null)
+        } catch {
+          // Failed parse / unexpected format → swallow. The user can
+          // always run `prjct remember` explicitly.
+        }
+      }
+
+      // M2: detect durable patterns (hot files for now) and persist them
+      // as learning memory entries. Lookup-first protocol means Claude
+      // finds them on next session start without inflating context.
+      try {
+        await detectAndPersistPatterns(p)
+      } catch {
+        // Git failure / non-repo → swallow; nothing to do here.
+      }
+
+      // Session-end housekeeping (Phase A): age-out inbox, prune archives
+      // and old checkpoints, rotate stale on-disk caches. Best-effort —
+      // each step internally swallows its own failures, so the rest of
+      // the cleanup still runs even if one step trips.
+      try {
+        const cleanup = await runSessionCleanup(config.projectId)
+        await recordCleanupReport(config.projectId, cleanup)
+      } catch {
+        /* never block session end on cleanup */
+      }
+
+      // Session-end friction capture (Phase B): scan the transcript for
+      // user-pushback moments (negation, correction, complaint markers)
+      // and persist them as `improvement-signal` memory entries. The
+      // next session's Claude reads them via topical recall and
+      // synthesises improvement ideas — no regex-based classification
+      // here, only signal extraction.
+      if (input.transcript_path) {
+        try {
+          await detectFriction(p, input.transcript_path, input.session_id ?? null)
+        } catch {
+          /* same contract as transcript-learner — silent best-effort */
+        }
+      }
+
+      await regenerateWikiDeferred(p, config.projectId).catch(() => undefined)
+    },
   })
 }

--- a/core/hooks/subagent-start.ts
+++ b/core/hooks/subagent-start.ts
@@ -8,13 +8,13 @@
  * WHAT (role, MCPs, recent memory), never CÓMO.
  */
 
-import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
+import { runHook } from './_runner'
 import { buildSessionContext } from './session-start'
 
-export async function runSubagentStartHook(projectPath: string = process.cwd()): Promise<void> {
-  await safeRun(async () => {
-    await readStdinSafe()
-    const context = await buildSessionContext(projectPath)
-    emit(buildHookOutput('SubagentStart', context))
+export function runSubagentStartHook(projectPath: string = process.cwd()): Promise<void> {
+  return runHook({
+    event: 'SubagentStart',
+    projectPath,
+    build: (_input, p) => buildSessionContext(p),
   })
 }


### PR DESCRIPTION
## Summary

Every hook used to repeat the same lifecycle quartet — `safeRun + readStdinSafe + buildHookOutput + emit` — plus its own ad-hoc emit-empty-on-no-input path. New `core/hooks/_runner.ts` exports a single `runHook<I>({ event, build, afterEmit, projectPath })` that handles the entire lifecycle declaratively.

**The runner guarantees:**
- `safeRun` wrap (never throws past the harness)
- 200ms stdin timeout via `readStdinSafe`
- Schema-correct envelope via `buildHookOutput` (SessionStart/UserPromptSubmit/PostToolUse get `hookSpecificOutput`; others get `systemMessage`)
- `afterEmit` runs AFTER `emit` so the host parser doesn't wait on housekeeping (vault regen, transcript ingest, friction detection, self-heal)

**Migrated all 7 hook entry-points:**
- `cwd-changed.ts`
- `subagent-start.ts`
- `post-edit.ts`
- `pre-commit.ts`
- `prompt.ts`
- `session-start.ts`
- `stop.ts`

`buildHookOutput`, `extractKeywords`, and the helpers in `_shared.ts` stay exactly where they are — `_runner.ts` composes them, doesn't replace them.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun x biome check core/hooks/` clean
- [x] `bun test` — 1029 pass, 0 fail (3461 expects)
- [x] `core/__tests__/hooks/hook-schema.test.ts` (schema-routing pin) untouched
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)