### PR TITLE
fix: WS3b — ship-atomicity marker + serialized daemon request handling

### DIFF
--- a/core/__tests__/commands/shipping.test.ts
+++ b/core/__tests__/commands/shipping.test.ts
@@ -15,7 +15,12 @@ import path from 'node:path'
 import { ShippingCommands } from '../../commands/shipping'
 import configManager from '../../infrastructure/config-manager'
 import pathManager from '../../infrastructure/path-manager'
+import { prjctDb } from '../../storage/database'
+import { shippedStorage } from '../../storage/shipped-storage'
 import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
+
+// Mirrors the (module-local) marker key in shipping.ts.
+const SHIP_MARKER_KEY = 'ship:in_progress'
 
 async function freshProject(): Promise<{ projectPath: string; projectId: string }> {
   const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-ship-test-'))
@@ -89,6 +94,43 @@ describe('ship() — workflow-first', () => {
       .then(() => true)
       .catch(() => false)
     expect(pkgExists).toBe(false)
+  })
+
+  test('reconciles an interrupted ship (marker → shipped row) idempotently', async () => {
+    // Simulate a prior ship that pushed v9.9.9 but crashed before recording.
+    prjctDb.setDoc(projectId, SHIP_MARKER_KEY, {
+      feature: 'lost feature',
+      version: '9.9.9',
+      startedAt: new Date().toISOString(),
+    })
+
+    // The next ship must reconcile the marker BEFORE its own work.
+    const r = await cmd.ship('next thing', projectPath, { md: true, intent: 'register-only' })
+    expect(r.success).toBe(true)
+
+    // The interrupted ship's row was recovered…
+    expect(await shippedStorage.getByVersion(projectId, '9.9.9')).toBeTruthy()
+    // …the marker was cleared…
+    expect(prjctDb.getDoc(projectId, SHIP_MARKER_KEY)).toBeNull()
+    // …and the current ship still recorded its own row.
+    const all = await shippedStorage.read(projectId)
+    expect(all.shipped.some((s: { name: string }) => s.name === 'next thing')).toBe(true)
+  })
+
+  test('reconcile is a no-op when the marker version is already recorded', async () => {
+    await shippedStorage.addShipped(projectId, { name: 'already done', version: '5.0.0' })
+    prjctDb.setDoc(projectId, SHIP_MARKER_KEY, {
+      feature: 'already done',
+      version: '5.0.0',
+      startedAt: new Date().toISOString(),
+    })
+
+    await cmd.ship('another', projectPath, { md: true, intent: 'register-only' })
+
+    const all = await shippedStorage.read(projectId)
+    // No duplicate 5.0.0 row, and the stale marker is cleared.
+    expect(all.shipped.filter((s: { version: string }) => s.version === '5.0.0')).toHaveLength(1)
+    expect(prjctDb.getDoc(projectId, SHIP_MARKER_KEY)).toBeNull()
   })
 
   test('code project auto-seeds ship rules on first run (migration path)', async () => {

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -14,6 +14,7 @@
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { syncService } from '../services/sync-service'
+import { prjctDb } from '../storage/database'
 import { shippedStorage } from '../storage/shipped-storage'
 import { stateStorage } from '../storage/state-storage'
 import { workflowRuleStorage } from '../storage/workflow-rule-storage'
@@ -29,6 +30,18 @@ import out from '../utils/output'
 import { executeWorkflowRules } from '../workflow/workflow-engine'
 import { PrjctCommandsBase } from './base'
 import { requireProject } from './guards'
+
+// kv marker written before the shipped row is recorded and cleared after.
+// If a ship pushes a version (via the before-rules) but crashes before
+// `addShipped`, this marker survives → the NEXT ship reconciles it
+// idempotently, closing the version-divergence class (mem_2920).
+const SHIP_MARKER_KEY = 'ship:in_progress'
+
+interface ShipMarker {
+  feature: string
+  version: string
+  startedAt: string
+}
 
 type ShipIntent = 'register-only' | 'seed-code-workflow' | 'proceed'
 
@@ -50,6 +63,26 @@ export class ShippingCommands extends PrjctCommandsBase {
       const proj = await requireProject(projectPath)
       if (!proj.ok) return proj.result
       const projectId = proj.value
+
+      // Crash recovery: a prior ship that pushed a version but died before
+      // recording the shipped row left a marker. Reconcile it idempotently
+      // (skip if that version is already recorded) before doing anything.
+      try {
+        const stale = prjctDb.getDoc<ShipMarker>(projectId, SHIP_MARKER_KEY)
+        if (stale?.version) {
+          const already = await shippedStorage.getByVersion(projectId, stale.version)
+          if (!already) {
+            await shippedStorage.addShipped(projectId, {
+              name: stale.feature,
+              version: stale.version,
+            })
+            console.log(`ℹ️  Reconciled an interrupted ship: ${stale.feature} (v${stale.version})`)
+          }
+          prjctDb.deleteDoc(projectId, SHIP_MARKER_KEY)
+        }
+      } catch {
+        // Best-effort recovery — never block a ship on reconciliation.
+      }
 
       let featureName = feature
 
@@ -145,10 +178,30 @@ export class ShippingCommands extends PrjctCommandsBase {
 
       const newVersion = typeof runCtx.version === 'string' ? runCtx.version : 'unversioned'
 
+      // The before-rules have already pushed `newVersion`. Drop a marker so
+      // a crash between here and `addShipped` is recoverable on the next
+      // ship; clear it once the shipped row is durably recorded.
+      try {
+        prjctDb.setDoc<ShipMarker>(projectId, SHIP_MARKER_KEY, {
+          feature: featureName,
+          version: newVersion,
+          startedAt: dateHelper.getTimestamp(),
+        })
+      } catch {
+        // marker is best-effort — never block the ship
+      }
+
       await shippedStorage.addShipped(projectId, {
         name: featureName,
         version: newVersion,
       })
+
+      try {
+        prjctDb.deleteDoc(projectId, SHIP_MARKER_KEY)
+      } catch {
+        // stale marker is harmless — next ship reconciles it as a no-op
+        // (getByVersion finds the row we just wrote → skip)
+      }
 
       await this.logToMemory(projectPath, 'feature_shipped', {
         feature: featureName,

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -41,6 +41,16 @@ let commands: PrjctCommands | null = null
 let state: DaemonState | null = null
 let ownVersion: string | null = null
 
+// Serializes command execution. handleRequestInner patches the GLOBAL
+// console.log/error to capture a command's output; with concurrent socket
+// connections (state.activeRequests can exceed 1) two requests would
+// cross-capture each other's output and whichever finishes first would
+// restore the real console while the other is still mid-command. Chaining
+// through one promise makes command execution strictly one-at-a-time —
+// SQLite is single-writer anyway and commands are short, so the throughput
+// cost is negligible next to the correctness win.
+let _requestChain: Promise<unknown> = Promise.resolve()
+
 export async function startDaemon(options: { foreground?: boolean }): Promise<void> {
   // Flag child services (wiki-generator etc.) can check to know they're
   // running under the long-lived daemon — lets them fire-and-forget safe
@@ -213,7 +223,17 @@ async function handleRequest(request: DaemonRequest): Promise<DaemonResponse> {
 
   state.activeRequests++
   try {
-    return await handleRequestInner(request)
+    // Run strictly after any in-flight command (see _requestChain). The
+    // catch arms keep the chain alive if a prior request rejected.
+    const run = _requestChain.then(
+      () => handleRequestInner(request),
+      () => handleRequestInner(request)
+    )
+    _requestChain = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return await run
   } finally {
     state.activeRequests--
     if (state.restartPending && state.activeRequests === 0) {


### PR DESCRIPTION
## WS3b — the two reliability fixes deferred from WS3 (#348)

### #2 ship atomicity (closes the version-divergence class, mem_2920)

`ship()` recorded the `shipped_features` row **after** the before-rules pushed
the version. A crash in that window = a pushed version with no recorded ship →
permanent divergence (the recurring pain). Now an idempotent
`ship:in_progress` kv marker is written before `addShipped` and cleared after;
the **next** ship reconciles a surviving marker (re-records the lost row,
skipped via `getByVersion` if already present) before its own work.
Best-effort — never blocks a ship.

### #4 daemon output race

`handleRequestInner` patches the **global** `console.log/error` to capture a
command's output. The daemon serves concurrent socket connections
(`state.activeRequests` can exceed 1), so two requests cross-captured each
other's output and the first `finally{}` restored the real console mid-flight
for the other. Command execution is now **serialized** through a single
promise chain — SQLite is single-writer and commands are short, so the
throughput cost is negligible vs the correctness win.

## Tests

`shipping.test.ts` +2 regressions: an interrupted ship is reconciled (marker
→ shipped row, marker cleared) **and** reconcile is a no-op when the version
is already recorded (no duplicate row). Full suite **1190 / 0**; typecheck +
biome clean. Daemon serialization is behaviorally transparent (daemon tests
green).

> Touches only `shipping.ts` + `daemon.ts` — disjoint from #347/#348/#349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)