### PR TITLE
fix(crew): stop writing .prjct/sessions/ into customer working tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.19.6] - 2026-05-13
+
+### Added
+- current work
+
 ## [2.19.5] - 2026-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [2.19.6] - 2026-05-13
 
+### Fixed
+- **Crew mode no longer writes `.prjct/sessions/` files into the customer's working tree.** The shipped templates (`templates/crew/agents/{leader,implementer,reviewer}.md`, `CHECKPOINTS.md`, `CLAUDE-leader-mode.md`) previously instructed subagents to persist plan / impl notes / review verdicts as loose markdown files under `.prjct/sessions/<task-slug>/<role>.md`. This violated the product invariant (SQLite + regenerated vault are the only allowed persistence surfaces) and was customer-reported. Subagents now reply inline; durable state goes through `prjct` CLI verbs only.
+
 ### Added
-- current work
+- Build-time guard in `scripts/build.js` that fails the bundle if any template under `templates/` reintroduces a forbidden persistence path (currently: `.prjct/sessions/`).
+- Regression test `core/__tests__/commands/crew-templates-no-disk-writes.test.ts` asserting the same invariant at unit-test time.
 
 ## [2.19.5] - 2026-05-13
 

--- a/core/__tests__/commands/crew-templates-no-disk-writes.test.ts
+++ b/core/__tests__/commands/crew-templates-no-disk-writes.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Architecture guard: shipped crew templates must not instruct subagents to
+ * write reports into the customer's working tree.
+ *
+ * A real customer reported `.prjct/sessions/<task>/<role>.md` files dirtying
+ * their repo because the crew templates told the leader/implementer/reviewer
+ * to persist output there. The product invariant is: SQLite + regenerated
+ * vault are the only allowed persistence surfaces. This test fails fast if
+ * any template under templates/crew/ reintroduces the pattern.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const CREW_DIR = path.join(REPO_ROOT, 'templates', 'crew')
+const FORBIDDEN = ['.prjct/sessions/']
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const out: string[] = []
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await collectFiles(full)))
+    } else {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+describe('crew templates: no disk-write instructions', () => {
+  test('no template under templates/crew/ references forbidden persistence paths', async () => {
+    const files = await collectFiles(CREW_DIR)
+    expect(files.length).toBeGreaterThan(0)
+
+    const offenders: Array<{ file: string; needle: string }> = []
+    for (const file of files) {
+      const content = await fs.readFile(file, 'utf-8')
+      for (const needle of FORBIDDEN) {
+        if (content.includes(needle)) {
+          offenders.push({ file: path.relative(REPO_ROOT, file), needle })
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.5",
+  "version": "2.19.6",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -256,6 +256,27 @@ function bundleTemplates() {
 
   walk(templatesDir, '')
 
+  // Architecture guard: no shipped template may instruct an agent to write
+  // outside the DB or the regenerated vault. `.prjct/sessions/` is the
+  // historical offender — block any reintroduction here so the bundle never
+  // re-ships disk-pollution patterns to customers.
+  const forbiddenSubstrings = ['.prjct/sessions/']
+  const offenders = []
+  for (const [relPath, content] of Object.entries(bundle)) {
+    for (const needle of forbiddenSubstrings) {
+      if (content.includes(needle)) offenders.push(`${relPath}: contains "${needle}"`)
+    }
+  }
+  if (offenders.length > 0) {
+    console.error('\n✗ Template bundle contains forbidden persistence paths:')
+    for (const line of offenders) console.error(`  - ${line}`)
+    console.error(
+      '\n  prjct ships only two persistence surfaces: SQLite (~/.prjct-cli/projects/<id>/) and the regenerated vault (~/Documents/prjct/<slug>/_generated/).'
+    )
+    console.error('  Templates must not instruct agents to write anywhere else.')
+    process.exit(1)
+  }
+
   const outPath = path.join(DIST, 'templates.json')
   fs.writeFileSync(outPath, JSON.stringify(bundle))
 

--- a/templates/crew/CHECKPOINTS.md
+++ b/templates/crew/CHECKPOINTS.md
@@ -37,9 +37,9 @@
 
 ## C5 — The session closed cleanly
 
-- [ ] No untracked junk in the worktree (`*.tmp`, scratch logs, accidental binaries).
-- [ ] The implementer's report exists at `.prjct/sessions/<task-slug>/impl.md`.
-- [ ] The reviewer's verdict exists at `.prjct/sessions/<task-slug>/review.md` and is `APPROVED`.
+- [ ] No untracked junk in the worktree (`*.tmp`, scratch logs, accidental binaries, any subdirectory of `.prjct/`).
+- [ ] The implementer replied inline with the summary block (STATUS / PLAN / FILES TOUCHED / VERIFICATION / NOTES).
+- [ ] The reviewer replied inline with `VERDICT: APPROVED` (first line).
 - [ ] The task's status was advanced (`prjct status done` for completed work, `prjct status paused` if intentionally paused).
 
 ---

--- a/templates/crew/CLAUDE-leader-mode.md
+++ b/templates/crew/CLAUDE-leader-mode.md
@@ -12,9 +12,11 @@ This project is in **crew mode**. The main session always acts as the `leader` s
   - `subagent_type: "reviewer"` → validates the implementer's work against `.prjct/CHECKPOINTS.md` before close.
   - For up-front investigation, launch 2-3 `Explore` (or `general-purpose`) subagents in parallel, each with a narrow question.
 
-### Anti-broken-telephone
+### Keep replies tight
 
-When you launch any subagent, instruct it to **write its results to a file** (e.g. `.prjct/sessions/<task-slug>/<role>.md`) and reply to you with **only the path reference**. You read the file from disk if you need detail. Never accept full diffs or long outputs in chat.
+Instruct every subagent to reply with a **one-screen summary** — files touched, verification command + result, blockers — not full diffs or transcripts. You consume the reply directly; never tell subagents to write reports to disk.
+
+If you need durable state that outlives the session, persist via `prjct` CLI verbs (`prjct spec`, `prjct remember`, `prjct capture`) — SQLite + the regenerated vault are the only allowed persistence surfaces.
 
 ### When this role does NOT apply
 

--- a/templates/crew/agents/implementer.md
+++ b/templates/crew/agents/implementer.md
@@ -12,15 +12,25 @@ You are an implementer. Your job is to take **one** prjct task from active to re
 
 1. **Orient.** Read `.prjct/CHECKPOINTS.md` and run `prjct context --md` to understand task and recent decisions.
 2. **Confirm scope.** Run `prjct status --md` — there must be exactly one active task. If not, stop and report `blocked -> no single active task`.
-3. **Plan.** Write a 3-5 bullet plan to `.prjct/sessions/<task-slug>/impl.md` (create the directory). Include: files you will touch, tests you will add, verification command.
+3. **Plan.** State a 3-5 bullet plan as the FIRST thing you reply with at the end (files you will touch, tests you will add, verification command). Keep it inline — do not write the plan to disk.
 4. **Implement.** Follow the project's existing conventions (read neighboring files first; do not invent style). Stay within the task scope — if you discover the change touches a separate concern, stop and capture it: `prjct capture "<text>" --tags scope-creep`.
 5. **Test.** Every code change is paired with a test before moving on. Use the project's existing test runner.
-6. **Self-verify.** Run the project's tests. If they fail, return to step 4. If they pass, run `prjct check --md` if available; otherwise note the verification command you ran in `.prjct/sessions/<task-slug>/impl.md`.
-7. **Do not mark `done`.** Append a final summary block to `.prjct/sessions/<task-slug>/impl.md` listing every file touched and the verification command output.
-8. **Hand off.** Reply to the leader with **one line**:
+6. **Self-verify.** Run the project's tests. If they fail, return to step 4. If they pass, run `prjct check --md` if available; otherwise note the verification command and its outcome inline for your final reply.
+7. **Do not mark `done`.** The reviewer must approve first. Do not run `prjct status done` until the reviewer's reply is `APPROVED`.
+8. **Hand off.** Reply to the leader with a compact summary (≈one screen):
 
    ```
-   done -> .prjct/sessions/<task-slug>/impl.md
+   STATUS: ready-for-review
+
+   PLAN: <3-5 bullets from step 3>
+
+   FILES TOUCHED:
+   - path/to/a.ts (added foo())
+   - path/to/a.test.ts (added test for foo())
+
+   VERIFICATION: bun test path/to/a.test.ts  →  PASS (4 tests)
+
+   NOTES: <surprises, scope-creep captures by mem id, blockers>
    ```
 
    The leader will launch a `reviewer` next. Only after the reviewer approves does the implementer (in a follow-up turn) run `prjct status done`.
@@ -31,7 +41,8 @@ You are an implementer. Your job is to take **one** prjct task from active to re
 - Every code edit must be accompanied by its test before the next edit.
 - Never declare a task `done` without the reviewer's explicit `APPROVED`.
 - Never write debug `console.log` / `print` / scratch files into source. Clean up before handing off.
+- Never write report files into the working tree — no scratch `.md`, no subdirectory under `.prjct/`. Durable state goes through `prjct` CLI verbs only.
 
-## Anti-broken-telephone
+## Keep your reply tight
 
-Your reply to the leader is **one line** with a file reference. Never paste diffs or large outputs into chat — write them to `.prjct/sessions/<task-slug>/impl.md`.
+Reply with the summary block above. Do not paste full diffs, do not paste full test output. If something is too long to summarize, capture it with `prjct remember <type> "<text>"` and cite the returned mem id in your NOTES line.

--- a/templates/crew/agents/leader.md
+++ b/templates/crew/agents/leader.md
@@ -26,13 +26,15 @@ For each request:
 4. Investigation needed first → 2-3 `Explore` subagents in parallel, each with a narrow question, **then** 1 `implementer`, **then** 1 `reviewer`.
 5. Refactor / architectural change → split into subtasks and apply this table again per subtask.
 
-## Anti-broken-telephone rule
+## Keep subagent replies tight
 
-When you launch subagents, instruct them to **write their results to a file** under `.prjct/sessions/<task-slug>/<role>.md` and return only that path. Never accept their full output in chat — read the file from disk if you need details.
+When you launch a subagent, instruct it to reply with a **one-screen summary** — files touched, verification command + outcome, blockers. Not a full diff, not a transcript, not a "see attached" file reference. You consume the reply directly.
+
+Subagents must not write reports to disk. Persistence on this project goes through `prjct` CLI verbs only — SQLite + the regenerated vault are the only allowed surfaces.
 
 Example correct prompt to a subagent:
 
-> "Investigate how `notes.py` serializes IDs. Write findings to `.prjct/sessions/cli-edit/explore_ids.md`. Reply to me with only `done -> .prjct/sessions/cli-edit/explore_ids.md` or a blocker message."
+> "Investigate how `notes.py` serializes IDs. Reply with up to ~25 lines: the relevant call sites (file:line), the serialization shape, and any surprises. If the answer is bigger, capture details with `prjct remember learning '<summary>'` and reply with the mem id + headline."
 
 ## Effort scaling
 
@@ -47,7 +49,7 @@ Example correct prompt to a subagent:
 
 - Do not edit files in the application's source/test directories directly.
 - Do not mark a task as `done` yourself — the implementer does that after the reviewer approves.
-- Do not accept subagent results delivered in chat without a file reference.
+- Do not paste full subagent transcripts or diffs back to the user — summarize.
 
 ## When this role does NOT apply
 

--- a/templates/crew/agents/reviewer.md
+++ b/templates/crew/agents/reviewer.md
@@ -10,7 +10,7 @@ You are a strict reviewer. Your only function is to **approve or reject** change
 
 ## Protocol
 
-1. Read `.prjct/CHECKPOINTS.md` and the implementer's report at `.prjct/sessions/<task-slug>/impl.md`.
+1. Read `.prjct/CHECKPOINTS.md`. The implementer's report is **in the leader's dispatch prompt** — read it from there; do not look for a report file on disk.
 2. Identify the modified files (use `git status --porcelain` and `git diff --stat`). Cross-reference with the implementer's stated file list — flag any discrepancy.
 3. For each modified file, verify:
    - It respects the project's conventions (style of neighboring files).
@@ -18,38 +18,28 @@ You are a strict reviewer. Your only function is to **approve or reject** change
    - No debug noise was left behind (`console.log`, `print`, `TODO` without a captured note).
 4. Run the project's test command. Tests must pass — if any test is red, that is an automatic rejection.
 5. Walk every checkbox in `.prjct/CHECKPOINTS.md`. Mark `[x]` for items met, `[ ]` for items missed.
-6. Emit verdict.
+6. Reply to the leader with the verdict block (inline, no files).
 
 ## Verdict format
 
-Write your verdict to `.prjct/sessions/<task-slug>/review.md`:
+Reply to the leader inline with this exact shape:
 
 ```markdown
-# Review — <task title>
+VERDICT: APPROVED | CHANGES_REQUESTED
 
-**Verdict:** APPROVED | CHANGES_REQUESTED
-
-## Checkpoints
+CHECKPOINTS:
 - C1: [x]
 - C2: [x]
 - C3: [ ]  ← Reason: src/foo.ts imports `lodash`; the project disallows new runtime deps without prior capture
 - C4: [x]
 - C5: [x]
 
-## Required changes (if any)
+REQUIRED CHANGES (if any):
 1. Remove `import lodash from 'lodash'` from src/foo.ts.
 2. ...
 ```
 
-Reply to the leader with **one line**:
-
-```
-APPROVED -> .prjct/sessions/<task-slug>/review.md
-```
-or
-```
-CHANGES_REQUESTED -> .prjct/sessions/<task-slug>/review.md
-```
+First line of the reply must be `VERDICT: APPROVED` or `VERDICT: CHANGES_REQUESTED`. The leader keys off that first token.
 
 ## Hard rules
 
@@ -57,3 +47,4 @@ CHANGES_REQUESTED -> .prjct/sessions/<task-slug>/review.md
 - Never approve with empty checkboxes in C1-C5.
 - Never edit the implementer's code. Your job is to say what fails — not to fix it.
 - Be concrete: cite file paths and line numbers. No generic feedback.
+- Never write your verdict to a file. The reply itself IS the verdict.


### PR DESCRIPTION
## Summary

- **Customer-reported bug**: shipped crew-mode templates instructed AI subagents to persist plan / impl notes / review verdicts as loose markdown files at `.prjct/sessions/<task-slug>/<role>.md` inside the customer's repo. That dirtied git status, got committed by accident, and violated the product invariant (SQLite + regenerated vault are the only allowed persistence surfaces).
- **Fix**: rewrote the five crew templates so subagents reply inline; durable state goes through `prjct` CLI verbs only.
- **Regression guard**: build-time check in `scripts/build.js` blocks the bundle if any template under `templates/` reintroduces `.prjct/sessions/`; unit test `core/__tests__/commands/crew-templates-no-disk-writes.test.ts` enforces the same invariant.

## What this does NOT solve (Tier 2)

- `.prjct/CHECKPOINTS.md` is still written by `prjct crew install`
- `.prjct/team.json` is still written by `prjct team`
- `.claude/*` writes from `prjct mcp`, `prjct crew install`, `prjct team`

Those go behind a revised crew-refactor spec (`a50b32d1-506c-4ed1-8813-bd9991fb1e0a` — currently in `draft` after the architecture audit flagged schema/state-machine debt: `SpecReviewer` enum is hardcoded to `strategic|architecture|design`, `recordReview` is last-write-wins not transactional, and the auto-promotion logic in `spec-service.ts:167` would mis-fire on implementer verdicts).

## Test plan

- [x] `bun test` → 1125 pass, 0 fail (+1 new guard test)
- [x] `tsc --noEmit -p core/tsconfig.json` → green
- [x] `grep -r '\.prjct/sessions/' templates/` → 0 matches
- [x] `grep -c '\.prjct/sessions/' dist/templates.json` → 0
- [x] Sanity-injected a violation into a template → build correctly exited 1 with the architecture-violation error message
- [ ] Manual: install crew mode in a scratch repo via \`prjct crew install\`, dispatch a task, confirm \`git status\` shows no \`.prjct/sessions/\` directory after the run

## Version note

Both this PR and the in-flight `refactor/sqlite-connection-factory` PR bump to v2.19.6 — they branched off the same main at v2.19.5. Whichever merges second will need a small CHANGELOG/package.json merge (distinct entries, low risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)