### PR TITLE
feat(crew-persistence): checkpoints + crew verbs + spec breakdown + wiki builders (spec a50b32d1 part 2)

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -715,22 +715,49 @@ async function main(): Promise<void> {
       process.exitCode = 0
     }
   } else if (args[0] === 'crew') {
-    // `prjct crew install|uninstall|status` — manage the multi-agent
-    // crew bundle (leader/implementer/reviewer + CHECKPOINTS + CLAUDE.md
-    // snippet). Strictly opt-in.
+    // `prjct crew install|uninstall|status|record-run|checkpoints …`
+    // Manages the multi-agent crew bundle. Strictly opt-in.
     const subcommand = args[1] ?? 'status'
     const { CrewCommands } = await import('../core/commands/crew')
     const cmd = new CrewCommands()
     const mdMode = args.includes('--md')
-    let result: Awaited<ReturnType<typeof cmd.install>>
+    const getFlag = (name: string): string | undefined => {
+      const idx = args.indexOf(`--${name}`)
+      if (idx >= 0 && idx + 1 < args.length && !args[idx + 1].startsWith('--')) {
+        return args[idx + 1]
+      }
+      return undefined
+    }
+    let result: { success: boolean; error?: string } = { success: false }
     if (subcommand === 'install') {
       result = await cmd.install(null, process.cwd(), { md: mdMode })
     } else if (subcommand === 'uninstall') {
       result = await cmd.uninstall(null, process.cwd(), { md: mdMode })
     } else if (subcommand === 'status') {
       result = await cmd.status(null, process.cwd(), { md: mdMode })
+    } else if (subcommand === 'checkpoints') {
+      // `prjct crew checkpoints [show|set|reset|export] [--content|--file]`
+      const checkpointsSub = args[2] ?? 'show'
+      result = await cmd.checkpoints(checkpointsSub, process.cwd(), {
+        md: mdMode,
+        content: getFlag('content'),
+        file: getFlag('file'),
+      })
+    } else if (subcommand === 'record-run') {
+      result = await cmd.recordRun(process.cwd(), {
+        md: mdMode,
+        spec: getFlag('spec'),
+        task: getFlag('task'),
+        'implementer-summary': getFlag('implementer-summary'),
+        files: getFlag('files'),
+        'reviewer-verdict': getFlag('reviewer-verdict'),
+        'reviewer-notes': getFlag('reviewer-notes'),
+        'run-id': getFlag('run-id'),
+      })
     } else {
-      console.error(`Unknown crew subcommand: ${subcommand}. Use: install, uninstall, status.`)
+      console.error(
+        `Unknown crew subcommand: ${subcommand}. Use: install, uninstall, status, checkpoints, record-run.`
+      )
       result = { success: false, error: `unknown subcommand: ${subcommand}` }
     }
     process.exitCode = result.success ? 0 : 1

--- a/core/__tests__/commands/crew.test.ts
+++ b/core/__tests__/commands/crew.test.ts
@@ -39,12 +39,21 @@ describe('prjct crew', () => {
       '.claude/agents/leader.md',
       '.claude/agents/implementer.md',
       '.claude/agents/reviewer.md',
-      '.prjct/CHECKPOINTS.md',
       'CLAUDE.md',
     ]) {
       const content = await fs.readFile(path.join(projectPath, f), 'utf-8')
       expect(content.length).toBeGreaterThan(0)
     }
+
+    // Post-spec-a50b32d1: checkpoints moved from `.prjct/CHECKPOINTS.md`
+    // to kv_store. The file is no longer written by install — the
+    // reviewer template carries the content inline between markers.
+    const reviewerMd = await fs.readFile(
+      path.join(projectPath, '.claude/agents/reviewer.md'),
+      'utf-8'
+    )
+    expect(reviewerMd).toContain('<!-- prjct:checkpoints:start')
+    expect(reviewerMd).toContain('<!-- prjct:checkpoints:end -->')
 
     const claudeMd = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
     expect(claudeMd).toContain(SNIPPET_START)

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -391,6 +391,14 @@ class PrjctCommands {
     return this.specCmds.audit(id, projectPath, options)
   }
 
+  async specBreakdown(
+    id: string | null = null,
+    projectPath: string = process.cwd(),
+    options: { md?: boolean; force?: boolean } = {}
+  ): Promise<CommandResult> {
+    return this.specCmds.breakdown(id, projectPath, options)
+  }
+
   async specInventory(
     projectPath: string = process.cwd(),
     options: { md?: boolean; json?: boolean } = {}

--- a/core/commands/crew.ts
+++ b/core/commands/crew.ts
@@ -11,16 +11,49 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { getTemplateContent } from '../agentic/template-loader'
+import configManager from '../infrastructure/config-manager'
+import { checkpointsStorage } from '../storage/checkpoints-storage'
+import crewRunStorage from '../storage/crew-run-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { fileExists } from '../utils/file-helper'
-import { failHard } from '../utils/md-aware'
+import { failHard, failWith } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 
 const SNIPPET_START = '<!-- prjct:crew:start - DO NOT REMOVE THIS MARKER -->'
 const SNIPPET_END = '<!-- prjct:crew:end - DO NOT REMOVE THIS MARKER -->'
+
+const CHECKPOINTS_START =
+  '<!-- prjct:checkpoints:start - DO NOT EDIT (managed by `prjct crew checkpoints set|reset`) -->'
+const CHECKPOINTS_END = '<!-- prjct:checkpoints:end -->'
+
+/**
+ * Splice the current checkpoints content into the reviewer agent
+ * template between the marker pair. Anchored regex — refuses to write
+ * if markers are missing or duplicated (defensive against template
+ * drift). Content outside the markers is preserved verbatim.
+ *
+ * See spec a50b32d1 AC #7.
+ */
+function spliceCheckpoints(reviewerTemplate: string, checkpointsContent: string): string {
+  const startIdx = reviewerTemplate.indexOf(CHECKPOINTS_START)
+  const endIdx = reviewerTemplate.indexOf(CHECKPOINTS_END)
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    throw new Error(
+      'reviewer template is missing the prjct:checkpoints marker pair — rebuild dist/templates.json or report a bug'
+    )
+  }
+  // Refuse if marker appears more than once — ambiguous splice.
+  if (reviewerTemplate.indexOf(CHECKPOINTS_START, startIdx + 1) >= 0) {
+    throw new Error('reviewer template has duplicated checkpoints start marker')
+  }
+  const before = reviewerTemplate.slice(0, startIdx + CHECKPOINTS_START.length)
+  const after = reviewerTemplate.slice(endIdx)
+  // Single newline separators keep the markdown rendering tight.
+  return `${before}\n${checkpointsContent.trimEnd()}\n${after}`
+}
 
 interface CrewFile {
   /** Path inside the templates/crew/ tree */
@@ -118,9 +151,25 @@ async function getStatus(projectPath: string): Promise<CrewStatus> {
     }))
   )
 
+  // Checkpoints moved from `.prjct/CHECKPOINTS.md` to kv_store
+  // `crew:checkpoints` per spec a50b32d1. "Installed" means a project
+  // exists with the row present (or the bundled default is reachable —
+  // which it always is, since the template is in the bundle).
+  let checkpointsInstalled = false
+  try {
+    const projectId = await configManager.getProjectId(projectPath)
+    if (projectId) {
+      // We always return SOMETHING from get() (bundled default fallback),
+      // so installed == has-customization-OR-bundled-default-available.
+      checkpointsStorage.get(projectId)
+      checkpointsInstalled = true
+    }
+  } catch {
+    checkpointsInstalled = false
+  }
   const checkpoints: PieceStatus = {
-    path: CHECKPOINTS_FILE.destRelative,
-    installed: await fileExists(path.join(projectPath, CHECKPOINTS_FILE.destRelative)),
+    path: 'kv_store[crew:checkpoints]',
+    installed: checkpointsInstalled,
   }
 
   const claudeContent = await readClaudeMd(projectPath)
@@ -149,27 +198,34 @@ export class CrewCommands extends PrjctCommandsBase {
       const written: string[] = []
       const skipped: string[] = []
 
-      // 1. Agents
+      // Resolve projectId so we can read user-customized checkpoints from
+      // kv_store and splice them into the reviewer template at install
+      // time. Required for the new (post-spec-a50b32d1) reviewer flow —
+      // no more `.prjct/CHECKPOINTS.md` on disk.
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+      const projectId = await configManager.getProjectId(projectPath)
+      if (!projectId) {
+        return failHard('No prjct project. Run `prjct init` first.', options)
+      }
+
+      const checkpointsRow = checkpointsStorage.get(projectId)
+
+      // 1. Agents — write each. For reviewer.md, splice the current
+      // checkpoints content into the marker region.
       for (const f of AGENT_FILES) {
         const dest = path.join(projectPath, f.destRelative)
-        const content = await readTemplate(f.templateKey)
+        let content = await readTemplate(f.templateKey)
+        if (f.destRelative === '.claude/agents/reviewer.md') {
+          content = spliceCheckpoints(content, checkpointsRow.content)
+        }
         const exists = await fileExists(dest)
         await writeFileEnsureDir(dest, content)
         if (exists) skipped.push(`${f.destRelative} (overwritten)`)
         else written.push(f.destRelative)
       }
 
-      // 2. CHECKPOINTS — never overwrite if user has customised it
-      const checkpointsDest = path.join(projectPath, CHECKPOINTS_FILE.destRelative)
-      if (await fileExists(checkpointsDest)) {
-        skipped.push(`${CHECKPOINTS_FILE.destRelative} (kept existing)`)
-      } else {
-        const content = await readTemplate(CHECKPOINTS_FILE.templateKey)
-        await writeFileEnsureDir(checkpointsDest, content)
-        written.push(CHECKPOINTS_FILE.destRelative)
-      }
-
-      // 3. CLAUDE.md snippet — append/replace marker block, idempotent
+      // 2. CLAUDE.md snippet — append/replace marker block, idempotent
       const snippet = await readSnippet()
       const claudePath = path.join(projectPath, CLAUDE_FILE)
       const existingClaude = (await readClaudeMd(projectPath)) ?? ''
@@ -224,7 +280,11 @@ export class CrewCommands extends PrjctCommandsBase {
       const removed: string[] = []
       const missing: string[] = []
 
-      for (const f of [...AGENT_FILES, CHECKPOINTS_FILE]) {
+      // AGENT_FILES + legacy .prjct/CHECKPOINTS.md if still present on disk
+      // (older installs wrote it before spec a50b32d1 moved checkpoints to
+      // kv_store). The file is no longer written by install.
+      const toRemove: CrewFile[] = [...AGENT_FILES, CHECKPOINTS_FILE]
+      for (const f of toRemove) {
         const dest = path.join(projectPath, f.destRelative)
         if (await fileExists(dest)) {
           await fs.rm(dest)
@@ -309,4 +369,175 @@ export class CrewCommands extends PrjctCommandsBase {
       return failHard(msg)
     }
   }
+
+  /**
+   * `prjct crew checkpoints` (no sub) → show
+   * `prjct crew checkpoints set [--content | --file | <stdin>]` → write
+   * `prjct crew checkpoints reset` → bundled default
+   * `prjct crew checkpoints export [--file]` → snapshot (NOT authoritative)
+   *
+   * See spec a50b32d1 ACs #7 and #8.
+   */
+  async checkpoints(
+    sub: string | null = null,
+    projectPath: string = process.cwd(),
+    options: {
+      md?: boolean
+      content?: string
+      file?: string
+    } = {}
+  ): Promise<CommandResult> {
+    try {
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+      const projectId = await configManager.getProjectId(projectPath)
+      if (!projectId) {
+        return failHard('No prjct project. Run `prjct init` first.', options)
+      }
+
+      // Default subverb: show
+      if (sub === null || sub === 'show') {
+        const row = checkpointsStorage.get(projectId)
+        process.stdout.write(row.content)
+        return { success: true, source: row.source }
+      }
+
+      if (sub === 'set') {
+        let content: string | null = null
+        if (typeof options.content === 'string' && options.content.length > 0) {
+          content = options.content
+        } else if (typeof options.file === 'string' && options.file.length > 0) {
+          content = await fs.readFile(path.resolve(projectPath, options.file), 'utf-8')
+        } else if (!process.stdin.isTTY) {
+          content = await readAllStdin()
+        } else {
+          // Stdin is a TTY → no content piped, no flag given. Error fast
+          // instead of blocking on a read that will never arrive. Exit 2.
+          process.stderr.write(
+            'error: no content provided; pipe to stdin, or pass --content / --file\n'
+          )
+          process.exitCode = 2
+          return failWith('checkpoints set: no content provided', options)
+        }
+        if (content === null || content.length === 0) {
+          return failWith('checkpoints set: content is empty', options)
+        }
+        const row = checkpointsStorage.set(projectId, content, 'user')
+        if (options.md) console.log(`✓ checkpoints updated (source=${row.source})`)
+        else out.done(`checkpoints updated (source=${row.source})`)
+        return { success: true, source: row.source }
+      }
+
+      if (sub === 'reset') {
+        checkpointsStorage.reset(projectId)
+        if (options.md) console.log('✓ checkpoints reset to bundled default')
+        else out.done('checkpoints reset to bundled default')
+        return { success: true, reset: true }
+      }
+
+      if (sub === 'export') {
+        const row = checkpointsStorage.get(projectId)
+        const isDefault = !checkpointsStorage.hasCustomization(projectId)
+        if (isDefault) {
+          process.stderr.write('(exporting bundled default; no user customization set)\n')
+        }
+        if (typeof options.file === 'string' && options.file.length > 0) {
+          const target = path.resolve(projectPath, options.file)
+          await fs.mkdir(path.dirname(target), { recursive: true })
+          await fs.writeFile(target, row.content, 'utf-8')
+          if (options.md) console.log(`✓ exported to \`${options.file}\``)
+          else out.done(`exported to ${options.file}`)
+          return { success: true, exported: true, file: options.file, isDefault }
+        }
+        process.stdout.write(row.content)
+        return { success: true, exported: true, isDefault }
+      }
+
+      return failWith(
+        `Unknown crew checkpoints subverb: ${sub}. Use: show, set, reset, export.`,
+        options
+      )
+    } catch (error) {
+      return failHard(getErrorMessage(error), options)
+    }
+  }
+
+  /**
+   * `prjct crew record-run` — at the end of a crew flow, the leader
+   * persists a single durable row capturing the implementer's summary
+   * + reviewer verdict. Idempotent on caller-supplied --run-id.
+   *
+   * See spec a50b32d1 AC #4.
+   */
+  async recordRun(
+    projectPath: string = process.cwd(),
+    options: {
+      md?: boolean
+      spec?: string
+      task?: string
+      'implementer-summary'?: string
+      files?: string
+      'reviewer-verdict'?: string
+      'reviewer-notes'?: string
+      'run-id'?: string
+    } = {}
+  ): Promise<CommandResult> {
+    try {
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+      const projectId = await configManager.getProjectId(projectPath)
+      if (!projectId) {
+        return failHard('No prjct project. Run `prjct init` first.', options)
+      }
+
+      const summary = options['implementer-summary']
+      const verdict = options['reviewer-verdict']
+      const filesArg = options.files ?? ''
+
+      if (!summary) {
+        return failWith('crew record-run: --implementer-summary is required', options)
+      }
+      if (verdict !== 'APPROVED' && verdict !== 'CHANGES_REQUESTED') {
+        return failWith(
+          'crew record-run: --reviewer-verdict must be APPROVED or CHANGES_REQUESTED',
+          options
+        )
+      }
+
+      const filesTouched = filesArg
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+
+      const run = crewRunStorage.record(projectId, {
+        runId: options['run-id'],
+        specId: options.spec ?? null,
+        taskId: options.task ?? null,
+        implementerSummary: summary,
+        filesTouched,
+        reviewerVerdict: verdict,
+        reviewerNotes: options['reviewer-notes'] ?? null,
+      })
+
+      const slug = run.spec_id ?? run.task_id ?? run.id
+      const vaultPath = `~/Documents/prjct/<slug>/_generated/crew-runs/${slug}-${run.started_at}.md`
+      if (options.md) {
+        console.log(`✓ crew run recorded: run-id=${run.id}`)
+        console.log(`  vault: ${vaultPath}`)
+      } else {
+        out.done(`crew run recorded: run-id=${run.id}`)
+      }
+      return { success: true, runId: run.id, vaultPath }
+    } catch (error) {
+      return failHard(getErrorMessage(error), options)
+    }
+  }
+}
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer))
+  }
+  return Buffer.concat(chunks).toString('utf-8')
 }

--- a/core/commands/spec.ts
+++ b/core/commands/spec.ts
@@ -17,6 +17,7 @@
  * body's intent map.
  */
 
+import configManager from '../infrastructure/config-manager'
 import { specService } from '../services/spec-service'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
@@ -383,6 +384,91 @@ export class SpecCommands extends PrjctCommandsBase {
       const dispatch = renderAuditDispatch(spec.id, spec.title, spec.content)
       console.log(dispatch)
       return { success: true, specId: id, dispatch: 'emitted' }
+    } catch (error) {
+      return failHard(getErrorMessage(error))
+    }
+  }
+
+  /**
+   * `prjct spec breakdown <id> [--force]` — manual recovery / re-trigger
+   * for breakdownSpecToTasks. Idempotent on tasks_created_at; safe to
+   * call repeatedly. Default gate: status='reviewed' or later. `--force`
+   * bypass emits an audit event (`type=spec.breakdown.forced`) and
+   * echoes the resulting mem id on stdout.
+   *
+   * See spec a50b32d1 AC #14.
+   */
+  async breakdown(
+    id: string | null = null,
+    projectPath: string = process.cwd(),
+    options: SpecCmdOptions & { force?: boolean } = {}
+  ): Promise<CommandResult> {
+    try {
+      if (!id) return failWith('Usage: prjct spec breakdown <id> [--force]')
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+
+      const spec = await specService.get(projectPath, id)
+      if (!spec) return failWith(`spec not found: ${id}`)
+
+      const GATED_STATES = new Set<SpecStatus>(['reviewed', 'shipped', 'archived'])
+      if (!GATED_STATES.has(spec.status as SpecStatus) && options.force !== true) {
+        process.stderr.write(
+          `error: spec status is '${spec.status}'; breakdown requires 'reviewed' or later. Re-run with --force if intentional.\n`
+        )
+        process.exitCode = 2
+        return {
+          success: false,
+          error: `spec status '${spec.status}' is below the breakdown gate`,
+        }
+      }
+
+      const forced = options.force === true && !GATED_STATES.has(spec.status as SpecStatus)
+      const projectId = await configManager.getProjectId(projectPath)
+      if (!projectId) return failHard('No prjct project. Run `prjct init` first.')
+      const { breakdownSpecToTasks } = await import('../services/spec-task-breakdown')
+      const result = await breakdownSpecToTasks(projectId, projectPath, spec)
+
+      let forcedEventMemId: string | null = null
+      if (forced) {
+        // Audit event so a forced breakdown shows up in `prjct context
+        // memory spec` and the event log. Free-form `type` string per
+        // publishEvent semantics.
+        const { projectMemory } = await import('../memory/project-memory')
+        const memId = await projectMemory.remember(projectPath, {
+          type: 'spec',
+          content: `prjct spec breakdown --force on '${spec.title}' (status was '${spec.status}')`,
+          tags: {
+            spec_id: spec.id,
+            event: 'spec.breakdown.forced',
+            from_status: spec.status,
+          },
+          source: spec.id,
+        })
+        forcedEventMemId = typeof memId === 'string' ? memId : null
+      }
+
+      const lines: string[] = []
+      if (forcedEventMemId) lines.push(`forced-breakdown event=${forcedEventMemId}`)
+      if (result.skippedReason === 'already_broken_down') {
+        lines.push(`skipped: already_broken_down (spec ${id})`)
+      } else if (result.skippedReason === 'no_acceptance_criteria') {
+        lines.push(`skipped: no_acceptance_criteria (spec ${id})`)
+      } else {
+        const tag = result.recoveredFromPartial ? ' (recovered from partial)' : ''
+        lines.push(`✓ breakdown: ${result.taskIds.length} task(s) linked${tag}`)
+      }
+      for (const line of lines) console.log(line)
+
+      return {
+        success: true,
+        specId: id,
+        forced,
+        forcedEventMemId,
+        taskIds: result.taskIds,
+        recoveredFromPartial: result.recoveredFromPartial === true,
+        skippedReason: result.skippedReason,
+      }
     } catch (error) {
       return failHard(getErrorMessage(error))
     }

--- a/core/commands/team.ts
+++ b/core/commands/team.ts
@@ -27,9 +27,17 @@ import { exec } from 'node:child_process'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { promisify } from 'node:util'
+import configManager from '../infrastructure/config-manager'
+import { projectMemory } from '../memory/project-memory'
+import {
+  serializeCanonical,
+  type TeamEnrollment,
+  teamEnrollmentStorage,
+} from '../storage/team-enrollment-storage'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
-import { failHard } from '../utils/md-aware'
+import { writeFileAtomic } from '../utils/file-helper'
+import { failHard, failWith } from '../utils/md-aware'
 import { mdOutput, mdSection } from '../utils/md-formatter'
 import out from '../utils/output'
 import { VERSION } from '../utils/version'
@@ -54,27 +62,76 @@ interface TeamConfig {
   enrolledAt: string
 }
 
+/**
+ * Render the enrollment as `.prjct/team.json` mirror content. The
+ * pre-commit hook (PRE_COMMIT_HOOK_BODY) does a string grep against
+ * this file, so the human-readable indented form is preferred.
+ */
+function renderTeamMirror(enrollment: TeamEnrollment): string {
+  // Strip enrolledBy=null from the on-disk shape — older readers (and
+  // the pre-commit hook's grep) only need {required, minVersion,
+  // enrolledAt}. Keep enrolledBy in the DB but skip it from the mirror
+  // when absent.
+  const mirror: Record<string, unknown> = {
+    required: enrollment.required,
+    minVersion: enrollment.minVersion,
+    enrolledAt: enrollment.enrolledAt,
+  }
+  if (enrollment.enrolledBy !== null) mirror.enrolledBy = enrollment.enrolledBy
+  return `${JSON.stringify(mirror, null, 2)}\n`
+}
+
 export class TeamCommands extends PrjctCommandsBase {
   async team(
-    _input: string | null = null,
+    input: string | null = null,
     projectPath: string = process.cwd(),
     options: TeamOptions = {}
   ): Promise<CommandResult> {
+    // Subverb dispatch. `prjct team check` runs the drift detector.
+    if (input === 'check') {
+      return this.check(projectPath, options)
+    }
+
     try {
-      const teamConfig: TeamConfig = {
+      const teamConfig: TeamEnrollment = {
         required: options.required === true,
         minVersion: options.minVersion ?? VERSION ?? '0.0.0',
         enrolledAt: new Date().toISOString(),
+        enrolledBy: null,
       }
 
       const teamPath = path.join(projectPath, '.prjct', 'team.json')
       const claudeMdPath = path.join(projectPath, '.claude', 'CLAUDE.md')
 
-      // 1. Write .prjct/team.json
-      await fs.mkdir(path.dirname(teamPath), { recursive: true })
-      await fs.writeFile(teamPath, `${JSON.stringify(teamConfig, null, 2)}\n`, 'utf-8')
+      // 1. Resolve projectId and write to SQLite (authoritative).
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+      const projectId = await configManager.getProjectId(projectPath)
+      if (!projectId) {
+        return failHard('No prjct project. Run `prjct init` first.', options)
+      }
+      teamEnrollmentStorage.set(projectId, teamConfig)
 
-      // 2. Upsert .claude/CLAUDE.md (per-project)
+      // 2. Regenerate .prjct/team.json from DB as a derived mirror. Atomic
+      // tmp+rename — the pre-commit hook must never read a half-written
+      // file. On mirror failure: log + inbox capture; DB stays ahead.
+      try {
+        await writeFileAtomic(teamPath, renderTeamMirror(teamConfig))
+      } catch (mirrorError) {
+        const msg = getErrorMessage(mirrorError)
+        await projectMemory
+          .remember(projectPath, {
+            type: 'inbox',
+            content: `team.json mirror write failed: ${msg}`,
+            tags: { 'mirror-drift': '1' },
+            provenance: 'declared',
+          })
+          .catch(() => {})
+        // Fall through — the DB row is authoritative; user can heal via
+        // `prjct team check` later.
+      }
+
+      // 3. Upsert .claude/CLAUDE.md (per-project)
       await fs.mkdir(path.dirname(claudeMdPath), { recursive: true })
       const block = teamClaudeMdBlock(teamConfig)
       let existing = ''
@@ -86,14 +143,14 @@ export class TeamCommands extends PrjctCommandsBase {
       const next = upsertBetweenMarkers(existing, block, CLAUDE_MD_START, CLAUDE_MD_END)
       await fs.writeFile(claudeMdPath, next, 'utf-8')
 
-      // 3. Stage both files. Don't fail the command if git isn't
+      // 4. Stage both files. Don't fail the command if git isn't
       // present or the user is outside a repo — print a hint instead.
       let staged = false
       const stagedPaths = [teamPath, claudeMdPath]
       try {
         await execP('git rev-parse --show-toplevel', { cwd: projectPath })
 
-        // 3a. Optional: install pre-commit hook that blocks commits
+        // 4a. Optional: install pre-commit hook that blocks commits
         // when team.json says required:true and prjct isn't on PATH.
         // Lives at .githooks/pre-commit (committed) and we point
         // core.hooksPath at it for THIS clone. Teammates run the same
@@ -165,6 +222,138 @@ export class TeamCommands extends PrjctCommandsBase {
       return failHard(msg)
     }
   }
+
+  /**
+   * `prjct team check` — drift detector + self-heal for the mirror.
+   *
+   * Compares the on-disk `.prjct/team.json` against the DB row via
+   * canonical JSON byte-equality (sorted keys, no extra whitespace).
+   * If they differ, rewrites the mirror atomically from the DB row.
+   * If the DB row is empty but the disk file exists (mid-migration
+   * state from a pre-v2.19.7 install), populates the DB from the disk
+   * then rewrites the mirror — a no-op churn that proves the round-trip.
+   *
+   * Placement is under `prjct team`, not `prjct doctor` — this is a
+   * team-config-specific drift check; the only consumer is the
+   * pre-commit hook, and folding into doctor would conflate concerns.
+   *
+   * See spec a50b32d1 AC #2.
+   */
+  async check(
+    projectPath: string = process.cwd(),
+    options: TeamOptions = {}
+  ): Promise<CommandResult> {
+    try {
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+      const projectId = await configManager.getProjectId(projectPath)
+      if (!projectId) {
+        return failHard('No prjct project. Run `prjct init` first.', options)
+      }
+
+      const teamPath = path.join(projectPath, '.prjct', 'team.json')
+      const dbRow = teamEnrollmentStorage.get(projectId)
+
+      let diskRaw: string | null = null
+      try {
+        diskRaw = await fs.readFile(teamPath, 'utf-8')
+      } catch {
+        diskRaw = null
+      }
+
+      // Case A: DB empty, disk has content → migration. Adopt disk into DB.
+      if (dbRow === null && diskRaw !== null) {
+        let parsed: unknown
+        try {
+          parsed = JSON.parse(diskRaw)
+        } catch {
+          return failWith(
+            `cannot parse ${teamPath} — fix or delete the file before running team check again`,
+            options
+          )
+        }
+        const enrollment: TeamEnrollment = {
+          required:
+            typeof (parsed as { required?: unknown }).required === 'boolean'
+              ? (parsed as { required: boolean }).required
+              : false,
+          minVersion:
+            typeof (parsed as { minVersion?: unknown }).minVersion === 'string'
+              ? (parsed as { minVersion: string }).minVersion
+              : (VERSION ?? '0.0.0'),
+          enrolledAt:
+            typeof (parsed as { enrolledAt?: unknown }).enrolledAt === 'string'
+              ? (parsed as { enrolledAt: string }).enrolledAt
+              : new Date().toISOString(),
+          enrolledBy:
+            typeof (parsed as { enrolledBy?: unknown }).enrolledBy === 'string'
+              ? (parsed as { enrolledBy: string }).enrolledBy
+              : null,
+        }
+        teamEnrollmentStorage.set(projectId, enrollment)
+        await writeFileAtomic(teamPath, renderTeamMirror(enrollment))
+        const msg = '✓ team check: migrated disk → DB; mirror rewritten'
+        if (options.md) console.log(`> ${msg}`)
+        else out.done(msg)
+        return { success: true, healed: true, migrated: true }
+      }
+
+      // Case B: DB has a row. Compare canonical-serialized DB vs disk.
+      if (dbRow !== null) {
+        const dbCanonical = serializeCanonical(dbRow)
+        const diskCanonical = diskRaw === null ? null : canonicalizeDiskTeamJson(diskRaw, dbRow)
+
+        if (diskCanonical === dbCanonical) {
+          const msg = '✓ team check: mirror in sync'
+          if (options.md) console.log(`> ${msg}`)
+          else out.done(msg)
+          return { success: true, healed: false }
+        }
+
+        // Drift — rewrite mirror from DB.
+        await writeFileAtomic(teamPath, renderTeamMirror(dbRow))
+        const msg = '✓ team check: drift detected; mirror rewritten from DB'
+        if (options.md) console.log(`> ${msg}`)
+        else out.done(msg)
+        return { success: true, healed: true }
+      }
+
+      // Case C: both empty. Nothing to check.
+      const msg = '✓ team check: no enrollment configured'
+      if (options.md) console.log(`> ${msg}`)
+      else out.done(msg)
+      return { success: true, healed: false, empty: true }
+    } catch (error) {
+      return failHard(getErrorMessage(error), options)
+    }
+  }
+}
+
+/**
+ * Canonicalize disk team.json to compare against DB. We parse, fill
+ * missing `enrolledBy` from the DB row (mirror omits null), and
+ * re-serialize with sorted keys.
+ */
+function canonicalizeDiskTeamJson(diskRaw: string, dbRow: TeamEnrollment): string | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(diskRaw)
+  } catch {
+    return null
+  }
+  const p = parsed as Record<string, unknown>
+  const enrollment: TeamEnrollment = {
+    required: p.required === true,
+    minVersion: typeof p.minVersion === 'string' ? p.minVersion : '',
+    enrolledAt: typeof p.enrolledAt === 'string' ? p.enrolledAt : '',
+    enrolledBy:
+      typeof p.enrolledBy === 'string'
+        ? p.enrolledBy
+        : // Mirror omits enrolledBy when DB has null — treat the
+          // absence on disk as matching whatever DB has.
+          dbRow.enrolledBy,
+  }
+  return serializeCanonical(enrollment)
 }
 
 /**

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -208,6 +208,8 @@ async function routeSpecDaemon(
       })
     case 'audit':
       return commands.specAudit(rest, undefined, { md })
+    case 'breakdown':
+      return commands.specBreakdown(rest, undefined, { md, force: opts.force === true })
     case 'inventory':
       return commands.specInventory(undefined, { md, json: opts.json === true })
     default:

--- a/core/index.ts
+++ b/core/index.ts
@@ -408,6 +408,8 @@ async function routeSpec(
       })
     case 'audit':
       return commands.specAudit(rest, cwd, { md })
+    case 'breakdown':
+      return commands.specBreakdown(rest, cwd, { md, force: options.force === true })
     case 'inventory':
       return commands.specInventory(cwd, { md, json: options.json === true })
     default:

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -152,26 +152,61 @@ class SpecService {
     review: Omit<SpecReview, 'ts'>
   ): Promise<Spec | null> {
     const projectId = await this.requireProjectId(projectPath)
-    const spec = specStorage.get(projectId, id)
-    if (!spec) return null
 
-    const fullReview: SpecReview = { ...review, ts: getTimestamp() }
-    const nextContent: SpecContent = {
-      ...spec.content,
-      reviews: {
-        ...(spec.content.reviews ?? {}),
-        [reviewer]: fullReview,
-      },
+    // Optimistic-concurrency loop: read spec + its updated_at, mutate
+    // content.reviews in memory, write via casUpdate (which only succeeds
+    // if updated_at still matches). On conflict, retry up to 3 times with
+    // 50ms backoff. We CANNOT pull breakdownSpecToTasks inside a sync
+    // db.transaction — it awaits async work (queueStorage.addTasks writes
+    // JSON via StorageManager, plus event publishes + memory writes). So
+    // breakdown runs AFTER the CAS-on-content succeeds, gated by
+    // tasks_created_at idempotency. See spec a50b32d1 AC #12.
+    const MAX_ATTEMPTS = 3
+    const BACKOFF_MS = 50
+    let attempts = 0
+    let winningWriteHappenedHere = false
+    let updated: Spec | null = null
+    while (attempts < MAX_ATTEMPTS) {
+      const spec = specStorage.get(projectId, id)
+      if (!spec) return null
+
+      const fullReview: SpecReview = { ...review, ts: getTimestamp() }
+      const nextContent: SpecContent = {
+        ...spec.content,
+        reviews: {
+          ...(spec.content.reviews ?? {}),
+          [reviewer]: fullReview,
+        },
+      }
+      const ok = specStorage.casUpdate(projectId, id, nextContent, spec.updatedAt)
+      if (ok) {
+        winningWriteHappenedHere = true
+        updated = specStorage.get(projectId, id)
+        break
+      }
+      attempts++
+      if (attempts < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, BACKOFF_MS))
+      }
     }
-    const updated = specStorage.updateContent(projectId, id, nextContent)
+
+    if (!winningWriteHappenedHere) {
+      throw new Error(
+        `SPEC_RECORD_REVIEW_CONFLICT_RETRY_EXHAUSTED: ${MAX_ATTEMPTS} retries failed for spec ${id}`
+      )
+    }
+
     if (updated && this.allReviewsPass(updated.content)) {
       // All three reviewers pass → auto-promote draft to reviewed.
       if (updated.status === 'draft') {
         const promoted = specStorage.setStatus(projectId, id, 'reviewed')
         // Auto-breakdown: materialize acceptance_criteria as granular
-        // queue tasks so the user gets row-per-AC in the DB and vault
-        // instead of a monolithic spec document. Idempotent (skipped on
-        // re-audit when linked_tasks already populated).
+        // queue tasks. Now made idempotent on spec_id via the
+        // `tasks_created_at` marker (spec-task-breakdown.ts). The CAS
+        // guarantees only one writer observes draft→reviewed; the marker
+        // gates the breakdown call itself against any other source
+        // (e.g. manual `prjct spec breakdown <id>`). See spec a50b32d1
+        // AC #12 + #13.
         if (promoted) {
           const { breakdownSpecToTasks } = await import('./spec-task-breakdown')
           await breakdownSpecToTasks(projectId, projectPath, promoted)

--- a/core/services/spec-task-breakdown.ts
+++ b/core/services/spec-task-breakdown.ts
@@ -4,34 +4,45 @@
  * When `audit-spec` promotes a spec from `draft` → `reviewed` (all three
  * reviewers pass), the spec's `acceptance_criteria` are materialized as
  * granular queue tasks — one per AC. Each task lands in the backlog
- * tagged with `featureId = spec.id` so the user can pick them up via
- * `prjct task` and the vault renders them as individual rows instead of
- * a single monolithic spec document.
+ * tagged with `featureId = spec.id`.
  *
- * Idempotent: if the spec already has linked_tasks, breakdown is a no-op.
- * That covers the re-audit path (a fail → pass cycle re-enters this code
- * but must not double-create tasks).
+ * Idempotency + crash recovery via the `tasks_created_at` completion
+ * marker on SpecContent:
+ *
+ *   - Marker set     → already broken down, skip.
+ *   - Marker null +
+ *     linked_tasks
+ *     non-empty      → PARTIAL breakdown (previous attempt crashed mid-
+ *                      flight). Wipe queue rows by featureId, clear
+ *                      linked_tasks, then re-run the full loop. The
+ *                      partial state cannot be transactional because
+ *                      queueStorage writes queue.json via StorageManager
+ *                      (async file I/O + event publishes, incompatible
+ *                      with sync SQLite tx). Recovery is convergent: the
+ *                      marker is set ONLY after the loop completes, so
+ *                      any crash leaves marker=null and the next caller
+ *                      re-enters the recovery branch.
+ *   - Marker null +
+ *     linked_tasks
+ *     empty          → fresh breakdown.
+ *
+ * See spec a50b32d1 AC #13.
  */
 import { projectMemory } from '../memory/project-memory'
 import { queueStorage } from '../storage/queue-storage'
 import { specStorage } from '../storage/spec-storage'
-import type { Spec } from '../types/spec'
+import type { Spec, SpecContent } from '../types/spec'
+import { getTimestamp } from '../utils/date-helper'
 
 export interface BreakdownResult {
   /** Task ids newly created. Empty when breakdown is a no-op. */
   taskIds: string[]
   /** Why we skipped (only present when taskIds is empty). */
   skippedReason?: 'no_acceptance_criteria' | 'already_broken_down'
+  /** Whether we entered the partial-recovery branch on this call. */
+  recoveredFromPartial?: boolean
 }
 
-/**
- * Materialize `spec.content.acceptance_criteria` as queue tasks.
- *
- * One AC → one queue task. The task's `description` is the AC text
- * (truncated to ~140 chars for readability); the full AC lands in `body`
- * unchanged. Tasks go to `backlog` so they don't auto-activate — the
- * user picks them up explicitly.
- */
 export async function breakdownSpecToTasks(
   projectId: string,
   projectPath: string,
@@ -41,8 +52,23 @@ export async function breakdownSpecToTasks(
   if (acs.length === 0) {
     return { taskIds: [], skippedReason: 'no_acceptance_criteria' }
   }
-  if (spec.content.linked_tasks.length > 0) {
+
+  // Entry guard: marker set ⇒ already complete.
+  if (spec.content.tasks_created_at !== null) {
     return { taskIds: [], skippedReason: 'already_broken_down' }
+  }
+
+  // Partial-recovery detection: marker null but linked_tasks non-empty
+  // means a previous attempt crashed mid-loop. Wipe + restart from scratch.
+  let recoveredFromPartial = false
+  if (spec.content.linked_tasks.length > 0) {
+    recoveredFromPartial = true
+    await queueStorage.deleteByFeatureId(projectId, spec.id)
+    const cleared: SpecContent = {
+      ...spec.content,
+      linked_tasks: [],
+    }
+    specStorage.updateContent(projectId, spec.id, cleared)
   }
 
   const newTasks = await queueStorage.addTasks(
@@ -65,20 +91,37 @@ export async function breakdownSpecToTasks(
     specStorage.linkTask(projectId, spec.id, task.id)
   }
 
+  // Completion marker — set ONLY after the full loop succeeds. A crash
+  // before this point leaves marker=null and we recover on next entry.
+  const fresh = specStorage.get(projectId, spec.id)
+  if (fresh) {
+    const withMarker: SpecContent = {
+      ...fresh.content,
+      tasks_created_at: getTimestamp(),
+    }
+    specStorage.updateContent(projectId, spec.id, withMarker)
+  }
+
   // Mirror to memory event stream so `prjct context memory spec` and the
   // user's session both surface the breakdown event.
   await projectMemory.remember(projectPath, {
     type: 'spec',
-    content: `Auto-breakdown: ${newTasks.length} tasks created from ${spec.title}`,
+    content: `Auto-breakdown: ${newTasks.length} tasks created from ${spec.title}${
+      recoveredFromPartial ? ' (recovered from partial)' : ''
+    }`,
     tags: {
       spec_id: spec.id,
       event: 'auto_breakdown',
       task_count: String(newTasks.length),
+      ...(recoveredFromPartial ? { recovered: 'partial' } : {}),
     },
     source: spec.id,
   })
 
-  return { taskIds: newTasks.map((t) => t.id) }
+  return {
+    taskIds: newTasks.map((t) => t.id),
+    ...(recoveredFromPartial ? { recoveredFromPartial: true } : {}),
+  }
 }
 
 /**

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -68,6 +68,33 @@ import { resolveVaultRoot } from './wiki-migration'
 // the vault root survive wiki rebuilds. Only this subdir gets touched.
 const GENERATED_SUBDIR = '_generated'
 
+/**
+ * Wrap a single builder call so an exception in one builder cannot abort
+ * the whole regen. Emits a structured log line per builder. The two
+ * builders added by spec a50b32d1 (`crew-runs`, `team`) use this; the
+ * pre-existing builders are progressively retrofitted in follow-up work.
+ *
+ * See spec a50b32d1 AC #15.
+ */
+function runBuilder<T>(
+  name: string,
+  fn: () => T,
+  onError: (e: unknown) => T
+): { result: T; ok: boolean; ms: number } {
+  const start = Date.now()
+  try {
+    const result = fn()
+    const ms = Date.now() - start
+    console.log(JSON.stringify({ builder: name, status: 'ok', ms }))
+    return { result, ok: true, ms }
+  } catch (error) {
+    const ms = Date.now() - start
+    const msg = error instanceof Error ? error.message : String(error)
+    console.log(JSON.stringify({ builder: name, status: 'error', ms, error: msg }))
+    return { result: onError(error), ok: false, ms }
+  }
+}
+
 export async function generateWiki(
   projectPath: string,
   projectId: string
@@ -104,6 +131,8 @@ export async function generateWiki(
   // --- Gather sources ---
   const { specStorage } = await import('../storage/spec-storage')
   const { queueStorage } = await import('../storage/queue-storage')
+  const { default: crewRunStorageMod } = await import('../storage/crew-run-storage')
+  const { teamEnrollmentStorage } = await import('../storage/team-enrollment-storage')
   const [ships, entries, analysis, llmAnalysis, workflowRules, specs, queueTasks] =
     await Promise.all([
       shippedStorage.getAll(projectId),
@@ -114,6 +143,20 @@ export async function generateWiki(
       Promise.resolve(specStorage.list(projectId, { includeArchived: true })).catch(() => []),
       queueStorage.getTasks(projectId).catch(() => []),
     ])
+  const crewRuns = (() => {
+    try {
+      return crewRunStorageMod.list(projectId)
+    } catch {
+      return []
+    }
+  })()
+  const teamEnrollment = (() => {
+    try {
+      return teamEnrollmentStorage.get(projectId)
+    } catch {
+      return null
+    }
+  })()
   const declared = entries.filter((e) => e.type !== 'shipped')
 
   // --- Build all file bodies in memory ---
@@ -125,6 +168,25 @@ export async function generateWiki(
   for (const [rel, body] of buildMemoryFiles(declared)) files.set(rel, body)
   for (const [rel, body] of buildTagFiles(declared)) files.set(rel, body)
   for (const [rel, body] of buildSpecFiles(specs, queueTasks)) files.set(rel, body)
+
+  // crew-runs/<slug>-<ts>.md — one file per recorded crew session.
+  // Isolated via runBuilder so a malformed run row doesn't take down
+  // the rest of the regen. See spec a50b32d1 AC #15.
+  const crewRunResult = runBuilder(
+    'crew-runs',
+    () => buildCrewRunFiles(crewRuns),
+    () => new Map<string, string>()
+  )
+  for (const [rel, body] of crewRunResult.result) files.set(rel, body)
+
+  // team.md — single page reflecting the kv_store team:enrollment row.
+  // Empty/no-enrollment is fine (we skip writing the page in that case).
+  const teamResult = runBuilder(
+    'team',
+    () => buildTeamFile(teamEnrollment),
+    () => null
+  )
+  if (teamResult.result !== null) files.set('team.md', teamResult.result)
 
   // Prefer LLM analysis (richer fields) when available, fallback to heuristic.
   const patterns = llmAnalysis?.patterns ?? analysis?.patterns ?? []
@@ -275,6 +337,85 @@ export async function generateWiki(
   await ensureObsidianVault(wikiRoot).catch(() => undefined)
 
   return { wikiRoot, filesWritten, filesSkipped, filesRemoved }
+}
+
+/**
+ * Render every crew-run row to `crew-runs/<slug>-<ts>.md`. Slug is
+ * spec_id || task_id || run.id; ts is the row's started_at timestamp.
+ *
+ * See spec a50b32d1 AC #3.
+ */
+function buildCrewRunFiles(
+  runs: ReadonlyArray<{
+    id: string
+    spec_id: string | null
+    task_id: string | null
+    started_at: string
+    ended_at: string
+    implementer_summary: string
+    files_touched: string[]
+    reviewer_verdict: 'APPROVED' | 'CHANGES_REQUESTED'
+    reviewer_notes: string | null
+  }>
+): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const run of runs) {
+    const slug = run.spec_id ?? run.task_id ?? run.id
+    const safeTs = run.started_at.replace(/[:.]/g, '-')
+    const rel = `crew-runs/${slug}-${safeTs}.md`
+    const body = [
+      `# Crew run — ${slug}`,
+      '',
+      `- **run-id**: \`${run.id}\``,
+      `- **spec**: ${run.spec_id ? `\`${run.spec_id}\`` : '_(none)_'}`,
+      `- **task**: ${run.task_id ? `\`${run.task_id}\`` : '_(none)_'}`,
+      `- **started**: ${run.started_at}`,
+      `- **ended**: ${run.ended_at}`,
+      `- **verdict**: **${run.reviewer_verdict}**`,
+      '',
+      '## Implementer summary',
+      '',
+      run.implementer_summary,
+      '',
+      '## Files touched',
+      '',
+      run.files_touched.length === 0
+        ? '_(none recorded)_'
+        : run.files_touched.map((f) => `- \`${f}\``).join('\n'),
+      ...(run.reviewer_notes ? ['', '## Reviewer notes', '', run.reviewer_notes] : []),
+      '',
+    ].join('\n')
+    out.set(rel, body)
+  }
+  return out
+}
+
+/**
+ * Render the team:enrollment row (if any) as a single team.md page.
+ * Returns null when no enrollment is configured.
+ *
+ * See spec a50b32d1 AC #1.
+ */
+function buildTeamFile(
+  enrollment: {
+    required: boolean
+    minVersion: string
+    enrolledAt: string
+    enrolledBy: string | null
+  } | null
+): string | null {
+  if (enrollment === null) return null
+  return [
+    '# Team enrollment',
+    '',
+    `- **required**: ${enrollment.required}`,
+    `- **minVersion**: \`${enrollment.minVersion}\``,
+    `- **enrolledAt**: ${enrollment.enrolledAt}`,
+    `- **enrolledBy**: ${enrollment.enrolledBy ?? '_(unspecified)_'}`,
+    '',
+    'Authoritative source: `kv_store["team:enrollment"]`. The `.prjct/team.json` file in the repo is a derived mirror written atomically by `prjct team` (the pre-commit hook reads it because it must work before prjct is installed). Do not hand-edit the mirror — run `prjct team check` to detect/heal drift.',
+    '',
+  ].join('\n')
 }
 
 /**

--- a/core/storage/checkpoints-storage.ts
+++ b/core/storage/checkpoints-storage.ts
@@ -1,0 +1,90 @@
+/**
+ * Crew Checkpoints Storage
+ *
+ * Single kv_store row at key `crew:checkpoints` per project. Source of
+ * truth for the reviewer subagent's gate criteria, replacing the legacy
+ * `.prjct/CHECKPOINTS.md` file write. The reviewer template gets the
+ * current content spliced into a marker region at install time — no
+ * disk read at run time.
+ *
+ * See spec a50b32d1 AC #7.
+ */
+
+import { z } from 'zod'
+import { getTemplateContent } from '../agentic/template-loader'
+import { getTimestamp } from '../utils/date-helper'
+import prjctDb from './database'
+
+export const CHECKPOINTS_KEY = 'crew:checkpoints'
+
+const BUNDLED_TEMPLATE_KEY = 'crew/CHECKPOINTS.md'
+
+export const CheckpointsRowSchema = z.object({
+  content: z.string(),
+  source: z.enum(['default', 'user', 'migrated']),
+  updated_at: z.string().min(1),
+})
+
+export type CheckpointsRow = z.infer<typeof CheckpointsRowSchema>
+
+/**
+ * Read the bundled default CHECKPOINTS content from the templates
+ * bundle. Throws if the template is missing (the bundle is required
+ * for crew mode to work at all — a missing template is a build error).
+ */
+export function getBundledDefault(): string {
+  const content = getTemplateContent(BUNDLED_TEMPLATE_KEY)
+  if (!content) {
+    throw new Error(`Missing bundled crew checkpoints template: ${BUNDLED_TEMPLATE_KEY}`)
+  }
+  return content
+}
+
+class CheckpointsStorage {
+  /**
+   * Get the user's current checkpoints content. If no row exists,
+   * returns the bundled default with `source='default'`.
+   */
+  get(projectId: string): CheckpointsRow {
+    const raw = prjctDb.getDoc<unknown>(projectId, CHECKPOINTS_KEY)
+    if (raw === null) {
+      return {
+        content: getBundledDefault(),
+        source: 'default',
+        updated_at: getTimestamp(),
+      }
+    }
+    return CheckpointsRowSchema.parse(raw)
+  }
+
+  /**
+   * Returns true if a user-set or migrated row exists; false if the
+   * caller would receive the bundled default on get().
+   */
+  hasCustomization(projectId: string): boolean {
+    return prjctDb.hasDoc(projectId, CHECKPOINTS_KEY)
+  }
+
+  set(projectId: string, content: string, source: 'user' | 'migrated' = 'user'): CheckpointsRow {
+    const row: CheckpointsRow = {
+      content,
+      source,
+      updated_at: getTimestamp(),
+    }
+    prjctDb.setDoc(projectId, CHECKPOINTS_KEY, row)
+    return row
+  }
+
+  /**
+   * Reset to the bundled default. Removes the kv_store row entirely
+   * (subsequent get() returns the freshly-resolved bundled content),
+   * which keeps the DB row count low and avoids drift if the bundled
+   * default ever changes in a future release.
+   */
+  reset(projectId: string): void {
+    prjctDb.deleteDoc(projectId, CHECKPOINTS_KEY)
+  }
+}
+
+export const checkpointsStorage = new CheckpointsStorage()
+export default checkpointsStorage

--- a/core/storage/crew-run-storage.ts
+++ b/core/storage/crew-run-storage.ts
@@ -1,0 +1,94 @@
+/**
+ * Crew Run Storage
+ *
+ * One kv_store row per crew session: key `crew-run:<run-id>`, value is
+ * the structured record below. Source-of-truth for what implementer +
+ * reviewer produced in a single crew flow; vault regen renders each
+ * row to `~/Documents/prjct/<slug>/_generated/crew-runs/...`.
+ *
+ * NOT a `prjct remember` entry — keeps the memory taxonomy clean of
+ * ephemeral per-role scratch. See spec a50b32d1 AC #3.
+ */
+
+import { z } from 'zod'
+import { generateUUID } from '../schemas/schemas'
+import { getTimestamp } from '../utils/date-helper'
+import prjctDb from './database'
+
+export const CREW_RUN_KEY_PREFIX = 'crew-run:'
+
+export const CrewRunSchema = z.object({
+  id: z.string().min(1),
+  spec_id: z.string().nullable().default(null),
+  task_id: z.string().nullable().default(null),
+  started_at: z.string().min(1),
+  ended_at: z.string().min(1),
+  implementer_summary: z.string().default(''),
+  files_touched: z.array(z.string()).default([]),
+  reviewer_verdict: z.enum(['APPROVED', 'CHANGES_REQUESTED']),
+  reviewer_notes: z.string().nullable().default(null),
+})
+
+export type CrewRun = z.infer<typeof CrewRunSchema>
+
+export interface RecordCrewRunInput {
+  /** Caller-supplied run-id for idempotent retry. Generated if omitted. */
+  runId?: string
+  specId?: string | null
+  taskId?: string | null
+  implementerSummary: string
+  filesTouched: string[]
+  reviewerVerdict: 'APPROVED' | 'CHANGES_REQUESTED'
+  reviewerNotes?: string | null
+  startedAt?: string
+  endedAt?: string
+}
+
+function keyFor(runId: string): string {
+  return `${CREW_RUN_KEY_PREFIX}${runId}`
+}
+
+class CrewRunStorage {
+  /**
+   * Idempotent on `runId`: re-invoking with the same id returns the
+   * existing row unchanged (no clobbering of started_at, no duplicate
+   * vault page). Generated UUID is returned in the `id` field when the
+   * caller doesn't supply one.
+   */
+  record(projectId: string, input: RecordCrewRunInput): CrewRun {
+    const runId = input.runId ?? generateUUID()
+    const existing = prjctDb.getDoc<CrewRun>(projectId, keyFor(runId))
+    if (existing) return existing
+
+    const now = getTimestamp()
+    const run = CrewRunSchema.parse({
+      id: runId,
+      spec_id: input.specId ?? null,
+      task_id: input.taskId ?? null,
+      started_at: input.startedAt ?? now,
+      ended_at: input.endedAt ?? now,
+      implementer_summary: input.implementerSummary,
+      files_touched: input.filesTouched,
+      reviewer_verdict: input.reviewerVerdict,
+      reviewer_notes: input.reviewerNotes ?? null,
+    })
+    prjctDb.setDoc(projectId, keyFor(runId), run)
+    return run
+  }
+
+  get(projectId: string, runId: string): CrewRun | null {
+    return prjctDb.getDoc<CrewRun>(projectId, keyFor(runId))
+  }
+
+  list(projectId: string): CrewRun[] {
+    const rows = prjctDb.listDocsByPrefix<CrewRun>(projectId, CREW_RUN_KEY_PREFIX)
+    return rows.map((r) => CrewRunSchema.parse(r.data))
+  }
+
+  delete(projectId: string, runId: string): void {
+    prjctDb.deleteDoc(projectId, keyFor(runId))
+  }
+}
+
+export const crewRunStorage = new CrewRunStorage()
+export default crewRunStorage

--- a/core/storage/database.ts
+++ b/core/storage/database.ts
@@ -27,6 +27,7 @@ import {
   openDatabase,
   type SqliteBindings,
   type SqliteDatabase,
+  type SqliteRunResult,
   type SqliteStatement,
 } from './database/sqlite-compat'
 
@@ -180,6 +181,24 @@ class PrjctDatabase {
     return row !== null
   }
 
+  /**
+   * List all kv_store docs whose key starts with `prefix`. Returns
+   * deserialized rows. Used by crew-run-storage to render every
+   * `crew-run:<id>` row into the vault on regen.
+   *
+   * Caller must filter out unrelated keys if `prefix` is ambiguous;
+   * SQL pattern is `prefix || '%'` (no LIKE wildcard injection because
+   * we control the call sites).
+   */
+  listDocsByPrefix<T>(projectId: string, prefix: string): Array<{ key: string; data: T }> {
+    const db = this.getDb(projectId)
+    const rows = this.prepareCached(
+      db,
+      "SELECT key, data FROM kv_store WHERE key LIKE ? || '%' ORDER BY key"
+    ).all(prefix) as Array<{ key: string; data: string }>
+    return rows.map((r) => ({ key: r.key, data: JSON.parse(r.data) as T }))
+  }
+
   // ===========================================================================
   // Event Log
   // ===========================================================================
@@ -240,9 +259,9 @@ class PrjctDatabase {
     return this.prepareCached(db, sql).all(...params) as T[]
   }
 
-  run(projectId: string, sql: string, ...params: SqliteBindings[]): void {
+  run(projectId: string, sql: string, ...params: SqliteBindings[]): SqliteRunResult {
     const db = this.getDb(projectId)
-    this.prepareCached(db, sql).run(...params)
+    return this.prepareCached(db, sql).run(...params)
   }
 
   get<T = Record<string, unknown>>(

--- a/core/storage/database/sqlite-compat.ts
+++ b/core/storage/database/sqlite-compat.ts
@@ -11,11 +11,22 @@ import { isBun } from '../../utils/runtime'
 /** Bind parameter types accepted by both drivers */
 export type SqliteBindings = string | number | bigint | Buffer | null | undefined
 
+/**
+ * Result of executing a prepared statement that mutates rows.
+ * Both bun:sqlite and better-sqlite3 return this shape natively from
+ * `Statement.run(...)`; the wrapper previously discarded it. Required
+ * by the optimistic-CAS path in spec-storage (`UPDATE … WHERE updated_at=?`
+ * only succeeds when `changes === 1`).
+ */
+export interface SqliteRunResult {
+  changes: number
+}
+
 /** Minimal prepared-statement interface shared by both drivers */
 export interface SqliteStatement {
   get(...params: SqliteBindings[]): unknown
   all(...params: SqliteBindings[]): unknown[]
-  run(...params: SqliteBindings[]): void
+  run(...params: SqliteBindings[]): SqliteRunResult
 }
 
 /** Minimal database interface shared by bun:sqlite and better-sqlite3 */

--- a/core/storage/queue-storage.ts
+++ b/core/storage/queue-storage.ts
@@ -135,6 +135,34 @@ class QueueStorage extends StorageManager<QueueJson> {
   }
 
   /**
+   * Remove every task whose `featureId` matches. Returns rows-deleted.
+   * Used by breakdownSpecToTasks partial-recovery: a crashed breakdown
+   * leaves orphan queue rows tagged with `featureId = spec.id`; recovery
+   * wipes them before re-running the loop. NOT `linkedSpecId` — that
+   * field is reserved for `prjct task --spec` invocations.
+   * See spec a50b32d1 AC #13.
+   */
+  async deleteByFeatureId(projectId: string, featureId: string): Promise<number> {
+    let deleted = 0
+    await this.update(projectId, (queue) => {
+      const before = queue.tasks.length
+      const remaining = queue.tasks.filter((t) => t.featureId !== featureId)
+      deleted = before - remaining.length
+      return {
+        tasks: remaining,
+        lastUpdated: getTimestamp(),
+      }
+    })
+    if (deleted > 0) {
+      await this.publishEvent(projectId, 'queue.tasks_removed_by_feature', {
+        featureId,
+        count: deleted,
+      })
+    }
+    return deleted
+  }
+
+  /**
    * Mark a task as completed
    */
   async completeTask(projectId: string, taskId: string): Promise<QueueTask | null> {

--- a/core/storage/spec-storage.ts
+++ b/core/storage/spec-storage.ts
@@ -123,6 +123,35 @@ class SpecStorage {
     return this.get(projectId, id)
   }
 
+  /**
+   * Optimistic-concurrency UPDATE on `specs.content`. Returns `true` iff
+   * the row's `updated_at` still matched `expectedUpdatedAt` at write time
+   * (i.e. nobody else has written since the caller read). Returns `false`
+   * on stale read (caller should re-read and retry).
+   *
+   * Used by recordReview (and breakdownSpecToTasks marker write) to
+   * serialize concurrent writers without pulling async work inside a sync
+   * SQLite transaction. See spec a50b32d1 AC #12.
+   */
+  casUpdate(
+    projectId: string,
+    id: string,
+    content: SpecContent,
+    expectedUpdatedAt: string
+  ): boolean {
+    const validated = SpecContentSchema.parse(content)
+    const now = getTimestamp()
+    const result = prjctDb.run(
+      projectId,
+      'UPDATE specs SET content = ?, updated_at = ? WHERE id = ? AND updated_at = ?',
+      JSON.stringify(validated),
+      now,
+      id,
+      expectedUpdatedAt
+    )
+    return result.changes === 1
+  }
+
   setStatus(projectId: string, id: string, status: SpecStatus): Spec | null {
     if (!SPEC_STATUSES.includes(status)) {
       throw new Error(`invalid spec status: ${status}`)

--- a/core/storage/team-enrollment-storage.ts
+++ b/core/storage/team-enrollment-storage.ts
@@ -1,0 +1,58 @@
+/**
+ * Team Enrollment Storage
+ *
+ * Single kv_store row at key `team:enrollment` per project. Source of
+ * truth for `prjct team` enrollment state — `prjct team` writes here
+ * first, then regenerates `.prjct/team.json` from the row as a derived
+ * disk mirror (the pre-commit hook reads the mirror because it must
+ * work BEFORE prjct is installed on a new contributor's machine).
+ *
+ * See spec a50b32d1 AC #1.
+ */
+
+import { z } from 'zod'
+import prjctDb from './database'
+
+export const TEAM_ENROLLMENT_KEY = 'team:enrollment'
+
+export const TeamEnrollmentSchema = z.object({
+  required: z.boolean(),
+  minVersion: z.string().min(1),
+  enrolledAt: z.string().min(1),
+  /** Identifies the user / mechanism that enrolled the repo. Optional. */
+  enrolledBy: z.string().nullable().default(null),
+})
+
+export type TeamEnrollment = z.infer<typeof TeamEnrollmentSchema>
+
+class TeamEnrollmentStorage {
+  get(projectId: string): TeamEnrollment | null {
+    const raw = prjctDb.getDoc<unknown>(projectId, TEAM_ENROLLMENT_KEY)
+    if (raw === null) return null
+    return TeamEnrollmentSchema.parse(raw)
+  }
+
+  set(projectId: string, enrollment: TeamEnrollment): void {
+    const validated = TeamEnrollmentSchema.parse(enrollment)
+    prjctDb.setDoc(projectId, TEAM_ENROLLMENT_KEY, validated)
+  }
+
+  clear(projectId: string): void {
+    prjctDb.deleteDoc(projectId, TEAM_ENROLLMENT_KEY)
+  }
+}
+
+/**
+ * Canonical JSON serializer for byte-equality comparison between the
+ * DB row and the on-disk mirror. Sorted keys, no whitespace beyond
+ * what JSON.stringify produces. Used by `prjct team check`.
+ */
+export function serializeCanonical(enrollment: TeamEnrollment): string {
+  const sortedKeys = Object.keys(enrollment).sort() as Array<keyof TeamEnrollment>
+  const ordered: Record<string, unknown> = {}
+  for (const k of sortedKeys) ordered[k] = enrollment[k]
+  return JSON.stringify(ordered)
+}
+
+export const teamEnrollmentStorage = new TeamEnrollmentStorage()
+export default teamEnrollmentStorage

--- a/core/types/spec.ts
+++ b/core/types/spec.ts
@@ -54,6 +54,12 @@ export const SpecContentSchema = z.object({
     .optional(),
   linked_tasks: z.array(z.string()).default([]),
   notes: z.string().default(''),
+  // Set ONLY after breakdownSpecToTasks completes its full loop. Acts as a
+  // completion marker for idempotency + partial-recovery: null + non-empty
+  // linked_tasks ⇒ partial breakdown; recovery wipes queue rows by featureId
+  // and re-runs the loop. Existing specs read as null via Zod's default fill
+  // (no DB migration needed; specs.content is a JSON blob).
+  tasks_created_at: z.string().nullable().default(null),
 })
 
 export type SpecContent = z.infer<typeof SpecContentSchema>

--- a/core/utils/file-helper.ts
+++ b/core/utils/file-helper.ts
@@ -152,6 +152,22 @@ export async function writeFile(filePath: string, content: string): Promise<void
 }
 
 /**
+ * Atomic write: write to `<filePath>.tmp`, then rename onto `filePath`.
+ * `fs.promises.rename` is atomic-overwrite on POSIX and Windows (Node 18+).
+ *
+ * Used when an external reader (e.g. the pre-commit hook reading
+ * `.prjct/team.json`) must never observe a half-written file. The DB
+ * row is the source of truth; this is the mirror writer.
+ */
+export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  const dir = path.dirname(filePath)
+  await fs.mkdir(dir, { recursive: true })
+  const tmpPath = `${filePath}.tmp`
+  await fs.writeFile(tmpPath, content, 'utf-8')
+  await fs.rename(tmpPath, filePath)
+}
+
+/**
  * Check if file exists
  */
 export async function fileExists(filePath: string): Promise<boolean> {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -257,10 +257,16 @@ function bundleTemplates() {
   walk(templatesDir, '')
 
   // Architecture guard: no shipped template may instruct an agent to write
-  // outside the DB or the regenerated vault. `.prjct/sessions/` is the
-  // historical offender — block any reintroduction here so the bundle never
-  // re-ships disk-pollution patterns to customers.
-  const forbiddenSubstrings = ['.prjct/sessions/']
+  // outside the DB or the regenerated vault. The list below tracks the
+  // disk-pollution paths we've explicitly retired:
+  //   - .prjct/sessions/      — crew templates (closed in v2.19.6 / PR #330)
+  //   - .prjct/CHECKPOINTS.md — moved to kv_store crew:checkpoints (spec a50b32d1)
+  //   - .prjct/team.json      — moved to kv_store team:enrollment + derived
+  //                              mirror (spec a50b32d1; the mirror still lives
+  //                              on disk but is REGENERATED from DB by
+  //                              `prjct team`, never template-written)
+  // Templates must not reference any of these paths.
+  const forbiddenSubstrings = ['.prjct/sessions/', '.prjct/CHECKPOINTS.md', '.prjct/team.json']
   const offenders = []
   for (const [relPath, content] of Object.entries(bundle)) {
     for (const needle of forbiddenSubstrings) {

--- a/templates/crew/CHECKPOINTS.md
+++ b/templates/crew/CHECKPOINTS.md
@@ -11,7 +11,7 @@
 ## C1 — The crew is wired
 
 - [ ] `.prjct/prjct.config.json` exists and points to a valid project ID.
-- [ ] `.prjct/CHECKPOINTS.md` exists (this file).
+- [ ] The `crew:checkpoints` row exists in kv_store (the gate criteria the reviewer applies — visible via `prjct crew checkpoints`).
 - [ ] `.claude/agents/leader.md`, `implementer.md`, `reviewer.md` are present.
 - [ ] Project `CLAUDE.md` (or equivalent) contains the crew leader-mode block.
 

--- a/templates/crew/CLAUDE-leader-mode.md
+++ b/templates/crew/CLAUDE-leader-mode.md
@@ -9,7 +9,7 @@ This project is in **crew mode**. The main session always acts as the `leader` s
 - ❌ Do not run `prjct status done` yourself — the implementer does that, but only after the reviewer approves.
 - ✅ For any code task, launch the appropriate subagent via the `Agent` tool:
   - `subagent_type: "implementer"` → writes code and tests for one prjct task.
-  - `subagent_type: "reviewer"` → validates the implementer's work against `.prjct/CHECKPOINTS.md` before close.
+  - `subagent_type: "reviewer"` → validates the implementer's work against the project checkpoints (embedded in the reviewer's prompt; manage via `prjct crew checkpoints`) before close.
   - For up-front investigation, launch 2-3 `Explore` (or `general-purpose`) subagents in parallel, each with a narrow question.
 
 ### Keep replies tight

--- a/templates/crew/agents/implementer.md
+++ b/templates/crew/agents/implementer.md
@@ -10,23 +10,23 @@ You are an implementer. Your job is to take **one** prjct task from active to re
 
 ## Protocol
 
-1. **Orient.** Read `.prjct/CHECKPOINTS.md` and run `prjct context --md` to understand task and recent decisions.
+1. **Orient.** Run `prjct context --md` to understand task and recent decisions. (The project's checkpoints are enforced by the reviewer at session close — you don't need to walk them yourself.)
 2. **Confirm scope.** Run `prjct status --md` — there must be exactly one active task. If not, stop and report `blocked -> no single active task`.
 3. **Plan.** State a 3-5 bullet plan as the FIRST thing you reply with at the end (files you will touch, tests you will add, verification command). Keep it inline — do not write the plan to disk.
 4. **Implement.** Follow the project's existing conventions (read neighboring files first; do not invent style). Stay within the task scope — if you discover the change touches a separate concern, stop and capture it: `prjct capture "<text>" --tags scope-creep`.
 5. **Test.** Every code change is paired with a test before moving on. Use the project's existing test runner.
 6. **Self-verify.** Run the project's tests. If they fail, return to step 4. If they pass, run `prjct check --md` if available; otherwise note the verification command and its outcome inline for your final reply.
 7. **Do not mark `done`.** The reviewer must approve first. Do not run `prjct status done` until the reviewer's reply is `APPROVED`.
-8. **Hand off.** Reply to the leader with a compact summary (≈one screen):
+8. **Hand off.** Reply to the leader with a compact summary (≈one screen). The `FILES:` block is parsed by the leader to invoke `prjct crew record-run` — keep it strict: one path per line, no parens, no leading dash, no annotations:
 
    ```
    STATUS: ready-for-review
 
    PLAN: <3-5 bullets from step 3>
 
-   FILES TOUCHED:
-   - path/to/a.ts (added foo())
-   - path/to/a.test.ts (added test for foo())
+   FILES:
+   path/to/a.ts
+   path/to/a.test.ts
 
    VERIFICATION: bun test path/to/a.test.ts  →  PASS (4 tests)
 

--- a/templates/crew/agents/leader.md
+++ b/templates/crew/agents/leader.md
@@ -10,10 +10,10 @@ You are the leader of this repository. Your only job is to **decompose and coord
 
 ## Boot protocol (run on first request of the session)
 
-1. Read `.prjct/CHECKPOINTS.md` to know what "done" looks like in this project.
-2. Run `prjct context --md` to load current task, recent memory, and project state.
-3. Run `prjct status --md` to confirm whether there is an active task.
-4. If there is no active task and the user asked you to work on one, register it with `prjct task "<description>"` before delegating.
+1. Run `prjct context --md` to load current task, recent memory, and project state.
+2. Run `prjct status --md` to confirm whether there is an active task.
+3. If there is no active task and the user asked you to work on one, register it with `prjct task "<description>"` before delegating.
+4. The project's checkpoints (the gate the reviewer applies at session close) are embedded in the reviewer's prompt — you don't need to read them yourself; `prjct crew checkpoints` will print them if you want to see them.
 
 ## How to break work down
 
@@ -35,6 +35,28 @@ Subagents must not write reports to disk. Persistence on this project goes throu
 Example correct prompt to a subagent:
 
 > "Investigate how `notes.py` serializes IDs. Reply with up to ~25 lines: the relevant call sites (file:line), the serialization shape, and any surprises. If the answer is bigger, capture details with `prjct remember learning '<summary>'` and reply with the mem id + headline."
+
+## Session close protocol
+
+When the reviewer replies `VERDICT: APPROVED`:
+
+1. Parse the implementer's `FILES:` block (one path per line; no annotations) into a comma-joined list.
+2. Call `prjct crew record-run` to persist the run as ONE durable DB row + vault page. Idempotent on `--run-id` (so a retry with the same id is safe):
+
+   ```
+   prjct crew record-run \
+     --spec <spec-id-if-any> \
+     --task <task-id-if-any> \
+     --implementer-summary "<the implementer's summary>" \
+     --files "path/to/a.ts,path/to/a.test.ts" \
+     --reviewer-verdict APPROVED \
+     --reviewer-notes "<reviewer notes if any>" \
+     --md
+   ```
+
+3. Only AFTER `record-run` returns successfully (echoes `run-id=<uuid>`) do you tell the implementer to run `prjct status done`. The order is a gate — never advance the task before recording the run.
+
+If the reviewer replies `VERDICT: CHANGES_REQUESTED`, do not call `record-run` for that round — pass the reviewer's notes back to the implementer for revision.
 
 ## Effort scaling
 

--- a/templates/crew/agents/reviewer.md
+++ b/templates/crew/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Strict reviewer. Approves or rejects an implementer's work against .prjct/CHECKPOINTS.md and project conventions. Never edits code.
+description: Strict reviewer. Approves or rejects an implementer's work against the project checkpoints and conventions. Never edits code.
 tools: Read, Glob, Grep, Bash
 ---
 
@@ -8,16 +8,23 @@ tools: Read, Glob, Grep, Bash
 
 You are a strict reviewer. Your only function is to **approve or reject** changes. You never edit code.
 
+The project's checkpoints are inlined below (spliced in by `prjct crew install` from the kv_store row `crew:checkpoints`; manage them via `prjct crew checkpoints set|reset|export`). Walk every checkbox — `[x]` for met, `[ ]` for missed.
+
+## Checkpoints
+
+<!-- prjct:checkpoints:start - DO NOT EDIT (managed by `prjct crew checkpoints set|reset`) -->
+<!-- prjct:checkpoints:end -->
+
 ## Protocol
 
-1. Read `.prjct/CHECKPOINTS.md`. The implementer's report is **in the leader's dispatch prompt** — read it from there; do not look for a report file on disk.
+1. The implementer's report is **in the leader's dispatch prompt** — read it from there; do not look for a report file on disk.
 2. Identify the modified files (use `git status --porcelain` and `git diff --stat`). Cross-reference with the implementer's stated file list — flag any discrepancy.
 3. For each modified file, verify:
    - It respects the project's conventions (style of neighboring files).
    - Test coverage exists for the new behavior (find the corresponding test file).
    - No debug noise was left behind (`console.log`, `print`, `TODO` without a captured note).
 4. Run the project's test command. Tests must pass — if any test is red, that is an automatic rejection.
-5. Walk every checkbox in `.prjct/CHECKPOINTS.md`. Mark `[x]` for items met, `[ ]` for items missed.
+5. Walk every checkbox in the **Checkpoints** section above. Mark `[x]` for met, `[ ]` for missed.
 6. Reply to the leader with the verdict block (inline, no files).
 
 ## Verdict format


### PR DESCRIPTION
## Summary

Part 2 of spec [`a50b32d1`](https://www.prjct.app/) — stacked on top of [#332](../pull/332). Adds the user-facing CLI surface (new crew verbs, spec breakdown) + reviewer-template marker-region splice + wiki regen builders. Migration on \`prjct sync\` and the dedicated regression test files land in **part 3** (smallest remaining slice).

> Base branch is \`feat/crew-persistence-v7\` (part 1) — merge part 1 first, then this rebases onto main cleanly.

## What's in this PR (ACs #3, #4, #7, #8, #9, #11-partial, #14, #15-partial)

### Checkpoints in kv_store + reviewer marker splice
- \`core/storage/checkpoints-storage.ts\` (new): kv_store key \`crew:checkpoints\` with \`{content, source, updated_at}\`. \`get()\` falls back to the bundled \`templates/crew/CHECKPOINTS.md\` content when no user customization. \`reset()\` deletes the row.
- \`core/commands/crew.ts\`: \`install\` no longer writes \`.prjct/CHECKPOINTS.md\`. The reviewer template gets the current checkpoints content spliced between \`<!-- prjct:checkpoints:start -->\` / \`<!-- prjct:checkpoints:end -->\` markers (anchored, refuses on missing/duplicated markers).
- \`uninstall\` still removes a legacy \`.prjct/CHECKPOINTS.md\` if found (migration support).

### New crew CLI verbs
- \`prjct crew checkpoints [show|set|reset|export]\`:
  - default (no arg) → \`show\`; prints current content
  - \`set [--content | --file | <stdin>]\` — \`set\` errors fast with exit 2 + stderr when stdin is a TTY and no flag given (matches \`capture.ts\` pattern)
  - \`reset\` → bundled default
  - \`export [--file]\` — empty-state emits bundled default + stderr log \`(exporting bundled default; no user customization set)\`
- \`prjct crew record-run [--spec --task --implementer-summary --files --reviewer-verdict --reviewer-notes --run-id --md]\`: persists one row per crew session at kv_store key \`crew-run:<id>\`. Idempotent on caller-supplied \`--run-id\`.

### Template updates
- \`templates/crew/agents/reviewer.md\` — added Checkpoints section with marker region; splice fills it at install time.
- \`templates/crew/agents/implementer.md\` — strict \`FILES:\` block format (one path per line, no annotations) for deterministic leader parsing.
- \`templates/crew/agents/leader.md\` — added **Session close protocol**: on reviewer \`VERDICT: APPROVED\`, parse FILES: → call \`prjct crew record-run\` → THEN tell implementer to run \`status done\`. Order is a gate.
- \`templates/crew/CLAUDE-leader-mode.md\` + \`CHECKPOINTS.md\` — internal references point at the kv_store row, not the disk file.

### Build-time architecture guard
- \`scripts/build.js\` — forbidden-substring list widened: bundle fails if any template references \`.prjct/sessions/\`, \`.prjct/CHECKPOINTS.md\`, or \`.prjct/team.json\`.

### \`prjct spec breakdown <id> [--force]\`
- New manual recovery verb in \`core/commands/spec.ts\`. Default gate: status='reviewed' or later. Below gate → stderr message + exit 2. \`--force\` bypass emits an audit event (\`type=spec.breakdown.forced\`) and echoes the mem id on stdout as \`forced-breakdown event=<mem-id>\`. Shares the same \`tasks_created_at\` entry guard as the auto-promote path (idempotent + partial-recovery via wipe-by-featureId).
- Routed through both daemon (\`core/daemon/dispatch.ts\`) and non-daemon (\`core/index.ts\`) spec subverb dispatchers.

### Wiki regen builders + isolation helper
- \`core/services/wiki-generator.ts\`:
  - New \`runBuilder(name, fn, onError)\` helper — wraps a builder call in try/catch + structured log line \`{builder, status, ms, error?}\`.
  - New \`buildCrewRunFiles(runs)\` — one \`crew-runs/<slug>-<ts>.md\` per recorded session.
  - New \`buildTeamFile(enrollment)\` — single \`team.md\` reflecting the kv_store enrollment row (returns null when no enrollment is configured).
  - Source gather pulls from \`crew-run-storage.list()\` + \`teamEnrollmentStorage.get()\` with try/catch — storage-level errors don't abort the rest of the regen.
  - **Existing builders keep their inline-throw shape** for now — full per-builder retrofit is follow-up work explicitly out of scope here.

## What's NOT in this PR (lands in part 3)

- **AC #10**: Migration on \`prjct sync\` (legacy \`.prjct/CHECKPOINTS.md\` + \`.prjct/team.json\` detection + DB adoption + mtime-cached hand-edit warning).
- **ACs #17–19**: Six dedicated test files (\`spec-storage-cas\`, \`queue-storage-delete-by-feature-id\`, \`spec-service-concurrent-review\`, \`spec-task-breakdown-partial-recovery\`, \`spec-breakdown\`, expanded \`crew-templates-no-disk-writes\`). The existing 1125-test suite exercises the new code paths through current call sites; the new tests add dedicated coverage for the concurrency + recovery scenarios called out in the spec.
- **AC #15 full retrofit**: per-builder isolation is wired for the two new builders but not retrofit across all pre-existing builders.
- **CHANGELOG entry + version bump**: lands with part 3 so the full spec ships under one release note.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` → 1125 pass, 0 fail through every commit on this branch
- [x] \`bun test core/__tests__/commands/crew.test.ts\` — 17 pass (test updated to drop the legacy \`.prjct/CHECKPOINTS.md\` existence check and verify marker-region presence on installed reviewer)
- [x] \`node scripts/build.js\` — bundle clean with the widened guard
- [ ] **Manual** (review-time): \`prjct crew install\` on a scratch repo, verify \`.prjct/CHECKPOINTS.md\` is NOT written, verify \`.claude/agents/reviewer.md\` contains the spliced checkpoints between markers; \`prjct crew checkpoints set --content '...' && prjct crew install\` — confirm the customized content lands in reviewer.md; \`prjct crew record-run\` end-to-end with sample flags.

## Risk notes

- This PR depends on part 1 (#332) — the compat wrapper widening, \`casUpdate\`, \`deleteByFeatureId\`, \`crew-run-storage\`, \`team-enrollment-storage\`. Don't merge this independently.
- The reviewer template marker-region splice requires \`dist/templates.json\` to contain the marker pair. Build pipeline rebuilds it; any consumer building from source must \`node scripts/build.js\` after a pull.
- Forced \`prjct spec breakdown\` on a draft spec creates queue tasks against an un-reviewed plan — the audit event provides traceability, but the footgun is real (documented in spec risk #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)