### PR TITLE
fix: WS2b SQLite hardening — BEGIN IMMEDIATE txns, statement-cache + daemon-cache gating

### DIFF
--- a/core/storage/database.ts
+++ b/core/storage/database.ts
@@ -35,6 +35,19 @@ import {
 // Database Manager
 // =============================================================================
 
+/**
+ * Run `fn` inside a BEGIN IMMEDIATE transaction. The driver default
+ * (calling the wrapper directly) is BEGIN DEFERRED — the write lock is only
+ * acquired at the first write, so two concurrent writers both enter and the
+ * loser aborts MID-transaction on SQLITE_BUSY. IMMEDIATE acquires the write
+ * lock up front: contention waits out busy_timeout then fails predictably,
+ * never mid-write. Defensive fallback for any driver lacking the variant.
+ */
+function runImmediate<T>(db: SqliteDatabase, fn: (db: SqliteDatabase) => T): T {
+  const txn = db.transaction(fn)
+  return typeof txn.immediate === 'function' ? txn.immediate(db) : txn(db)
+}
+
 /** Max concurrent DB connections before evicting least-recently-used */
 const MAX_DB_CONNECTIONS = 3
 
@@ -101,12 +114,18 @@ class PrjctDatabase {
     if (projectId) {
       const db = this.connections.get(projectId)
       if (db) {
+        // Drop cached statements bound to this connection BEFORE closing it.
+        // The WeakMap auto-GCs only once the db object is unreachable; an
+        // explicit delete prevents a stale statement (bound to a now-closed
+        // connection) from being reused if a caller still holds the ref.
+        this.statementCache.delete(db)
         db.close()
         this.connections.delete(projectId)
         this.accessOrder = this.accessOrder.filter((id) => id !== projectId)
       }
     } else {
       this.connections.forEach((db) => {
+        this.statementCache.delete(db)
         db.close()
       })
       this.connections.clear()
@@ -124,6 +143,7 @@ class PrjctDatabase {
     const lruId = this.accessOrder.shift()!
     const db = this.connections.get(lruId)
     if (db) {
+      this.statementCache.delete(db) // see close(): drop bound statements first
       db.close()
       this.connections.delete(lruId)
     }
@@ -344,7 +364,7 @@ class PrjctDatabase {
 
   transaction<T>(projectId: string, fn: (db: SqliteDatabase) => T): T {
     const db = this.getDb(projectId)
-    return db.transaction(fn)(db)
+    return runImmediate(db, fn)
   }
 
   // ===========================================================================
@@ -369,14 +389,14 @@ class PrjctDatabase {
     for (const migration of migrations) {
       if (applied.has(migration.version)) continue
 
-      db.transaction(() => {
+      runImmediate(db, () => {
         migration.up(db)
         db.prepare('INSERT INTO _migrations (version, name, applied_at) VALUES (?, ?, ?)').run(
           migration.version,
           migration.name,
           new Date().toISOString()
         )
-      })()
+      })
     }
   }
 

--- a/core/storage/database/sqlite-compat.ts
+++ b/core/storage/database/sqlite-compat.ts
@@ -29,12 +29,28 @@ export interface SqliteStatement {
   run(...params: SqliteBindings[]): SqliteRunResult
 }
 
+/**
+ * A transaction wrapper. Both bun:sqlite and better-sqlite3 return a callable
+ * that ALSO carries `.deferred`/`.immediate`/`.exclusive` variants. Default
+ * (calling it directly) is DEFERRED — the write lock is only taken at the
+ * first write, so two concurrent writers can both enter and then collide,
+ * aborting one MID-transaction on SQLITE_BUSY. `.immediate` takes the write
+ * lock up front: contention fails fast/predictably (or waits out
+ * busy_timeout), never mid-write.
+ */
+export interface SqliteTransaction<T> {
+  (...args: SqliteDatabase[]): T
+  deferred: (...args: SqliteDatabase[]) => T
+  immediate: (...args: SqliteDatabase[]) => T
+  exclusive: (...args: SqliteDatabase[]) => T
+}
+
 /** Minimal database interface shared by bun:sqlite and better-sqlite3 */
 export interface SqliteDatabase {
   prepare(sql: string): SqliteStatement
   run(sql: string): void
   close(): void
-  transaction<T>(fn: (...args: SqliteDatabase[]) => T): (...args: SqliteDatabase[]) => T
+  transaction<T>(fn: (...args: SqliteDatabase[]) => T): SqliteTransaction<T>
 }
 
 /**

--- a/core/storage/storage-manager.ts
+++ b/core/storage/storage-manager.ts
@@ -121,10 +121,20 @@ export abstract class StorageManager<T> {
    * Path: cache → SQLite kv_store → default
    */
   async read(projectId: string): Promise<T> {
+    // Cross-process staleness gate: the daemon is long-lived, so its 5s TTL
+    // cache can serve a value a concurrent short-lived CLI process already
+    // overwrote in SQLite (the daemon never saw that write). Inside the
+    // daemon, always read SQLite — it's the source of truth and the per-op
+    // cost is a single indexed kv_store lookup. Short-lived CLI processes
+    // keep the cache (their lifetime rarely outlives a concurrent write).
+    const inDaemon = process.env.PRJCT_IN_DAEMON === '1' || process.env.PRJCT_DAEMON === '1'
+
     // Check cache first (with expiration)
-    const cached = this.cache.get(projectId)
-    if (cached !== null) {
-      return cached
+    if (!inDaemon) {
+      const cached = this.cache.get(projectId)
+      if (cached !== null) {
+        return cached
+      }
     }
 
     // Try SQLite kv_store (primary store)


### PR DESCRIPTION
## WS2b — deferred SQLite hardening

The lost-update **data-loss** fix (optimistic CAS) shipped in #346. This is the
remaining lock/cache robustness the audit flagged.

| # | Fix |
|---|---|
| 1 | **BEGIN IMMEDIATE** for every `transaction()` + migration. Driver default is DEFERRED → the write lock is taken at first write, so two concurrent writers both enter and the loser aborts **mid-transaction** on SQLITE_BUSY. IMMEDIATE takes the lock up front: contention waits out `busy_timeout` then fails predictably, never mid-write. `sqlite-compat` exposes the typed `.immediate` variant; `runImmediate()` has a defensive fallback. |
| 2 | `storage-manager.read()` skips the 5s TTL cache when **inside the daemon** (`PRJCT_IN_DAEMON`/`PRJCT_DAEMON`) — the long-lived daemon could serve a value a concurrent short-lived CLI already overwrote in SQLite. CLI keeps the cache. |
| 3 | Explicit `statementCache.delete(db)` before `db.close()` in `evictLru()`/`close()` — the WeakMap auto-GCs only once the db is unreachable; explicit drop prevents reuse of a statement bound to a now-closed connection. |

## Deliberately NOT done

An app-level SQLITE_BUSY retry wrapper: `busy_timeout=5000` + IMMEDIATE + the
#346 CAS already cover contention, and `transaction()` is synchronous — an
app-level retry would mean a busy-wait spin (anti-pattern). Documented in the
commit rationale.

## Tests

Behaviorally transparent (no contract change — transactions still
commit/rollback, just acquire the lock earlier; cache/cleanup changes are
robustness-only). Full suite **1188 / 0**, including #346's concurrency
regression tests which exercise the transaction path. typecheck + biome clean.

> Note: touches `database.ts` (disjoint regions from #348's `checkpointAll`);
> trivial 3-way if both land — independent otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)