### PR TITLE
fix(spec-storage): strictly-monotonic updated_at so the CAS token can't collide

### DIFF
--- a/core/__tests__/storage/spec-storage-cas.test.ts
+++ b/core/__tests__/storage/spec-storage-cas.test.ts
@@ -72,13 +72,11 @@ describe('specStorage.casUpdate', () => {
     const after = specStorage.get(projectId, created.id)
     expect(after?.content.eli10).toBe('updated via CAS')
     expect(after?.content.goal).toBe('test CAS happy path')
-    // updated_at is monotonic, not strictly-greater per write: getTimestamp()
-    // is ISO8601 ms-precision, so a create + casUpdate inside the same
-    // millisecond (fast CI) legitimately produce equal stamps. The CAS
-    // contract under test is "matching token → write succeeds + content
-    // updated", which the assertions above already cover; only assert the
-    // stamp did not go backwards.
-    expect((after?.updatedAt ?? '') >= original.updatedAt).toBe(true)
+    // updated_at is now STRICTLY monotonic per write (specStorage
+    // .nextUpdatedAt forces it greater than the row's current stamp so
+    // the CAS token can't collide at sub-millisecond write rates).
+    expect(after?.updatedAt).not.toBe(original.updatedAt)
+    expect((after?.updatedAt ?? '') > original.updatedAt).toBe(true)
   })
 
   test('rejects stale write (returns false) when updated_at has moved', async () => {

--- a/core/storage/spec-storage.ts
+++ b/core/storage/spec-storage.ts
@@ -34,6 +34,31 @@ interface SpecRow {
 
 class SpecStorage {
   /**
+   * Strictly-monotonic `updated_at` for a spec row.
+   *
+   * `updated_at` doubles as the optimistic-concurrency token in
+   * `casUpdate`. `getTimestamp()` is ISO8601 millisecond precision, so
+   * two writes to the same row inside one millisecond would produce an
+   * EQUAL token — a stale CAS read (`WHERE updated_at = <oldToken>`)
+   * would still match and silently succeed (last-write-wins; the
+   * conflict goes undetected). Forcing the new stamp strictly greater
+   * than the row's current one closes that sub-millisecond hole without
+   * a schema change. ISO8601 sorts chronologically as a string, so the
+   * `>` comparison and the `< vs >` SQL CAS stay correct.
+   */
+  private nextUpdatedAt(projectId: string, id: string): string {
+    const now = getTimestamp()
+    const row = prjctDb.get<{ updated_at: string }>(
+      projectId,
+      'SELECT updated_at FROM specs WHERE id = ?',
+      id
+    )
+    const prev = row?.updated_at
+    if (!prev || now > prev) return now
+    return new Date(new Date(prev).getTime() + 1).toISOString()
+  }
+
+  /**
    * Create a new spec. Returns the spec id.
    */
   create(
@@ -112,7 +137,7 @@ class SpecStorage {
 
   updateContent(projectId: string, id: string, content: SpecContent): Spec | null {
     const validated = SpecContentSchema.parse(content)
-    const now = getTimestamp()
+    const now = this.nextUpdatedAt(projectId, id)
     prjctDb.run(
       projectId,
       'UPDATE specs SET content = ?, updated_at = ? WHERE id = ?',
@@ -140,7 +165,7 @@ class SpecStorage {
     expectedUpdatedAt: string
   ): boolean {
     const validated = SpecContentSchema.parse(content)
-    const now = getTimestamp()
+    const now = this.nextUpdatedAt(projectId, id)
     const result = prjctDb.run(
       projectId,
       'UPDATE specs SET content = ?, updated_at = ? WHERE id = ? AND updated_at = ?',
@@ -156,7 +181,7 @@ class SpecStorage {
     if (!SPEC_STATUSES.includes(status)) {
       throw new Error(`invalid spec status: ${status}`)
     }
-    const now = getTimestamp()
+    const now = this.nextUpdatedAt(projectId, id)
     const extras: string[] = []
     const params: SqliteBindings[] = [status, now]
     if (status === 'shipped') {
@@ -178,7 +203,7 @@ class SpecStorage {
       projectId,
       'UPDATE specs SET shipped_pr = ?, updated_at = ? WHERE id = ?',
       pr,
-      getTimestamp(),
+      this.nextUpdatedAt(projectId, id),
       id
     )
     return this.get(projectId, id)
@@ -194,7 +219,7 @@ class SpecStorage {
       projectId,
       'UPDATE specs SET shipped_sha = ?, updated_at = ? WHERE id = ?',
       sha,
-      getTimestamp(),
+      this.nextUpdatedAt(projectId, id),
       id
     )
     return this.get(projectId, id)


### PR DESCRIPTION
## The real bug (not a flake)

Main CI failed **deterministically** post-#336 on `specStorage.casUpdate > rejects stale write (returns false)` → `Expected: false, Received: true`. #336 weakened an *incidental* assertion in a sibling test; **this** test exercises the actual CAS contract and was correctly failing. PR CI passed only by timing luck — the bug is real.

**Root cause:** `specStorage` wrote `updated_at` straight from `getTimestamp()` (ISO8601 **millisecond** precision). `updated_at` doubles as the optimistic-concurrency token in `casUpdate`. Two writes to the same spec inside one millisecond produce an **equal token**, so a stale CAS read (`WHERE updated_at = <oldToken>`) still matches → the write silently succeeds, conflict undetected, last-write-wins. This is exactly the hole captured as a gotcha earlier — now fixed at the source.

## Fix (KISS / DRY)

New private `specStorage.nextUpdatedAt(projectId, id)` → `max(getTimestamp(), rowUpdatedAt + 1ms)`, strictly greater than the row's current stamp. Applied to every spec `updated_at` writer: `updateContent`, `casUpdate`, `setStatus`, `setShippedPr`, `setShippedSha`. No schema migration; ISO8601 sorts chronologically as a string so the `>` compare and SQL CAS stay correct. `create()` keeps `getTimestamp()` for the initial `created_at == updated_at` (no prior row — correct baseline).

Restored the strict assertion in `spec-storage-cas.test.ts` test 1 — with monotonic stamps it verifies the real contract instead of being timing-fragile.

## Why this is the right fix, not a test patch

The `a50b32d1` audit chain reasoned about `updated_at` as monotonic and never asked "strictly increasing *per write*?" — the precise plausible-but-false assumption the audit-learning (`mem_2776`) is about. Weakening the assertion would have shipped a real concurrency bug in `recordReview`/`breakdownSpecToTasks`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `spec-storage-cas` 6× isolated → 6/6 stable (was deterministically failing)
- [x] `bun test` → 1134 pass / 0 fail across **two** consecutive full-suite runs
- [ ] Post-merge: confirm main **push** CI green (the asymmetry that bit twice — verifying, not claiming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)