### PR TITLE
feat(daemon): add restart + logs subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.19.3] - 2026-05-11
+
+### Features
+
+- `prjct daemon restart` — graceful stop (with force-kill fallback) followed by a fresh spawn. Mirrors the existing top-level `prjct restart` shortcut so users who think of `daemon` as a noun discover it under the same namespace as `start`/`stop`/`status`.
+- `prjct daemon logs [--lines=N | -n N] [--all] [--follow|-f]` — prints the tail of `~/.prjct-cli/run/daemon.log`. Defaults to the last 50 lines; `--all` dumps the entire file; `-f` streams via `tail -f` and forwards SIGINT for clean exit.
+- The unknown-subcommand error now lists all five `daemon` subcommands.
+
 ## [2.19.2] - 2026-05-11
 
 ### Bug Fixes

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -404,8 +404,63 @@ async function main(): Promise<void> {
         console.log('Daemon is not running.')
       }
       process.exitCode = 0
+    } else if (subcommand === 'restart') {
+      const { isDaemonRunning, stopDaemon, forceKillDaemon, spawnDaemon } = await import(
+        '../core/daemon/client'
+      )
+
+      if (await isDaemonRunning()) {
+        const stopped = await stopDaemon()
+        if (!stopped) forceKillDaemon()
+        await new Promise((resolve) => setTimeout(resolve, 300))
+      } else {
+        forceKillDaemon()
+      }
+
+      const started = await spawnDaemon()
+      if (started) {
+        console.log('Daemon restarted.')
+        process.exitCode = 0
+      } else {
+        console.error('Failed to restart daemon.')
+        process.exitCode = 1
+      }
+    } else if (subcommand === 'logs') {
+      const fs = await import('node:fs')
+      const { DAEMON_PATHS } = await import('../core/daemon/protocol')
+      const logPath = DAEMON_PATHS.log()
+
+      if (!fs.existsSync(logPath)) {
+        console.error(`No daemon log at ${logPath}. Start the daemon first.`)
+        process.exitCode = 1
+      } else {
+        const follow = args.includes('--follow') || args.includes('-f')
+        const all = args.includes('--all')
+        const linesArg =
+          args.find((a) => a.startsWith('--lines='))?.split('=')[1] ||
+          (args.includes('-n') ? args[args.indexOf('-n') + 1] : undefined)
+        const lines = linesArg ? parseInt(linesArg, 10) : 50
+
+        if (follow) {
+          const { spawn } = await import('node:child_process')
+          const child = spawn('tail', ['-n', String(lines), '-f', logPath], { stdio: 'inherit' })
+          process.on('SIGINT', () => child.kill('SIGINT'))
+          await new Promise<void>((resolve) => child.on('exit', () => resolve()))
+        } else if (all) {
+          process.stdout.write(fs.readFileSync(logPath, 'utf-8'))
+        } else {
+          const content = fs.readFileSync(logPath, 'utf-8')
+          const allLines = content.split('\n')
+          const tail = allLines.slice(-Math.max(1, lines))
+          process.stdout.write(tail.join('\n'))
+          if (!content.endsWith('\n')) process.stdout.write('\n')
+        }
+        process.exitCode = 0
+      }
     } else {
-      console.error(`Unknown daemon command: ${subcommand}. Use: start, stop, status`)
+      console.error(
+        `Unknown daemon command: ${subcommand}. Use: start, stop, restart, status, logs`
+      )
       process.exitCode = 1
     }
   } else if (args[0] === 'stop') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Closes the inbox follow-up captured during the v2.19.2 sync-hang fix. Diagnosing a stuck daemon previously required reading `~/.prjct-cli/run/daemon.pid` by hand and `tail -f ~/.prjct-cli/run/daemon.log` — both are now first-class subcommands under the existing `daemon` namespace.

## What changed

- `prjct daemon restart` — graceful stop (with force-kill fallback) + fresh spawn. Mirrors the existing top-level `prjct restart` shortcut so users who think of `daemon` as a noun discover it next to `start`/`stop`/`status`.
- `prjct daemon logs [--lines=N | -n N] [--all] [--follow | -f]` — defaults to the last 50 lines; `--all` dumps the full log; `-f` streams via `tail -f` and forwards SIGINT for clean exit.
- The unknown-subcommand error now lists all five `daemon` subcommands.

No new top-level verbs — strictly additive under the existing `daemon` namespace per the inbox note ("mantener mínimo, sin nuevos verbos memorizables").

## Test plan

- [x] `bun test` — 1120/1120 pass
- [x] `bun run typecheck` clean
- [x] `bunx biome check bin/prjct.ts` clean
- [x] `bun run build` clean
- [x] Manual: `prjct daemon status` → reports running PID, uptime, commands served
- [x] Manual: `prjct daemon restart` → stops the live daemon, spawns a fresh one, status confirms new PID with uptime 0s
- [x] Manual: `prjct daemon logs` → prints last 50 lines from `daemon.log`
- [x] Manual: `prjct daemon logs --lines=5` → prints last 5 lines
- [x] Manual: `prjct daemon bogus` → `Unknown daemon command: bogus. Use: start, stop, restart, status, logs`
- [ ] Manual `-f` (tail-follow) — not exercised in this PR, code path is a thin `spawn('tail', ['-n', String(lines), '-f', logPath])`

## Out of scope

- Structured-log JSON output (`--json`) — current daemon.log is plaintext, no consumer for JSON yet.
- Log rotation — daemon.log is append-only and not rotated; capture as separate inbox if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)