### PR TITLE
feat: prjct update self-cleanup of parallel installs + prjct upgrade alias + one-command notify (WS4+WS5)

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -51,6 +51,7 @@ const _binCommands = new Set([
   'start',
   'setup',
   'update',
+  'upgrade',
   'context',
   'hooks',
   'doctor',
@@ -88,7 +89,15 @@ const { REGISTERED_VERBS_SET } = await import('../core/commands/verb-names')
 // machine-consumed paths (`hook`, `--md`/`--json`, `--quiet`) and for
 // the updater itself. Awaited at top-level so the exit handler is
 // installed BEFORE the daemon fast path's `process.exit` runs.
-const _updateSkipCommands = new Set(['update', 'daemon', 'hook', 'version', '-v', '--version'])
+const _updateSkipCommands = new Set([
+  'update',
+  'upgrade',
+  'daemon',
+  'hook',
+  'version',
+  '-v',
+  '--version',
+])
 if (
   _fastCommand &&
   !_updateSkipCommands.has(_fastCommand) &&
@@ -147,7 +156,7 @@ if (
 //   - `hook` (session-start fires its own self-heal; other hook events
 //     fire too often to pay even the fs-read cost)
 //   - PRJCT_NO_SELF_SYNC=1 (escape hatch)
-const _selfHealSkip = new Set(['daemon', 'update', 'version', '-v', '--version', 'hook'])
+const _selfHealSkip = new Set(['daemon', 'update', 'upgrade', 'version', '-v', '--version', 'hook'])
 if (_fastCommand && !_selfHealSkip.has(_fastCommand) && process.env.PRJCT_NO_SELF_SYNC !== '1') {
   try {
     const { VERSION } = await import('../core/utils/version')

--- a/core/__tests__/commands/update-cleanup.test.ts
+++ b/core/__tests__/commands/update-cleanup.test.ts
@@ -1,0 +1,72 @@
+/**
+ * WS4+WS5 — `prjct update` install consolidation + one-command notify.
+ *
+ *  - the new-version banner must point at `prjct upgrade` (the ONE command
+ *    that updates every install AND consolidates), never the hardcoded
+ *    `npm install -g` that creates the multi-install footgun;
+ *  - `--no-cleanup` must deterministically skip consolidation;
+ *  - `planCleanup()` is defensive — it never throws and never proposes
+ *    removing without a provable winner.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, setDefaultTimeout } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { consolidateInstalls, planCleanup } from '../../commands/update/cleanup-installs'
+import pathManager from '../../infrastructure/path-manager'
+import { getUpdateNotificationSync } from '../../infrastructure/update-checker'
+
+// planCleanup() shells out to real PM detection (brew list, npm/pnpm/yarn
+// root -g) — slower than bun's 5s default; give it headroom.
+setDefaultTimeout(60_000)
+
+describe('WS5 — new-version banner is one-command', () => {
+  let tmp: string
+  const origBase = pathManager.getGlobalBasePath()
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-banner-'))
+    pathManager.setGlobalBaseDir(tmp)
+    await fs.mkdir(path.join(tmp, 'config'), { recursive: true })
+    await fs.writeFile(
+      path.join(tmp, 'config', 'update-cache.json'),
+      JSON.stringify({ lastCheck: Date.now(), latestVersion: '99.0.0' })
+    )
+  })
+  afterEach(async () => {
+    pathManager.setGlobalBaseDir(origBase)
+    await fs.rm(tmp, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('recommends `prjct upgrade`, never `npm install -g`', () => {
+    const banner = getUpdateNotificationSync('1.0.0')
+    expect(banner).not.toBeNull()
+    expect(banner).toContain('prjct upgrade')
+    expect(banner).not.toContain('npm install -g')
+    expect(banner).toContain('99.0.0') // the cached latest
+  })
+})
+
+describe('WS4 — consolidateInstalls', () => {
+  it('--no-cleanup (off) deterministically skips, no errors', async () => {
+    const r = await consolidateInstalls('off', false, false)
+    expect(r.errors).toEqual([])
+    expect(r.details.join(' ')).toContain('--no-cleanup')
+  })
+
+  it('dry-run never removes — only reports intent', async () => {
+    // dry-run must not shell out to any uninstall; details only.
+    const r = await consolidateInstalls('auto', true, false)
+    expect(r.errors).toEqual([])
+    for (const d of r.details) expect(d).not.toContain('Removed redundant')
+  })
+
+  it('planCleanup() is defensive: never throws, well-formed shape', () => {
+    const plan = planCleanup()
+    expect(Array.isArray(plan.removable)).toBe(true)
+    expect(Array.isArray(plan.skipped)).toBe(true)
+    // Safety invariant: nothing is ever removable without a winner.
+    if (plan.winner === null) expect(plan.removable).toEqual([])
+  })
+})

--- a/core/__tests__/e2e/install-flow.e2e.test.ts
+++ b/core/__tests__/e2e/install-flow.e2e.test.ts
@@ -105,3 +105,26 @@ describe('e2e: install/upgrade onboarding contract', () => {
     expect(r.stdout + r.stderr).not.toMatch(/Cannot read|TypeError|unhandled|is not a function/i)
   })
 })
+
+describe('e2e: `prjct upgrade` is an alias of `prjct update` (WS5)', () => {
+  let sb: Sandbox
+  beforeAll(async () => {
+    sb = await makeSandbox()
+  })
+  afterAll(async () => {
+    await sb.cleanup()
+  })
+
+  // The alias must route to the update command, NOT fall through to the
+  // bare-capture path (which would silently inbox "upgrade" as a note).
+  test('`upgrade` behaves identically to `update`, not bare-capture', async () => {
+    const up = await sb.cli(['upgrade'])
+    const ud = await sb.cli(['update'])
+    expect(up.code).toBe(ud.code)
+    const upOut = (up.stdout + up.stderr).toLowerCase()
+    // Recognized as a real verb: it hits update's path (here: the
+    // not-configured guard), never "captured to inbox".
+    expect(upOut).not.toContain('captured')
+    expect(upOut).not.toContain('inbox')
+  })
+})

--- a/core/commands/update.ts
+++ b/core/commands/update.ts
@@ -21,6 +21,7 @@ import { failFromError } from '../utils/md-aware'
 import out from '../utils/output'
 import { VERSION } from '../utils/version'
 import { PrjctCommandsBase } from './base'
+import { type CleanupMode, consolidateInstalls } from './update/cleanup-installs'
 import { formatMdOutput, formatTerminalOutput, type PhaseResult } from './update/output'
 import {
   getAllInstalledLocations,
@@ -34,6 +35,11 @@ import {
 interface UpdateOptions {
   'dry-run'?: boolean
   md?: boolean
+  /** --cleanup forces consolidation; --no-cleanup disables it (parsed as false) */
+  cleanup?: boolean
+  /** --yes / -y: skip the consolidation confirmation prompt */
+  yes?: boolean
+  y?: boolean
 }
 
 export class UpdateCommands extends PrjctCommandsBase {
@@ -51,6 +57,10 @@ export class UpdateCommands extends PrjctCommandsBase {
   ): Promise<CommandResult> {
     const dryRun = options['dry-run'] === true
     const md = options.md === true
+    // --no-cleanup → cleanup===false → 'off'; --cleanup → 'force'; default 'auto'
+    const cleanupMode: CleanupMode =
+      options.cleanup === false ? 'off' : options.cleanup === true ? 'force' : 'auto'
+    const assumeYes = options.yes === true || options.y === true
 
     const results = {
       phase1: { success: true, details: [], errors: [] } as PhaseResult,
@@ -74,7 +84,7 @@ export class UpdateCommands extends PrjctCommandsBase {
 
       // ── Phase 2: Global Cleanup ──
       if (!md) out.step(2, 3, 'Cleaning up all projects...')
-      results.phase2 = await this.phaseGlobalCleanup(dryRun)
+      results.phase2 = await this.phaseGlobalCleanup(dryRun, cleanupMode, assumeYes)
       if (!md) out.stop()
 
       // ── Phase 3: Daemon Restart ──
@@ -212,7 +222,11 @@ export class UpdateCommands extends PrjctCommandsBase {
 
   // ── Phase 2: Global Cleanup ──
 
-  private async phaseGlobalCleanup(dryRun: boolean): Promise<PhaseResult> {
+  private async phaseGlobalCleanup(
+    dryRun: boolean,
+    cleanupMode: CleanupMode = 'auto',
+    assumeYes = false
+  ): Promise<PhaseResult> {
     const result: PhaseResult = { success: true, details: [], errors: [] }
 
     // 2a. Migrate all projects
@@ -338,6 +352,17 @@ export class UpdateCommands extends PrjctCommandsBase {
       } catch {
         // Provider detection failed — non-critical
       }
+    }
+
+    // 2c. Consolidate parallel/stale installs (after redirect, before daemon
+    // restart). Folded into the Cleanup phase rather than a new top-level
+    // phase — keeps the 3-phase shape, no renumber churn.
+    try {
+      const cz = await consolidateInstalls(cleanupMode, dryRun, assumeYes)
+      result.details.push(...cz.details)
+      result.errors.push(...cz.errors)
+    } catch (e) {
+      result.errors.push(`install consolidation skipped: ${getErrorMessage(e)}`)
     }
 
     if (result.errors.length > 0) result.success = false

--- a/core/commands/update/cleanup-installs.ts
+++ b/core/commands/update/cleanup-installs.ts
@@ -1,0 +1,215 @@
+/**
+ * Install consolidation — the durable fix for the "4 parallel prjct installs"
+ * footgun the README warns about. After Phase 1 has updated every detected
+ * install, the user still has N copies across pnpm/bun/npm/yarn/brew at the
+ * same version, with one shadowing the rest in PATH. This removes the
+ * redundant non-winner copies so the machine ends with ONE canonical install.
+ *
+ * Destructive — the README explicitly warns aggressive cleanup can brick a
+ * shell, so removal is gated behind a strict safety model and (by default)
+ * a TTY confirmation; non-interactive runs warn only.
+ */
+
+import { execSync } from 'node:child_process'
+import { realpathSync } from 'node:fs'
+import path from 'node:path'
+import readline from 'node:readline'
+import {
+  detectInstallerFromRunningBinary,
+  getAllInstalledLocations,
+  isHomebrewInstall,
+  type PkgManagerName,
+} from './package-managers'
+
+/** How aggressively `prjct update` consolidates parallel installs. */
+export type CleanupMode = 'auto' | 'force' | 'off'
+
+/** PM-native global uninstall (preferred over rm — keeps PM metadata sane). */
+const UNINSTALL_ARGS: Record<PkgManagerName, string> = {
+  npm: 'npm uninstall -g prjct-cli',
+  pnpm: 'pnpm remove -g prjct-cli',
+  bun: 'bun remove -g prjct-cli',
+  yarn: 'yarn global remove prjct-cli',
+}
+
+export interface CleanupPlan {
+  /** the PM that owns the PATH-winning binary — never removed */
+  winner: PkgManagerName | 'brew' | null
+  /** redundant copies safe to remove */
+  removable: Array<{ pm: PkgManagerName | 'brew'; version: string }>
+  /** copies left alone, with a human reason */
+  skipped: Array<{ pm: string; reason: string }>
+}
+
+/** realpath of the prjct binary the user's shell actually runs, or null. */
+function pathWinnerReal(): string | null {
+  try {
+    const p = execSync('command -v prjct', { stdio: 'pipe', shell: '/bin/sh' }).toString().trim()
+    if (!p) return null
+    try {
+      return realpathSync(p)
+    } catch {
+      return p
+    }
+  } catch {
+    return null
+  }
+}
+
+/** The dev source tree (npm/bun link) — never remove it. */
+function sourceRoot(): string {
+  try {
+    return realpathSync(path.resolve(__dirname, '..', '..', '..'))
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Pure: decide which copies are safe to remove. Never removes the PATH
+ * winner, the dev checkout, or anything whose ownership can't be proven
+ * (getAllInstalledLocations already verifies `prjct-cli/package.json`).
+ */
+export function planCleanup(): CleanupPlan {
+  const winnerReal = pathWinnerReal()
+  const winnerPm = detectInstallerFromRunningBinary()
+  const src = sourceRoot()
+  const skipped: CleanupPlan['skipped'] = []
+
+  // Gate #1: a provable winner is mandatory. Without it we cannot know
+  // which copy to keep → refuse to remove anything.
+  if (!winnerReal && !winnerPm) {
+    return {
+      winner: null,
+      removable: [],
+      skipped: [
+        { pm: '(all)', reason: 'cannot resolve the PATH-winning binary — refusing to remove' },
+      ],
+    }
+  }
+
+  const brewWinner = winnerReal?.includes('/Cellar/') || winnerReal?.includes('/homebrew/')
+  const winner: CleanupPlan['winner'] = brewWinner ? 'brew' : winnerPm
+
+  const removable: CleanupPlan['removable'] = []
+  for (const loc of getAllInstalledLocations()) {
+    if (loc.pm.name === winnerPm) {
+      skipped.push({ pm: loc.pm.name, reason: 'PATH winner — kept' })
+      continue
+    }
+    // Gate: never remove the dev source tree (npm/bun link).
+    const root = loc.pm.getInstallRoot()
+    if (root && src) {
+      let resolved = path.join(root, 'prjct-cli')
+      try {
+        resolved = realpathSync(resolved)
+      } catch {
+        /* ignore */
+      }
+      if (resolved === src) {
+        skipped.push({ pm: loc.pm.name, reason: 'resolves to the dev source tree (link) — kept' })
+        continue
+      }
+    }
+    removable.push({ pm: loc.pm.name, version: loc.version })
+  }
+
+  // Brew: only if a brew copy exists AND it is not the winner.
+  if (isHomebrewInstall() && !brewWinner) {
+    removable.push({ pm: 'brew', version: '(homebrew)' })
+  } else if (isHomebrewInstall() && brewWinner) {
+    skipped.push({ pm: 'brew', reason: 'PATH winner — kept' })
+  }
+
+  return { winner, removable, skipped }
+}
+
+function removeOne(pm: PkgManagerName | 'brew'): { ok: boolean; error?: string } {
+  const cmd = pm === 'brew' ? 'brew uninstall prjct-cli' : UNINSTALL_ARGS[pm]
+  try {
+    execSync(cmd, { stdio: 'pipe', shell: '/bin/sh' })
+    return { ok: true }
+  } catch (e) {
+    return { ok: false, error: `${pm}: ${(e as Error).message.split('\n')[0]}` }
+  }
+}
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const a = await new Promise<string>((res) => rl.question(`${question} [y/N] `, res))
+    return /^y(es)?$/i.test(a.trim())
+  } finally {
+    rl.close()
+  }
+}
+
+/**
+ * Consolidate parallel installs. Returns details/errors to merge into the
+ * update Cleanup phase (no new top-level phase — keeps the 3-phase shape).
+ *
+ *   mode 'off'   → skip entirely
+ *   mode 'force' → remove without asking (used by `--yes`)
+ *   mode 'auto'  → TTY: preview + confirm; non-TTY: warn only, remove nothing
+ */
+export async function consolidateInstalls(
+  mode: CleanupMode,
+  dryRun: boolean,
+  assumeYes: boolean
+): Promise<{ details: string[]; errors: string[] }> {
+  const details: string[] = []
+  const errors: string[] = []
+
+  if (mode === 'off') {
+    details.push('Install consolidation skipped (--no-cleanup)')
+    return { details, errors }
+  }
+
+  const plan = planCleanup()
+
+  if (plan.removable.length === 0) {
+    details.push(
+      plan.skipped.some((s) => s.pm === '(all)')
+        ? `Consolidation skipped — ${plan.skipped[0].reason}`
+        : 'Single install — nothing to consolidate'
+    )
+    return { details, errors }
+  }
+
+  const list = plan.removable.map((r) => `${r.pm} (${r.version})`).join(', ')
+  details.push(`Winner: ${plan.winner ?? 'unknown'} — redundant copies: ${list}`)
+
+  if (dryRun) {
+    for (const r of plan.removable) details.push(`Would remove ${r.pm} copy`)
+    return { details, errors }
+  }
+
+  const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true
+  const proceed =
+    mode === 'force' ||
+    assumeYes ||
+    (interactive &&
+      (await confirm(
+        `Remove ${plan.removable.length} redundant prjct install(s) [${list}], keeping ${plan.winner}?`
+      )))
+
+  if (!proceed) {
+    if (interactive) {
+      details.push('Consolidation declined — left all installs in place')
+    } else {
+      details.push(
+        `Multiple installs detected [${list}]. Run \`prjct upgrade --yes\` to consolidate (kept ${plan.winner}).`
+      )
+    }
+    return { details, errors }
+  }
+
+  for (const r of plan.removable) {
+    const res = removeOne(r.pm)
+    if (res.ok) details.push(`Removed redundant ${r.pm} install`)
+    else errors.push(res.error ?? `failed to remove ${r.pm}`)
+  }
+  for (const s of plan.skipped) details.push(`Kept ${s.pm}: ${s.reason}`)
+
+  return { details, errors }
+}

--- a/core/index.ts
+++ b/core/index.ts
@@ -175,7 +175,7 @@ async function main(): Promise<void> {
       result = await commands.analyze(options)
     } else if (commandName === 'setup') {
       result = await commands.setup(options)
-    } else if (commandName === 'update') {
+    } else if (commandName === 'update' || commandName === 'upgrade') {
       result = await commands.update(options)
     } else {
       // Standard commands - type-safe invocation

--- a/core/infrastructure/update-checker.ts
+++ b/core/infrastructure/update-checker.ts
@@ -257,7 +257,10 @@ function readCacheSync(): { lastCheck: number; latestVersion: string } | null {
 
 function formatUpdateBanner(current: string, latest: string): string {
   const headline = `Update available! ${current} → ${latest}`
-  const cmd = 'npm install -g prjct-cli@latest'
+  // ONE command that updates every install AND consolidates parallel copies.
+  // The old hardcoded `npm install -g` ignored the user's actual package
+  // manager and is exactly what creates the multi-install footgun.
+  const cmd = 'prjct upgrade'
   // Pad to whatever length the longest visible line needs — do this
   // dynamically rather than baking widths into the literal so locale
   // changes don't cause misalignment.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -186,7 +186,7 @@ import{connect}from"node:net";import{existsSync}from"node:fs";import{randomUUID}
 const sockPath=homedir()+"/.prjct-cli/run/daemon.sock";
 const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
-const skip=new Set(["daemon","stop","restart","start","setup","update","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health","skill-adherence","review-risk","context-save","context-restore","spec","audit-spec"]);
+const skip=new Set(["daemon","stop","restart","start","setup","update","upgrade","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health","skill-adherence","review-risk","context-save","context-restore","spec","audit-spec"]);
 function refuse(m){console.error("prjct: daemon dropped the request ("+m+"). Retry: prjct "+args.join(" "));process.exit(1)}
 function isSafeRetry(e){const c=e&&e.code||"",m=e&&e.message||"";return c==="ECONNREFUSED"||c==="ENOENT"||m.includes("ECONNREFUSED")||m.includes("ENOENT")}
 if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){


### PR DESCRIPTION
## What the user asked for

`prjct update` should clean up parallel/stale installs itself, plus a more
efficient new-version notification with a single update command. (The user hit
the exact README footgun: 4 parallel installs — pnpm/bun/npm/brew — one
shadowing the rest.)

## WS4 — install consolidation

`core/commands/update/cleanup-installs.ts`: `planCleanup()` (pure) never
removes the PATH winner, the dev-link source tree, or anything without a
provable winner / valid `prjct-cli/package.json` (reuses existing
`package-managers.ts` detection; brew handled). PM-native uninstall, no raw
`rm`. Default `auto`: TTY → preview + confirm; non-TTY → **warn only, removes
nothing**. `--cleanup` forces, `--no-cleanup` skips, `--yes`/`-y`
auto-confirms, `--dry-run` reports intent. Folded into the existing Cleanup
phase — no 3→4 renumber churn (the plan flagged the renumber as a risk;
DRY/KISS).

## WS5 — one-command notify + `prjct upgrade`

`formatUpdateBanner` → `Run: prjct upgrade` (updates every install **and**
consolidates) instead of the hardcoded `npm install -g` that ignored the
user's PM and *creates* the multi-install mess. New `prjct upgrade` alias
wired in `_binCommands` / `_updateSkipCommands` / `_selfHealSkip` /
`scripts/build.js` shim + `core/index.ts` routing; `daemon-shim-sync` green.

## Safety

Destructive removal is gated (provable winner, ≠winner, valid package.json,
not dev-link) and conservative by default (confirm on TTY, warn-only on CI);
single-install machines are unaffected.

## Tests

`core/__tests__/commands/update-cleanup.test.ts` (banner→`prjct upgrade` not
npm; `--no-cleanup` deterministic; dry-run never removes; `planCleanup`
defensive — never removable without a winner) + e2e (`upgrade` ≡ `update`,
not bare-capture). Full suite **1193 / 0**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)