### PR TITLE
fix(config): getProjectId must not silently mint random orphan projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`getProjectId` no longer silently mints a random orphan project.** Root cause: `ConfigManager.getProjectId()` fell through to `pathManager.generateProjectId()` (`crypto.randomUUID()`) whenever `readConfig()` returned null, so any path-resolution miss (daemon resolving the wrong cwd, config transiently unreadable, case-variant path) forked a brand-new project and scattered specs/memory across ghost projects with no error surfaced. Now returns `''` — the falsy sentinel 31/32 call sites already guard with `if (!projectId)` → callers fail loud ("run prjct init") instead of writing into a random new project. Only explicit `prjct init` (`createConfig`) mints. Regression test: `core/__tests__/infrastructure/config-manager-getprojectid.test.ts`.
+
 ## [2.19.8] - 2026-05-14
 
 Crew-mode persistence v7 (spec a50b32d1). SQLite becomes the single source of truth for crew runs, team enrollment, and checkpoint customization. Disk mirrors exist only where an external read contract demands one (the pre-commit hook).

--- a/core/__tests__/infrastructure/config-manager-getprojectid.test.ts
+++ b/core/__tests__/infrastructure/config-manager-getprojectid.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression: getProjectId must NOT silently mint a random orphan project.
+ *
+ * Root cause it guards against: getProjectId() used to fall through to
+ * pathManager.generateProjectId() === crypto.randomUUID() whenever
+ * readConfig() returned null. Any path-resolution miss (daemon resolving
+ * the wrong cwd, config transiently unreadable) forked a brand-new
+ * project, scattering specs/memory across ghost projects with no error.
+ *
+ * Contract now: an uninitialized path resolves to '' (falsy sentinel
+ * every caller already guards with `if (!projectId)`), never a UUID.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-getpid-'))
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('getProjectId — no silent orphan mint', () => {
+  test('uninitialized path → empty string, NOT a random uuid', async () => {
+    const id = await configManager.getProjectId(dir)
+    expect(id).toBe('')
+    // Belt: never a uuid-shaped value
+    expect(id).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/i)
+  })
+
+  test('two consecutive calls on an uninitialized path are stable (no fork)', async () => {
+    const a = await configManager.getProjectId(dir)
+    const b = await configManager.getProjectId(dir)
+    expect(a).toBe('')
+    expect(b).toBe('')
+    expect(a).toBe(b)
+  })
+
+  test('initialized path → the config projectId, unchanged', async () => {
+    await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+    await configManager.writeConfig(dir, {
+      projectId: 'bc401c41-c8b9-436a-ac78-c91cac82ab4f',
+      dataPath: path.join(dir, '.prjct-data'),
+    } as Parameters<typeof configManager.writeConfig>[1])
+
+    const id = await configManager.getProjectId(dir)
+    expect(id).toBe('bc401c41-c8b9-436a-ac78-c91cac82ab4f')
+  })
+})

--- a/core/infrastructure/config-manager.ts
+++ b/core/infrastructure/config-manager.ts
@@ -221,9 +221,20 @@ class ConfigManager {
   }
 
   /**
-   * Get the project ID from config, or generate it if config doesn't exist.
-   * When running from a git worktree, falls back to the main worktree's config
-   * so all worktrees share the same projectId.
+   * Resolve the project ID from config (or the main worktree's config when
+   * running in a child worktree).
+   *
+   * Returns `''` when the path is not an initialized prjct project. It does
+   * NOT mint a new id here: `generateProjectId()` is `crypto.randomUUID()`,
+   * so minting on a config-read miss silently forks a fresh orphan project
+   * every time a path-resolution miss happens (daemon resolving the wrong
+   * cwd, config transiently unreadable, etc.) — scattering specs/memory
+   * across ghost projects with no error surfaced. Only explicit project
+   * creation (`createConfig`, i.e. `prjct init`) is allowed to mint.
+   *
+   * The empty-string sentinel is what 31/32 call sites already guard for
+   * (`if (!projectId) return "run prjct init"`), so callers fail loud
+   * instead of writing into a random new project.
    */
   async getProjectId(projectPath: string): Promise<string> {
     const config = await this.readConfig(projectPath)
@@ -248,7 +259,9 @@ class ConfigManager {
       // worktree detection failed — not critical, fall through
     }
 
-    return pathManager.generateProjectId(projectPath)
+    // Not an initialized project. Fail loud (callers guard `!projectId`),
+    // never silently mint a random orphan project.
+    return ''
   }
 
   /**


### PR DESCRIPTION
## Root cause (one sentence)

`ConfigManager.getProjectId()` fell through to `pathManager.generateProjectId()` — which is `crypto.randomUUID()` — whenever `readConfig()` returned null, so **any path-resolution miss forked a brand-new project with no error surfaced**: daemon resolving the wrong cwd, config transiently unreadable, or a `/Users/jj/apps` vs `/Users/jj/Apps` case variant. This session it stranded a spec in catch-all project `04ca041a` and spawned several orphan drafts.

## Fix (KISS / DRY, minimal blast radius)

`getProjectId()` returns `''` on the no-config / no-worktree fallthrough instead of minting.

- `''` is the falsy sentinel **31 of 32 call sites already guard** with `if (!projectId) return "run prjct init"` — callers now fail loud instead of writing into a random new project.
- Return type unchanged (`Promise<string>`) → zero signature blast radius.
- Only explicit project creation (`createConfig` = `prjct init`) still mints a fresh id.

No spec/audit ceremony: this is investigate-discipline (root cause stated + regression test), not a feature.

## Test plan

- [x] `core/__tests__/infrastructure/config-manager-getprojectid.test.ts` (new) — uninitialized path → `''` not a uuid; two calls stable (no fork); initialized path → config id unchanged. 3 pass.
- [x] `bun run typecheck` clean
- [x] `bun test` → **1134 pass, 0 fail** (+3 new; no existing caller relied on the silent-mint behavior)

## Not in scope

- Cleaning the already-created orphan projects (`04ca041a`, junk drafts `da88be86`/`d546917a`/`4ea6e532`) — they need the `prjct memory/spec forget` verb which is a separate (currently parked) spec. This PR stops *new* orphans; it doesn't retroactively merge existing ones.
- The bare-route-to-capture footgun (`prjct spec view X` → junk draft) — distinct input-validation concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)