### PR TITLE
refactor(storage): centralize SQLite connection factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.19.7] - 2026-05-13
+
+### Changed
+- **SQLite connection factory centralized.** `openDatabase()` in `core/storage/database/sqlite-compat.ts` now bakes `PRAGMA journal_mode=WAL` + `PRAGMA busy_timeout=5000` into every connection it returns. The duplicated PRAGMA calls in `core/storage/database.ts` and `core/storage/system-database.ts` were removed, and `system-database.ts` no longer ships its own copy of the `bun:sqlite` / `better-sqlite3` shim. Eliminates the regression class behind the v2.19.0 sync hang — a new SQLite caller cannot forget the daemon-safety pragma because the factory enforces it.
+
 ## [2.19.6] - 2026-05-13
 
 ### Fixed

--- a/core/storage/database.ts
+++ b/core/storage/database.ts
@@ -77,17 +77,10 @@ class PrjctDatabase {
     const dbPath = this.getDbPath(projectId)
     const dbDir = path.dirname(dbPath)
     if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true })
+    // openDatabase bakes in WAL + busy_timeout=5000 — daemon-safety pragmas
+    // every connection needs. Performance tuning stays here.
     const db = openDatabase(dbPath)
 
-    // Enable WAL mode for concurrent reads + single writer
-    db.run('PRAGMA journal_mode = WAL')
-
-    // Wait up to 5s on writer/schema lock contention instead of failing
-    // (or hanging silently) when the daemon holds an overlapping connection.
-    // Must run before runMigrations — migrations open a write transaction.
-    db.run('PRAGMA busy_timeout = 5000')
-
-    // Performance tuning
     db.run('PRAGMA synchronous = NORMAL')
     db.run('PRAGMA cache_size = -2000') // 2MB cache
     db.run('PRAGMA temp_store = MEMORY')

--- a/core/storage/database/sqlite-compat.ts
+++ b/core/storage/database/sqlite-compat.ts
@@ -29,8 +29,25 @@ export interface SqliteDatabase {
 /**
  * Open a SQLite database using the runtime-appropriate driver.
  * bun:sqlite on Bun, better-sqlite3 on Node.js.
+ *
+ * Every connection is opened with the correctness PRAGMAs baked in:
+ *   - journal_mode = WAL       — concurrent reads + single writer
+ *   - busy_timeout = 5000      — wait on lock contention instead of hanging
+ *                                silently when the daemon holds an overlapping
+ *                                connection (see [[gotcha_sync_hang]])
+ *
+ * Performance-tuning PRAGMAs (synchronous, cache_size, mmap_size, …) remain
+ * the caller's responsibility — they differ per database (per-project vs
+ * system) and aren't correctness-critical.
  */
 export function openDatabase(dbPath: string): SqliteDatabase {
+  const db = openRaw(dbPath)
+  db.run('PRAGMA journal_mode = WAL')
+  db.run('PRAGMA busy_timeout = 5000')
+  return db
+}
+
+function openRaw(dbPath: string): SqliteDatabase {
   if (isBun()) {
     const { Database } = require('bun:sqlite')
     return new Database(dbPath, { create: true }) as SqliteDatabase

--- a/core/storage/system-database.ts
+++ b/core/storage/system-database.ts
@@ -12,37 +12,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { McpHealthRow, McpHealthStatus } from '../types/storage/extended'
-import { isBun } from '../utils/runtime'
-
-// =============================================================================
-// SQLite Compatibility Layer (same pattern as database.ts)
-// =============================================================================
-
-type SqliteBindings = string | number | bigint | Buffer | null | undefined
-
-interface SqliteStatement {
-  get(...params: SqliteBindings[]): unknown
-  all(...params: SqliteBindings[]): unknown[]
-  run(...params: SqliteBindings[]): void
-}
-
-interface SqliteDatabase {
-  prepare(sql: string): SqliteStatement
-  run(sql: string): void
-  close(): void
-}
-
-function openDatabase(dbPath: string): SqliteDatabase {
-  if (isBun()) {
-    const { Database } = require('bun:sqlite')
-    return new Database(dbPath, { create: true }) as SqliteDatabase
-  }
-  const BetterSqlite3 = require('better-sqlite3')
-  const db = new BetterSqlite3(dbPath)
-  const origExec = db.exec.bind(db)
-  db.run = (sql: string) => origExec(sql)
-  return db as SqliteDatabase
-}
+import { openDatabase, type SqliteDatabase } from './database/sqlite-compat'
 
 // =============================================================================
 // System Database
@@ -68,10 +38,9 @@ class SystemDatabase {
       fs.mkdirSync(dbDir, { recursive: true })
     }
 
+    // openDatabase bakes in WAL + busy_timeout=5000 (daemon-safety pragmas).
     const db = openDatabase(this.dbPath)
 
-    db.run('PRAGMA journal_mode = WAL')
-    db.run('PRAGMA busy_timeout = 5000')
     db.run('PRAGMA synchronous = NORMAL')
     db.run('PRAGMA cache_size = -1000')
     db.run('PRAGMA temp_store = MEMORY')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.6",
+  "version": "2.19.7",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- **Goal**: eliminate the class of bug behind the v2.19.0 sync hang by guaranteeing every SQLite connection gets the daemon-safety PRAGMAs.
- **Change**: `openDatabase()` in \`core/storage/database/sqlite-compat.ts\` now bakes \`PRAGMA journal_mode=WAL\` + \`PRAGMA busy_timeout=5000\` into every connection it returns.
- **Cleanup**: dropped the duplicated PRAGMA calls at \`core/storage/database.ts:80\` and removed the local copy of \`openDatabase\` + duplicate type defs from \`core/storage/system-database.ts\`; it now imports the shared factory.

## Context

The v2.19.0 sync hang ([gotcha mem_2522]) was caused by the daemon holding RW handles on \`prjct.db\` while a CLI connection that lacked \`PRAGMA busy_timeout\` blocked silently on writer/schema lock. Fix #325 set the PRAGMA at the two callsites (\`database.ts:80\` and \`system-database.ts:73\`) but kept it caller-managed — any new SQLite consumer that forgot the PRAGMA would reintroduce the hang. \`mem_2524\` flagged this as a follow-up: move the PRAGMA into the factory so it cannot be skipped.

This PR makes the factory itself the choke point: WAL + busy_timeout are correctness pragmas, baked in; performance-tuning pragmas (\`synchronous\`, \`cache_size\`, \`mmap_size\`) stay at the callsites since they legitimately differ per-database.

## Net change

\`\`\`
core/storage/database.ts               | 11 ++---------
core/storage/database/sqlite-compat.ts | 17 +++++++++++++++++
core/storage/system-database.ts        | 35 ++--------------------------------
\`\`\`
+21 / -42 LOC. \`system-database.ts\` loses its duplicate driver shim (the \`bun:sqlite\` vs \`better-sqlite3\` switch) and shares the canonical one.

## Test plan

- [x] \`bun test\` → 1124 pass, 0 fail
- [x] \`tsc --noEmit -p core/tsconfig.json\` → green
- [x] Storage tests in particular (\`bun test core/__tests__/storage\`) → 236 pass

## Version note

Both this PR and the in-flight #330 (crew-mode hotfix) bump to v2.19.6 — they branched off the same main at v2.19.5. Whichever lands second will need a small CHANGELOG/package.json merge (distinct entries, low risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)