### PR TITLE
feat: Skill Resolution Feedback (#16) — skill-miss detector + improvement-signals widening + prjct skill-adherence (v2.19.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
+## [2.19.9] - 2026-05-16
+
+### Added
+- Skill Resolution Feedback (#16): skill-miss-detector + improvement-signals widening + prjct skill-adherence verb
+
 ## [Unreleased]
+
+### Added
+
+- **Skill Resolution Feedback (harness #16, spec `08344b7d`).** At Stop, `core/services/skill-miss-detector.ts` flags captured project knowledge (`decision` / `gotcha` / `anti-pattern`) that was relevant to the session's work but never referenced — a "skill-miss" — and persists it as an `improvement-signal` tagged `source:skill-miss-detector`. Transcript-primary; changed-file overlap is a best-effort booster via `getModifiedFiles()` (absent on a clean tree → degrades to token overlap, never errors). Precision-leaning: relevance needs a path hit OR ≥2 distinctive shared tokens; `inferred`-provenance and captured-this-session memories are excluded; hashed `(type,key)` dedup makes Stop re-runs idempotent (mirrors `friction-detector`).
+- **`prjct skill-adherence [window] [--md]`** — read-only QA surface: skill-misses vs resolutions over a window (7d default), with an addressed ratio. Same Tier-1 read-only contract as `prjct retro` / `prjct health`.
+
+### Changed
+
+- **`buildImprovementSignals` now carries both detectors under one block.** The recall no longer hard-filters `source:friction-detector`; friction and skill-miss signals render under the existing `# prjct: improvement signals` header with **per-source budgets** (friction ≤3, skill-miss ≤2) so a noisy friction session can't starve skill-miss out of the shared 24h window. No parallel block (session-start advisory density stays bounded). The `resolves:` prose is extended with `resolves:skill-miss`; the 24h age-out remains the actual drop-from-rotation mechanism (a real `resolves:` consumer stays owned by the memory close|forget spec).
 
 ### Fixed
 - **`getProjectId` no longer silently mints a random orphan project.** Root cause: `ConfigManager.getProjectId()` fell through to `pathManager.generateProjectId()` (`crypto.randomUUID()`) whenever `readConfig()` returned null, so any path-resolution miss (daemon resolving the wrong cwd, config transiently unreadable, case-variant path) forked a brand-new project and scattered specs/memory across ghost projects with no error surfaced. Now returns `''` — the falsy sentinel 31/32 call sites already guard with `if (!projectId)` → callers fail loud ("run prjct init") instead of writing into a random new project. Only explicit `prjct init` (`createConfig`) mints. Regression test: `core/__tests__/infrastructure/config-manager-getprojectid.test.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
-## [2.19.9] - 2026-05-16
-
-### Added
-- Skill Resolution Feedback (#16): skill-miss-detector + improvement-signals widening + prjct skill-adherence verb
-
 ## [Unreleased]
+
+## [2.19.9] - 2026-05-16
 
 ### Added
 

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -71,6 +71,7 @@ const _binCommands = new Set([
   'prefs',
   'retro',
   'health',
+  'skill-adherence',
   'context-save',
   'context-restore',
 ])
@@ -614,6 +615,16 @@ async function main(): Promise<void> {
     const { RetroCommands } = await import('../core/commands/retro')
     const cmd = new RetroCommands()
     const result = await cmd.retro(windowArg, process.cwd(), { md: mdMode })
+    process.exitCode = result.success ? 0 : 1
+  } else if (args[0] === 'skill-adherence') {
+    // `prjct skill-adherence [window]` — harness #16 QA surface: how
+    // often captured project knowledge went unreferenced, and how much
+    // got resolved. Read-only; window defaults to 7d.
+    const windowArg = args.slice(1).find((a) => !a.startsWith('-')) ?? null
+    const mdMode = args.includes('--md')
+    const { SkillAdherenceCommands } = await import('../core/commands/skill-adherence')
+    const cmd = new SkillAdherenceCommands()
+    const result = await cmd.skillAdherence(windowArg, process.cwd(), { md: mdMode })
     process.exitCode = result.success ? 0 : 1
   } else if (args[0] === 'prefs') {
     // `prjct prefs list|get|check|set|clear [...]` — gstack-inspired

--- a/core/__tests__/commands/skill-adherence.test.ts
+++ b/core/__tests__/commands/skill-adherence.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `prjct skill-adherence [window]` — read-only harness #16 QA surface.
+ *
+ * Pins: window grammar (mirrors retro), empty-state is success, a
+ * miss + its `resolves:skill-miss` resolution produce a non-zero
+ * adherence ratio, and `--md` emits valid markdown.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { SkillAdherenceCommands } from '../../commands/skill-adherence'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+
+let dir: string
+let projectId: string
+const cmd = new SkillAdherenceCommands()
+
+function logMiss(relates: string): void {
+  prjctDb.appendEvent(projectId, 'memory.remember.improvement-signal', {
+    content: `[skill-miss] Unused project knowledge (decision, ${relates}): "x"`,
+    tags: { source: 'skill-miss-detector', category: 'skill-miss', relates, key: `k-${relates}` },
+    provenance: 'extracted',
+  })
+}
+
+function logResolution(relates: string): void {
+  prjctDb.appendEvent(projectId, 'memory.remember.decision', {
+    content: 'addressed it',
+    tags: { resolves: 'skill-miss', relates },
+    provenance: 'declared',
+  })
+}
+
+beforeEach(async () => {
+  prjctDb.close()
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-skilladh-test-'))
+  await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+  projectId = `skilladh-${crypto.randomUUID()}`
+  await configManager.writeConfig(dir, {
+    projectId,
+    dataPath: path.join(dir, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  prjctDb.close()
+})
+
+describe('prjct skill-adherence', () => {
+  it('rejects an invalid window', async () => {
+    const r = await cmd.skillAdherence('not-a-window', dir, { md: true })
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/Invalid window/)
+  })
+
+  it('is a clean success when no skill-misses exist', async () => {
+    const r = await cmd.skillAdherence('7d', dir, { md: true })
+    expect(r.success).toBe(true)
+    expect(r.misses).toBe(0)
+    expect(r.adherence).toBe(1)
+  })
+
+  it('computes the resolved ratio from resolves:skill-miss decisions', async () => {
+    logMiss('mem_1')
+    logMiss('mem_2')
+    logResolution('mem_1')
+    const r = await cmd.skillAdherence('7d', dir, { md: true })
+    expect(r.success).toBe(true)
+    expect(r.misses).toBe(2)
+    expect(r.resolved).toBe(1)
+    expect(r.adherence).toBe(0.5)
+  })
+
+  it('emits markdown under --md', async () => {
+    logMiss('mem_9')
+    const out: string[] = []
+    const orig = console.log
+    console.log = (m?: unknown) => {
+      out.push(String(m))
+    }
+    try {
+      await cmd.skillAdherence('30d', dir, { md: true })
+    } finally {
+      console.log = orig
+    }
+    const text = out.join('\n')
+    expect(text).toContain('## Skill adherence — last 30d')
+    expect(text).toContain('| State | Memory | File | Signal |')
+  })
+})

--- a/core/__tests__/hooks/prompt.test.ts
+++ b/core/__tests__/hooks/prompt.test.ts
@@ -128,7 +128,7 @@ describe('UserPromptSubmit — improvement signals', () => {
     })
     const r = await buildImprovementSignals(projectPath)
     expect(r).toContain('# prjct: improvement signals')
-    expect(r).toContain('1 friction moment captured')
+    expect(r).toContain('1 signal captured at last session-end')
     expect(r).toContain('[negation] User pushback')
   })
 
@@ -160,7 +160,7 @@ describe('UserPromptSubmit — improvement signals', () => {
     }
     const r = await buildImprovementSignals(projectPath)
     expect(r).not.toBeNull()
-    // Heading line says "3 friction moments captured" — caps verified.
-    expect(r).toMatch(/3 friction moments captured/)
+    // Friction per-source budget is 3 even when 5 exist.
+    expect(r).toMatch(/3 signals captured at last session-end/)
   })
 })

--- a/core/__tests__/hooks/skill-miss-signal.test.ts
+++ b/core/__tests__/hooks/skill-miss-signal.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Harness #16 surfacing — `buildImprovementSignals` carries both
+ * detectors under ONE block with per-source budgets.
+ *
+ * Pins: skill-miss renders under the existing header with a
+ * [skill-miss] label (no parallel block); the `resolves:skill-miss`
+ * prose is present; a noisy friction session cannot starve skill-miss
+ * out of the shared 24h window (per-source budget, not a flat cap).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildImprovementSignals } from '../../hooks/prompt'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+
+let projectPath: string
+let projectId: string
+
+async function freshProject(): Promise<void> {
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-skillmiss-signal-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `skillmiss-sig-${crypto.randomUUID()}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+}
+
+function appendFriction(i: number): void {
+  prjctDb.appendEvent(projectId, 'memory.remember.improvement-signal', {
+    content: `[negation] User pushback: "no, friction ${i}"`,
+    tags: { source: 'friction-detector', category: 'negation', key: `f${i}` },
+    provenance: 'extracted',
+  })
+}
+
+function appendSkillMiss(i: number): void {
+  prjctDb.appendEvent(projectId, 'memory.remember.improvement-signal', {
+    content: `[skill-miss] Unused project knowledge (decision, mem_${i}): "do X the captured way"`,
+    tags: {
+      source: 'skill-miss-detector',
+      kind: 'skill-miss',
+      category: 'skill-miss',
+      relates: `mem_${i}`,
+      key: `s${i}`,
+    },
+    provenance: 'extracted',
+  })
+}
+
+beforeEach(async () => {
+  prjctDb.close()
+})
+
+afterEach(async () => {
+  if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  prjctDb.close()
+})
+
+describe('buildImprovementSignals — harness #16 widening', () => {
+  it('surfaces a skill-miss under the existing block with a [skill-miss] label', async () => {
+    await freshProject()
+    appendSkillMiss(1)
+    const r = await buildImprovementSignals(projectPath)
+    expect(r).not.toBeNull()
+    expect(r).toContain('# prjct: improvement signals')
+    expect(r).toContain('(friction + skill-miss)')
+    expect(r).toContain('[skill-miss] Unused project knowledge')
+    expect(r).toContain('resolves:skill-miss')
+  })
+
+  it('does not starve skill-miss when friction is noisy (per-source budget)', async () => {
+    await freshProject()
+    for (let i = 0; i < 5; i++) appendFriction(i)
+    for (let i = 0; i < 5; i++) appendSkillMiss(i)
+    const r = await buildImprovementSignals(projectPath)
+    expect(r).not.toBeNull()
+    const frictionLines = (r!.match(/- \[negation\]/g) ?? []).length
+    const skillMissLines = (r!.match(/- \[skill-miss\]/g) ?? []).length
+    expect(frictionLines).toBe(3) // FRICTION_BUDGET
+    expect(skillMissLines).toBe(2) // SKILL_MISS_BUDGET — survived the friction flood
+    expect(r).toContain('5 signals captured at last session-end')
+  })
+
+  it('still works with only skill-miss signals (no friction)', async () => {
+    await freshProject()
+    appendSkillMiss(99)
+    const r = await buildImprovementSignals(projectPath)
+    expect(r).not.toBeNull()
+    expect(r).toContain('1 signal captured at last session-end')
+    expect(r).toContain('[skill-miss]')
+  })
+
+  it('ignores skill-miss signals older than 24h', async () => {
+    await freshProject()
+    const oldTs = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    prjctDb.run(
+      projectId,
+      "INSERT INTO events (type, data, timestamp) VALUES ('memory.remember.improvement-signal', ?, ?)",
+      JSON.stringify({
+        content: '[skill-miss] stale',
+        tags: { source: 'skill-miss-detector', category: 'skill-miss', key: 'old' },
+        provenance: 'extracted',
+      }),
+      oldTs
+    )
+    const r = await buildImprovementSignals(projectPath)
+    expect(r).toBeNull()
+  })
+})

--- a/core/__tests__/services/skill-miss-detector.test.ts
+++ b/core/__tests__/services/skill-miss-detector.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Skill-miss detector (harness #16).
+ *
+ * Pure-core tests pin the heuristic contract: relevance needs a path
+ * hit OR ≥2 distinctive shared tokens, a referenced memory is never a
+ * miss, token-only detection survives an empty changed-file list,
+ * hashKey is stable. The DB integration test pins persistence shape,
+ * idempotent dedup, inferred/recency containment, and the
+ * no-loose-files persistence rule.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { _internal, detectSkillMisses } from '../../services/skill-miss-detector'
+import prjctDb from '../../storage/database'
+
+interface CM {
+  id: string
+  type: string
+  content: string
+  fileTag: string
+  rememberedAt: string
+  provenance: string
+  session: string
+}
+
+function mem(over: Partial<CM>): CM {
+  return {
+    id: over.id ?? 'mem_1',
+    type: over.type ?? 'decision',
+    content: over.content ?? '',
+    fileTag: over.fileTag ?? '',
+    rememberedAt: over.rememberedAt ?? new Date(0).toISOString(),
+    provenance: over.provenance ?? 'declared',
+    session: over.session ?? '',
+  }
+}
+
+describe('skill-miss-detector — tokenize', () => {
+  it('drops short tokens and stopwords, lowercases', () => {
+    const t = _internal.tokenize('Always wrap the SQLite busy PRAGMA handle')
+    expect(t.has('always')).toBe(false) // stopword
+    expect(t.has('the')).toBe(false) // too short
+    expect(t.has('busy')).toBe(false) // < MIN_TOKEN_LEN (4)
+    expect(t.has('sqlite')).toBe(true)
+    expect(t.has('pragma')).toBe(true)
+    expect(t.has('handle')).toBe(true)
+  })
+})
+
+describe('skill-miss-detector — analyze', () => {
+  it('flags a relevant-but-unreferenced memory (token overlap, no git)', () => {
+    const transcript = 'edited the sqlite connection and pragma handling for the project'
+    const out = _internal.analyze(
+      transcript,
+      [],
+      [mem({ id: 'mem_42', content: 'Set sqlite pragma busy_timeout to 5000 on every handle' })]
+    )
+    expect(out.length).toBe(1)
+    expect(out[0]?.memId).toBe('mem_42')
+    expect(out[0]?.reason).toBe('topic-overlap-unused')
+    expect(out[0]?.evidenceFile).toBe('')
+  })
+
+  it('does NOT flag when a distinctive token was referenced (knowledge applied)', () => {
+    // "busy_timeout" → token "timeout" (len 7, distinctive) appears in the
+    // transcript → the memory was consulted.
+    const transcript = 'set the sqlite pragma busy timeout to 5000 like the decision said'
+    const out = _internal.analyze(
+      transcript,
+      [],
+      [mem({ content: 'Set sqlite pragma busy_timeout to 5000 on every handle' })]
+    )
+    expect(out.length).toBe(0)
+  })
+
+  it('requires ≥2 token overlap OR a path hit (false-positive containment)', () => {
+    const transcript = 'worked on the unrelated billing invoice export feature today'
+    const out = _internal.analyze(
+      transcript,
+      [],
+      [mem({ content: 'Set sqlite pragma busy_timeout to 5000' })]
+    )
+    expect(out.length).toBe(0)
+  })
+
+  it('flags via changed-file path overlap and records the evidence file', () => {
+    const transcript = 'made some edits and moved on to the next thing entirely'
+    const out = _internal.analyze(
+      transcript,
+      ['core/storage/database.ts'],
+      [
+        mem({
+          id: 'mem_7',
+          content: 'database connections need pragma busy_timeout',
+          fileTag: 'core/storage/database.ts',
+        }),
+      ]
+    )
+    expect(out.length).toBe(1)
+    expect(out[0]?.reason).toBe('path-overlap-unused')
+    expect(out[0]?.evidenceFile).toBe('core/storage/database.ts')
+  })
+
+  it('empty changed-file list never breaks token-based detection (criterion #4)', () => {
+    // Transcript shares TOPIC tokens (ranker, scoring) but never the
+    // memory's signature ("retrieval") → relevant, unreferenced → miss.
+    const transcript = 'tuned the ranker scoring and reranker heuristics today'
+    const out = _internal.analyze(
+      transcript,
+      [],
+      [mem({ content: 'retrieval ranker scoring must combine bm25 and import-graph' })]
+    )
+    expect(out.length).toBe(1)
+  })
+
+  it('orders path-overlap misses before token-only ones', () => {
+    const out = _internal.analyze(
+      'changed the ranker scoring weights and cache plumbing extensively',
+      ['core/domain/file-ranker.ts'],
+      [
+        mem({ id: 'tok', content: 'ranker scoring weights need tuning indexes' }),
+        mem({
+          id: 'pathy',
+          content: 'recompute caches eagerly',
+          fileTag: 'core/domain/file-ranker.ts',
+        }),
+      ]
+    )
+    expect(out.length).toBe(2)
+    expect(out[0]?.memId).toBe('pathy')
+  })
+})
+
+describe('skill-miss-detector — hashKey', () => {
+  it('normalises whitespace + casing and is memId-scoped', () => {
+    const a = _internal.hashKey('mem_1', 'Set  PRAGMA   busy_timeout')
+    const b = _internal.hashKey('mem_1', 'set pragma busy_timeout')
+    const c = _internal.hashKey('mem_2', 'set pragma busy_timeout')
+    expect(a).toBe(b)
+    expect(a).not.toBe(c)
+  })
+
+  it('caps misses per session conservatively', () => {
+    expect(_internal.MAX_SKILL_MISSES_PER_SESSION).toBeLessThanOrEqual(5)
+  })
+})
+
+describe('skill-miss-detector — persistence + containment (DB)', () => {
+  let dir: string
+  let projectId: string
+  let transcriptPath: string
+
+  async function seedDecision(
+    content: string,
+    opts: { ageMs?: number; provenance?: string } = {}
+  ): Promise<void> {
+    const ts = new Date(Date.now() - (opts.ageMs ?? 7 * 24 * 60 * 60 * 1000)).toISOString()
+    prjctDb.run(
+      projectId,
+      "INSERT INTO events (type, data, timestamp) VALUES ('memory.remember.decision', ?, ?)",
+      JSON.stringify({
+        content,
+        tags: { key: `seed-${Math.random().toString(36).slice(2, 8)}` },
+        provenance: opts.provenance ?? 'declared',
+      }),
+      ts
+    )
+  }
+
+  beforeEach(async () => {
+    prjctDb.close()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-skillmiss-test-'))
+    await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+    projectId = `skillmiss-${crypto.randomUUID()}`
+    await configManager.writeConfig(dir, {
+      projectId,
+      dataPath: path.join(dir, '.prjct-data'),
+    } as Parameters<typeof configManager.writeConfig>[1])
+    await pathManager.ensureProjectStructure(projectId)
+    transcriptPath = path.join(dir, 'transcript.jsonl')
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    prjctDb.close()
+  })
+
+  function writeTranscript(text: string): Promise<void> {
+    return fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ role: 'user', content: 'do the work' }),
+        JSON.stringify({ role: 'assistant', content: text }),
+      ].join('\n')
+    )
+  }
+
+  it('persists a skill-miss as a tagged improvement-signal, idempotently', async () => {
+    await seedDecision('Set sqlite pragma busy_timeout to 5000 on every connection')
+    await writeTranscript('edited the sqlite pragma handling in the storage layer')
+
+    const r1 = await detectSkillMisses(dir, transcriptPath, 'sess-1')
+    expect(r1.signalsRecorded).toBe(1)
+
+    const signals = (await import('../../memory/project-memory')).projectMemory.recall(projectId, {
+      types: ['improvement-signal'],
+      tags: { source: 'skill-miss-detector' },
+      dedupeByKey: false,
+    })
+    expect(signals.length).toBe(1)
+    expect(signals[0]?.tags.kind).toBe('skill-miss')
+    expect(signals[0]?.tags.category).toBe('skill-miss')
+    expect(signals[0]?.tags.relates).toMatch(/^mem_/)
+    expect(signals[0]?.content).toContain('[skill-miss]')
+
+    // Re-run on the same transcript → dedup, no second row.
+    const r2 = await detectSkillMisses(dir, transcriptPath, 'sess-1')
+    expect(r2.signalsRecorded).toBe(0)
+    const after = (await import('../../memory/project-memory')).projectMemory.recall(projectId, {
+      types: ['improvement-signal'],
+      tags: { source: 'skill-miss-detector' },
+      dedupeByKey: false,
+    })
+    expect(after.length).toBe(1)
+  })
+
+  it('excludes inferred-provenance candidates', async () => {
+    await seedDecision('Set sqlite pragma busy_timeout to 5000', { provenance: 'inferred' })
+    await writeTranscript('edited the sqlite pragma handling in the storage layer')
+    const r = await detectSkillMisses(dir, transcriptPath, 's')
+    expect(r.signalsRecorded).toBe(0)
+  })
+
+  it('excludes memories captured this session (recency containment)', async () => {
+    await seedDecision('Set sqlite pragma busy_timeout to 5000', { ageMs: 60 * 1000 })
+    await writeTranscript('edited the sqlite pragma handling in the storage layer')
+    const r = await detectSkillMisses(dir, transcriptPath, 's')
+    expect(r.signalsRecorded).toBe(0)
+  })
+
+  it('writes nothing to disk outside SQLite (persistence rule)', async () => {
+    await seedDecision('Set sqlite pragma busy_timeout to 5000 on every connection')
+    await writeTranscript('edited the sqlite pragma handling in the storage layer')
+    const before = (await fs.readdir(dir)).sort()
+    await detectSkillMisses(dir, transcriptPath, 's')
+    const afterEntries = (await fs.readdir(dir)).sort()
+    // Only the things we created (.prjct, .prjct-data, transcript.jsonl)
+    // — the detector must not drop a report/markdown file in the project.
+    expect(afterEntries).toEqual(before)
+  })
+})

--- a/core/commands/skill-adherence.ts
+++ b/core/commands/skill-adherence.ts
@@ -1,0 +1,194 @@
+/**
+ * Skill-adherence command — `prjct skill-adherence [window]`
+ *
+ * Read-only QA surface for harness #16 (Skill Resolution Feedback).
+ * Reports, over a time window, how often captured project knowledge was
+ * relevant to the work but went unreferenced (skill-misses), and how
+ * many of those were subsequently resolved.
+ *
+ * A skill-miss = an `improvement-signal` written by `skill-miss-detector`.
+ * A resolution = a `decision` tagged `resolves:skill-miss` (matched back
+ * to the miss by its shared `relates:<memId>` tag when present). This
+ * mirrors the existing advisory `resolves:improvement-signal` convention.
+ *
+ * No gate, no side effects — same read-only/Tier-1 contract as
+ * `prjct retro` / `prjct health`.
+ *
+ * Windows: `prjct skill-adherence` (7d default) · `24h` · `14d` · `30d`.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { projectMemory } from '../memory/project-memory'
+import type { MdOption } from '../types/cli'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+interface MissRow {
+  memId: string
+  excerpt: string
+  file: string
+  rememberedAt: string
+  resolved: boolean
+}
+
+export class SkillAdherenceCommands extends PrjctCommandsBase {
+  async skillAdherence(
+    arg: string | null = null,
+    projectPath: string = process.cwd(),
+    options: MdOption = {}
+  ): Promise<CommandResult> {
+    try {
+      const initResult = await this.ensureProjectInit(projectPath)
+      if (!initResult.success) return initResult
+
+      const window = parseWindow(arg)
+      if (!window) {
+        out.fail(`Invalid window "${arg}". Use: 7d, 24h, 14d, 30d (units: h or d).`)
+        return { success: false, error: 'Invalid window' }
+      }
+
+      const config = await configManager.readConfig(projectPath)
+      if (!config?.projectId) {
+        out.fail('No prjct project here — run `prjct start` first.')
+        return { success: false, error: 'No project' }
+      }
+
+      const sinceMs = Date.now() - window.hours * 60 * 60 * 1000
+
+      const misses = projectMemory
+        .recall(config.projectId, {
+          types: ['improvement-signal'],
+          tags: { source: 'skill-miss-detector' },
+          limit: 300,
+          dedupeByKey: false,
+        })
+        .filter((e) => Date.parse(e.rememberedAt) >= sinceMs)
+
+      // Resolutions: decisions tagged resolves:skill-miss in the window.
+      // Indexed by the `relates` mem-id they point back at; a bare
+      // resolves:skill-miss with no relates counts as a general signal
+      // the user addressed the surface but doesn't match a specific row.
+      const resolutions = projectMemory
+        .recall(config.projectId, {
+          types: ['decision'],
+          tags: { resolves: 'skill-miss' },
+          limit: 300,
+          dedupeByKey: false,
+        })
+        .filter((e) => Date.parse(e.rememberedAt) >= sinceMs)
+      const resolvedRelates = new Set(
+        resolutions.map((e) => e.tags.relates).filter((r): r is string => Boolean(r))
+      )
+
+      const rows: MissRow[] = misses.map((e) => ({
+        memId: e.tags.relates ?? '—',
+        excerpt: firstLine(e.content),
+        file: e.tags.file ?? '',
+        rememberedAt: e.rememberedAt,
+        resolved: e.tags.relates ? resolvedRelates.has(e.tags.relates) : false,
+      }))
+
+      const total = rows.length
+      const resolved = rows.filter((r) => r.resolved).length
+      const ratio = total === 0 ? 1 : resolved / total
+
+      if (options.md) {
+        console.log(formatMarkdown(window.label, rows, total, resolved, ratio, resolutions.length))
+      } else {
+        console.log(formatText(window.label, rows, total, resolved, ratio))
+      }
+
+      return {
+        success: true,
+        window: window.label,
+        misses: total,
+        resolved,
+        adherence: Number(ratio.toFixed(2)),
+      }
+    } catch (error) {
+      return failHard(getErrorMessage(error))
+    }
+  }
+}
+
+// ============================================================================
+// Window parsing — same grammar as `prjct retro`.
+// ============================================================================
+
+interface ParsedWindow {
+  label: string
+  hours: number
+}
+
+function parseWindow(arg: string | null): ParsedWindow | null {
+  const raw = (arg ?? '7d').trim().toLowerCase()
+  const m = raw.match(/^(\d+)\s*([hd])$/)
+  if (!m) return null
+  const n = Number.parseInt(m[1]!, 10)
+  if (!Number.isFinite(n) || n <= 0 || n > 365) return null
+  return m[2] === 'h' ? { label: `${n}h`, hours: n } : { label: `${n}d`, hours: n * 24 }
+}
+
+function firstLine(content: string): string {
+  const line = content.split('\n')[0] ?? ''
+  return line.replace(/^\[skill-miss\]\s*/, '').trim()
+}
+
+// ============================================================================
+// Output formatters
+// ============================================================================
+
+function formatText(
+  label: string,
+  rows: MissRow[],
+  total: number,
+  resolved: number,
+  ratio: number
+): string {
+  if (total === 0) {
+    return `Skill adherence — last ${label}: no skill-misses captured. Clean.`
+  }
+  const lines: string[] = []
+  lines.push(
+    `Skill adherence — last ${label} · ${total} miss${total === 1 ? '' : 'es'} · ${resolved} resolved · ${(ratio * 100).toFixed(0)}% addressed`
+  )
+  lines.push('')
+  for (const r of rows.slice(0, 20)) {
+    const mark = r.resolved ? '✓' : '·'
+    const where = r.file ? ` (${r.file})` : ''
+    lines.push(`  ${mark} ${r.memId}${where}  ${r.excerpt.slice(0, 100)}`)
+  }
+  return lines.join('\n')
+}
+
+function formatMarkdown(
+  label: string,
+  rows: MissRow[],
+  total: number,
+  resolved: number,
+  ratio: number,
+  resolutionCount: number
+): string {
+  if (total === 0) {
+    return `## Skill adherence — last ${label}\n\n_No skill-misses captured in the window._\n`
+  }
+  const lines: string[] = []
+  lines.push(`## Skill adherence — last ${label}`)
+  lines.push('')
+  lines.push(`- **Skill-misses**: ${total}`)
+  lines.push(`- **Resolved**: ${resolved} (${(ratio * 100).toFixed(0)}% addressed)`)
+  lines.push(`- **Resolution decisions logged**: ${resolutionCount}`)
+  lines.push('')
+  lines.push('| State | Memory | File | Signal |')
+  lines.push('|---|---|---|---|')
+  for (const r of rows.slice(0, 30)) {
+    const state = r.resolved ? '✓ resolved' : '· open'
+    const file = r.file || '—'
+    const excerpt = r.excerpt.slice(0, 110).replace(/\|/g, '\\|')
+    lines.push(`| ${state} | ${r.memId} | ${file} | ${excerpt} |`)
+  }
+  return lines.join('\n')
+}

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -199,15 +199,24 @@ async function captureGit(projectPath: string): Promise<GitSnapshot> {
 }
 
 /**
- * Read the most recent improvement-signals captured by the friction
- * detector at the previous session's Stop hook. Surfaces ONCE per
- * signal: as soon as the LLM (or the user) acts on a signal, it
- * should be addressed — repeated injection across turns is noise.
+ * Read the most recent improvement-signals captured at the previous
+ * session's Stop hook — two sources, one block:
+ *   - `friction-detector` — user-pushback moments.
+ *   - `skill-miss-detector` — captured project knowledge that was
+ *     relevant to the work but never referenced (harness #16).
  *
- * Implementation note: we cap surfacing at the 3 newest signals from
- * the last 24h, so a single noisy session can't flood the prompt
- * context indefinitely.
+ * Surfaces ONCE per signal window: as soon as the LLM (or the user)
+ * acts on one it should be addressed — repeated injection is noise.
+ *
+ * Budgets are PER SOURCE (friction ≤3, skill-miss ≤2) so a noisy
+ * friction session can't starve skill-miss signals out of the shared
+ * 24h window — that starvation was the design flaw of a single flat
+ * cap. Both render under the same header (no parallel block) to keep
+ * session-start advisory density bounded.
  */
+const FRICTION_BUDGET = 3
+const SKILL_MISS_BUDGET = 2
+
 export async function buildImprovementSignals(projectPath: string): Promise<string | null> {
   const config = await configManager.readConfig(projectPath)
   if (!config?.projectId) return null
@@ -216,8 +225,7 @@ export async function buildImprovementSignals(projectPath: string): Promise<stri
   try {
     signals = projectMemory.recall(config.projectId, {
       types: ['improvement-signal'],
-      tags: { source: 'friction-detector' },
-      limit: 8,
+      limit: 16,
     })
   } catch {
     return null
@@ -226,25 +234,41 @@ export async function buildImprovementSignals(projectPath: string): Promise<stri
 
   // Keep only signals from the last 24h. Older ones either got
   // addressed or aren't pressing — surfacing them on every turn
-  // forever would be noise.
+  // forever would be noise. (This 24h age-out IS the drop-from-rotation
+  // mechanism today; the `resolves:` prose below is advisory until a
+  // real consumer lands — owned by the memory close|forget spec.)
   const recentCutoff = Date.now() - 24 * 60 * 60 * 1000
-  const recent = signals.filter((e) => Date.parse(e.rememberedAt) > recentCutoff).slice(0, 3)
+  const recent = signals.filter((e) => Date.parse(e.rememberedAt) > recentCutoff)
   if (recent.length === 0) return null
+
+  // Per-source budget, then re-merge newest-first so the block stays
+  // chronologically coherent. Unknown sources are ignored — only the
+  // two detectors feed this block.
+  const friction = recent
+    .filter((e) => e.tags.source === 'friction-detector')
+    .slice(0, FRICTION_BUDGET)
+  const skillMiss = recent
+    .filter((e) => e.tags.source === 'skill-miss-detector')
+    .slice(0, SKILL_MISS_BUDGET)
+  const shown = [...friction, ...skillMiss].sort((a, b) =>
+    b.rememberedAt.localeCompare(a.rememberedAt)
+  )
+  if (shown.length === 0) return null
 
   const lines: string[] = ['# prjct: improvement signals (from prior session)']
   lines.push('')
   lines.push(
-    `${recent.length} friction moment${recent.length === 1 ? '' : 's'} captured at last session-end. Consider whether any of these are relevant to what the user is asking now — if so, propose a fix proactively. Otherwise ignore.`
+    `${shown.length} signal${shown.length === 1 ? '' : 's'} captured at last session-end (friction + skill-miss). Consider whether any of these are relevant to what the user is asking now — if so, propose a fix proactively. Otherwise ignore.`
   )
   lines.push('')
-  for (const e of recent) {
+  for (const e of shown) {
     const category = e.tags.category ?? 'unknown'
     const oneLine = e.content.split('\n')[0] ?? ''
     lines.push(`- [${category}] ${oneLine}`)
   }
   lines.push('')
   lines.push(
-    '> If the user explicitly addresses one, drop it from rotation by `prjct remember decision "<resolution>" --tags resolves:improvement-signal`.'
+    '> If the user explicitly addresses one, drop it from rotation by `prjct remember decision "<resolution>" --tags resolves:improvement-signal` (friction) or `--tags resolves:skill-miss` (skill-miss).'
   )
   return lines.join('\n')
 }

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -21,6 +21,7 @@ import configManager from '../infrastructure/config-manager'
 import { detectFriction } from '../services/friction-detector'
 import { detectAndPersistPatterns } from '../services/pattern-detector'
 import { recordCleanupReport, runSessionCleanup } from '../services/session-cleanup'
+import { detectSkillMisses } from '../services/skill-miss-detector'
 import { ingestTranscript } from '../services/transcript-learner'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
@@ -95,6 +96,20 @@ export function runStopHook(projectPath: string = process.cwd()): Promise<void> 
           await detectFriction(p, input.transcript_path, input.session_id ?? null)
         } catch {
           /* same contract as transcript-learner — silent best-effort */
+        }
+      }
+
+      // Session-end skill-miss capture (harness #16): flag captured
+      // project knowledge (decision/gotcha/anti-pattern) that was
+      // relevant to this session's work but never referenced. Persisted
+      // as `improvement-signal` and surfaced under the existing block at
+      // the next session start — advisory, never a gate. Same silent
+      // best-effort contract as the friction detector above.
+      if (input.transcript_path) {
+        try {
+          await detectSkillMisses(p, input.transcript_path, input.session_id ?? null)
+        } catch {
+          /* silent best-effort — must never block session end */
         }
       }
 

--- a/core/services/skill-miss-detector.ts
+++ b/core/services/skill-miss-detector.ts
@@ -1,0 +1,451 @@
+/**
+ * Skill-miss detector — at Stop time, finds captured project knowledge
+ * (decision / gotcha / anti-pattern) that was RELEVANT to the work this
+ * session did but was never REFERENCED in the transcript. Persists each
+ * as an `improvement-signal` memory entry tagged `source:skill-miss-detector`.
+ *
+ * This is harness #16 (Skill Resolution Feedback) in prjct's anti-harness
+ * idiom: it is a STATE SIGNAL surfaced at the next session start (under the
+ * existing improvement-signals block), never a gate. The next session's
+ * Claude reads it and decides whether the knowledge should have been
+ * applied — we never block or enforce.
+ *
+ * Sibling of `friction-detector.ts`: same Stop-hook rail, same hashed
+ * dedup + (type,key) latest-winner mechanism, same conservative cap, same
+ * silent best-effort contract. Differs only in WHAT it detects.
+ *
+ * Precision over recall (matches friction-detector's stated philosophy):
+ *   - relevance requires path-overlap with a changed file OR >=2 shared
+ *     distinctive tokens — a single coincidental token is not enough.
+ *   - the candidate is excluded if it was captured THIS session
+ *     (recency containment) or has `inferred` provenance (low-confidence).
+ *   - "referenced" = a distinctive token of the memory appears in the
+ *     transcript; if so, the knowledge was applied — no signal.
+ *
+ * Transcript-primary: the Stop hook input is only {transcript_path,
+ * session_id} — there is no diff. Changed-file overlap is a best-effort
+ * BOOSTER fetched via getModifiedFiles() (uncommitted-only at Stop, may
+ * be empty on a clean tree); its absence never errors and never blocks
+ * token-based detection.
+ */
+
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import { projectMemory } from '../memory/project-memory'
+import { getModifiedFiles } from '../session/git-helpers'
+
+const SOURCE_TAG = 'skill-miss-detector'
+const MAX_SKILL_MISSES_PER_SESSION = 3
+const MAX_EXCERPT_CHARS = 280
+/** Candidate memory types — captured project knowledge worth applying. */
+const CANDIDATE_TYPES = ['decision', 'gotcha', 'anti-pattern'] as const
+/**
+ * Recency containment: a memory captured within this window of "now" is
+ * treated as captured-this-session and never flagged (you cannot have
+ * "missed" knowledge you just wrote). Coarse but robust — Stop fires
+ * minutes after the work, and `prjct remember` rarely carries a session
+ * tag we could match precisely.
+ */
+const CAPTURED_THIS_SESSION_MS = 90 * 60 * 1000
+/** Minimum distinctive-token overlap to call a memory "relevant" sans path hit. */
+const MIN_TOKEN_OVERLAP = 2
+/** Tokens shorter than this are too generic to be evidence of relevance. */
+const MIN_TOKEN_LEN = 5
+/**
+ * A token this long is specific enough that its presence in the
+ * transcript is evidence the agent actually engaged the memory (its
+ * "signature"). Signature tokens establish APPLIED; the remaining
+ * shorter "topic" tokens establish RELEVANCE. The two sets are kept
+ * DISJOINT on purpose — otherwise the same token would prove a memory
+ * both relevant and applied, and nothing could ever be a miss.
+ */
+const SIGNATURE_TOKEN_LEN = 8
+
+// Generic words that overlap between almost any code memory and any
+// coding session — excluded so they can't manufacture false relevance.
+const STOPWORDS = new Set([
+  'should',
+  'because',
+  'project',
+  'prjct',
+  'instead',
+  'always',
+  'never',
+  'using',
+  'value',
+  'state',
+  'change',
+  'changes',
+  'update',
+  'updated',
+  'function',
+  'return',
+  'returns',
+  'error',
+  'errors',
+  'tests',
+  'testing',
+  'config',
+  'default',
+  'import',
+  'export',
+  'before',
+  'after',
+  'without',
+])
+
+interface TranscriptLine {
+  message?: { role?: string; content?: unknown }
+  role?: string
+  content?: unknown
+}
+
+interface CandidateMemory {
+  id: string
+  type: string
+  content: string
+  fileTag: string
+  rememberedAt: string
+  provenance: string
+  session: string
+}
+
+export interface SkillMiss {
+  memId: string
+  memType: string
+  excerpt: string
+  /** Changed file that made this relevant, or '' when relevance was token-only. */
+  evidenceFile: string
+  reason: 'path-overlap-unused' | 'topic-overlap-unused'
+}
+
+export interface SkillMissResult {
+  signalsRecorded: number
+  signalsSkipped: number
+}
+
+/**
+ * Public entry. Reads the transcript, recalls captured project knowledge,
+ * flags relevant-but-unreferenced entries, persists up to
+ * MAX_SKILL_MISSES_PER_SESSION as `improvement-signal` memory. Idempotent
+ * (hashed dedup against existing skill-miss entries). Best-effort: any
+ * failure (no transcript, no project, git error) returns a zero result.
+ */
+export async function detectSkillMisses(
+  projectPath: string,
+  transcriptPath: string,
+  sessionId: string | null
+): Promise<SkillMissResult> {
+  let raw = ''
+  try {
+    raw = await fs.readFile(transcriptPath, 'utf-8')
+  } catch {
+    return { signalsRecorded: 0, signalsSkipped: 0 }
+  }
+
+  const projectId = projectIdFromPath(projectPath)
+  if (!projectId) return { signalsRecorded: 0, signalsSkipped: 0 }
+
+  const transcriptText = transcriptTextOf(parseJsonl(raw))
+  if (!transcriptText) return { signalsRecorded: 0, signalsSkipped: 0 }
+
+  let candidates: CandidateMemory[]
+  try {
+    candidates = recallCandidates(projectId, sessionId)
+  } catch {
+    return { signalsRecorded: 0, signalsSkipped: 0 }
+  }
+  if (candidates.length === 0) return { signalsRecorded: 0, signalsSkipped: 0 }
+
+  // Best-effort booster — absence never blocks token-based detection.
+  let changedFiles: string[] = []
+  try {
+    changedFiles = await getModifiedFiles(projectPath)
+  } catch {
+    changedFiles = []
+  }
+
+  const misses = analyze(transcriptText, changedFiles, candidates)
+  if (misses.length === 0) return { signalsRecorded: 0, signalsSkipped: 0 }
+
+  const existing = existingSkillMissKeys(projectId)
+  let recorded = 0
+  let skipped = 0
+  for (const miss of misses.slice(0, MAX_SKILL_MISSES_PER_SESSION)) {
+    const key = hashKey(miss.memId, miss.excerpt).slice(0, 12)
+    if (existing.has(key)) {
+      skipped++
+      continue
+    }
+    try {
+      await projectMemory.remember(projectPath, {
+        type: 'improvement-signal',
+        content: formatSkillMiss(miss),
+        tags: {
+          source: SOURCE_TAG,
+          kind: 'skill-miss',
+          category: 'skill-miss',
+          relates: miss.memId,
+          file: miss.evidenceFile,
+          key,
+          ...(sessionId ? { session: sessionId } : {}),
+        },
+        provenance: 'extracted',
+      })
+      recorded++
+    } catch {
+      skipped++
+    }
+  }
+  return { signalsRecorded: recorded, signalsSkipped: skipped }
+}
+
+// ============================================================================
+// Pure core — exported via _internal for unit tests (no DB / no fs).
+// ============================================================================
+
+/**
+ * Given the session transcript text, the changed-file list, and candidate
+ * memories, return the skill-misses ordered strongest-first (path-overlap
+ * beats token-only). Pure + deterministic — the unit-test seam.
+ */
+function analyze(
+  transcriptText: string,
+  changedFiles: string[],
+  candidates: CandidateMemory[]
+): SkillMiss[] {
+  const sessionTokens = tokenize(transcriptText)
+  if (sessionTokens.size === 0) return []
+  const changedStems = fileStems(changedFiles)
+
+  const scored: Array<{ miss: SkillMiss; rank: number; overlap: number }> = []
+  for (const mem of candidates) {
+    const memTokens = tokenize(`${mem.content} ${mem.fileTag}`)
+    if (memTokens.size === 0) continue
+
+    // Relevance signal A — a changed file this memory is about.
+    const pathHit =
+      (mem.fileTag !== '' && changedFiles.some((f) => sharesStem(f, mem.fileTag))) ||
+      [...changedStems].some((stem) => memTokens.has(stem))
+
+    // Split the memory's vocabulary into a SIGNATURE (specific/long
+    // tokens — their presence proves the agent engaged this memory) and
+    // TOPIC tokens (the broader area). The sets are disjoint so the
+    // token that makes a memory relevant can never also mark it applied.
+    const signature = signatureOf(memTokens)
+    let overlap = 0
+    for (const t of memTokens) {
+      if (signature.has(t)) continue
+      if (sessionTokens.has(t)) overlap++
+    }
+
+    // Relevance signal B — shared topic vocabulary (signature excluded).
+    const relevant = pathHit || overlap >= MIN_TOKEN_OVERLAP
+    if (!relevant) continue
+
+    // Applied? A signature token of the memory appears in the transcript
+    // → the agent engaged its specific content. Touching the file alone
+    // is NOT enough (pathHit does not imply applied).
+    const referenced = [...signature].some((t) => sessionTokens.has(t))
+    if (referenced) continue
+
+    const evidenceFile =
+      mem.fileTag !== '' && changedFiles.some((f) => sharesStem(f, mem.fileTag))
+        ? mem.fileTag
+        : (changedFiles.find((f) => [...fileStems([f])].some((s) => memTokens.has(s))) ?? '')
+
+    scored.push({
+      miss: {
+        memId: mem.id,
+        memType: mem.type,
+        excerpt: mem.content.replace(/\s+/g, ' ').trim().slice(0, MAX_EXCERPT_CHARS),
+        evidenceFile,
+        reason: pathHit ? 'path-overlap-unused' : 'topic-overlap-unused',
+      },
+      // path-overlap is the stronger signal — surface it first.
+      rank: pathHit ? 2 : 1,
+      overlap,
+    })
+  }
+
+  scored.sort((a, b) => b.rank - a.rank || b.overlap - a.overlap)
+  return scored.map((s) => s.miss)
+}
+
+function parseJsonl(raw: string): TranscriptLine[] {
+  const out: TranscriptLine[] = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      out.push(JSON.parse(line) as TranscriptLine)
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return out
+}
+
+/** Flatten all user + assistant turn text into one lowercased blob. */
+function transcriptTextOf(lines: TranscriptLine[]): string {
+  const parts: string[] = []
+  for (const line of lines) {
+    const role = line.role ?? line.message?.role
+    if (role !== 'user' && role !== 'assistant') continue
+    const text = textOf(line.content ?? line.message?.content)
+    if (text) parts.push(text)
+  }
+  return parts.join('\n').toLowerCase()
+}
+
+function textOf(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === 'string') return block
+        if (block && typeof block === 'object' && 'text' in block) {
+          const t = (block as { text?: unknown }).text
+          return typeof t === 'string' ? t : ''
+        }
+        return ''
+      })
+      .join('\n')
+      .trim()
+  }
+  return ''
+}
+
+function tokenize(text: string): Set<string> {
+  const out = new Set<string>()
+  for (const rawTok of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (rawTok.length < MIN_TOKEN_LEN) continue
+    if (STOPWORDS.has(rawTok)) continue
+    out.add(rawTok)
+  }
+  return out
+}
+
+/**
+ * The memory's "signature" — tokens specific enough that seeing one in
+ * the transcript proves the agent engaged this memory. Long tokens
+ * (≥ SIGNATURE_TOKEN_LEN) qualify; if a memory has none, fall back to
+ * its single longest token (deterministic: length desc, then
+ * lexicographic) so there is always an APPLIED anchor disjoint from
+ * the topic tokens.
+ */
+function signatureOf(memTokens: Set<string>): Set<string> {
+  const long = [...memTokens].filter((t) => t.length >= SIGNATURE_TOKEN_LEN)
+  if (long.length > 0) return new Set(long)
+  let best = ''
+  for (const t of memTokens) {
+    if (t.length > best.length || (t.length === best.length && t < best)) best = t
+  }
+  return best ? new Set([best]) : new Set()
+}
+
+/** Path basenames without extension, plus meaningful path segments. */
+function fileStems(files: string[]): Set<string> {
+  const stems = new Set<string>()
+  for (const f of files) {
+    for (const seg of f.split('/')) {
+      const stem = seg.replace(/\.[a-z0-9]+$/i, '').toLowerCase()
+      if (stem.length >= MIN_TOKEN_LEN && !STOPWORDS.has(stem)) stems.add(stem)
+    }
+  }
+  return stems
+}
+
+function sharesStem(file: string, other: string): boolean {
+  const a = fileStems([file])
+  for (const s of fileStems([other])) {
+    if (a.has(s)) return true
+  }
+  return false
+}
+
+function formatSkillMiss(miss: SkillMiss): string {
+  const where =
+    miss.evidenceFile !== '' ? `touched \`${miss.evidenceFile}\`` : 'worked the same area'
+  return [
+    `[skill-miss] Unused project knowledge (${miss.memType}, ${miss.memId}): "${miss.excerpt}"`,
+    `This session ${where} but never referenced it. Apply it, or supersede it via: prjct remember decision "<resolution>" --tags resolves:skill-miss,relates:${miss.memId}`,
+  ].join('\n')
+}
+
+function hashKey(memId: string, excerpt: string): string {
+  const normalised = `${memId}::${excerpt.toLowerCase().replace(/\s+/g, ' ').trim()}`
+  return crypto.createHash('sha256').update(normalised).digest('hex')
+}
+
+function recallCandidates(projectId: string, sessionId: string | null): CandidateMemory[] {
+  const entries = projectMemory.recall(projectId, {
+    types: [...CANDIDATE_TYPES],
+    limit: 120,
+  })
+  const cutoff = Date.now() - CAPTURED_THIS_SESSION_MS
+  const out: CandidateMemory[] = []
+  for (const e of entries) {
+    // Low-confidence inferences are not "missed knowledge" — only the
+    // user/LLM-asserted (declared) and verifiable (extracted) entries
+    // and ambiguous ones count.
+    if (e.provenance === 'inferred') continue
+    // Recency containment — captured this session can't be a "miss".
+    if (Date.parse(e.rememberedAt) > cutoff) continue
+    if (sessionId && e.tags.session === sessionId) continue
+    out.push({
+      id: e.id,
+      type: e.type,
+      content: e.content,
+      fileTag: e.tags.file ?? '',
+      rememberedAt: e.rememberedAt,
+      provenance: e.provenance,
+      session: e.tags.session ?? '',
+    })
+  }
+  return out
+}
+
+function existingSkillMissKeys(projectId: string): Set<string> {
+  try {
+    const entries = projectMemory.recall(projectId, {
+      types: ['improvement-signal'],
+      tags: { source: SOURCE_TAG },
+      limit: 100,
+      dedupeByKey: false,
+    })
+    const keys = new Set<string>()
+    for (const e of entries) {
+      if (e.tags.key) keys.add(e.tags.key)
+    }
+    return keys
+  } catch {
+    return new Set()
+  }
+}
+
+function projectIdFromPath(projectPath: string): string | null {
+  // Lightweight sync read — mirrors friction-detector, avoids the full
+  // config-manager round trip on the Stop hot path.
+  try {
+    const fs2 = require('node:fs') as typeof import('node:fs')
+    const path2 = require('node:path') as typeof import('node:path')
+    const file = path2.join(projectPath, '.prjct', 'prjct.config.json')
+    const parsed = JSON.parse(fs2.readFileSync(file, 'utf-8')) as { projectId?: string }
+    return parsed.projectId ?? null
+  } catch {
+    return null
+  }
+}
+
+export const _internal = {
+  analyze,
+  parseJsonl,
+  transcriptTextOf,
+  textOf,
+  tokenize,
+  fileStems,
+  sharesStem,
+  formatSkillMiss,
+  hashKey,
+  MAX_SKILL_MISSES_PER_SESSION,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.8",
+  "version": "2.19.9",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -186,7 +186,7 @@ import{connect}from"node:net";import{existsSync}from"node:fs";import{randomUUID}
 const sockPath=homedir()+"/.prjct-cli/run/daemon.sock";
 const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
-const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health","context-save","context-restore","spec","audit-spec"]);
+const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health","skill-adherence","context-save","context-restore","spec","audit-spec"]);
 function refuse(m){console.error("prjct: daemon dropped the request ("+m+"). Retry: prjct "+args.join(" "));process.exit(1)}
 function isSafeRetry(e){const c=e&&e.code||"",m=e&&e.message||"";return c==="ECONNREFUSED"||c==="ENOENT"||m.includes("ECONNREFUSED")||m.includes("ENOENT")}
 if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){


### PR DESCRIPTION
## Context

Closes harness gap **#16 (Skill Resolution Feedback)** — the only fully-absent harness in the 20-harness audit of prjct-cli. Built in prjct's anti-harness idiom: an **advisory state signal**, never a gate. Spec `08344b7d` (audit-spec 3/3 pass, corrections folded pre-breakdown).

## What it does

At Stop, `skill-miss-detector` flags captured project knowledge (`decision`/`gotcha`/`anti-pattern`) that was relevant to the session's work but never referenced, and surfaces unresolved misses at the next session start **under the existing `# prjct: improvement signals` block** (no parallel block). Rides the existing `friction-detector` rail.

## Spec acceptance criteria — all 10 met

- [x] Stop persists one tagged `improvement-signal` on relevant+unreferenced (`source:skill-miss-detector,kind:skill-miss,relates:,file:,key:`)
- [x] Stop re-run → no duplicate (hash `(type,key)` dedup)
- [x] captured-this-session + `inferred`-provenance excluded
- [x] empty git tree → degrades to token-only, never errors
- [x] combined per-source budget (friction ≤3, skill-miss ≤2) — no starvation
- [x] `buildImprovementSignals` recall widened; renders under existing block with `[skill-miss]`, not a parallel block
- [x] drop path = existing 24h recency + extended `resolves:` prose; no new consumer (left to spec `cc402523`)
- [x] `prjct skill-adherence [window] --md` read-only, retro/health dispatch pattern
- [x] nothing written outside SQLite / `_generated/` (smoke-verified)
- [x] typecheck + biome + lefthook + full bun suite (1155 pass / 0 fail)

## Design note

First `analyze` heuristic self-contradicted (same token proved a memory both *relevant* and *applied* → nothing could ever flag). Fixed by splitting memory vocab into a disjoint **signature** (long/specific → proves applied) vs **topic** (proves relevant). Caught by the criterion-#4 test pre-merge.

## Files

New: `core/services/skill-miss-detector.ts`, `core/commands/skill-adherence.ts`, +3 test files. Edited: `core/hooks/stop.ts`, `core/hooks/prompt.ts`, `bin/prjct.ts` + `scripts/build.js` (daemon-shim invariant), `CHANGELOG.md`.

## Follow-ups (separate specs)

- Real `resolves:` consumer → owned by `cc402523` (memory close|forget)
- skill-generator recurring-miss → Gotchas feed (deferred)
- Remaining harness gaps: #18/19/20, #3/6/11, infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)