### PR TITLE
fix(spec): make spec update --json a PATCH (shallow merge), not full replace

### DIFF
--- a/core/__tests__/commands/spec-update-merge.test.ts
+++ b/core/__tests__/commands/spec-update-merge.test.ts
@@ -1,0 +1,180 @@
+/**
+ * `prjct spec update --json` — PATCH semantics test.
+ *
+ * The bug being fixed: previously, --json did a full-replace via Zod's
+ * default-filling parser, which silently wiped reviews / linked_tasks /
+ * acceptance_criteria when the caller sent a partial payload (e.g.
+ * updating just `goal`). Dogfood reality (Claude iterating on a spec
+ * mid-audit) means partial patches must preserve untouched fields.
+ *
+ * These tests pin the new contract: shallow merge over existing content,
+ * fields you provide replace, fields you omit preserve.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { SpecCommands } from '../../commands/spec'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { specService } from '../../services/spec-service'
+import prjctDb from '../../storage/database'
+
+let projectPath: string
+let projectId: string
+let originalProjectsDir: string | undefined
+let cmd: SpecCommands
+
+async function freshProject(): Promise<void> {
+  const tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-update-merge-pd-'))
+  originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+  process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-update-merge-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `merge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+}
+
+beforeEach(async () => {
+  prjctDb.close()
+  await freshProject()
+  cmd = new SpecCommands()
+})
+
+afterEach(async () => {
+  if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+  else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+  if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  prjctDb.close()
+})
+
+describe('spec update --json shallow-merge', () => {
+  test('partial patch preserves omitted fields (the wipe bug)', async () => {
+    const created = await specService.create(projectPath, {
+      title: 'rate limit auth',
+      content: {
+        goal: 'limit /auth to 10/min',
+        acceptance_criteria: ['returns 429 after 10 in 60s', 'X-RateLimit-* headers'],
+        scope: ['auth/middleware.ts'],
+      },
+      autoContext: false,
+    })
+    // Pre-record a review so we can prove it survives a content patch.
+    await specService.recordReview(projectPath, created.id, 'strategic', {
+      verdict: 'pass',
+      notes: 'scope is right',
+    })
+
+    const result = await cmd.update(created.id, projectPath, {
+      json: JSON.stringify({ goal: 'limit /auth to 5/min — tightened after audit' }),
+      md: true,
+    })
+    expect(result.success).toBe(true)
+
+    const refreshed = await specService.get(projectPath, created.id)
+    expect(refreshed?.content.goal).toBe('limit /auth to 5/min — tightened after audit')
+    // Omitted fields must be preserved verbatim:
+    expect(refreshed?.content.acceptance_criteria).toEqual([
+      'returns 429 after 10 in 60s',
+      'X-RateLimit-* headers',
+    ])
+    expect(refreshed?.content.scope).toEqual(['auth/middleware.ts'])
+    expect(refreshed?.content.reviews?.strategic?.verdict).toBe('pass')
+    expect(refreshed?.content.reviews?.strategic?.notes).toBe('scope is right')
+  })
+
+  test('explicit field in patch replaces existing value (not merged into array)', async () => {
+    const created = await specService.create(projectPath, {
+      title: 'replacement test',
+      content: {
+        goal: 'g',
+        acceptance_criteria: ['old AC 1', 'old AC 2'],
+      },
+      autoContext: false,
+    })
+
+    const result = await cmd.update(created.id, projectPath, {
+      json: JSON.stringify({ acceptance_criteria: ['new AC only'] }),
+      md: true,
+    })
+    expect(result.success).toBe(true)
+
+    const refreshed = await specService.get(projectPath, created.id)
+    expect(refreshed?.content.acceptance_criteria).toEqual(['new AC only'])
+    // goal preserved (not in patch):
+    expect(refreshed?.content.goal).toBe('g')
+  })
+
+  test('linked_tasks survive content patch (the originally-bitten case)', async () => {
+    const created = await specService.create(projectPath, {
+      title: 'linked tasks survival',
+      content: { goal: 'g', acceptance_criteria: ['AC 1'] },
+      autoContext: false,
+    })
+    await specService.linkTask(projectPath, created.id, 'task-uuid-foo')
+    await specService.linkTask(projectPath, created.id, 'task-uuid-bar')
+
+    await cmd.update(created.id, projectPath, {
+      json: JSON.stringify({ goal: 'updated goal' }),
+      md: true,
+    })
+
+    const refreshed = await specService.get(projectPath, created.id)
+    expect(refreshed?.content.linked_tasks).toEqual(['task-uuid-foo', 'task-uuid-bar'])
+    expect(refreshed?.content.goal).toBe('updated goal')
+  })
+
+  test('explicit empty array DOES replace (caller can intentionally clear)', async () => {
+    const created = await specService.create(projectPath, {
+      title: 'explicit clear',
+      content: { goal: 'g', acceptance_criteria: ['old'] },
+      autoContext: false,
+    })
+
+    await cmd.update(created.id, projectPath, {
+      json: JSON.stringify({ acceptance_criteria: [] }),
+      md: true,
+    })
+
+    const refreshed = await specService.get(projectPath, created.id)
+    expect(refreshed?.content.acceptance_criteria).toEqual([])
+  })
+
+  test('non-object JSON payloads fail clean (no spec mutation)', async () => {
+    const created = await specService.create(projectPath, {
+      title: 'guard payload type',
+      content: { goal: 'pristine' },
+      autoContext: false,
+    })
+
+    const arrayPayload = await cmd.update(created.id, projectPath, {
+      json: '["not an object"]',
+      md: true,
+    })
+    expect(arrayPayload.success).toBe(false)
+
+    const nullPayload = await cmd.update(created.id, projectPath, {
+      json: 'null',
+      md: true,
+    })
+    expect(nullPayload.success).toBe(false)
+
+    const refreshed = await specService.get(projectPath, created.id)
+    expect(refreshed?.content.goal).toBe('pristine')
+  })
+
+  test('unknown spec id returns clean failure', async () => {
+    const result = await cmd.update('00000000-0000-0000-0000-000000000000', projectPath, {
+      json: JSON.stringify({ goal: 'whatever' }),
+      md: true,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/core/commands/spec.ts
+++ b/core/commands/spec.ts
@@ -4,7 +4,7 @@
  *   prjct spec "<title>"                    # create draft (Claude fills body)
  *   prjct spec list [--status <s>]          # ranked by created_at
  *   prjct spec show <id>                    # render one (--md for vault format)
- *   prjct spec update <id> --json '{...}'   # replace content (Zod-validated)
+ *   prjct spec update <id> --json '{...}'   # PATCH content (shallow merge, Zod-validated)
  *   prjct spec set-status <id> <status>     # draft|reviewed|in_progress|shipped|archived
  *   prjct spec record-review <id> <reviewer> <pass|fail> --notes "..."
  *   prjct spec link-task <id> <task-id>
@@ -188,8 +188,16 @@ export class SpecCommands extends PrjctCommandsBase {
   }
 
   /**
-   * Replace the spec content. Pass full content as JSON via --json.
-   * Validation happens in service via SpecContentSchema.
+   * PATCH the spec content. Pass any subset of fields as JSON via --json;
+   * fields you omit are PRESERVED from the existing spec, fields you
+   * include REPLACE the existing value (shallow merge at top level).
+   *
+   * This avoids the wipe footgun where a partial payload (e.g. updating
+   * just the goal) would silently zero out reviews / acceptance_criteria
+   * / linked_tasks because their schema defaults are empty. PATCH-style
+   * semantics match user expectation and dogfood reality — when Claude
+   * iterates on a spec mid-audit, it shouldn't have to re-send every
+   * field to keep the rest intact.
    */
   async update(
     id: string | null = null,
@@ -204,14 +212,24 @@ export class SpecCommands extends PrjctCommandsBase {
       const initResult = await this.ensureProjectInit(projectPath)
       if (!initResult.success) return initResult
 
-      let parsed: unknown
+      let patch: unknown
       try {
-        parsed = JSON.parse(jsonInput)
+        patch = JSON.parse(jsonInput)
       } catch {
         return failWith('--json is not valid JSON')
       }
-      const validated = SpecContentSchema.parse(parsed)
-      const updated = await specService.update(projectPath, id, validated as SpecContent)
+      if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) {
+        return failWith('--json must decode to an object')
+      }
+
+      const existing = await specService.get(projectPath, id)
+      if (!existing) return failWith(`spec not found: ${id}`)
+
+      const merged: SpecContent = SpecContentSchema.parse({
+        ...existing.content,
+        ...(patch as Record<string, unknown>),
+      })
+      const updated = await specService.update(projectPath, id, merged)
       if (!updated) return failWith(`spec not found: ${id}`)
 
       if (options.md) console.log(`✓ spec updated: ${updated.title}`)


### PR DESCRIPTION
## Summary

`prjct spec update <id> --json '{...}'` now does a shallow merge over existing content instead of a full replace. Fields you provide override; fields you omit are preserved.

This fixes a wipe-on-partial-update bug where calling \`update\` with just \`{goal: \"...\"}\` would silently zero out reviews, \`linked_tasks\`, and \`acceptance_criteria\` because Zod's defaults filled them with empty values.

## Why

Surfaced while dogfooding the new SDD auto-breakdown (PR #322): mid-audit, I needed to revise acceptance_criteria after a design reviewer failed the spec. The partial \`update --json\` call wiped previously-recorded \`strategic\`/\`architecture\` reviews and the \`linked_tasks\` array, forcing 3 unnecessary re-records before auto-promotion (and breakdown) could fire.

PATCH semantics match what callers actually expect — and what Claude actually does when iterating on a spec.

## Behavior

- \`{goal: \"new\"}\` → replaces goal, preserves AC/scope/reviews/linked_tasks/etc.
- \`{acceptance_criteria: [\"new\"]}\` → replaces AC entirely (not merged with existing array).
- \`{acceptance_criteria: []}\` → explicitly clears (caller intent honored).
- Non-object payloads (\`null\`, arrays, primitives) → fail clean with \`--json must decode to an object\`.
- Unknown spec id → \`spec not found\`.

## Test plan

- [x] \`bun test core/__tests__/commands/spec-update-merge.test.ts\` — 6/6 pass (preserves omitted, replaces provided, linked_tasks survive, explicit empty array clears, payload guard, unknown id)
- [x] \`bun test core/__tests__/commands/ core/__tests__/services/spec-task-breakdown.test.ts core/__tests__/storage/spec-storage.test.ts\` — 83/83 pass
- [x] \`bun run typecheck\` — clean
- [x] \`bunx biome check\` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)