### PR TITLE
fix(sync): drop unused imports in entity-handlers

### DIFF
--- a/core/sync/entity-handlers/ideas.ts
+++ b/core/sync/entity-handlers/ideas.ts
@@ -7,7 +7,7 @@
 
 import type { IdeaPriority } from '../../schemas/ideas'
 import { ideasStorage } from '../../storage/ideas-storage'
-import type { ApplyData, EntityHandler } from './types'
+import type { EntityHandler } from './types'
 
 export const ideasHandler: EntityHandler = {
   async upsert(projectId, data) {

--- a/core/sync/entity-handlers/queue-tasks.ts
+++ b/core/sync/entity-handlers/queue-tasks.ts
@@ -8,7 +8,7 @@
 
 import type { Priority, TaskSection, TaskType } from '../../schemas/state'
 import { queueStorage } from '../../storage/queue-storage'
-import type { ApplyData, EntityHandler } from './types'
+import type { EntityHandler } from './types'
 
 export const queueTasksHandler: EntityHandler = {
   async upsert(projectId, data) {

--- a/core/sync/entity-handlers/shipped.ts
+++ b/core/sync/entity-handlers/shipped.ts
@@ -8,7 +8,7 @@
  */
 
 import { shippedStorage } from '../../storage/shipped-storage'
-import type { ApplyData, EntityHandler } from './types'
+import type { EntityHandler } from './types'
 
 export const shippedHandler: EntityHandler = {
   async upsert(projectId, data) {

--- a/core/sync/entity-handlers/tasks.ts
+++ b/core/sync/entity-handlers/tasks.ts
@@ -14,7 +14,7 @@
 import type { Priority, TaskSection, TaskType } from '../../schemas/state'
 import { queueStorage } from '../../storage/queue-storage'
 import { stateStorage } from '../../storage/state-storage'
-import type { ApplyData, EntityHandler } from './types'
+import type { EntityHandler } from './types'
 
 export const tasksHandler: EntityHandler = {
   async upsert(projectId, data) {


### PR DESCRIPTION
Unblocks Release CI for #319 — biome flagged 4 unused `ApplyData` imports in the entity-handler files. Pure removal, no behavior change. 1067/1067 tests pass.