### PR TITLE
ci: debounce Release — coalesce a merge burst into one release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,54 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Debounce: coalesce a burst of merges into ONE release.
+  #
+  # `concurrency` already serializes runs, but every push still queues a run;
+  # the superseded ones then collide on push/publish (main moved, version
+  # already published) and show up as red "failure"s. This gate waits a short
+  # window and bails if `main` advanced meanwhile — only the newest push's run
+  # survives to release the whole burst. It runs BEFORE any publish step, so
+  # (unlike `cancel-in-progress: true`) it can never cancel a release
+  # mid-`npm publish`/`git push`. Cheap: checkout + one sleep, no install/build.
+  debounce:
+    name: Debounce
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.guard.outputs.proceed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Skip if superseded by a newer push
+        id: guard
+        run: |
+          # Manual runs (workflow_dispatch) are explicit — never debounce them.
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "Manual trigger — proceeding without debounce."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TRIGGER_SHA="${{ github.sha }}"
+          # Window long enough to absorb a rapid merge sequence.
+          sleep 90
+          git fetch origin main --quiet
+          HEAD_SHA=$(git rev-parse origin/main)
+
+          if [ "$TRIGGER_SHA" != "$HEAD_SHA" ]; then
+            echo "main advanced ($TRIGGER_SHA → $HEAD_SHA) during debounce —"
+            echo "a newer run will release this burst. Skipping cleanly."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "main stable at $TRIGGER_SHA — proceeding to release."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Run CI checks first
   ci:
     name: CI Checks
+    needs: debounce
+    if: needs.debounce.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}


### PR DESCRIPTION
## Problem

Merging a queue of PRs rapidly produced **3 red `failure` Release runs + 1 success**. `concurrency: { group: release, cancel-in-progress: false }` already *serializes* runs — but every push still **queues** a run, and by the time a superseded queued run executes, `main` has moved and the version is already published, so it collides on `git push` / `npm publish` and fails.

## Fix

A cheap `debounce` job (checkout + 90 s sleep — no install/build) that bails if `origin/main` advanced during the window. Only the **newest** push's run survives to release the whole burst; superseded runs **skip cleanly** (green, gated out) instead of failing mid-release.

- `ci` and (transitively) `release` now `needs: debounce` and gate on its `proceed` output.
- Runs strictly **before** any publish step → can never cancel a release mid-`npm publish`/`git push` (that's why `cancel-in-progress: true` was the *wrong* tool here — a publish workflow must not be cancelled mid-flight).
- `workflow_dispatch` is exempt — explicit manual runs never debounce.

## Net effect

A burst of N merges → one Release run for the final commit; the other N−1 are a ~90 s no-op skip (clean). No more red release noise, no risk to publish atomicity.

Workflow-only change (validated by the next merge burst). YAML validated; job wiring: `debounce → ci → release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)