### PR TITLE
feat(sdd): auto-breakdown spec acceptance criteria into queue tasks on audit pass

### DIFF
--- a/core/__tests__/services/spec-task-breakdown.test.ts
+++ b/core/__tests__/services/spec-task-breakdown.test.ts
@@ -1,0 +1,201 @@
+/**
+ * spec → tasks auto-breakdown tests.
+ *
+ * Pins the behavior the user pushed back on: when audit-spec promotes a
+ * spec to `reviewed`, the acceptance_criteria materialize as queue tasks
+ * automatically — no new verb to memorize.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { specService } from '../../services/spec-service'
+import { breakdownSpecToTasks } from '../../services/spec-task-breakdown'
+import prjctDb from '../../storage/database'
+import { queueStorage } from '../../storage/queue-storage'
+import { specStorage } from '../../storage/spec-storage'
+import { emptySpecContent } from '../../types/spec'
+
+let projectPath: string
+let projectId: string
+let originalProjectsDir: string | undefined
+
+async function freshProject(): Promise<void> {
+  const tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-bd-projects-'))
+  originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+  process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-bd-test-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `bd-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+}
+
+beforeEach(async () => {
+  prjctDb.close()
+  await freshProject()
+})
+
+afterEach(async () => {
+  if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+  else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+  if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  prjctDb.close()
+})
+
+describe('breakdownSpecToTasks', () => {
+  test('one queue task per acceptance criterion, linked to the spec', async () => {
+    const spec = specStorage.create(projectId, {
+      title: 'rate limit auth',
+      content: {
+        ...emptySpecContent('limit /auth/* to 10 req/min/IP'),
+        acceptance_criteria: [
+          'returns 429 after 10 requests in 60s window',
+          'rate limit headers (X-RateLimit-*) present on every /auth response',
+          'whitelisted IPs bypass the limit',
+        ],
+      },
+    })
+
+    const result = await breakdownSpecToTasks(projectId, projectPath, spec)
+    expect(result.taskIds).toHaveLength(3)
+    expect(result.skippedReason).toBeUndefined()
+
+    const queue = await queueStorage.getTasks(projectId)
+    expect(queue).toHaveLength(3)
+    for (const task of queue) {
+      expect(task.featureId).toBe(spec.id)
+      expect(task.groupId).toBe(spec.id)
+      expect(task.groupName).toBe('rate limit auth')
+      expect(task.section).toBe('backlog')
+      expect(task.priority).toBe('medium')
+    }
+
+    const refetched = specStorage.get(projectId, spec.id)
+    expect(refetched?.content.linked_tasks).toHaveLength(3)
+    expect(refetched?.content.linked_tasks).toEqual(result.taskIds)
+  })
+
+  test('skips when acceptance_criteria is empty', async () => {
+    const spec = specStorage.create(projectId, {
+      title: 'empty spec',
+      content: emptySpecContent('nothing yet'),
+    })
+
+    const result = await breakdownSpecToTasks(projectId, projectPath, spec)
+    expect(result.taskIds).toHaveLength(0)
+    expect(result.skippedReason).toBe('no_acceptance_criteria')
+
+    const queue = await queueStorage.getTasks(projectId)
+    expect(queue).toHaveLength(0)
+  })
+
+  test('idempotent: skips when linked_tasks already populated (re-audit case)', async () => {
+    const spec = specStorage.create(projectId, {
+      title: 'idempotent',
+      content: {
+        ...emptySpecContent('test re-audit'),
+        acceptance_criteria: ['AC one', 'AC two'],
+      },
+    })
+
+    const first = await breakdownSpecToTasks(projectId, projectPath, spec)
+    expect(first.taskIds).toHaveLength(2)
+
+    const after = specStorage.get(projectId, spec.id)
+    expect(after).toBeTruthy()
+    if (!after) return
+    const second = await breakdownSpecToTasks(projectId, projectPath, after)
+    expect(second.taskIds).toHaveLength(0)
+    expect(second.skippedReason).toBe('already_broken_down')
+
+    const queue = await queueStorage.getTasks(projectId)
+    expect(queue).toHaveLength(2) // not 4
+  })
+
+  test('long AC truncates description but preserves full text in body', async () => {
+    const longAc =
+      'when an authenticated user uploads a file larger than 50 MB, the server must reject with HTTP 413 and a Problem Details body that includes the maxBytes constant from config so the client can surface it correctly without hard-coding'
+    const spec = specStorage.create(projectId, {
+      title: 'upload limits',
+      content: {
+        ...emptySpecContent('cap upload size'),
+        acceptance_criteria: [longAc],
+      },
+    })
+
+    await breakdownSpecToTasks(projectId, projectPath, spec)
+    const [task] = await queueStorage.getTasks(projectId)
+    expect(task).toBeTruthy()
+    if (!task) return
+    expect(task.description.length).toBeLessThanOrEqual(140)
+    expect(task.description.endsWith('…')).toBe(true)
+    expect(task.body).toBe(longAc)
+  })
+})
+
+describe('spec-service.recordReview → auto-breakdown', () => {
+  test('all three reviewers passing triggers breakdown automatically', async () => {
+    const spec = await specService.create(projectPath, {
+      title: 'auto-breakdown via review',
+      content: {
+        goal: 'prove the SDD chain wires up end-to-end',
+        acceptance_criteria: ['ac alpha', 'ac beta'],
+      },
+      autoContext: false,
+    })
+
+    await specService.recordReview(projectPath, spec.id, 'strategic', {
+      verdict: 'pass',
+      notes: 'looks aligned',
+    })
+    await specService.recordReview(projectPath, spec.id, 'architecture', {
+      verdict: 'pass',
+      notes: 'no concerns',
+    })
+    const final = await specService.recordReview(projectPath, spec.id, 'design', {
+      verdict: 'pass',
+      notes: 'fine',
+    })
+
+    expect(final?.status).toBe('reviewed')
+    expect(final?.content.linked_tasks).toHaveLength(2)
+
+    const queue = await queueStorage.getTasks(projectId)
+    expect(queue).toHaveLength(2)
+    expect(queue.every((t) => t.featureId === spec.id)).toBe(true)
+  })
+
+  test('partial reviews leave spec in draft and DO NOT create tasks', async () => {
+    const spec = await specService.create(projectPath, {
+      title: 'partial review',
+      content: {
+        goal: 'only two reviewers pass — should stay draft',
+        acceptance_criteria: ['ac one'],
+      },
+      autoContext: false,
+    })
+
+    await specService.recordReview(projectPath, spec.id, 'strategic', {
+      verdict: 'pass',
+      notes: '',
+    })
+    const after = await specService.recordReview(projectPath, spec.id, 'architecture', {
+      verdict: 'pass',
+      notes: '',
+    })
+
+    expect(after?.status).toBe('draft')
+    expect(after?.content.linked_tasks).toHaveLength(0)
+    const queue = await queueStorage.getTasks(projectId)
+    expect(queue).toHaveLength(0)
+  })
+})

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -167,7 +167,17 @@ class SpecService {
     if (updated && this.allReviewsPass(updated.content)) {
       // All three reviewers pass → auto-promote draft to reviewed.
       if (updated.status === 'draft') {
-        return specStorage.setStatus(projectId, id, 'reviewed')
+        const promoted = specStorage.setStatus(projectId, id, 'reviewed')
+        // Auto-breakdown: materialize acceptance_criteria as granular
+        // queue tasks so the user gets row-per-AC in the DB and vault
+        // instead of a monolithic spec document. Idempotent (skipped on
+        // re-audit when linked_tasks already populated).
+        if (promoted) {
+          const { breakdownSpecToTasks } = await import('./spec-task-breakdown')
+          await breakdownSpecToTasks(projectId, projectPath, promoted)
+          return specStorage.get(projectId, id)
+        }
+        return promoted
       }
     }
     return updated

--- a/core/services/spec-task-breakdown.ts
+++ b/core/services/spec-task-breakdown.ts
@@ -1,0 +1,93 @@
+/**
+ * Spec → Tasks auto-breakdown.
+ *
+ * When `audit-spec` promotes a spec from `draft` → `reviewed` (all three
+ * reviewers pass), the spec's `acceptance_criteria` are materialized as
+ * granular queue tasks — one per AC. Each task lands in the backlog
+ * tagged with `featureId = spec.id` so the user can pick them up via
+ * `prjct task` and the vault renders them as individual rows instead of
+ * a single monolithic spec document.
+ *
+ * Idempotent: if the spec already has linked_tasks, breakdown is a no-op.
+ * That covers the re-audit path (a fail → pass cycle re-enters this code
+ * but must not double-create tasks).
+ */
+import { projectMemory } from '../memory/project-memory'
+import { queueStorage } from '../storage/queue-storage'
+import { specStorage } from '../storage/spec-storage'
+import type { Spec } from '../types/spec'
+
+export interface BreakdownResult {
+  /** Task ids newly created. Empty when breakdown is a no-op. */
+  taskIds: string[]
+  /** Why we skipped (only present when taskIds is empty). */
+  skippedReason?: 'no_acceptance_criteria' | 'already_broken_down'
+}
+
+/**
+ * Materialize `spec.content.acceptance_criteria` as queue tasks.
+ *
+ * One AC → one queue task. The task's `description` is the AC text
+ * (truncated to ~140 chars for readability); the full AC lands in `body`
+ * unchanged. Tasks go to `backlog` so they don't auto-activate — the
+ * user picks them up explicitly.
+ */
+export async function breakdownSpecToTasks(
+  projectId: string,
+  projectPath: string,
+  spec: Spec
+): Promise<BreakdownResult> {
+  const acs = spec.content.acceptance_criteria
+  if (acs.length === 0) {
+    return { taskIds: [], skippedReason: 'no_acceptance_criteria' }
+  }
+  if (spec.content.linked_tasks.length > 0) {
+    return { taskIds: [], skippedReason: 'already_broken_down' }
+  }
+
+  const newTasks = await queueStorage.addTasks(
+    projectId,
+    acs.map((ac) => ({
+      description: truncateForDescription(ac),
+      body: ac,
+      priority: 'medium' as const,
+      type: 'feature' as const,
+      section: 'backlog' as const,
+      featureId: spec.id,
+      groupId: spec.id,
+      groupName: spec.title,
+    }))
+  )
+
+  // Persist the link both directions so spec.content.linked_tasks reflects
+  // the new task ids and the vault renders them under "Linked tasks".
+  for (const task of newTasks) {
+    specStorage.linkTask(projectId, spec.id, task.id)
+  }
+
+  // Mirror to memory event stream so `prjct context memory spec` and the
+  // user's session both surface the breakdown event.
+  await projectMemory.remember(projectPath, {
+    type: 'spec',
+    content: `Auto-breakdown: ${newTasks.length} tasks created from ${spec.title}`,
+    tags: {
+      spec_id: spec.id,
+      event: 'auto_breakdown',
+      task_count: String(newTasks.length),
+    },
+    source: spec.id,
+  })
+
+  return { taskIds: newTasks.map((t) => t.id) }
+}
+
+/**
+ * Acceptance criteria are often long sentences with rationale; the queue
+ * description is meant to be glanceable. Cap at ~140 chars and append an
+ * ellipsis so the user knows there's more in the body.
+ */
+function truncateForDescription(ac: string): string {
+  const oneLine = ac.replace(/\s+/g, ' ').trim()
+  if (oneLine.length <= 140) return oneLine
+  return `${oneLine.slice(0, 137)}…`
+}

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -103,14 +103,17 @@ export async function generateWiki(
 
   // --- Gather sources ---
   const { specStorage } = await import('../storage/spec-storage')
-  const [ships, entries, analysis, llmAnalysis, workflowRules, specs] = await Promise.all([
-    shippedStorage.getAll(projectId),
-    Promise.resolve(projectMemory.recall(projectId, { limit: 5000 })),
-    analysisStorage.getActive(projectId).catch(() => null),
-    Promise.resolve(llmAnalysisStorage.getActive(projectId)).catch(() => null),
-    Promise.resolve(workflowRuleStorage.getAllRules(projectId)).catch(() => [] as WorkflowRule[]),
-    Promise.resolve(specStorage.list(projectId, { includeArchived: true })).catch(() => []),
-  ])
+  const { queueStorage } = await import('../storage/queue-storage')
+  const [ships, entries, analysis, llmAnalysis, workflowRules, specs, queueTasks] =
+    await Promise.all([
+      shippedStorage.getAll(projectId),
+      Promise.resolve(projectMemory.recall(projectId, { limit: 5000 })),
+      analysisStorage.getActive(projectId).catch(() => null),
+      Promise.resolve(llmAnalysisStorage.getActive(projectId)).catch(() => null),
+      Promise.resolve(workflowRuleStorage.getAllRules(projectId)).catch(() => [] as WorkflowRule[]),
+      Promise.resolve(specStorage.list(projectId, { includeArchived: true })).catch(() => []),
+      queueStorage.getTasks(projectId).catch(() => []),
+    ])
   const declared = entries.filter((e) => e.type !== 'shipped')
 
   // --- Build all file bodies in memory ---
@@ -121,7 +124,7 @@ export async function generateWiki(
   }
   for (const [rel, body] of buildMemoryFiles(declared)) files.set(rel, body)
   for (const [rel, body] of buildTagFiles(declared)) files.set(rel, body)
-  for (const [rel, body] of buildSpecFiles(specs)) files.set(rel, body)
+  for (const [rel, body] of buildSpecFiles(specs, queueTasks)) files.set(rel, body)
 
   // Prefer LLM analysis (richer fields) when available, fallback to heuristic.
   const patterns = llmAnalysis?.patterns ?? analysis?.patterns ?? []

--- a/core/services/wiki/spec-builder.ts
+++ b/core/services/wiki/spec-builder.ts
@@ -11,20 +11,26 @@
  * stream alone wouldn't carry.
  */
 
+import type { QueueTask } from '../../schemas/state'
 import { SPEC_REVIEWERS, type Spec } from '../../types/spec'
 import { slugify } from './_shared'
 
-export function buildSpecFiles(specs: Spec[]): Map<string, string> {
+export function buildSpecFiles(specs: Spec[], queueTasks: QueueTask[] = []): Map<string, string> {
   const files = new Map<string, string>()
 
   if (specs.length === 0) return files
+
+  // Index queue tasks by id so per-spec rendering can resolve linked task
+  // descriptions (otherwise "Linked tasks" would be a wall of UUIDs).
+  const taskById = new Map<string, QueueTask>()
+  for (const t of queueTasks) taskById.set(t.id, t)
 
   // Per-spec markdown
   const indexEntries: { slug: string; spec: Spec }[] = []
   for (const spec of specs) {
     const slug = slugify(spec.title) || spec.id.slice(0, 8)
     const rel = `specs/${slug}.md`
-    files.set(rel, formatSpecBody(spec))
+    files.set(rel, formatSpecBody(spec, taskById))
     indexEntries.push({ slug, spec })
   }
 
@@ -63,7 +69,7 @@ export function buildSpecFiles(specs: Spec[]): Map<string, string> {
   return files
 }
 
-function formatSpecBody(spec: Spec): string {
+function formatSpecBody(spec: Spec, taskById: Map<string, QueueTask>): string {
   const c = spec.content
   const lines: string[] = [
     `# ${spec.title}`,
@@ -119,7 +125,17 @@ function formatSpecBody(spec: Spec): string {
 
   if (c.linked_tasks.length > 0) {
     lines.push('', '## Linked tasks')
-    for (const t of c.linked_tasks) lines.push(`- ${t}`)
+    for (const id of c.linked_tasks) {
+      const task = taskById.get(id)
+      if (task) {
+        const status = task.completed ? 'x' : ' '
+        const section = task.section === 'backlog' ? ' _(backlog)_' : ''
+        lines.push(`- [${status}] ${task.description}${section} · \`${id}\``)
+      } else {
+        // Task no longer in queue (removed/completed/archived) — render id only.
+        lines.push(`- \`${id}\``)
+      }
+    }
   }
 
   if (c.notes) lines.push('', '## Notes', c.notes)


### PR DESCRIPTION
## Summary

When all three `audit-spec` reviewers pass and the spec auto-promotes `draft → reviewed`, materialize each acceptance_criterion as a granular queue task — one per AC, no new verb to memorize.

Resolves the gap the user surfaced: specs were monolithic in DB and vault. Now the agent can pick up tasks one at a time instead of re-reading the whole spec each turn.

## What changed

- `core/services/spec-task-breakdown.ts` (new) — `breakdownSpecToTasks()` emits one queue task per AC with `featureId=spec.id`, `groupId=spec.id`, `groupName=spec.title`, `section=backlog`. Description truncated to 140 chars; full AC in `body`. Idempotent (skips if `linked_tasks.length > 0`).
- `core/services/spec-service.ts` — hook in `recordReview()`. After auto-promoting `draft → reviewed`, fires `breakdownSpecToTasks` automatically.
- `core/services/wiki/spec-builder.ts` — accepts queue tasks; renders linked tasks with `- [ ] description _(backlog)_ · UUID` instead of bare UUIDs.
- `core/services/wiki-generator.ts` — fetches queue tasks alongside specs, threads them through.

## Why

Spec without breakdown forces the agent to re-read the entire spec document every turn. The user's request (in es): "necesitamos ser granulares en todo momento" / "eso lo debe hacer en automático no quiero más verbos para que el cliente memorice". This change makes SDD granular by default with zero new verbs.

## Behavior

- New spec → `audit-spec` (3 reviewers pass) → tasks auto-created in `queueStorage`, linked back to spec.
- Re-audit (fail → pass cycle) → no duplication.
- Spec with empty `acceptance_criteria` → no tasks created.
- Already-shipped specs → not retro-fixed (only fires on draft → reviewed transition).

## Test plan

- [x] `bun test core/__tests__/services/spec-task-breakdown.test.ts` — 6/6 pass (per-AC, empty AC, idempotent, long-AC truncation, end-to-end via recordReview, partial reviews stay draft)
- [x] `bun test core/__tests__/services/ core/__tests__/storage/` — 496/496 pass
- [x] `bun run typecheck` — clean
- [x] `bunx biome check <changed files>` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)