### PR TITLE
fix: skill-miss-detector — crew-isolation guard (no false nags after crew runs) (v2.19.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [2.19.10] - 2026-05-17
 
-### Added
-- Crew-awareness guard for skill-miss-detector: recent crew-run files_touched no longer trigger path-overlap false positives (#16 follow-up)
-
-## [Unreleased]
-
 ### Fixed
 
 - **skill-miss-detector no longer false-positives after a crew run (#16 follow-up).** Crew implementer/reviewer run as isolated subagents in the *shared* working tree, so at the leader's Stop hook `getModifiedFiles()` saw their edits and path-overlap relevance fired — but the leader transcript never carries the memory references the subagent made in its own isolated transcript, producing a false skill-miss nag for every crew-touched file. Fix: `detectSkillMisses` collects the `files_touched` of crew runs whose `ended_at` is within `CREW_RUN_RECENCY_MS` (6h) via `crewRunStorage.list` and excludes them from path-overlap relevance; token-overlap detection stays active so non-crew work in the same session is still covered. Crew itself is unchanged (it was architecturally correct). Best-effort — any failure degrades to prior behavior. Tests: `core/__tests__/services/skill-miss-detector.test.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-## [2.19.9] - 2026-05-16
+## [2.19.10] - 2026-05-17
 
-### Bug Fixes
-
-- strictly-monotonic updated_at so the CAS token can't collide (#337)
-
+### Added
+- Crew-awareness guard for skill-miss-detector: recent crew-run files_touched no longer trigger path-overlap false positives (#16 follow-up)
 
 ## [Unreleased]
+
+### Fixed
+
+- **skill-miss-detector no longer false-positives after a crew run (#16 follow-up).** Crew implementer/reviewer run as isolated subagents in the *shared* working tree, so at the leader's Stop hook `getModifiedFiles()` saw their edits and path-overlap relevance fired — but the leader transcript never carries the memory references the subagent made in its own isolated transcript, producing a false skill-miss nag for every crew-touched file. Fix: `detectSkillMisses` collects the `files_touched` of crew runs whose `ended_at` is within `CREW_RUN_RECENCY_MS` (6h) via `crewRunStorage.list` and excludes them from path-overlap relevance; token-overlap detection stays active so non-crew work in the same session is still covered. Crew itself is unchanged (it was architecturally correct). Best-effort — any failure degrades to prior behavior. Tests: `core/__tests__/services/skill-miss-detector.test.ts`.
 
 ## [2.19.9] - 2026-05-16
 
@@ -21,6 +23,7 @@
 - **`buildImprovementSignals` now carries both detectors under one block.** The recall no longer hard-filters `source:friction-detector`; friction and skill-miss signals render under the existing `# prjct: improvement signals` header with **per-source budgets** (friction ≤3, skill-miss ≤2) so a noisy friction session can't starve skill-miss out of the shared 24h window. No parallel block (session-start advisory density stays bounded). The `resolves:` prose is extended with `resolves:skill-miss`; the 24h age-out remains the actual drop-from-rotation mechanism (a real `resolves:` consumer stays owned by the memory close|forget spec).
 
 ### Fixed
+- strictly-monotonic updated_at so the CAS token can't collide (#337)
 - **`getProjectId` no longer silently mints a random orphan project.** Root cause: `ConfigManager.getProjectId()` fell through to `pathManager.generateProjectId()` (`crypto.randomUUID()`) whenever `readConfig()` returned null, so any path-resolution miss (daemon resolving the wrong cwd, config transiently unreadable, case-variant path) forked a brand-new project and scattered specs/memory across ghost projects with no error surfaced. Now returns `''` — the falsy sentinel 31/32 call sites already guard with `if (!projectId)` → callers fail loud ("run prjct init") instead of writing into a random new project. Only explicit `prjct init` (`createConfig`) mints. Regression test: `core/__tests__/infrastructure/config-manager-getprojectid.test.ts`.
 
 ## [2.19.8] - 2026-05-14

--- a/core/__tests__/services/skill-miss-detector.test.ts
+++ b/core/__tests__/services/skill-miss-detector.test.ts
@@ -16,7 +16,9 @@ import path from 'node:path'
 import configManager from '../../infrastructure/config-manager'
 import pathManager from '../../infrastructure/path-manager'
 import { _internal, detectSkillMisses } from '../../services/skill-miss-detector'
+import { crewRunStorage } from '../../storage/crew-run-storage'
 import prjctDb from '../../storage/database'
+import { execFileAsync } from '../../utils/exec'
 
 interface CM {
   id: string
@@ -252,5 +254,150 @@ describe('skill-miss-detector — persistence + containment (DB)', () => {
     // Only the things we created (.prjct, .prjct-data, transcript.jsonl)
     // — the detector must not drop a report/markdown file in the project.
     expect(afterEntries).toEqual(before)
+  })
+})
+
+describe('skill-miss-detector — crew-isolation guard (analyze)', () => {
+  it('a crew-touched file does not trigger path-overlap relevance', () => {
+    const candidate = mem({
+      id: 'mem_c',
+      content: 'rotate refresh credentials hourly',
+      fileTag: 'core/auth-service.ts',
+    })
+    const transcript = 'did some unrelated plumbing work and moved on entirely'
+    // Control: no crew files → path-overlap flags it.
+    expect(_internal.analyze(transcript, ['core/auth-service.ts'], [candidate]).length).toBe(1)
+    // Guarded: the file was crew-touched → no longer relevant.
+    expect(
+      _internal.analyze(
+        transcript,
+        ['core/auth-service.ts'],
+        [candidate],
+        new Set(['core/auth-service.ts'])
+      ).length
+    ).toBe(0)
+  })
+
+  it('token-overlap still flags even when the file is crew-touched', () => {
+    const candidate = mem({
+      id: 'mem_t',
+      content: 'rotate refresh credentials hourly',
+      fileTag: 'core/auth-service.ts',
+    })
+    // Shares ≥2 TOPIC tokens (rotate, refresh, hourly) but not the
+    // signature (credentials) → relevant via tokens, still unreferenced.
+    const transcript = 'we rotate the refresh logic here but skipped the hourly cadence'
+    const out = _internal.analyze(
+      transcript,
+      ['core/auth-service.ts'],
+      [candidate],
+      new Set(['core/auth-service.ts'])
+    )
+    expect(out.length).toBe(1)
+    expect(out[0]?.reason).toBe('topic-overlap-unused')
+  })
+
+  it('a non-crew changed file is still flagged via path-overlap', () => {
+    const candidate = mem({
+      id: 'mem_n',
+      content: 'rotate refresh credentials hourly',
+      fileTag: 'core/billing-engine.ts',
+    })
+    const transcript = 'did some unrelated plumbing work and moved on entirely'
+    const out = _internal.analyze(
+      transcript,
+      ['core/billing-engine.ts'],
+      [candidate],
+      new Set(['core/auth-service.ts'])
+    )
+    expect(out.length).toBe(1)
+    expect(out[0]?.reason).toBe('path-overlap-unused')
+  })
+})
+
+describe('skill-miss-detector — crew-isolation guard (DB + git)', () => {
+  let dir: string
+  let projectId: string
+  let transcriptPath: string
+
+  function seedOldDecision(content: string, fileTag: string): void {
+    prjctDb.run(
+      projectId,
+      "INSERT INTO events (type, data, timestamp) VALUES ('memory.remember.decision', ?, ?)",
+      JSON.stringify({
+        content,
+        tags: { file: fileTag, key: `s-${Math.random().toString(36).slice(2, 8)}` },
+        provenance: 'declared',
+      }),
+      new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+    )
+  }
+
+  beforeEach(async () => {
+    prjctDb.close()
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-skillmiss-crew-'))
+    await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
+    await execFileAsync('git', ['config', 'user.email', 't@example.com'], { cwd: dir })
+    await execFileAsync('git', ['config', 'user.name', 'Tester'], { cwd: dir })
+    await execFileAsync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir })
+    await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+    await fs.mkdir(path.join(dir, 'core'), { recursive: true })
+    await fs.writeFile(path.join(dir, 'core/auth-service.ts'), 'export const v = 1\n')
+    await execFileAsync('git', ['add', '.'], { cwd: dir })
+    await execFileAsync('git', ['commit', '-q', '-m', 'init'], { cwd: dir })
+    // Uncommitted modification → getModifiedFiles() sees core/auth-service.ts.
+    await fs.writeFile(path.join(dir, 'core/auth-service.ts'), 'export const v = 2\n')
+    projectId = `skillmiss-crew-${crypto.randomUUID()}`
+    await configManager.writeConfig(dir, {
+      projectId,
+      dataPath: path.join(dir, '.prjct-data'),
+    } as Parameters<typeof configManager.writeConfig>[1])
+    await pathManager.ensureProjectStructure(projectId)
+    transcriptPath = path.join(dir, 'transcript.jsonl')
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ role: 'user', content: 'do the work' }),
+        JSON.stringify({
+          role: 'assistant',
+          content: 'did some unrelated plumbing work and moved on entirely',
+        }),
+      ].join('\n')
+    )
+    seedOldDecision('rotate refresh credentials hourly', 'core/auth-service.ts')
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    prjctDb.close()
+  })
+
+  it('flags a path-overlap miss when NO crew run is present (control)', async () => {
+    const r = await detectSkillMisses(dir, transcriptPath, 's')
+    expect(r.signalsRecorded).toBe(1)
+  })
+
+  it('suppresses the miss when a RECENT crew run touched the file', async () => {
+    crewRunStorage.record(projectId, {
+      filesTouched: ['core/auth-service.ts'],
+      reviewerVerdict: 'APPROVED',
+      implementerSummary: 'edited auth-service',
+      endedAt: new Date().toISOString(),
+    })
+    const r = await detectSkillMisses(dir, transcriptPath, 's')
+    expect(r.signalsRecorded).toBe(0)
+  })
+
+  it('does NOT suppress when the crew run is older than the recency window', async () => {
+    const old = new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString()
+    crewRunStorage.record(projectId, {
+      filesTouched: ['core/auth-service.ts'],
+      reviewerVerdict: 'APPROVED',
+      implementerSummary: 'edited auth-service long ago',
+      startedAt: old,
+      endedAt: old,
+    })
+    const r = await detectSkillMisses(dir, transcriptPath, 's')
+    expect(r.signalsRecorded).toBe(1)
   })
 })

--- a/core/services/skill-miss-detector.ts
+++ b/core/services/skill-miss-detector.ts
@@ -33,6 +33,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import { projectMemory } from '../memory/project-memory'
 import { getModifiedFiles } from '../session/git-helpers'
+import { crewRunStorage } from '../storage/crew-run-storage'
 
 const SOURCE_TAG = 'skill-miss-detector'
 const MAX_SKILL_MISSES_PER_SESSION = 3
@@ -47,6 +48,18 @@ const CANDIDATE_TYPES = ['decision', 'gotcha', 'anti-pattern'] as const
  * tag we could match precisely.
  */
 const CAPTURED_THIS_SESSION_MS = 90 * 60 * 1000
+/**
+ * Crew-isolation guard. Crew implementer/reviewer run as isolated
+ * subagents in the SHARED working tree, so at the leader's Stop hook
+ * `getModifiedFiles()` sees their edits — but the leader transcript
+ * never carries the memory references the subagent made in its own
+ * isolated transcript. A crew run whose `ended_at` is within this
+ * window of "now" is plausibly the source of the current uncommitted
+ * changes (older runs are normally committed), so its `files_touched`
+ * are excluded from path-overlap relevance — token-overlap detection
+ * stays active for non-crew work in the same session.
+ */
+const CREW_RUN_RECENCY_MS = 6 * 60 * 60 * 1000
 /** Minimum distinctive-token overlap to call a memory "relevant" sans path hit. */
 const MIN_TOKEN_OVERLAP = 2
 /** Tokens shorter than this are too generic to be evidence of relevance. */
@@ -165,7 +178,22 @@ export async function detectSkillMisses(
     changedFiles = []
   }
 
-  const misses = analyze(transcriptText, changedFiles, candidates)
+  // Files a recent crew run touched: their edits are in the shared tree
+  // but the references happened in the subagent's isolated transcript,
+  // invisible here. Exclude them from path-overlap relevance so crew
+  // runs don't generate false nags. Best-effort — never blocks.
+  let crewFiles = new Set<string>()
+  try {
+    const cutoff = Date.now() - CREW_RUN_RECENCY_MS
+    for (const run of crewRunStorage.list(projectId)) {
+      if (Date.parse(run.ended_at) <= cutoff) continue
+      for (const f of run.files_touched) crewFiles.add(f)
+    }
+  } catch {
+    crewFiles = new Set()
+  }
+
+  const misses = analyze(transcriptText, changedFiles, candidates, crewFiles)
   if (misses.length === 0) return { signalsRecorded: 0, signalsSkipped: 0 }
 
   const existing = existingSkillMissKeys(projectId)
@@ -212,20 +240,26 @@ export async function detectSkillMisses(
 function analyze(
   transcriptText: string,
   changedFiles: string[],
-  candidates: CandidateMemory[]
+  candidates: CandidateMemory[],
+  crewFiles: Set<string> = new Set()
 ): SkillMiss[] {
   const sessionTokens = tokenize(transcriptText)
   if (sessionTokens.size === 0) return []
-  const changedStems = fileStems(changedFiles)
+  // Crew-isolation guard: a file edited by a recent crew subagent must
+  // not, by itself, make a memory "relevant" — the leader transcript is
+  // blind to whether the subagent referenced it. Token-overlap on the
+  // leader transcript still applies, so non-crew work stays covered.
+  const effectiveChanged = changedFiles.filter((f) => !crewFiles.has(f))
+  const changedStems = fileStems(effectiveChanged)
 
   const scored: Array<{ miss: SkillMiss; rank: number; overlap: number }> = []
   for (const mem of candidates) {
     const memTokens = tokenize(`${mem.content} ${mem.fileTag}`)
     if (memTokens.size === 0) continue
 
-    // Relevance signal A — a changed file this memory is about.
+    // Relevance signal A — a non-crew changed file this memory is about.
     const pathHit =
-      (mem.fileTag !== '' && changedFiles.some((f) => sharesStem(f, mem.fileTag))) ||
+      (mem.fileTag !== '' && effectiveChanged.some((f) => sharesStem(f, mem.fileTag))) ||
       [...changedStems].some((stem) => memTokens.has(stem))
 
     // Split the memory's vocabulary into a SIGNATURE (specific/long
@@ -250,9 +284,9 @@ function analyze(
     if (referenced) continue
 
     const evidenceFile =
-      mem.fileTag !== '' && changedFiles.some((f) => sharesStem(f, mem.fileTag))
+      mem.fileTag !== '' && effectiveChanged.some((f) => sharesStem(f, mem.fileTag))
         ? mem.fileTag
-        : (changedFiles.find((f) => [...fileStems([f])].some((s) => memTokens.has(s))) ?? '')
+        : (effectiveChanged.find((f) => [...fileStems([f])].some((s) => memTokens.has(s))) ?? '')
 
     scored.push({
       miss: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.19.9",
+  "version": "2.19.10",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Context

Follow-up to harness #16 (shipped v2.19.9, PR #338). Question raised: does crew mode need changing? Two parallel audits answered **no — crew is architecturally correct** (isolated subagents, shared tree, SQLite-only). The defect was in the just-shipped `skill-miss-detector`.

## Bug

Crew implementer/reviewer run as isolated Agent-tool subagents in the **shared working tree**. At the leader's Stop hook, `getModifiedFiles()` saw their edits → path-overlap relevance fired. But the implementer applied/referenced the captured `decision`/`gotcha` in its **isolated transcript**; the leader only gets a one-screen summary. The memory's signature tokens never reach the leader transcript `detectSkillMisses` analyzes → **false skill-miss nag for every crew-touched file**. (`recallCandidates`' session-tag exclusion doesn't help: subagent session_id ≠ leader session_id.)

## Fix (surgical per-file suppression)

`detectSkillMisses` collects `files_touched` from crew runs whose `ended_at` is within `CREW_RUN_RECENCY_MS` (6h) via `crewRunStorage.list`, and excludes them from path-overlap relevance. **Token-overlap detection stays active** → non-crew work in the same session is still covered. Best-effort: any failure degrades to prior behavior. Crew unchanged.

## Verification — all green

- [x] pure `analyze`: crew-touched file → not flagged (control w/ empty set → flagged); token-overlap still flags despite crew file; non-crew file still flagged
- [x] DB+git integration: recent crew run → 0 signals; crew run >6h → 1; no crew run → 1 (control)
- [x] typecheck + biome + lefthook + full bun suite (**1161 pass / 0 fail**)

## Files

`core/services/skill-miss-detector.ts` (`CREW_RUN_RECENCY_MS`, `crewFiles` derivation, `analyze` 4th param), `core/__tests__/services/skill-miss-detector.test.ts` (+6 cases), `CHANGELOG.md`. Reuses `crewRunStorage.list` (`core/storage/crew-run-storage.ts:83`) — no crew changes.

## Out of scope (follow-ups)

Reviewer-subagent residual; using crew `reviewer_notes` as a positive "applied" signal; remaining harness gaps (#18/19/20, #3/6/11, infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)