### PR TITLE
fix(build): stop daemon shim from silently re-running slow commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.19.4] - 2026-05-11
+
+### Bug Fixes
+
+- Stop `prjct ship` from creating two release commits per invocation. Root cause: the production CLI shim emitted by `generateDaemonShim()` in `scripts/build.js` had a 5s timeout and unconditionally called `fallback()` on timeout/error/close — re-importing `prjct-core.mjs` in-process while the daemon kept running. For any daemon-routed command that took longer than 5s (notably `ship`, whose push step alone is ~10s), the in-process fallback ran a second copy that saw the daemon's first commit at HEAD, bumped the version again, and produced a duplicate release commit. Sync the shim's fallback policy with the hardening from commit d08727b8 (May 1): timeout = 30s, refuse to re-execute on anything except `ECONNREFUSED`/`ENOENT`. Adds 4 regression tests in `core/__tests__/infrastructure/daemon-shim-sync.test.ts` that fail if the shim's policy drifts from the source again.
+
 ## [2.19.3] - 2026-05-11
 
 ### Features

--- a/core/__tests__/infrastructure/daemon-shim-sync.test.ts
+++ b/core/__tests__/infrastructure/daemon-shim-sync.test.ts
@@ -62,3 +62,59 @@ describe('daemon-shim ↔ bin/prjct.ts sync', () => {
     expect(shim.has('crew')).toBe(true)
   })
 })
+
+/**
+ * Fallback-policy regression: the shim must NOT silently re-execute a command
+ * that the daemon may have already started running.
+ *
+ * Background: v2.19.1 → v2.19.2 and v2.19.3 → v2.19.4 each shipped twice
+ * because the shim's 5s timeout fell through to a full re-import of
+ * prjct-core, while the daemon's slow `ship` step kept running. Source
+ * `bin/prjct.ts` (commit d08727b8) was hardened to refuse retry on anything
+ * except ECONNREFUSED/ENOENT — the shim was missed.
+ */
+describe('daemon-shim fallback policy', () => {
+  const buildSrc = fs.readFileSync(path.join(ROOT, 'scripts/build.js'), 'utf-8')
+
+  test('timeout is 30s, matching core/daemon/client.ts sendRequest', () => {
+    expect(buildSrc).toContain('30000)')
+    // 5000 was the old hair-trigger timeout that caused the double-fire.
+    expect(buildSrc).not.toMatch(/setTimeout\([^)]*,\s*5000\)/)
+  })
+
+  test('socket error path checks ECONNREFUSED / ENOENT before fallback', () => {
+    // Must whitelist the safe-retry conditions, matching bin/prjct.ts:238-242.
+    expect(buildSrc).toContain('ECONNREFUSED')
+    expect(buildSrc).toContain('ENOENT')
+    expect(buildSrc).toMatch(/isSafeRetry|safeRetry/)
+  })
+
+  test('socket close before response does NOT silently re-import core', () => {
+    // The pre-fix shim had `sock.on("close",()=>{...;fallback()})` — that's
+    // what made ship re-run mid-flight. Reject any line that pairs
+    // `sock.on("close"` with an unconditional fallback().
+    const closeHandler = buildSrc.match(/sock\.on\("close"[^)]*\)[^;]*;?/g) ?? []
+    expect(closeHandler.length).toBeGreaterThan(0)
+    for (const h of closeHandler) {
+      // It is OK if the close handler calls refuse() or another non-recursive
+      // helper; it is NOT OK if it falls through to fallback() unconditionally.
+      const callsFallback = /fallback\(\)/.test(h)
+      const callsRefuse = /refuse\(/.test(h)
+      // If we ever fall back from close, it must be gated by a safe-retry check
+      // — which today only lives in the error handler. Close = always refuse.
+      if (callsFallback) expect(callsRefuse).toBe(true)
+    }
+  })
+
+  test('timeout path does NOT silently re-import core', () => {
+    // Same hazard: the daemon may still be working when the shim gives up.
+    const timeoutBlock = buildSrc.match(/setTimeout\(\(\)\s*=>\s*\{[^}]+\}/g) ?? []
+    const shimTimeout = timeoutBlock.find((b) => b.includes('done') && b.includes('sock'))
+    expect(shimTimeout).toBeDefined()
+    if (shimTimeout) {
+      const callsFallback = /fallback\(\)/.test(shimTimeout)
+      const callsRefuse = /refuse\(/.test(shimTimeout)
+      if (callsFallback) expect(callsRefuse).toBe(true)
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.3",
+  "version": "2.19.4",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -167,22 +167,38 @@ var __dirname = __pathDirname(__filename);`,
  * This avoids parsing the ~600KB core bundle when daemon handles the command.
  */
 function generateDaemonShim() {
+  // Fallback policy MUST mirror bin/prjct.ts:206-251 + core/daemon/client.ts:87-145:
+  //
+  //   - Timeout = 30s (sendRequest uses 30_000).
+  //   - On socket error: fall through ONLY for ECONNREFUSED / ENOENT (stale
+  //     socket, no listener — the request never reached a daemon, safe to
+  //     re-run). Anything else (timeout, "Connection closed before response",
+  //     misc network errors) MAY mean the daemon already started executing
+  //     the request, so re-running can double-bump version / double-push.
+  //   - On socket close before response: NEVER fall through — exit 1.
+  //
+  // This blocked the bin/prjct.ts hardening from commit d08727b8 from
+  // reaching production for ~10 days (the shim is what end users actually
+  // execute via dist/bin/prjct.mjs). Any future change to the fallback
+  // policy MUST update both this string and bin/prjct.ts.
   return `#!/usr/bin/env node
 import{connect}from"node:net";import{existsSync}from"node:fs";import{randomUUID}from"node:crypto";import{homedir}from"node:os";
 const sockPath=homedir()+"/.prjct-cli/run/daemon.sock";
 const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
 const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health","context-save","context-restore","spec","audit-spec"]);
+function refuse(m){console.error("prjct: daemon dropped the request ("+m+"). Retry: prjct "+args.join(" "));process.exit(1)}
+function isSafeRetry(e){const c=e&&e.code||"",m=e&&e.message||"";return c==="ECONNREFUSED"||c==="ENOENT"||m.includes("ECONNREFUSED")||m.includes("ENOENT")}
 if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
   const cArgs=[],cOpts={};
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}
   const msg=JSON.stringify({id:randomUUID(),command:cmd,args:cArgs,options:cOpts,cwd:process.cwd()})+"\\n";
   const sock=connect(sockPath);let buf="",done=false;
-  const t=setTimeout(()=>{if(!done){done=true;sock.destroy();fallback()}},5000);
+  const t=setTimeout(()=>{if(!done){done=true;sock.destroy();refuse("timed out")}},30000);
   sock.on("connect",()=>sock.write(msg));
   sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));done=true;clearTimeout(t);sock.end();if(r.stdout)console.log(r.stdout);if(r.stderr)console.error(r.stderr);process.exit(r.exitCode)}});
-  sock.on("error",()=>{if(!done){done=true;clearTimeout(t);fallback()}});
-  sock.on("close",()=>{if(!done){done=true;clearTimeout(t);fallback()}});
+  sock.on("error",e=>{if(!done){done=true;clearTimeout(t);if(isSafeRetry(e))fallback();else refuse(e&&e.message||String(e))}});
+  sock.on("close",()=>{if(!done){done=true;clearTimeout(t);refuse("Connection closed before response")}});
 }else{fallback()}
 async function fallback(){await import("./prjct-core.mjs")}
 `


### PR DESCRIPTION
## Summary

Root cause of the **ship double-fire** bug (v2.19.1→v2.19.2 in PR #325; v2.19.3→v2.19.4 in PR #327): the production CLI entrypoint, `dist/bin/prjct.mjs`, is generated by `generateDaemonShim()` in `scripts/build.js`. The previous shim had a **5-second timeout** and three socket handlers (timeout, error, close) that **all unconditionally** called `fallback()` → `await import("./prjct-core.mjs")`. When `prjct ship` ran through the daemon and exceeded 5s (the push step alone takes ~10s), the shim destroyed its socket and re-executed the entire command in-process while the daemon kept working. The fallback's `version:bump` saw HEAD already at v+1 (committed by the still-running daemon) and produced a second commit.

This regressed the hardening from commit `d08727b8` (May 1) — `bin/prjct.ts` was patched with a `safeRetry` whitelist, but the inline shim string in `scripts/build.js` was missed. End users execute `dist/bin/prjct.mjs`, not `bin/prjct.ts`, so the fix never landed in production.

**Smoking gun**: reflog shows v+1 and v+2 commits exactly 5–6 seconds apart, matching the shim's timeout.

## Changes

### `scripts/build.js`
Sync `generateDaemonShim()` with `bin/prjct.ts:206-251` + `core/daemon/client.ts:87-145`:
- Timeout: 5s → **30s** (same as `sendRequest`).
- Socket error: fall through ONLY for `ECONNREFUSED` / `ENOENT` (stale socket, no listener — the request never reached a daemon, safe to re-run). Anything else → exit 1 with a "daemon dropped the request — retry: prjct <args>" message.
- Socket close before response: **never** fall through; always exit 1 (the daemon may have already committed/pushed).

Adds a leading comment explaining the dual-entrypoint hazard so the next change won't drift again.

### `core/__tests__/infrastructure/daemon-shim-sync.test.ts`
Adds a new `describe('daemon-shim fallback policy', …)` block with 4 regression tests:
1. `timeout is 30s, matching core/daemon/client.ts sendRequest` (forbids the 5s value).
2. `socket error path checks ECONNREFUSED / ENOENT before fallback`.
3. `socket close before response does NOT silently re-import core`.
4. `timeout path does NOT silently re-import core`.

## Test plan

- [x] `bun test core/__tests__/infrastructure/daemon-shim-sync.test.ts` — 6 pass (2 existing + 4 new)
- [x] `bun test` — 1124 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] `bunx biome check scripts/build.js core/__tests__/infrastructure/daemon-shim-sync.test.ts` clean
- [x] `bun run build` produces a shim of ~2.2 KB with the new policy
- [x] Smoke: `node dist/bin/prjct.mjs --version` and `node dist/bin/prjct.mjs status` route through the daemon and print correct output

## Notes

- This PR cannot be ship-tested through the existing `prjct ship` workflow until the new shim is installed globally (otherwise the OLD shim still runs, still falls back, and still double-fires — exactly the failure mode we are fixing). The release commit `v2.19.4` was created manually to avoid the bug while it ships itself.
- Once merged + published, future installations will inherit the hardened shim. Existing installations should run `bun add -g prjct-cli@latest` (or equivalent) to pick it up.

## Persisted to memory

- Gotcha: prjct has TWO entrypoints (`bin/prjct.ts` source + the inline shim baked into `scripts/build.js`). Any future change to the daemon-fallback policy must touch both.
- Learning: ship double-fire = the shim's 5s timeout + unconditional fallback re-running command in-process while the daemon's first request was still active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)