### PR TITLE
refactor(analysis): zod-validate analysis-save-llm input

### DIFF
--- a/core/__tests__/schemas/llm-analysis.test.ts
+++ b/core/__tests__/schemas/llm-analysis.test.ts
@@ -1,0 +1,121 @@
+/**
+ * LLM Analysis schema — pins the validation contract used by
+ * `prjct analysis-save-llm`. The bar: the LLM CAN'T accidentally
+ * write garbage into SQLite that breaks the vault generator
+ * downstream.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { LLMAnalysisSchema, parseLlmAnalysis } from '../../schemas/llm-analysis'
+
+const MINIMAL_VALID = {
+  version: 1 as const,
+  commitHash: null,
+  analyzedAt: '2026-05-02T12:00:00.000Z',
+  architecture: { style: 'monolith', insights: [], domains: [] },
+  patterns: [],
+  antiPatterns: [],
+  techDebt: [],
+  riskAreas: [],
+  refactorSuggestions: [],
+  projectInsights: [],
+  conventions: [],
+}
+
+describe('LLMAnalysisSchema', () => {
+  it('accepts a minimally valid payload', () => {
+    const r = parseLlmAnalysis(MINIMAL_VALID)
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects missing required field with a path-prefixed error', () => {
+    const broken = { ...MINIMAL_VALID, architecture: undefined }
+    const r = parseLlmAnalysis(broken)
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('architecture')
+  })
+
+  it('rejects scalar where array is required (the regression class)', () => {
+    const r = parseLlmAnalysis({ ...MINIMAL_VALID, patterns: 42 })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('patterns')
+  })
+
+  it('rejects out-of-range confidence', () => {
+    const r = parseLlmAnalysis({
+      ...MINIMAL_VALID,
+      patterns: [
+        {
+          name: 'x',
+          description: 'd',
+          locations: [],
+          confidence: 1.5, // > 1
+          category: 'c',
+        },
+      ],
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('patterns.0.confidence')
+  })
+
+  it('rejects unknown severity enum', () => {
+    const r = parseLlmAnalysis({
+      ...MINIMAL_VALID,
+      antiPatterns: [
+        {
+          issue: 'x',
+          reasoning: 'y',
+          files: [],
+          suggestion: 'z',
+          severity: 'critical', // not in enum
+          confidence: 0.5,
+        },
+      ],
+    })
+    expect(r.ok).toBe(false)
+  })
+
+  it('accepts the full schema with optional fields populated', () => {
+    const full = {
+      ...MINIMAL_VALID,
+      patterns: [
+        {
+          name: 'p1',
+          description: 'd',
+          locations: ['a/b.ts'],
+          confidence: 0.9,
+          category: 'arch',
+        },
+      ],
+      antiPatterns: [
+        {
+          issue: 'i',
+          reasoning: 'r',
+          files: ['x'],
+          suggestion: 's',
+          severity: 'high' as const,
+          confidence: 0.8,
+        },
+      ],
+      techDebt: [
+        {
+          description: 't',
+          area: 'a',
+          effort: 'small' as const,
+          impact: 'i',
+          priority: 'medium' as const,
+        },
+      ],
+      commands: { build: 'bun run build' },
+      stack: { languages: ['TypeScript'], frameworks: ['Bun'] },
+    }
+    const r = LLMAnalysisSchema.safeParse(full)
+    expect(r.success).toBe(true)
+  })
+
+  it('produces a multi-issue error string when several fields fail', () => {
+    const r = parseLlmAnalysis({ version: 'wrong', architecture: 'string' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error.split(';').length).toBeGreaterThan(1)
+  })
+})

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs/promises'
 import analyzer from '../domain/analyzer'
 import configManager from '../infrastructure/config-manager'
 import pathManager from '../infrastructure/path-manager'
+import { parseLlmAnalysis } from '../schemas/llm-analysis'
 import { formatCost } from '../schemas/metrics'
 import { formatAnalysisDiffMd, formatAnalysisDiffText } from '../services/analysis-diff'
 import { buildAnalysisPayload } from '../services/analysis-payload-builder'
@@ -453,12 +454,24 @@ export class AnalysisCommands extends PrjctCommandsBase {
         return { success: false, error: 'No project ID found' }
       }
 
-      const analysis = JSON.parse(analysisJson)
-
-      // Validate basic structure
-      if (!analysis.version || !analysis.architecture || !analysis.patterns) {
-        return { success: false, error: 'Invalid LLM analysis format. Missing required fields.' }
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(analysisJson)
+      } catch (error) {
+        return {
+          success: false,
+          error: `Invalid JSON: ${error instanceof Error ? error.message : 'parse failed'}`,
+        }
       }
+
+      const validation = parseLlmAnalysis(parsed)
+      if (!validation.ok) {
+        return {
+          success: false,
+          error: `Invalid LLM analysis schema: ${validation.error}`,
+        }
+      }
+      const analysis = validation.value
 
       llmAnalysisStorage.save(projectId, analysis)
 

--- a/core/schemas/llm-analysis.ts
+++ b/core/schemas/llm-analysis.ts
@@ -1,0 +1,120 @@
+/**
+ * Zod schema mirroring `core/types/llm-analysis.ts`.
+ *
+ * Used by `prjct analysis-save-llm` (and any caller persisting LLM
+ * output) to validate the payload BEFORE it lands in SQLite. The
+ * previous validation was a three-field truthy check
+ * (`!analysis.version || !analysis.architecture || !analysis.patterns`),
+ * which let through structurally-broken payloads (e.g. `architecture`
+ * as a string, `patterns` as a number) that broke the wiki-generator
+ * downstream when it tried to iterate fields that weren't arrays.
+ *
+ * The schema accepts unknown extra keys (`.passthrough()` would defeat
+ * the purpose) but enforces the shape for every field we actually
+ * read.
+ */
+
+import { z } from 'zod'
+
+const ArchitectureInsightSchema = z.object({
+  style: z.string(),
+  insights: z.array(z.string()),
+  domains: z.array(z.string()),
+})
+
+const LLMPatternSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  locations: z.array(z.string()),
+  confidence: z.number().min(0).max(1),
+  category: z.string(),
+})
+
+const LLMAntiPatternSchema = z.object({
+  issue: z.string(),
+  reasoning: z.string(),
+  files: z.array(z.string()),
+  suggestion: z.string(),
+  severity: z.enum(['low', 'medium', 'high']),
+  confidence: z.number().min(0).max(1),
+})
+
+const TechDebtItemSchema = z.object({
+  description: z.string(),
+  area: z.string(),
+  effort: z.enum(['small', 'medium', 'large']),
+  impact: z.string(),
+  priority: z.enum(['low', 'medium', 'high']),
+})
+
+const RiskAreaSchema = z.object({
+  path: z.string(),
+  reason: z.string(),
+  risk: z.string(),
+  severity: z.enum(['low', 'medium', 'high']),
+})
+
+const RefactorSuggestionSchema = z.object({
+  description: z.string(),
+  files: z.array(z.string()),
+  benefit: z.string(),
+  effort: z.enum(['small', 'medium', 'large']),
+})
+
+const ConventionSchema = z.object({
+  category: z.string(),
+  rule: z.string(),
+  example: z.string().optional(),
+})
+
+const CommandsSchema = z.object({
+  build: z.string().optional(),
+  test: z.string().optional(),
+  lint: z.string().optional(),
+  dev: z.string().optional(),
+  format: z.string().optional(),
+  install: z.string().optional(),
+})
+
+const StackSchema = z.object({
+  languages: z.array(z.string()),
+  frameworks: z.array(z.string()),
+  packageManager: z.string().optional(),
+})
+
+export const LLMAnalysisSchema = z.object({
+  version: z.literal(1),
+  commitHash: z.string().nullable(),
+  analyzedAt: z.string(),
+  architecture: ArchitectureInsightSchema,
+  patterns: z.array(LLMPatternSchema),
+  antiPatterns: z.array(LLMAntiPatternSchema),
+  techDebt: z.array(TechDebtItemSchema),
+  riskAreas: z.array(RiskAreaSchema),
+  refactorSuggestions: z.array(RefactorSuggestionSchema),
+  projectInsights: z.array(z.string()),
+  conventions: z.array(ConventionSchema),
+  commands: CommandsSchema.optional(),
+  stack: StackSchema.optional(),
+})
+
+/**
+ * `safeParse` wrapper that returns either the validated payload or a
+ * formatted error string (no exceptions). Caller decides whether to
+ * surface the error to the user via the CLI's normal `success/error`
+ * envelope.
+ */
+export function parseLlmAnalysis(
+  data: unknown
+): { ok: true; value: z.infer<typeof LLMAnalysisSchema> } | { ok: false; error: string } {
+  const result = LLMAnalysisSchema.safeParse(data)
+  if (result.success) return { ok: true, value: result.data }
+  // Flatten zod's nested issue tree into a single readable line per error
+  // so the LLM sees actionable feedback ("patterns.0.confidence: expected
+  // number, received string") instead of the full ZodError dump.
+  const messages = result.error.issues.map((i) => {
+    const path = i.path.length > 0 ? i.path.join('.') : '<root>'
+    return `${path}: ${i.message}`
+  })
+  return { ok: false, error: messages.join('; ') }
+}


### PR DESCRIPTION
## Summary

`prjct analysis-save-llm` accepted a JSON blob from the LLM with a three-field truthy check:

```ts
if (!analysis.version || !analysis.architecture || !analysis.patterns) {
  return { success: false, error: 'Invalid LLM analysis format. Missing required fields.' }
}
```

This let through structurally-broken payloads (e.g. `architecture` as a string, `patterns` as a number, `confidence` > 1) that broke the wiki-generator downstream when it tried to iterate fields that weren't arrays. Vault-flagged refactor (`stillActive: true`).

## Changes

- **`core/schemas/llm-analysis.ts`** — zod schema mirroring `LLMAnalysis` from `core/types/llm-analysis.ts`. Validates every field we read downstream (architecture, patterns, anti-patterns, tech-debt, risk-areas, refactor-suggestions, conventions, project-insights, optional commands/stack).
- **`core/commands/analysis.ts`** — replaces the truthy check with `parseLlmAnalysis()`. Failure modes become path-prefixed messages (`patterns.0.confidence: expected number, received string`) instead of generic "Invalid format".
- **`core/__tests__/schemas/llm-analysis.test.ts`** — 7 tests pinning the contract: minimal valid, missing required field, scalar-where-array (the regression class), out-of-range confidence, unknown enum, full payload, multi-issue error.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun x biome check core/schemas/ core/commands/analysis.ts` clean
- [x] `bun test` — 1036 pass, 0 fail (was 1029, +7 new schema tests)
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)