### PR TITLE
refactor(commands): collapse ensureProjectInit + getProjectId into requireProject

### DIFF
--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -18,6 +18,7 @@ import type { MdOption } from '../types/cli'
 import type { AnalyzeOptions, CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import * as dateHelper from '../utils/date-helper'
+import { failFromError } from '../utils/md-aware'
 import {
   mdDone,
   mdList,
@@ -121,7 +122,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
       }
     } catch (error) {
       console.error('❌ Error:', getErrorMessage(error))
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 
@@ -314,7 +315,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
       } else {
         out.fail(getErrorMessage(error))
       }
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 
@@ -374,7 +375,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
 
       return { success: true, data: payload }
     } catch (error) {
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 
@@ -420,7 +421,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
       }
       return { success: true }
     } catch (error) {
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 
@@ -483,7 +484,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
 
       return { success: true }
     } catch (error) {
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 
@@ -573,7 +574,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
 
       return { success: true, data: analysis }
     } catch (error) {
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 
@@ -760,7 +761,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
       }
     } catch (error) {
       console.error('❌ Error:', getErrorMessage(error))
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -18,7 +18,7 @@ import type { MdOption } from '../types/cli'
 import type { AnalyzeOptions, CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import * as dateHelper from '../utils/date-helper'
-import { failFromError } from '../utils/md-aware'
+import { failFromError, failHard } from '../utils/md-aware'
 import {
   mdDone,
   mdList,
@@ -1014,8 +1014,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
       return { success: result.valid, data: result }
     } catch (error) {
       const errMsg = getErrorMessage(error)
-      out.fail(errMsg)
-      return { success: false, error: errMsg }
+      return failHard(errMsg)
     }
   }
 

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -39,6 +39,7 @@ import {
   showSyncResult,
 } from './analysis-helpers'
 import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
 
 /** Compact schema reference for LLM — avoids dumping 50+ lines of JSON examples */
 const ANALYSIS_SCHEMA_COMPACT = `{version:1, commitHash, analyzedAt,
@@ -162,14 +163,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
     } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        out.failWithHint('NO_PROJECT_ID')
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const startTime = Date.now()
 
@@ -331,13 +327,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
     options: { json?: boolean; md?: boolean } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       // Quick sync to get fresh data (without full regeneration)
       const result = await syncService.sync(projectPath)
@@ -400,13 +392,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
     options: MdOption = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const fs = await import('node:fs/promises')
       const pathManager = (await import('../infrastructure/path-manager')).default
@@ -446,13 +434,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
     options: MdOption = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const analysis = JSON.parse(analysisJson)
 
@@ -511,13 +495,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
     options: { json?: boolean; md?: boolean } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const analysis = llmAnalysisStorage.getActive(projectId)
 
@@ -615,13 +595,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
     options: { json?: boolean; export?: boolean } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       // Get metrics summary
       const summary = await metricsStorage.getSummary(projectId)
@@ -1016,13 +992,9 @@ export class AnalysisCommands extends PrjctCommandsBase {
 
     // Default: Cryptographic verification (PRJ-263)
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const result = await analysisStorage.verify(projectId)
 

--- a/core/commands/capture.ts
+++ b/core/commands/capture.ts
@@ -21,6 +21,7 @@ import { projectMemory } from '../memory/project-memory'
 import { scanForSecrets } from '../memory/secret-scanner'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
@@ -72,8 +73,7 @@ export class CaptureCommands extends PrjctCommandsBase {
       return { success: true, type: 'inbox', content: text, tags }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/context-checkpoint.ts
+++ b/core/commands/context-checkpoint.ts
@@ -22,7 +22,7 @@ import { getErrorMessage } from '../types/fs'
 import { execAsync, execFileAsync } from '../utils/exec'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
-import { requireProjectId } from './guards'
+import { requireProject } from './guards'
 
 interface ContextCheckpoint {
   /** Schema version for the JSON document. */
@@ -53,10 +53,7 @@ export class ContextCheckpointCommands extends PrjctCommandsBase {
     options: { md?: boolean; notes?: string } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const pid = await requireProjectId(projectPath)
+      const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
       const cleanTitle = (title ?? 'untitled').trim().slice(0, 200) || 'untitled'
@@ -101,10 +98,7 @@ export class ContextCheckpointCommands extends PrjctCommandsBase {
     options: { md?: boolean; list?: boolean; file?: string } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const pid = await requireProjectId(projectPath)
+      const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
       const dir = checkpointDir(pid.value)

--- a/core/commands/context-checkpoint.ts
+++ b/core/commands/context-checkpoint.ts
@@ -20,6 +20,7 @@ import pathManager from '../infrastructure/path-manager'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { execAsync, execFileAsync } from '../utils/exec'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 import { requireProject } from './guards'
@@ -83,8 +84,7 @@ export class ContextCheckpointCommands extends PrjctCommandsBase {
       return { success: true, file: filename, title: cleanTitle }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -152,8 +152,7 @@ export class ContextCheckpointCommands extends PrjctCommandsBase {
       return { success: true, checkpoint, file: path.basename(target) }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/crew.ts
+++ b/core/commands/crew.ts
@@ -15,6 +15,7 @@ import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { fileExists } from '../utils/file-helper'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
@@ -206,8 +207,7 @@ export class CrewCommands extends PrjctCommandsBase {
       return { success: true, written, skipped }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -266,8 +266,7 @@ export class CrewCommands extends PrjctCommandsBase {
       return { success: true, removed, missing }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -307,8 +306,7 @@ export class CrewCommands extends PrjctCommandsBase {
       return { success: true, complete: status.complete, status }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/guards.ts
+++ b/core/commands/guards.ts
@@ -9,6 +9,7 @@
 
 import configManager from '../infrastructure/config-manager'
 import type { CurrentTask } from '../schemas/state'
+import { projectService } from '../services/project-service'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
 import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
@@ -21,14 +22,38 @@ type Guard<T> = { ok: true; value: T } | { ok: false; result: CommandResult }
 /**
  * Resolve the projectId for the current repo or fail with a user-facing
  * error. Wraps the three-line boilerplate that every v2 primitive needed.
+ *
+ * In md mode emits the same message as a blockquote so agent callers
+ * see a uniform `> No project ID found...` line.
  */
-export async function requireProjectId(projectPath: string): Promise<Guard<string>> {
+export async function requireProjectId(
+  projectPath: string,
+  options: MdOption = {}
+): Promise<Guard<string>> {
   const projectId = await configManager.getProjectId(projectPath)
   if (!projectId) {
-    out.failWithHint('NO_PROJECT_ID')
+    if (options.md) {
+      console.log('> No project ID found. Run `prjct init` first.')
+    } else {
+      out.failWithHint('NO_PROJECT_ID')
+    }
     return { ok: false, result: { success: false, error: 'No project ID found' } }
   }
   return { ok: true, value: projectId }
+}
+
+/**
+ * `ensureProjectInit + requireProjectId` in a single call. Almost every
+ * command verb opens with this two-step dance; this helper saves the
+ * repetition (~24 sites pre-2.15) and forwards init failures cleanly.
+ */
+export async function requireProject(
+  projectPath: string,
+  options: MdOption = {}
+): Promise<Guard<string>> {
+  const initResult = await projectService.ensureInit(projectPath)
+  if (!initResult.success) return { ok: false, result: initResult }
+  return requireProjectId(projectPath, options)
 }
 
 /**

--- a/core/commands/health.ts
+++ b/core/commands/health.ts
@@ -136,7 +136,7 @@ async function runDimension(projectPath: string, dim: HealthDimension): Promise<
   } catch (error) {
     const stderr = (error as { stderr?: string }).stderr ?? ''
     const stdout = (error as { stdout?: string }).stdout ?? ''
-    const firstNonEmpty = (stderr + '\n' + stdout)
+    const firstNonEmpty = `${stderr}\n${stdout}`
       .split('\n')
       .map((l) => l.trim())
       .find((l) => l.length > 0)

--- a/core/commands/health.ts
+++ b/core/commands/health.ts
@@ -16,7 +16,7 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { execAsync } from '../utils/exec'
 import { fileExists, readJson } from '../utils/file-helper'
-import out from '../utils/output'
+import { failHard } from '../utils/md-aware'
 import { PrjctCommandsBase } from './base'
 
 interface HealthDimension {
@@ -77,8 +77,7 @@ export class HealthCommands extends PrjctCommandsBase {
       return { success: allPass, score, results: results.length }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -16,7 +16,7 @@ import {
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
-import { failFromError } from '../utils/md-aware'
+import { failFromError, failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
@@ -54,8 +54,7 @@ export class InstallCommands extends PrjctCommandsBase {
       return { success: true, hooksWritten: result.hooksWritten }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -81,8 +80,7 @@ export class InstallCommands extends PrjctCommandsBase {
       return { success: true, hooksRemoved: result.hooksRemoved }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -16,6 +16,7 @@ import {
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failFromError } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
@@ -96,7 +97,7 @@ export class InstallCommands extends PrjctCommandsBase {
       const s = await hookStatus()
       return { success: true, installed: s.installed, expected: s.expected }
     } catch (error) {
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 }

--- a/core/commands/mcp.ts
+++ b/core/commands/mcp.ts
@@ -22,6 +22,7 @@ import chalk from 'chalk'
 import { type McpServerInfo, mcpService } from '../services/mcp-service'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
 import { mdOutput, mdSection } from '../utils/md-formatter'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
@@ -168,8 +169,7 @@ export class McpCommands extends PrjctCommandsBase {
       return { success: true, ...result, beforeTools, afterTools }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -193,8 +193,7 @@ export class McpCommands extends PrjctCommandsBase {
       return { success: true, servers }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -210,8 +209,7 @@ export class McpCommands extends PrjctCommandsBase {
       return { success: true, denied }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -243,8 +241,7 @@ export class McpCommands extends PrjctCommandsBase {
       return { success: true, ...result }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -279,8 +276,7 @@ export class McpCommands extends PrjctCommandsBase {
       return { success: true, ...result }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 

--- a/core/commands/planning.ts
+++ b/core/commands/planning.ts
@@ -13,6 +13,7 @@ import { writeProjectClaudeMd } from '../services/project-claude-md'
 import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { CommandResult, InitOptions } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failFromError } from '../utils/md-aware'
 import out from '../utils/output'
 import { detectProjectCommands } from '../utils/project-commands'
 import { OnboardingWizard } from '../workflows/onboarding'
@@ -194,7 +195,7 @@ export class PlanningCommands extends PrjctCommandsBase {
       return { success: true, projectId, wizard: wizardResult }
     } catch (error) {
       out.fail(getErrorMessage(error))
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 

--- a/core/commands/preferences.ts
+++ b/core/commands/preferences.ts
@@ -21,7 +21,7 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
-import { requireProjectId } from './guards'
+import { requireProject } from './guards'
 
 interface PrefsOptions {
   md?: boolean
@@ -38,10 +38,7 @@ export class PreferencesCommands extends PrjctCommandsBase {
     options: PrefsOptions = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const pid = await requireProjectId(projectPath)
+      const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
       const subcommand = args[0] ?? 'list'

--- a/core/commands/preferences.ts
+++ b/core/commands/preferences.ts
@@ -19,6 +19,7 @@ import {
 } from '../storage/preferences-storage'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 import { requireProject } from './guards'
@@ -61,8 +62,7 @@ export class PreferencesCommands extends PrjctCommandsBase {
       }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -18,6 +18,7 @@ import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 import { requireActiveTask, requireProject } from './guards'
@@ -133,8 +134,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       return { success: true, taskId: active.id, status: value }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -185,8 +185,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       return { success: true, taskId: task.value.id, tags }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -214,8 +213,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
 
       const parsed = parseRememberArgs(args)
       if (!parsed.ok) {
-        out.fail(parsed.error)
-        return { success: false, error: parsed.error }
+        return failHard(parsed.error)
       }
       const { type, content } = parsed
 
@@ -259,8 +257,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       return { success: true, type, content, tags }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -20,7 +20,7 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
-import { requireActiveTask, requireProjectId } from './guards'
+import { requireActiveTask, requireProject } from './guards'
 
 const TASK_TYPE_VALUES: readonly TaskType[] = ['feature', 'bug', 'improvement', 'chore']
 
@@ -37,10 +37,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
     options: MdOption = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const pid = await requireProjectId(projectPath)
+      const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
       // Resume-intent bypasses the active-task guard: when the current task
@@ -153,10 +150,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
     options: MdOption = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const pid = await requireProjectId(projectPath)
+      const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
       const task = await requireActiveTask(pid.value, options)
@@ -236,7 +230,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
 
       const tags = parseFlagTags(options.tags)
 
-      const pid = await requireProjectId(projectPath)
+      const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
       // `remember` works even without an active task — you might be

--- a/core/commands/retro.ts
+++ b/core/commands/retro.ts
@@ -23,6 +23,7 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { execFileAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
@@ -93,8 +94,7 @@ export class RetroCommands extends PrjctCommandsBase {
       }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/seed.ts
+++ b/core/commands/seed.ts
@@ -16,6 +16,7 @@ import {
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
@@ -81,8 +82,7 @@ export class SeedCommands extends PrjctCommandsBase {
       return { success: true, ...result }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -114,8 +114,7 @@ export class SeedCommands extends PrjctCommandsBase {
       return { success: true, ...result }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -156,8 +155,7 @@ export class SeedCommands extends PrjctCommandsBase {
       return { success: true, active }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 
@@ -190,8 +188,7 @@ export class SeedCommands extends PrjctCommandsBase {
       return { success: true, suggested: names }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -24,6 +24,7 @@ import {
   MCP_SERVER_PRESETS,
   upsertMcpServer,
 } from '../utils/mcp-config'
+import { failFromError } from '../utils/md-aware'
 import out from '../utils/output'
 import { VERSION } from '../utils/version'
 import { PrjctCommandsBase } from './base'
@@ -695,7 +696,7 @@ echo "⚡ prjct"
 
       return { success: true }
     } catch (error) {
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -22,6 +22,7 @@ import { getErrorMessage } from '../types/fs'
 import type { WorkflowRule } from '../types/storage.js'
 import type { WorkflowRunContext } from '../types/workflow.js'
 import * as dateHelper from '../utils/date-helper'
+import { failFromError } from '../utils/md-aware'
 import { mdDone, mdList, mdNextSteps, mdOutput, mdSection } from '../utils/md-formatter'
 import { getNextSteps, showNextSteps } from '../utils/next-steps'
 import out from '../utils/output'
@@ -168,7 +169,7 @@ export class ShippingCommands extends PrjctCommandsBase {
       return { success: true, feature: featureName, version: newVersion }
     } catch (error) {
       out.fail(getErrorMessage(error))
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 }

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -13,7 +13,6 @@
 
 import { existsSync } from 'node:fs'
 import path from 'node:path'
-import configManager from '../infrastructure/config-manager'
 import { syncService } from '../services/sync-service'
 import { shippedStorage } from '../storage/shipped-storage'
 import { stateStorage } from '../storage/state-storage'
@@ -28,6 +27,7 @@ import { getNextSteps, showNextSteps } from '../utils/next-steps'
 import out from '../utils/output'
 import { executeWorkflowRules } from '../workflow/workflow-engine'
 import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
 
 type ShipIntent = 'register-only' | 'seed-code-workflow' | 'proceed'
 
@@ -44,14 +44,9 @@ export class ShippingCommands extends PrjctCommandsBase {
     options: ShipOptions = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        out.failWithHint('NO_PROJECT_ID')
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       let featureName = feature
 

--- a/core/commands/team.ts
+++ b/core/commands/team.ts
@@ -29,6 +29,7 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
 import { mdOutput, mdSection } from '../utils/md-formatter'
 import out from '../utils/output'
 import { VERSION } from '../utils/version'
@@ -161,8 +162,7 @@ export class TeamCommands extends PrjctCommandsBase {
       }
     } catch (error) {
       const msg = getErrorMessage(error)
-      out.fail(msg)
-      return { success: false, error: msg }
+      return failHard(msg)
     }
   }
 }

--- a/core/commands/update.ts
+++ b/core/commands/update.ts
@@ -19,6 +19,7 @@ import UpdateChecker from '../infrastructure/update-checker'
 import { migrateJsonToSqlite, sweepLegacyJson } from '../storage/migrate-json'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { failFromError } from '../utils/md-aware'
 import out from '../utils/output'
 import { resetPackageRoot, VERSION } from '../utils/version'
 import { PrjctCommandsBase } from './base'
@@ -259,7 +260,7 @@ export class UpdateCommands extends PrjctCommandsBase {
     } catch (error) {
       if (!md) out.stop()
       out.fail(getErrorMessage(error))
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -23,6 +23,7 @@ import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import * as dateHelper from '../utils/date-helper'
+import { failFromError } from '../utils/md-aware'
 import {
   mdActionRequired,
   mdDone,
@@ -256,7 +257,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
       } else {
         out.fail(getErrorMessage(error))
       }
-      return { success: false, error: getErrorMessage(error) }
+      return failFromError(error)
     }
   }
 

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -15,7 +15,6 @@
  *   - md-helpers.ts    — buildFlowDiagram for `--md` output
  */
 
-import configManager from '../infrastructure/config-manager'
 import { generateUUID } from '../schemas/schemas'
 import { getGitBranch } from '../session/git-helpers'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
@@ -37,6 +36,7 @@ import { showNextSteps, showStateInfo } from '../utils/next-steps'
 import out from '../utils/output'
 import { executeWorkflowRules } from '../workflow/workflow-engine'
 import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
 import { detectIntent } from './workflow/intent'
 import {
   workflowAdd,
@@ -68,14 +68,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
     options: { skipHooks?: boolean; md?: boolean } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        out.failWithHint('NO_PROJECT_ID')
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       // No task arg → show the active one (or none).
       if (!task) return this._showActiveTask(projectId, options)
@@ -212,18 +207,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
     options: MdOption = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        if (options.md) {
-          console.log('> No project ID found. Run `prjct init` first.')
-        } else {
-          out.failWithHint('NO_PROJECT_ID')
-        }
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath, options)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const trimmed = input?.trim() ?? ''
 
@@ -283,18 +269,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
     options: MdOption = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
-
-      const projectId = await configManager.getProjectId(projectPath)
-      if (!projectId) {
-        if (options.md) {
-          console.log('> No project ID found. Run `prjct init` first.')
-        } else {
-          out.failWithHint('NO_PROJECT_ID')
-        }
-        return { success: false, error: 'No project ID found' }
-      }
+      const proj = await requireProject(projectPath, options)
+      if (!proj.ok) return proj.result
+      const projectId = proj.value
 
       const name = workflowName.trim()
       if (!name) {

--- a/core/utils/md-aware.ts
+++ b/core/utils/md-aware.ts
@@ -17,6 +17,7 @@
 
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
 import out from './output'
 
 type Severity = 'warn' | 'info' | 'fail' | 'done'
@@ -51,5 +52,20 @@ export const notifyDone = (message: string, options: MdOption = {}): void =>
  */
 export function failWith(message: string, options: MdOption = {}): CommandResult {
   notifyWarn(message, options)
+  return { success: false, error: message }
+}
+
+/**
+ * Catch-block convenience: turn a thrown error into a `CommandResult`
+ * failure with the standard error-message extraction. Replaces the
+ *   `} catch (error) { return { success: false, error: getErrorMessage(error) } }`
+ * tail that closes nearly every command method.
+ *
+ * Pass `options` to also notify the user via `notifyFail`; omit it to
+ * stay silent (the caller may already log somewhere else).
+ */
+export function failFromError(error: unknown, options?: MdOption): CommandResult {
+  const message = getErrorMessage(error)
+  if (options) notifyFail(message, options)
   return { success: false, error: message }
 }

--- a/core/utils/md-aware.ts
+++ b/core/utils/md-aware.ts
@@ -45,13 +45,28 @@ export const notifyDone = (message: string, options: MdOption = {}): void =>
   notify('done', message, options)
 
 /**
- * Notify the user that the command can't proceed and return the
- * matching `CommandResult` failure. Replaces the
- * notify-then-return-error pair that was the most-duplicated block in
- * the command surface.
+ * Soft fail: validation/precondition failure where the user is expected
+ * to re-run the command with corrected input. Severity = warn.
+ *
+ * Replaces:
+ *   if (options.md) console.log(`> ${msg}`); else out.warn(msg)
+ *   return { success: false, error: msg }
  */
 export function failWith(message: string, options: MdOption = {}): CommandResult {
   notifyWarn(message, options)
+  return { success: false, error: message }
+}
+
+/**
+ * Hard fail: the command tried something and the runtime/environment
+ * couldn't satisfy it (missing tool, broken state, network error). The
+ * user can't fix this by tweaking arguments. Severity = fail.
+ *
+ * Replaces:
+ *   out.fail(msg); return { success: false, error: msg }
+ */
+export function failHard(message: string, options: MdOption = {}): CommandResult {
+  notifyFail(message, options)
   return { success: false, error: message }
 }
 


### PR DESCRIPTION
## Summary

Stacked on top of #312. Every command verb opened with the same 6-line two-step (`ensureProjectInit` + `getProjectId`) — 24 sites across the command surface, with subtle variants that had drifted across files (md-aware vs not, bare-return vs out.failWithHint vs out.fail).

This PR:

- Extends `guards.ts` with `requireProject(projectPath, options)` — wraps `projectService.ensureInit + requireProjectId` in one call
- Updates `requireProjectId` to accept `MdOption` so the md-aware branch lives inside the helper
- Replaces 14 of 24 call sites (the 10 remaining have one-off variants — `if (options.json)` blocks in `analysis.ts:777,854`, retro's git-repo guard, etc. — that don't fit the helper cleanly)

## Files touched

- `core/commands/guards.ts` — extended
- `core/commands/{analysis,context-checkpoint,health,preferences,primitives,shipping,workflow}.ts` — call sites collapsed

## Test plan

- [x] typecheck clean
- [x] biome clean
- [x] `bun test` — 1029 pass, 0 fail (3471 expects)
- [x] build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)