### PR TITLE
fix: route all remaining os.homedir()/.prjct-cli sites through pathManager

### DIFF
--- a/core/__tests__/e2e/_harness.ts
+++ b/core/__tests__/e2e/_harness.ts
@@ -29,8 +29,11 @@ export interface CliResult {
 export interface Sandbox {
   /** tmp working dir — a real git repo on branch `main` */
   dir: string
-  /** isolated PRJCT_CLI_HOME (and HOME) — no real data is touched */
+  /** isolated PRJCT_CLI_HOME — where ALL prjct data must land */
   home: string
+  /** the HOME env value (== home unless splitCliHome) — used to assert
+   *  no prjct data leaked to `<HOME>/.prjct-cli` */
+  osHome: string
   /** run the real CLI in this sandbox; never throws on non-zero exit */
   cli: (args: string[], opts?: { cwd?: string; timeoutMs?: number }) => Promise<CliResult>
   cleanup: () => Promise<void>
@@ -140,6 +143,7 @@ export async function makeSandbox(opts: SandboxOpts | boolean = true): Promise<S
   return {
     dir,
     home: cliHome,
+    osHome: home,
     cli: (args, opts = {}) => runCli(args, baseEnv, opts.cwd ?? dir, opts.timeoutMs),
     cleanup: () => fs.rm(root, { recursive: true, force: true }).catch(() => {}),
   }

--- a/core/__tests__/e2e/install-flow.e2e.test.ts
+++ b/core/__tests__/e2e/install-flow.e2e.test.ts
@@ -47,6 +47,21 @@ describe('e2e: PRJCT_CLI_HOME is honored when it differs from HOME (regression)'
     expect(r.code).toBe(0)
     expect((r.stdout + r.stderr).toLowerCase()).not.toContain('not configured')
   })
+
+  // Bullet-proof for the whole os.homedir()/.prjct-cli sweep: after a full
+  // flow, ALL prjct data must live under PRJCT_CLI_HOME and NOTHING may leak
+  // to <HOME>/.prjct-cli. If any swept site (provider-cache, update-checker,
+  // self-heal, setup projects/statusline, command-installer docs, …) still
+  // used os.homedir(), it would create <HOME>/.prjct-cli/* and fail here.
+  test('no prjct data leaks to <HOME>/.prjct-cli (entire sweep)', async () => {
+    expect((await sb.cli(['remember', 'decision', 'split-home persists'])).code).toBe(0)
+    expect((await sb.cli(['review-risk', '--md'])).code).toBe(0)
+
+    // Data is under PRJCT_CLI_HOME …
+    expect(existsSync(path.join(sb.home, 'projects'))).toBe(true)
+    // … and the os.homedir-based path was never created.
+    expect(existsSync(path.join(sb.osHome, '.prjct-cli'))).toBe(false)
+  })
 })
 
 describe('e2e: install/upgrade onboarding contract', () => {

--- a/core/infrastructure/command-installer/global-config.ts
+++ b/core/infrastructure/command-installer/global-config.ts
@@ -8,12 +8,12 @@
  */
 
 import fs from 'node:fs/promises'
-import os from 'node:os'
 import path from 'node:path'
 import { getTemplateContent, listTemplates } from '../../agentic/template-loader'
 import { getErrorMessage, isNotFoundError } from '../../types/fs'
 import type { GlobalConfigResult } from '../../types/infrastructure'
 import { mergeWithMarkers } from '../ide-project-installer'
+import pathManager from '../path-manager'
 
 const GLOBAL_CLAUDE_MD_CONTENT = `<!-- prjct:start - DO NOT REMOVE THIS MARKER -->
 # p/ — Project knowledge layer
@@ -66,7 +66,7 @@ The vault regenerates automatically on \`remember\`, \`capture\`, \`ship\`, \`sy
 
 export async function installDocs(): Promise<{ success: boolean; error?: string }> {
   try {
-    const docsDir = path.join(os.homedir(), '.prjct-cli', 'docs')
+    const docsDir = pathManager.getDocsPath()
     await fs.mkdir(docsDir, { recursive: true })
 
     // Try bundled templates first

--- a/core/infrastructure/path-manager.ts
+++ b/core/infrastructure/path-manager.ts
@@ -255,6 +255,21 @@ class PathManager {
     return path.join(this.globalBaseDir, 'docs')
   }
 
+  /** Global cache dir (~/.prjct-cli/cache by default; honors PRJCT_CLI_HOME). */
+  getCachePath(): string {
+    return path.join(this.globalBaseDir, 'cache')
+  }
+
+  /** Global state dir (~/.prjct-cli/state by default; honors PRJCT_CLI_HOME). */
+  getStatePath(): string {
+    return path.join(this.globalBaseDir, 'state')
+  }
+
+  /** Global statusline dir (~/.prjct-cli/statusline; honors PRJCT_CLI_HOME). */
+  getStatusLinePath(): string {
+    return path.join(this.globalBaseDir, 'statusline')
+  }
+
   /**
    * Get the Claude/Gemini directory path (~/.claude or ~/.gemini)
    */

--- a/core/infrastructure/self-heal.ts
+++ b/core/infrastructure/self-heal.ts
@@ -26,15 +26,17 @@
  */
 
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
+import pathManager from './path-manager'
 
-const STAMP_DIR = path.join(os.homedir(), '.prjct-cli', 'state')
-const STAMP_PATH = path.join(STAMP_DIR, 'installed-version')
+// Lazy: resolve via pathManager at call time (honors PRJCT_CLI_HOME and
+// test-time setGlobalBaseDir). Production === ~/.prjct-cli/state, unchanged.
+const stampDir = (): string => pathManager.getStatePath()
+const stampPath = (): string => path.join(stampDir(), 'installed-version')
 
 function readStamp(): string | null {
   try {
-    return fs.readFileSync(STAMP_PATH, 'utf-8').trim()
+    return fs.readFileSync(stampPath(), 'utf-8').trim()
   } catch {
     return null
   }
@@ -42,8 +44,8 @@ function readStamp(): string | null {
 
 function writeStamp(version: string): void {
   try {
-    fs.mkdirSync(STAMP_DIR, { recursive: true })
-    fs.writeFileSync(STAMP_PATH, version, 'utf-8')
+    fs.mkdirSync(stampDir(), { recursive: true })
+    fs.writeFileSync(stampPath(), version, 'utf-8')
   } catch {
     // best-effort
   }

--- a/core/infrastructure/setup.ts
+++ b/core/infrastructure/setup.ts
@@ -44,6 +44,7 @@ import {
 import installer from './command-installer'
 import editorsConfig from './editors-config'
 import { mergeWithMarkers } from './ide-project-installer'
+import pathManager from './path-manager'
 
 interface ProviderSetupResult {
   provider: AIProviderName
@@ -602,7 +603,7 @@ export async function verifyCodexPRouterReady(
  */
 async function migrateProjectsCliVersion(): Promise<void> {
   try {
-    const projectsDir = path.join(os.homedir(), '.prjct-cli', 'projects')
+    const projectsDir = pathManager.globalProjectsDir
 
     if (!(await fileExists(projectsDir))) {
       return
@@ -680,7 +681,7 @@ async function installStatusLine(): Promise<void> {
     const claudeStatusLinePath = path.join(claudeDir, 'prjct-statusline.sh')
 
     // Target location for the actual script
-    const prjctStatusLineDir = path.join(os.homedir(), '.prjct-cli', 'statusline')
+    const prjctStatusLineDir = pathManager.getStatusLinePath()
     const prjctStatusLinePath = path.join(prjctStatusLineDir, 'statusline.sh')
     const prjctThemesDir = path.join(prjctStatusLineDir, 'themes')
     const prjctLibDir = path.join(prjctStatusLineDir, 'lib')

--- a/core/infrastructure/update-checker.ts
+++ b/core/infrastructure/update-checker.ts
@@ -7,12 +7,12 @@
 import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import https from 'node:https'
-import os from 'node:os'
 import path from 'node:path'
 import chalk from 'chalk'
 import { getErrorMessage } from '../types/fs'
 import { fileExists, readJson, writeJson } from '../utils/file-helper'
 import { PACKAGE_ROOT } from '../utils/version'
+import pathManager from './path-manager'
 
 interface UpdateCache {
   lastCheck: number
@@ -33,7 +33,8 @@ class UpdateChecker {
 
   constructor() {
     this.packageName = 'prjct-cli'
-    this.cacheDir = path.join(os.homedir(), '.prjct-cli', 'config')
+    // Via pathManager so PRJCT_CLI_HOME is honored (prod === ~/.prjct-cli/config).
+    this.cacheDir = pathManager.globalConfigDir
     this.cacheFile = path.join(this.cacheDir, 'update-cache.json')
     this.checkInterval = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
   }
@@ -227,8 +228,10 @@ export { UpdateChecker }
 // spawns an unref'd child process to do the network fetch without delaying
 // the user-visible command.
 
-const CACHE_DIR = path.join(os.homedir(), '.prjct-cli', 'config')
-const CACHE_FILE = path.join(CACHE_DIR, 'update-cache.json')
+// Lazy: resolve via pathManager at call time (honors PRJCT_CLI_HOME and
+// test-time setGlobalBaseDir). Production === ~/.prjct-cli/config, unchanged.
+const updateCacheDir = (): string => pathManager.globalConfigDir
+const updateCacheFile = (): string => path.join(updateCacheDir(), 'update-cache.json')
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
 
 function compareSemver(a: string, b: string): number {
@@ -245,7 +248,7 @@ function compareSemver(a: string, b: string): number {
 
 function readCacheSync(): { lastCheck: number; latestVersion: string } | null {
   try {
-    const raw = fs.readFileSync(CACHE_FILE, 'utf-8')
+    const raw = fs.readFileSync(updateCacheFile(), 'utf-8')
     return JSON.parse(raw)
   } catch {
     return null
@@ -306,7 +309,7 @@ export function triggerBackgroundRefreshIfStale(): void {
   }
 
   try {
-    fs.mkdirSync(CACHE_DIR, { recursive: true })
+    fs.mkdirSync(updateCacheDir(), { recursive: true })
   } catch {
     return
   }
@@ -318,7 +321,7 @@ export function triggerBackgroundRefreshIfStale(): void {
   const scriptPath = path.join(PACKAGE_ROOT, 'assets', 'scripts', 'refresh-update.mjs')
   if (!fs.existsSync(scriptPath)) return
   try {
-    const child = spawn(process.execPath, [scriptPath, CACHE_FILE], {
+    const child = spawn(process.execPath, [scriptPath, updateCacheFile()], {
       detached: true,
       stdio: 'ignore',
     })

--- a/core/utils/provider-cache.ts
+++ b/core/utils/provider-cache.ts
@@ -1,12 +1,14 @@
 import fs from 'node:fs/promises'
-import os from 'node:os'
 import path from 'node:path'
+import pathManager from '../infrastructure/path-manager'
 import type { ProviderDetectionResult } from '../types/provider'
 import { isExpired } from './cache'
 import { writeJson } from './file-helper'
 
-const CACHE_DIR = path.join(os.homedir(), '.prjct-cli', 'cache')
-const CACHE_FILE = path.join(CACHE_DIR, 'providers.json')
+// Lazy (not a module const): resolve via pathManager at call time so
+// PRJCT_CLI_HOME and test-time setGlobalBaseDir overrides are honored.
+// Production (no override) === ~/.prjct-cli/cache, unchanged.
+const cacheFile = (): string => path.join(pathManager.getCachePath(), 'providers.json')
 const TTL_MS = 10 * 60 * 1000 // 10 minutes
 
 interface ProviderCache {
@@ -20,7 +22,7 @@ interface ProviderCache {
 
 export async function readProviderCache(): Promise<ProviderCache['detection'] | null> {
   try {
-    const raw = await fs.readFile(CACHE_FILE, 'utf-8')
+    const raw = await fs.readFile(cacheFile(), 'utf-8')
     const cache: ProviderCache = JSON.parse(raw)
 
     if (!cache.timestamp || !cache.detection) return null
@@ -39,12 +41,12 @@ export async function writeProviderCache(detection: ProviderCache['detection']):
     timestamp: new Date().toISOString(),
     detection,
   }
-  await writeJson(CACHE_FILE, cache)
+  await writeJson(cacheFile(), cache)
 }
 
 export async function invalidateProviderCache(): Promise<void> {
   try {
-    await fs.unlink(CACHE_FILE)
+    await fs.unlink(cacheFile())
   } catch {
     // File doesn't exist — fine
   }


### PR DESCRIPTION
## Summary

Follow-up to #340 — sweeps the **deferred** half of the `os.homedir()/.prjct-cli` footgun (the ~8 sites flagged out-of-scope there). All now resolve via `pathManager`, so `PRJCT_CLI_HOME` is honored everywhere.

## Sites fixed

| File | Path | Now |
|---|---|---|
| `core/utils/provider-cache.ts` | cache | `pathManager.getCachePath()` (lazy) |
| `core/infrastructure/self-heal.ts` | state stamp | `pathManager.getStatePath()` (lazy) |
| `core/infrastructure/update-checker.ts` | config cache (ctor + module-level bg) | `pathManager.globalConfigDir` (lazy) |
| `core/infrastructure/setup.ts` | projects migration | `pathManager.globalProjectsDir` |
| `core/infrastructure/setup.ts` | statusline | `pathManager.getStatusLinePath()` |
| `core/infrastructure/command-installer/global-config.ts` | docs | `pathManager.getDocsPath()` |

New `pathManager` getters: `getCachePath` / `getStatePath` / `getStatusLinePath` (siblings of the existing `getDocsPath`). Module-level `const`s were converted to **lazy** resolvers so test-time `setGlobalBaseDir` + env overrides are honored, not frozen at import.

## Deliberately NOT changed

`core/storage/system-database.ts` — it **already** honors `PRJCT_CLI_HOME` via its own `envOverride` check and intentionally avoids the pathManager dependency in the storage layer. Correct, not a footgun; touching DB init is risk for zero correctness gain.

## Backward compatibility

By construction: `pathManager` with no override === `~/.prjct-cli`, so **production paths are byte-identical**. Zero behavior change for real users; only relocates correctly under an override.

## Tests

- Full suite **1184 / 0**.
- e2e **17 / 17**, including a new **bullet-proof** split-home assertion: after a full flow with `PRJCT_CLI_HOME ≠ HOME`, ZERO prjct data may leak to `<HOME>/.prjct-cli`. Any missed site would create that dir and fail the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)