### PR TITLE
feat(spec): Phase 1.6 — brownfield-aware SDD (auto-context + codebase reviewers + inventory)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"18468b54-d843-406c-9867-3500042d2db3","pid":78358,"procStart":"Sun May  3 06:01:31 2026","acquiredAt":1777927056119}

--- a/core/__tests__/services/spec-inventory.test.ts
+++ b/core/__tests__/services/spec-inventory.test.ts
@@ -1,0 +1,136 @@
+/**
+ * spec-inventory tests (Phase 1.6 / B-INV).
+ *
+ * Exercises:
+ *   - Coverage map per module (excluding types/tests/index.ts)
+ *   - Drift unknown for shipped specs without shipped_sha (legacy)
+ *   - Markdown render shape
+ *   - JSON shape (machine-readable for B-JSON consumers)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildInventory, renderInventoryMd } from '../../services/spec-inventory'
+import prjctDb from '../../storage/database'
+import { specStorage } from '../../storage/spec-storage'
+import { emptySpecContent } from '../../types/spec'
+
+let projectRoot: string
+let projectId: string
+let originalProjectsDir: string | undefined
+
+describe('spec-inventory', () => {
+  beforeEach(async () => {
+    const tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-inv-test-'))
+    originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+    process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+
+    // Build a fake project tree under projectRoot/core/<module>/
+    projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-inv-proj-'))
+    await fs.mkdir(path.join(projectRoot, 'core', 'sync'), { recursive: true })
+    await fs.mkdir(path.join(projectRoot, 'core', 'auth'), { recursive: true })
+    await fs.writeFile(
+      path.join(projectRoot, 'core', 'sync', 'sync-manager.ts'),
+      'export const x = 1\n'
+    )
+    await fs.writeFile(
+      path.join(projectRoot, 'core', 'sync', 'sync-client.ts'),
+      'export const y = 2\n'
+    )
+    await fs.writeFile(path.join(projectRoot, 'core', 'sync', 'types.ts'), 'export type T = 1\n') // excluded
+    await fs.writeFile(
+      path.join(projectRoot, 'core', 'auth', 'auth-config.ts'),
+      'export const z = 3\n'
+    )
+    await fs.writeFile(path.join(projectRoot, 'core', 'auth', 'index.ts'), 'export {} \n') // excluded
+
+    projectId = `inv-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+  })
+
+  afterEach(async () => {
+    if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+    else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+    await fs.rm(projectRoot, { recursive: true, force: true })
+  })
+
+  test('coverage map groups specs by module + excludes types/index', async () => {
+    const spec = specStorage.create(projectId, {
+      title: 'sync hardening',
+      content: {
+        ...emptySpecContent('keep sync correct'),
+        scope: ['core/sync/sync-manager.ts — bla', 'core/sync/sync-client.ts — bla'],
+      },
+    })
+    expect(spec.id).toBeTruthy()
+
+    const report = await buildInventory(projectRoot, projectId)
+    const sync = report.modules.find((m) => m.module === 'core/sync')
+    expect(sync).toBeTruthy()
+    if (!sync) return
+
+    expect(sync.specCount).toBe(1)
+    // 2 code files (types.ts excluded)
+    expect(sync.totalFiles).toBe(2)
+    expect(sync.coveredFiles).toBe(2)
+    expect(sync.coveredPct).toBe(100)
+  })
+
+  test('uncovered modules listed when no spec mentions them', async () => {
+    specStorage.create(projectId, {
+      title: 'sync hardening',
+      content: {
+        ...emptySpecContent('sync'),
+        scope: ['core/sync/sync-manager.ts'],
+      },
+    })
+
+    const report = await buildInventory(projectRoot, projectId)
+    expect(report.uncoveredModules).toContain('core/auth')
+    expect(report.uncoveredModules).not.toContain('core/sync')
+  })
+
+  test('shipped spec without shipped_sha reports drift=unknown', async () => {
+    const spec = specStorage.create(projectId, {
+      title: 'shipped legacy',
+      content: { ...emptySpecContent('legacy'), scope: ['core/sync/sync-manager.ts'] },
+    })
+    specStorage.setStatus(projectId, spec.id, 'shipped')
+
+    const report = await buildInventory(projectRoot, projectId)
+    const detail = report.driftDetail.find((d) => d.specId === spec.id)
+    expect(detail).toBeTruthy()
+    expect(detail?.drift).toBe('unknown')
+  })
+
+  test('renderInventoryMd produces a Markdown table', async () => {
+    specStorage.create(projectId, {
+      title: 'sync',
+      content: { ...emptySpecContent('sync'), scope: ['core/sync/sync-manager.ts'] },
+    })
+    const report = await buildInventory(projectRoot, projectId)
+    const md = renderInventoryMd(report)
+    expect(md).toContain('# Spec inventory')
+    expect(md).toContain('## Coverage by module')
+    expect(md).toContain('core/sync')
+  })
+
+  test('byStatus aggregates spec counts', async () => {
+    const a = specStorage.create(projectId, {
+      title: 'A',
+      content: emptySpecContent('a'),
+    })
+    specStorage.create(projectId, {
+      title: 'B',
+      content: emptySpecContent('b'),
+    })
+    specStorage.setStatus(projectId, a.id, 'shipped')
+
+    const report = await buildInventory(projectRoot, projectId)
+    expect(report.totalSpecs).toBe(2)
+    expect(report.byStatus.draft).toBe(1)
+    expect(report.byStatus.shipped).toBe(1)
+  })
+})

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -390,6 +390,13 @@ class PrjctCommands {
   ): Promise<CommandResult> {
     return this.specCmds.audit(id, projectPath, options)
   }
+
+  async specInventory(
+    projectPath: string = process.cwd(),
+    options: { md?: boolean; json?: boolean } = {}
+  ): Promise<CommandResult> {
+    return this.specCmds.inventory(null, projectPath, options)
+  }
 }
 
 // Export both class and singleton instance

--- a/core/commands/spec.ts
+++ b/core/commands/spec.ts
@@ -35,11 +35,13 @@ import { PrjctCommandsBase } from './base'
 interface SpecCmdOptions {
   md?: boolean
   status?: string
-  json?: string
+  json?: string | boolean
   notes?: string
   tags?: string
   pr?: number | string
   goal?: string
+  /** Phase 1.6 / B-CTX: skip auto-inferring codebase context on draft. */
+  skipContext?: boolean
 }
 
 export class SpecCommands extends PrjctCommandsBase {
@@ -69,6 +71,7 @@ export class SpecCommands extends PrjctCommandsBase {
         title: title.trim(),
         content: { goal },
         tags,
+        autoContext: !options.skipContext,
       })
 
       if (options.md) {
@@ -195,14 +198,15 @@ export class SpecCommands extends PrjctCommandsBase {
   ): Promise<CommandResult> {
     try {
       if (!id) return failWith('Usage: prjct spec update <id> --json \'{"goal": "...", ...}\'')
-      if (!options.json) return failWith('--json is required')
+      const jsonInput = typeof options.json === 'string' ? options.json : ''
+      if (!jsonInput) return failWith('--json is required')
 
       const initResult = await this.ensureProjectInit(projectPath)
       if (!initResult.success) return initResult
 
       let parsed: unknown
       try {
-        parsed = JSON.parse(options.json)
+        parsed = JSON.parse(jsonInput)
       } catch {
         return failWith('--json is not valid JSON')
       }
@@ -361,6 +365,55 @@ export class SpecCommands extends PrjctCommandsBase {
       const dispatch = renderAuditDispatch(spec.id, spec.title, spec.content)
       console.log(dispatch)
       return { success: true, specId: id, dispatch: 'emitted' }
+    } catch (error) {
+      return failHard(getErrorMessage(error))
+    }
+  }
+
+  /**
+   * `prjct spec inventory [--md|--json]` — coverage map per module +
+   * drift detection over shipped specs (Phase 1.6 / B-INV).
+   *
+   * Drift definition: shipped specs whose scope[] paths accumulated
+   * >5 LOC of NON-cosmetic changes between shipped_sha and HEAD.
+   * Shipped specs without shipped_sha (legacy) report drift=unknown.
+   */
+  async inventory(
+    _arg: string | null = null,
+    projectPath: string = process.cwd(),
+    options: SpecCmdOptions = {}
+  ): Promise<CommandResult> {
+    try {
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+
+      const { default: configManager } = await import('../infrastructure/config-manager')
+      const cfg = await configManager.readConfig(projectPath)
+      const projectId = cfg?.projectId
+      if (!projectId) return failWith('not a prjct project')
+
+      const { buildInventory, renderInventoryMd } = await import('../services/spec-inventory')
+      const report = await buildInventory(projectPath, projectId)
+
+      if (options.json) {
+        console.log(JSON.stringify(report, null, 2))
+      } else if (options.md) {
+        console.log(renderInventoryMd(report))
+      } else {
+        // Compact human-readable summary (no flag).
+        out.info(`${report.totalSpecs} specs across ${report.modules.length} modules`)
+        for (const m of report.modules) {
+          const pct = m.coveredPct === null ? 'n/a' : `${m.coveredPct}%`
+          const drift = m.drift === true ? ' DRIFT' : m.drift === 'unknown' ? ' ?' : ''
+          console.log(
+            `  ${m.module.padEnd(20)} ${String(m.specCount).padStart(3)} specs · ${pct.padStart(6)} covered${drift}`
+          )
+        }
+        if (report.uncoveredModules.length > 0) {
+          out.info(`${report.uncoveredModules.length} module(s) without specs`)
+        }
+      }
+      return { success: true, totalSpecs: report.totalSpecs }
     } catch (error) {
       return failHard(getErrorMessage(error))
     }

--- a/core/commands/spec.ts
+++ b/core/commands/spec.ts
@@ -492,21 +492,30 @@ function renderSpecMarkdown(spec: {
  */
 function renderAuditDispatch(id: string, title: string, content: SpecContent): string {
   const summary = JSON.stringify(content)
+  // Phase 1.6 / B-RVW: extract scope paths so each reviewer can read
+  // the actual codebase via the Read tool instead of judging the spec
+  // in isolation.
+  const scopePaths = extractScopePaths(content.scope)
+  const scopeBlock =
+    scopePaths.length > 0
+      ? `\n\n## Codebase paths to read (from spec.scope)\n${scopePaths.map((p) => `- \`${p}\``).join('\n')}\n\nEach reviewer SHOULD use the Read tool on these paths (cap 10 per reviewer) to ground the verdict in the actual code. Cite specific symbols / files / line numbers in notes when applicable.`
+      : '\n\n## Codebase paths\n_No path-shaped scope entries found. Reviewers judge the spec body alone._'
   return [
     `# audit-spec dispatch — ${title}`,
     '',
     `Spec id: \`${id}\``,
     '',
-    'Run three review subagents IN PARALLEL via the Agent tool — one tool-use block per reviewer, all in the SAME message so they run concurrently. Each subagent reads the spec body and applies its rubric, then returns a structured verdict.',
+    'Run three review subagents IN PARALLEL via the Agent tool — one tool-use block per reviewer, all in the SAME message so they run concurrently. Each subagent reads the spec body, reads the relevant codebase paths, applies its rubric, then returns a structured verdict.',
+    scopeBlock,
     '',
     '## Reviewer A — strategic (scope sanity)',
-    'Subagent prompt: "Review this spec for strategic soundness. Does it solve a real problem? Is the goal worth the cost? Is out_of_scope coherent with goal? Is the spec OVER- or UNDER-scoped? Return verdict (pass|fail) and 2-4 sentence notes."',
+    'Subagent prompt: "Review this spec for strategic soundness. Does it solve a real problem? Is the goal worth the cost? Is out_of_scope coherent with goal? Is the spec OVER- or UNDER-scoped? Cross-reference relevant prior memory if available (decisions tagged by domain). Return verdict (pass|fail) and 2-4 sentence notes."',
     '',
     '## Reviewer B — architecture (eng feasibility)',
-    'Subagent prompt: "Review this spec for engineering feasibility. Can this be built? Is the data flow / state machine implicit in the acceptance criteria coherent? What failure modes / dependencies / edge cases are missing? Include a short ASCII diagram of the proposed architecture in notes if applicable. Return verdict (pass|fail) and 2-4 sentence notes."',
+    'Subagent prompt: "Review this spec for engineering feasibility. Read the codebase paths listed above (Read tool, cap 10 files). Can this be built ON TOP of what exists? Does the spec contradict an existing state machine, schema, or contract? What failure modes / dependencies / edge cases are missing? Include a short ASCII diagram + cite at least one concrete symbol from the codebase in notes when applicable. Return verdict (pass|fail) and 2-4 sentence notes."',
     '',
     '## Reviewer C — design (UX/DX)',
-    'Subagent prompt: "Review this spec for design quality. Rate 0-10 across {clarity, ergonomics, consistency, accessibility} for the user-facing or developer-facing surface this spec defines. Note the lowest-scoring dimension and why. Return verdict (pass if all dimensions ≥6, fail otherwise) and notes including the four scores."',
+    'Subagent prompt: "Review this spec for design quality. Rate 0-10 across {clarity, ergonomics, consistency, accessibility} for the user-facing or developer-facing surface. If scope touches existing UI/CLI patterns (read the listed paths), consistency must be judged against those — not against your priors. Return verdict (pass if all dimensions ≥6, fail otherwise) + the four scores."',
     '',
     '## Spec body (verbatim, pass to each reviewer)',
     '```json',
@@ -519,4 +528,19 @@ function renderAuditDispatch(id: string, title: string, content: SpecContent): s
     '',
     'When all three are recorded, the spec auto-promotes from `draft` → `reviewed`.',
   ].join('\n')
+}
+
+/**
+ * Pull file/dir paths from spec.scope entries (entries are typically
+ * "core/sync/sync-manager.ts — desc" — peel off the path-like prefix).
+ * Cap to 12 to stay within reviewer-tool budgets.
+ */
+function extractScopePaths(scope: string[]): string[] {
+  const out: string[] = []
+  for (const entry of scope) {
+    const m = entry.match(/[a-zA-Z0-9_./-]+\.[a-zA-Z]+/) ?? entry.match(/[a-zA-Z0-9_./-]+\//)
+    if (m && !out.includes(m[0])) out.push(m[0])
+    if (out.length >= 12) break
+  }
+  return out
 }

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -148,6 +148,7 @@ async function routeSpecDaemon(
     'link-task',
     'ship',
     'audit',
+    'inventory',
   ])
   if (!sub || !knownSubverbs.has(sub)) {
     const title = rawArgs.join(' ') || null
@@ -195,6 +196,8 @@ async function routeSpecDaemon(
       })
     case 'audit':
       return commands.specAudit(rest, undefined, { md })
+    case 'inventory':
+      return commands.specInventory(undefined, { md, json: opts.json === true })
     default:
       return { success: false, error: `unknown spec subverb: ${sub}` }
   }

--- a/core/index.ts
+++ b/core/index.ts
@@ -348,6 +348,7 @@ async function routeSpec(
     'link-task',
     'ship',
     'audit',
+    'inventory',
   ])
   if (!sub || !knownSubverbs.has(sub)) {
     return commands.spec(param, process.cwd(), {
@@ -395,6 +396,8 @@ async function routeSpec(
       })
     case 'audit':
       return commands.specAudit(rest, cwd, { md })
+    case 'inventory':
+      return commands.specInventory(cwd, { md, json: options.json === true })
     default:
       return { success: false, message: `unknown spec subverb: ${sub}` }
   }

--- a/core/services/spec-context-inference.ts
+++ b/core/services/spec-context-inference.ts
@@ -16,8 +16,8 @@
  * stderr warning (B-ERR-CONTRACT) but does not block spec creation.
  */
 
-import { findRelevantFiles } from '../tools/context/files-tool'
 import { projectMemory } from '../memory/project-memory'
+import { findRelevantFiles } from '../tools/context/files-tool'
 
 const PATH_CAP = 5
 const MEMORY_LIMIT = 8
@@ -58,7 +58,10 @@ export async function inferSpecContext(
     ).catch(() => []),
   ])
 
-  const paths = dedupeTopDirs(filesOut.files.map((f) => f.path), PATH_CAP)
+  const paths = dedupeTopDirs(
+    filesOut.files.map((f) => f.path),
+    PATH_CAP
+  )
   const empty = paths.length === 0 && memoryHits.length === 0
 
   if (empty) {
@@ -95,9 +98,7 @@ function buildNotesBlock(
   lines.push('<!-- auto-context:tentative -->')
   lines.push('## Existing context (auto-inferred)')
   lines.push('')
-  lines.push(
-    `_Inferred from title "${title}". Validate before audit — entries tagged tentative._`
-  )
+  lines.push(`_Inferred from title "${title}". Validate before audit — entries tagged tentative._`)
   lines.push('')
 
   if (paths.length > 0) {
@@ -132,8 +133,7 @@ export function warnNoContextMatch(title: string, suggestion?: string): void {
     level: 'warn',
     code: 'no_context_match',
     message: `No codebase or memory context matched "${title}"`,
-    suggestion:
-      suggestion ?? 'Fill spec.notes manually or run with `--skip-context` next time.',
+    suggestion: suggestion ?? 'Fill spec.notes manually or run with `--skip-context` next time.',
   }
   // stderr is reserved for diagnostics; stdout stays for command output.
   process.stderr.write(`${JSON.stringify(payload)}\n`)

--- a/core/services/spec-context-inference.ts
+++ b/core/services/spec-context-inference.ts
@@ -1,0 +1,140 @@
+/**
+ * Spec context inference (Phase 1.6 / B-CTX).
+ *
+ * When `prjct spec <title>` is called in a brownfield project,
+ * compose existing primitives to surface the relevant slice of the
+ * codebase + project memory:
+ *   - findRelevantFiles(title) — BM25-style scoring over code paths
+ *   - projectMemory.recall(topic) — decisions / gotchas / learnings
+ *     filtered by inferred domain tag
+ *
+ * Output is a Markdown block tagged `<!-- auto-context:tentative -->`
+ * that the spec service writes into `spec.notes` when the field is
+ * empty. Humans validate or replace before audit-spec runs.
+ *
+ * Errors are non-fatal: a context-recall miss emits a structured
+ * stderr warning (B-ERR-CONTRACT) but does not block spec creation.
+ */
+
+import { findRelevantFiles } from '../tools/context/files-tool'
+import { projectMemory } from '../memory/project-memory'
+
+const PATH_CAP = 5
+const MEMORY_LIMIT = 8
+const MIN_SCORE = 0.15
+
+export interface ContextInferenceResult {
+  /** Markdown block ready to slot into spec.notes. Empty string when
+   *  no signal found (caller decides whether to skip or warn). */
+  notesBlock: string
+  /** Inferred paths — also handed to audit-spec dispatch (B-RVW). */
+  paths: string[]
+  /** Memory entries the recall surfaced. */
+  memoryHits: number
+  /** True when neither files nor memory matched. Drives B-ERR. */
+  empty: boolean
+}
+
+/**
+ * Compose `findRelevantFiles` + `projectMemory.recall` into a
+ * Markdown notes block. `projectId` is required for the memory
+ * recall; `projectPath` for file inference.
+ */
+export async function inferSpecContext(
+  title: string,
+  projectId: string,
+  projectPath: string
+): Promise<ContextInferenceResult> {
+  const [filesOut, memoryHits] = await Promise.all([
+    findRelevantFiles(title, projectPath, {
+      maxFiles: PATH_CAP * 4, // over-fetch then dedupe by dir
+      minScore: MIN_SCORE,
+    }).catch(() => ({ files: [] as Array<{ path: string; score: number }> })),
+    Promise.resolve(
+      projectMemory.recall(projectId, {
+        topic: title,
+        limit: MEMORY_LIMIT,
+      })
+    ).catch(() => []),
+  ])
+
+  const paths = dedupeTopDirs(filesOut.files.map((f) => f.path), PATH_CAP)
+  const empty = paths.length === 0 && memoryHits.length === 0
+
+  if (empty) {
+    return { notesBlock: '', paths: [], memoryHits: 0, empty: true }
+  }
+
+  const notesBlock = buildNotesBlock(title, paths, memoryHits)
+  return { notesBlock, paths, memoryHits: memoryHits.length, empty: false }
+}
+
+/**
+ * Collapse a long file list to ≤ N representative top-level dirs +
+ * the highest-scoring file in each. Keeps the notes block compact.
+ */
+function dedupeTopDirs(files: string[], cap: number): string[] {
+  const seenDirs = new Set<string>()
+  const out: string[] = []
+  for (const f of files) {
+    const topDir = f.split('/').slice(0, 2).join('/')
+    if (seenDirs.has(topDir)) continue
+    seenDirs.add(topDir)
+    out.push(f)
+    if (out.length >= cap) break
+  }
+  return out
+}
+
+function buildNotesBlock(
+  title: string,
+  paths: string[],
+  memoryHits: Array<{ type: string; content: string; tags: Record<string, string> }>
+): string {
+  const lines: string[] = []
+  lines.push('<!-- auto-context:tentative -->')
+  lines.push('## Existing context (auto-inferred)')
+  lines.push('')
+  lines.push(
+    `_Inferred from title "${title}". Validate before audit — entries tagged tentative._`
+  )
+  lines.push('')
+
+  if (paths.length > 0) {
+    lines.push('### Likely paths')
+    for (const p of paths) lines.push(`- \`${p}\``)
+    lines.push('')
+  }
+
+  if (memoryHits.length > 0) {
+    lines.push('### Relevant prior memory')
+    for (const m of memoryHits) {
+      const preview = m.content.length > 140 ? `${m.content.slice(0, 137)}…` : m.content
+      const tags = Object.entries(m.tags)
+        .map(([k, v]) => `${k}:${v}`)
+        .join(' ')
+      lines.push(`- **${m.type}**${tags ? ` _(${tags})_` : ''} — ${preview}`)
+    }
+    lines.push('')
+  }
+
+  lines.push('<!-- /auto-context -->')
+  return lines.join('\n')
+}
+
+/**
+ * Emit a structured stderr warning per the B-ERR-CONTRACT acceptance
+ * criterion. Callers use this when `inferSpecContext` returns empty
+ * and they want the user / agent to know context recall missed.
+ */
+export function warnNoContextMatch(title: string, suggestion?: string): void {
+  const payload = {
+    level: 'warn',
+    code: 'no_context_match',
+    message: `No codebase or memory context matched "${title}"`,
+    suggestion:
+      suggestion ?? 'Fill spec.notes manually or run with `--skip-context` next time.',
+  }
+  // stderr is reserved for diagnostics; stdout stays for command output.
+  process.stderr.write(`${JSON.stringify(payload)}\n`)
+}

--- a/core/services/spec-inventory.ts
+++ b/core/services/spec-inventory.ts
@@ -198,11 +198,7 @@ async function countModuleFiles(projectPath: string, mod: string): Promise<numbe
   return total
 }
 
-async function countCoveredFiles(
-  projectPath: string,
-  mod: string,
-  specs: Spec[]
-): Promise<number> {
+async function countCoveredFiles(projectPath: string, mod: string, specs: Spec[]): Promise<number> {
   // A file is "covered" if at least one spec.scope entry references it
   // (either by full path or by parent dir).
   const dir = path.join(projectPath, mod)
@@ -316,7 +312,9 @@ export function renderInventoryMd(report: InventoryReport): string {
   const lines: string[] = []
   lines.push('# Spec inventory')
   lines.push('')
-  lines.push(`_${report.totalSpecs} specs across ${report.modules.length} modules · generated ${report.generatedAt}_`)
+  lines.push(
+    `_${report.totalSpecs} specs across ${report.modules.length} modules · generated ${report.generatedAt}_`
+  )
   lines.push('')
 
   if (Object.keys(report.byStatus).length > 0) {

--- a/core/services/spec-inventory.ts
+++ b/core/services/spec-inventory.ts
@@ -1,0 +1,350 @@
+/**
+ * Spec Inventory (Phase 1.6 / B-INV).
+ *
+ * Per-module coverage map + drift detection over the `specs` table.
+ * Called from `prjct spec inventory`; exposes both --md and --json
+ * shapes (B-JSON).
+ *
+ * Drift definition (locked in --help):
+ *   For each spec with status=shipped and shipped_sha set, diff the
+ *   spec's `scope[]` paths between shipped_sha and HEAD. If any path
+ *   accumulated >5 LOC of NON-cosmetic changes, drift=true. Cosmetic
+ *   = commits whose subject matches `^(chore|style|format|fmt)`.
+ *
+ *   shipped_sha NULL (legacy / pre-migration-18) → drift=unknown.
+ *   Project not a git repo → drift=unknown.
+ *
+ * Coverage definition:
+ *   Per top-level module dir (e.g. `core/auth/`, `core/sync/`):
+ *     covered_pct = files_with_spec / total_files
+ *   excluding: types.ts, **​/types/**, **​/__tests__/**, *.d.ts,
+ *              index.ts re-export shims, .test.ts, .spec.ts.
+ */
+
+import { execFile } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { specStorage } from '../storage/spec-storage'
+import type { Spec } from '../types/spec'
+
+const execFileAsync = promisify(execFile)
+
+const DRIFT_LOC_THRESHOLD = 5
+const COSMETIC_COMMIT_RE = /^(chore|style|format|fmt|docs|typo)(\(|:|!)/i
+const COVERAGE_EXCLUDE_RE = [
+  /(^|\/)types\.ts$/,
+  /(^|\/)types\//,
+  /\/__tests__\//,
+  /\.d\.ts$/,
+  /(^|\/)index\.ts$/,
+  /\.test\.ts$/,
+  /\.spec\.ts$/,
+]
+
+export type DriftStatus = true | false | 'unknown'
+
+export interface ModuleStats {
+  module: string
+  specCount: number
+  /** files in module that are referenced by at least one spec.scope */
+  coveredFiles: number
+  /** total non-excluded code files in the module */
+  totalFiles: number
+  /** coveredFiles / totalFiles, rounded 2 decimals; null if 0 files */
+  coveredPct: number | null
+  /** ISO of the most recent spec.updatedAt in this module */
+  lastUpdated: string | null
+  /** True iff ANY shipped spec in this module reports drift=true. */
+  drift: DriftStatus
+}
+
+export interface InventoryReport {
+  generatedAt: string
+  projectPath: string
+  totalSpecs: number
+  byStatus: Record<string, number>
+  modules: ModuleStats[]
+  /** Per-spec drift detail (for `--json` consumers that need granularity). */
+  driftDetail: Array<{
+    specId: string
+    title: string
+    status: string
+    drift: DriftStatus
+    locChanged?: number
+    cosmeticOnly?: boolean
+  }>
+  /** Top-level dirs that appear in NO spec.scope (full coverage holes). */
+  uncoveredModules: string[]
+}
+
+/**
+ * Build the inventory report. `git` is optional — without it, drift
+ * detection degrades to `unknown` for all shipped specs.
+ */
+export async function buildInventory(
+  projectPath: string,
+  projectId: string
+): Promise<InventoryReport> {
+  const allSpecs = specStorage.list(projectId, { includeArchived: true })
+  const byStatus: Record<string, number> = {}
+  for (const s of allSpecs) {
+    byStatus[s.status] = (byStatus[s.status] ?? 0) + 1
+  }
+
+  // Group specs by inferred module (top 2 path segments of first scope entry).
+  const specsByModule = new Map<string, Spec[]>()
+  const allModuleDirs = new Set<string>()
+  for (const s of allSpecs) {
+    const mod = inferModule(s)
+    if (!mod) continue
+    allModuleDirs.add(mod)
+    const bucket = specsByModule.get(mod) ?? []
+    bucket.push(s)
+    specsByModule.set(mod, bucket)
+  }
+
+  // Discover candidate top-level dirs from the project tree (`core/*`).
+  const candidateModules = await listTopLevelModules(projectPath)
+  for (const m of candidateModules) allModuleDirs.add(m)
+
+  const modules: ModuleStats[] = []
+  const driftDetail: InventoryReport['driftDetail'] = []
+
+  for (const mod of [...allModuleDirs].sort()) {
+    const specs = specsByModule.get(mod) ?? []
+    const totalFiles = await countModuleFiles(projectPath, mod)
+    const coveredFiles = await countCoveredFiles(projectPath, mod, specs)
+    const lastUpdated =
+      specs.length > 0 ? specs.reduce((m, s) => (s.updatedAt > m ? s.updatedAt : m), '') : null
+
+    let drift: DriftStatus = false
+    for (const s of specs.filter((sp) => sp.status === 'shipped')) {
+      const detail = await driftForSpec(projectPath, s)
+      driftDetail.push({
+        specId: s.id,
+        title: s.title,
+        status: s.status,
+        drift: detail.drift,
+        locChanged: detail.locChanged,
+        cosmeticOnly: detail.cosmeticOnly,
+      })
+      if (detail.drift === true) drift = true
+      else if (detail.drift === 'unknown' && drift === false) drift = 'unknown'
+    }
+
+    modules.push({
+      module: mod,
+      specCount: specs.length,
+      coveredFiles,
+      totalFiles,
+      coveredPct: totalFiles === 0 ? null : Math.round((coveredFiles / totalFiles) * 10000) / 100,
+      lastUpdated: lastUpdated || null,
+      drift,
+    })
+  }
+
+  const uncoveredModules = modules.filter((m) => m.specCount === 0).map((m) => m.module)
+
+  return {
+    generatedAt: new Date().toISOString(),
+    projectPath,
+    totalSpecs: allSpecs.length,
+    byStatus,
+    modules,
+    driftDetail,
+    uncoveredModules,
+  }
+}
+
+/** Pick the top-2-segment module path from the spec's scope. */
+function inferModule(spec: Spec): string | null {
+  const first = spec.content.scope[0]
+  if (!first) return null
+  // scope items are often "core/sync/sync-manager.ts — desc" — peel
+  // off the path-like prefix.
+  const m = first.match(/([a-zA-Z0-9_./-]+\/[a-zA-Z0-9_-]+)/)
+  if (!m) return null
+  const segments = m[1].split('/').slice(0, 2)
+  return segments.length === 2 ? segments.join('/') : null
+}
+
+async function listTopLevelModules(projectPath: string): Promise<string[]> {
+  // Project layout convention: `core/*` is where modules live.
+  const coreDir = path.join(projectPath, 'core')
+  try {
+    const entries = await fs.readdir(coreDir, { withFileTypes: true })
+    return entries
+      .filter((e) => e.isDirectory() && !e.name.startsWith('.') && !e.name.startsWith('__'))
+      .map((e) => `core/${e.name}`)
+  } catch {
+    return []
+  }
+}
+
+async function countModuleFiles(projectPath: string, mod: string): Promise<number> {
+  const dir = path.join(projectPath, mod)
+  let total = 0
+  try {
+    await walk(dir, async (full) => {
+      const rel = path.relative(projectPath, full)
+      if (excluded(rel)) return
+      if (!isCodeFile(rel)) return
+      total++
+    })
+  } catch {
+    // Directory missing — counts as 0
+  }
+  return total
+}
+
+async function countCoveredFiles(
+  projectPath: string,
+  mod: string,
+  specs: Spec[]
+): Promise<number> {
+  // A file is "covered" if at least one spec.scope entry references it
+  // (either by full path or by parent dir).
+  const dir = path.join(projectPath, mod)
+  const refs = new Set<string>()
+  for (const s of specs) {
+    for (const entry of s.content.scope) {
+      const m = entry.match(/[a-zA-Z0-9_./-]+\.[a-z]+/)
+      if (m) refs.add(m[0])
+    }
+  }
+  let covered = 0
+  try {
+    await walk(dir, async (full) => {
+      const rel = path.relative(projectPath, full)
+      if (excluded(rel)) return
+      if (!isCodeFile(rel)) return
+      for (const ref of refs) {
+        if (rel === ref || rel.startsWith(ref.endsWith('/') ? ref : `${ref}/`)) {
+          covered++
+          break
+        }
+      }
+    })
+  } catch {
+    // Directory missing
+  }
+  return covered
+}
+
+async function walk(dir: string, visit: (full: string) => Promise<void>): Promise<void> {
+  let entries: import('node:fs').Dirent[]
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const e of entries) {
+    if (e.name.startsWith('.') || e.name === 'node_modules' || e.name === 'dist') continue
+    const full = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      await walk(full, visit)
+    } else if (e.isFile()) {
+      await visit(full)
+    }
+  }
+}
+
+function excluded(rel: string): boolean {
+  return COVERAGE_EXCLUDE_RE.some((re) => re.test(rel))
+}
+
+function isCodeFile(rel: string): boolean {
+  return /\.(ts|tsx|js|jsx|mjs|cjs)$/.test(rel)
+}
+
+async function driftForSpec(
+  projectPath: string,
+  spec: Spec
+): Promise<{ drift: DriftStatus; locChanged?: number; cosmeticOnly?: boolean }> {
+  if (!spec.shippedSha) return { drift: 'unknown' }
+
+  const scopePaths = spec.content.scope
+    .map((s) => s.match(/[a-zA-Z0-9_./-]+\.[a-z]+/)?.[0] ?? s.match(/[a-zA-Z0-9_./-]+\//)?.[0])
+    .filter((s): s is string => Boolean(s))
+  if (scopePaths.length === 0) return { drift: 'unknown' }
+
+  // Total LOC delta in the scope between shipped_sha and HEAD.
+  let locChanged = 0
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['diff', '--shortstat', `${spec.shippedSha}..HEAD`, '--', ...scopePaths],
+      { cwd: projectPath }
+    )
+    // Format: " 3 files changed, 42 insertions(+), 17 deletions(-)"
+    const ins = stdout.match(/(\d+) insertions?/)
+    const del = stdout.match(/(\d+) deletions?/)
+    locChanged = (ins ? Number.parseInt(ins[1], 10) : 0) + (del ? Number.parseInt(del[1], 10) : 0)
+  } catch {
+    return { drift: 'unknown' }
+  }
+
+  if (locChanged <= DRIFT_LOC_THRESHOLD) {
+    return { drift: false, locChanged, cosmeticOnly: false }
+  }
+
+  // Check if all the commits that touched the scope are cosmetic-only.
+  let cosmeticOnly = true
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['log', '--format=%s', `${spec.shippedSha}..HEAD`, '--', ...scopePaths],
+      { cwd: projectPath }
+    )
+    const subjects = stdout.split('\n').filter(Boolean)
+    if (subjects.length === 0) return { drift: false, locChanged, cosmeticOnly: true }
+    cosmeticOnly = subjects.every((s) => COSMETIC_COMMIT_RE.test(s))
+  } catch {
+    cosmeticOnly = false
+  }
+
+  return {
+    drift: cosmeticOnly ? false : true,
+    locChanged,
+    cosmeticOnly,
+  }
+}
+
+/** Render the inventory report as a Markdown table. */
+export function renderInventoryMd(report: InventoryReport): string {
+  const lines: string[] = []
+  lines.push('# Spec inventory')
+  lines.push('')
+  lines.push(`_${report.totalSpecs} specs across ${report.modules.length} modules · generated ${report.generatedAt}_`)
+  lines.push('')
+
+  if (Object.keys(report.byStatus).length > 0) {
+    lines.push('## By status')
+    for (const [status, count] of Object.entries(report.byStatus)) {
+      lines.push(`- ${status}: ${count}`)
+    }
+    lines.push('')
+  }
+
+  lines.push('## Coverage by module')
+  lines.push('')
+  lines.push('| Module | Specs | Files | Covered | % | Drift | Last updated |')
+  lines.push('|---|---|---|---|---|---|---|')
+  for (const m of report.modules) {
+    const pct = m.coveredPct === null ? 'n/a' : `${m.coveredPct}%`
+    const drift = m.drift === true ? '⚠️ yes' : m.drift === 'unknown' ? '❔' : '✓'
+    const updated = m.lastUpdated ? m.lastUpdated.slice(0, 10) : '—'
+    lines.push(
+      `| \`${m.module}\` | ${m.specCount} | ${m.totalFiles} | ${m.coveredFiles} | ${pct} | ${drift} | ${updated} |`
+    )
+  }
+
+  if (report.uncoveredModules.length > 0) {
+    lines.push('')
+    lines.push('## Modules with NO specs')
+    for (const m of report.uncoveredModules) lines.push(`- \`${m}\``)
+  }
+
+  return lines.join('\n')
+}

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -55,9 +55,34 @@ class SpecService {
       title: string
       content: Partial<SpecContent> & { goal: string }
       tags?: Record<string, string>
+      /**
+       * Phase 1.6 / B-CTX: auto-populate `notes` with codebase + memory
+       * context inferred from the title. Default true (brownfield-aware
+       * by default). Pass false from greenfield init flows or when the
+       * caller already supplied notes.
+       */
+      autoContext?: boolean
     }
   ): Promise<Spec> {
     const projectId = await this.requireProjectId(projectPath)
+
+    // Auto-context inference (B-CTX): only if `notes` is empty and the
+    // caller didn't opt out. The composer reads `findRelevantFiles` +
+    // `projectMemory.recall` and returns a tentative Markdown block.
+    let notes = args.content.notes ?? ''
+    const autoContext = args.autoContext !== false
+    if (autoContext && !notes.trim()) {
+      const { inferSpecContext, warnNoContextMatch } = await import(
+        './spec-context-inference'
+      )
+      const ctx = await inferSpecContext(args.title, projectId, projectPath)
+      if (ctx.empty) {
+        warnNoContextMatch(args.title)
+      } else {
+        notes = ctx.notesBlock
+      }
+    }
+
     const validated = SpecContentSchema.parse({
       goal: args.content.goal,
       eli10: args.content.eli10 ?? '',
@@ -69,7 +94,7 @@ class SpecService {
       test_plan: args.content.test_plan ?? [],
       reviews: args.content.reviews,
       linked_tasks: args.content.linked_tasks ?? [],
-      notes: args.content.notes ?? '',
+      notes,
     })
 
     const spec = specStorage.create(projectId, {

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -13,9 +13,27 @@
  * service owns persistence + invariants only.
  */
 
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
 import { specStorage } from '../storage/spec-storage'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Read git HEAD sha at `projectPath`. Returns null when not a git repo
+ * or git is unavailable — callers treat this as best-effort.
+ */
+async function readGitHead(projectPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: projectPath })
+    const sha = stdout.trim()
+    return /^[0-9a-f]{7,40}$/.test(sha) ? sha : null
+  } catch {
+    return null
+  }
+}
 import {
   type Spec,
   type SpecContent,
@@ -141,6 +159,14 @@ class SpecService {
     const projectId = await this.requireProjectId(projectPath)
     if (pr !== undefined) {
       specStorage.setShippedPr(projectId, specId, pr)
+    }
+    // Phase 1.6 / B-DRIFT-ANCHOR: capture the HEAD sha at ship time so
+    // `prjct spec inventory` can diff against it later. Best-effort —
+    // ship still succeeds in non-git contexts (the spec just gets
+    // drift=unknown in the inventory output).
+    const sha = await readGitHead(projectPath)
+    if (sha) {
+      specStorage.setShippedSha(projectId, specId, sha)
     }
     return specStorage.setStatus(projectId, specId, 'shipped')
   }

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -18,6 +18,15 @@ import { promisify } from 'node:util'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
 import { specStorage } from '../storage/spec-storage'
+import {
+  type Spec,
+  type SpecContent,
+  SpecContentSchema,
+  type SpecReview,
+  type SpecReviewer,
+  type SpecStatus,
+} from '../types/spec'
+import { getTimestamp } from '../utils/date-helper'
 
 const execFileAsync = promisify(execFile)
 
@@ -34,15 +43,6 @@ async function readGitHead(projectPath: string): Promise<string | null> {
     return null
   }
 }
-import {
-  type Spec,
-  type SpecContent,
-  SpecContentSchema,
-  type SpecReview,
-  type SpecReviewer,
-  type SpecStatus,
-} from '../types/spec'
-import { getTimestamp } from '../utils/date-helper'
 
 class SpecService {
   /**
@@ -72,9 +72,7 @@ class SpecService {
     let notes = args.content.notes ?? ''
     const autoContext = args.autoContext !== false
     if (autoContext && !notes.trim()) {
-      const { inferSpecContext, warnNoContextMatch } = await import(
-        './spec-context-inference'
-      )
+      const { inferSpecContext, warnNoContextMatch } = await import('./spec-context-inference')
       const ctx = await inferSpecContext(args.title, projectId, projectPath)
       if (ctx.empty) {
         warnNoContextMatch(args.title)

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -606,4 +606,22 @@ export const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 18,
+    name: 'specs-shipped-sha',
+    up: (db: SqliteDatabase) => {
+      // Phase 1.6 (B-DRIFT-ANCHOR): ship() captures the git HEAD sha at
+      // ship time. `prjct spec inventory` uses this as the diff base for
+      // drift detection — diffing against shipped_at timestamp via
+      // `git log --since` is fragile under rebases / squash-merges.
+      //
+      // Nullable: existing shipped specs predate this migration and
+      // simply report drift=unknown until manually re-shipped.
+      try {
+        db.run('ALTER TABLE specs ADD COLUMN shipped_sha TEXT')
+      } catch {
+        // Column may already exist (re-run safety)
+      }
+    },
+  },
 ]

--- a/core/storage/spec-storage.ts
+++ b/core/storage/spec-storage.ts
@@ -28,6 +28,7 @@ interface SpecRow {
   updated_at: string
   shipped_at: string | null
   shipped_pr: number | null
+  shipped_sha: string | null
   archived_at: string | null
 }
 
@@ -69,6 +70,7 @@ class SpecStorage {
       updatedAt: now,
       shippedAt: null,
       shippedPr: null,
+      shippedSha: null,
       archivedAt: null,
     }
   }
@@ -154,6 +156,22 @@ class SpecStorage {
   }
 
   /**
+   * Capture the git HEAD sha at ship time. Phase 1.6 / B-DRIFT-ANCHOR:
+   * inventory uses this as the diff base for drift detection (not the
+   * shipped_at timestamp, which is fragile under rebases).
+   */
+  setShippedSha(projectId: string, id: string, sha: string): Spec | null {
+    prjctDb.run(
+      projectId,
+      'UPDATE specs SET shipped_sha = ?, updated_at = ? WHERE id = ?',
+      sha,
+      getTimestamp(),
+      id
+    )
+    return this.get(projectId, id)
+  }
+
+  /**
    * Append a task id to the spec's `linked_tasks`. Idempotent.
    */
   linkTask(projectId: string, specId: string, taskId: string): Spec | null {
@@ -201,6 +219,7 @@ class SpecStorage {
       updatedAt: row.updated_at,
       shippedAt: row.shipped_at,
       shippedPr: row.shipped_pr,
+      shippedSha: row.shipped_sha,
       archivedAt: row.archived_at,
     }
   }

--- a/core/types/spec.ts
+++ b/core/types/spec.ts
@@ -68,6 +68,12 @@ export interface Spec {
   updatedAt: string
   shippedAt: string | null
   shippedPr: number | null
+  /**
+   * Git HEAD sha at ship time (Phase 1.6 / B-DRIFT-ANCHOR). NULL for
+   * legacy shipped specs that predate migration 18 — inventory marks
+   * those as drift=unknown.
+   */
+  shippedSha: string | null
   archivedAt: string | null
 }
 


### PR DESCRIPTION
## Summary

Make `prjct spec` useful in **large existing projects**, not just greenfield. Today specs are drafted blind and audit-spec reviewers see only the spec body — for brownfield this means audits pass on specs that contradict the existing architecture.

Spec: `e1808dfc-ca2b-4640-95d4-45d9249ee426` (audited pre-implementation by 3 reviewers — strategic ✓ architecture ✓ design ✓; auto-promoted draft → reviewed; gaps that arch + design surfaced were incorporated into the spec content before any code landed).

## Acceptance criteria — all 5 features (B1–B5)

| Block | Commit | What |
|---|---|---|
| **B-DRIFT-ANCHOR** | `191d0044` | Migration 18: `specs.shipped_sha TEXT`. `specService.ship()` captures `git rev-parse HEAD`. Anchor for B-INV drift detection (timestamp-based diffing was fragile under rebases). |
| **B-CTX + B-ERR-CONTRACT** | `1bbeb35c` | New `core/services/spec-context-inference.ts`. `prjct spec <title>` infers paths via `findRelevantFiles(title)` + memory recall, populates `spec.notes` with a tagged Markdown block. On miss → structured stderr warn `{level:warn, code:no_context_match, …}` (exit 0). `--skip-context` flag for greenfield. |
| **B-INV + B-JSON** | `5e31f172` | New verb `prjct spec inventory` — per-module coverage table (excluding types.ts/__tests__/index.ts/.d.ts) + drift detection (>5 LOC of non-cosmetic changes between `shipped_sha..HEAD`). Three output modes: no flag → compact text, `--md` → Markdown table, `--json` → full structured report. |
| **B-RVW** | `998c46ef` | `audit-spec` dispatch prompt extracts scope paths and instructs each reviewer to use the Read tool on them (cap 10 files). Strategic reads memory by domain; architecture reads code + cites concrete symbols + flags contradictions; design judges consistency vs existing patterns in scope, not priors. |
| **Tests + cleanup** | `ace8d1ca` | 5 unit tests for spec-inventory (coverage, uncovered, drift=unknown, MD render, byStatus). Biome import-sort cleanup. |

## Verification

- [x] `npm run typecheck` clean
- [x] `npm run lint` (biome) clean (1 info note, 0 errors)
- [x] `bun test` — **1072/1072 pass**, 3785 expectations
- [x] No new top-level dependencies (uses `node:child_process` + existing `findRelevantFiles` + `projectMemory`)
- [x] Migration 18 is additive only — pre-existing shipped specs report `drift=unknown` (no breaking change)

## Reviewer-surfaced gaps that were incorporated BEFORE coding

- **architecture:** flagged that `prjct context impact` doesn't exist → composer uses existing `findRelevantFiles` + `projectMemory.recall` instead.
- **architecture:** flagged that timestamp-based drift is fragile → added `shipped_sha` column + git-sha anchor.
- **design:** flagged missing `--json` for machine-readable consumers → cross-cutting B-JSON criterion.
- **design:** flagged missing error contract on context misses → B-ERR-CONTRACT structured stderr.

## Out of scope (intentional, separate PRs)

- OpenSpec adoption: hierarchical tasks within `SpecContent`, `prjct spec verify`, `prjct spec continue` — orthogonal, follow-up PR.
- `prjct spec from-code <path>` retroactive doc generation — Bundle 2.
- Specs as files in repo — explicitly rejected (breaks SoT in SQLite + sync to prjct-cloud).
- Telemetry, multi-AI client expansion, "fluid no-gates" philosophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)