### PR TITLE
chore: add context7.json for library claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.19.5] - 2026-05-13
+
+### Added
+- current work
+
 ## [2.19.4] - 2026-05-11
 
 ### Bug Fixes

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/jlopezlira/prjct-cli",
+  "public_key": "pk_SC4Izw8T9pMEgouCFeFWY"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.4",
+  "version": "2.19.5",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Add `context7.json` at repo root with Context7 library URL + public key to claim ownership of the prjct-cli library on Context7.

## Test plan
- [ ] Click "Claim Library" on Context7 to verify ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)