### PR TITLE
fix: changelog generator PROMOTES [Unreleased] instead of stranding it (mem_2895 root cause)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,16 @@ jobs:
             const lines = changelog.split('\n');
             let insertIndex = 0;
 
+            // Insert the new release ABOVE the first RELEASED version but
+            // never above '## [Unreleased]' — putting it above Unreleased is
+            // the mem_2895 stranding bug (Unreleased ends up orphaned below
+            // every release). The primary writer (prjct ship's
+            // ChangelogService) PROMOTES Unreleased; this CI fallback at
+            // least keeps it correctly on top.
             for (let i = 0; i < lines.length; i++) {
-              if (lines[i].startsWith('## [') || lines[i].startsWith('## v')) {
+              const ln = lines[i].trim().toLowerCase();
+              const isUnreleased = ln === '## [unreleased]';
+              if (!isUnreleased && (lines[i].startsWith('## [') || lines[i].startsWith('## v'))) {
                 insertIndex = i;
                 break;
               }

--- a/core/__tests__/services/changelog-service.test.ts
+++ b/core/__tests__/services/changelog-service.test.ts
@@ -53,6 +53,71 @@ describe('ChangelogService.addFeature (idempotency)', () => {
     expect(content).toContain('## [1.3.0]')
   })
 
+  it('PROMOTES [Unreleased] into the release, leaving a fresh empty one (mem_2895)', async () => {
+    const file = path.join(dir, 'CHANGELOG.md')
+    await fs.writeFile(
+      file,
+      [
+        '# Changelog',
+        '',
+        'Based on [Keep a Changelog](https://keepachangelog.com/).',
+        '',
+        '## [Unreleased]',
+        '',
+        '### Added',
+        '- **rich hand-written entry** with detail',
+        '',
+        '### Fixed',
+        '- a real bug fix',
+        '',
+        '## [1.2.3] - 2025-01-01',
+        '',
+        '### Added',
+        '- old release',
+        '',
+      ].join('\n')
+    )
+    const svc = new ChangelogService(dir)
+    await svc.addFeature('1.3.0', 'ship feature line')
+    const c = await readChangelog()
+
+    // Exactly ONE [Unreleased], and it is empty + on top.
+    expect((c.match(/^## \[Unreleased\]/gm) ?? []).length).toBe(1)
+    // The rich content was carried INTO the release, not stranded.
+    const relIdx = c.indexOf('## [1.3.0]')
+    const unrelIdx = c.indexOf('## [Unreleased]')
+    expect(unrelIdx).toBeLessThan(relIdx) // Unreleased above the new release
+    expect(c).toContain('## [1.3.0]')
+    expect(c.slice(relIdx)).toContain('rich hand-written entry') // rich content under the release
+    expect(c.slice(relIdx)).toContain('a real bug fix')
+    expect(c.slice(relIdx)).toContain('ship feature line') // ship feature folded in
+    // No stranded [Unreleased] below a version, prior release intact.
+    expect(c).toContain('## [1.2.3] - 2025-01-01')
+    expect(c).not.toMatch(/## \[1\.3\.0\][\s\S]*## \[Unreleased\]/) // Unreleased never below the release
+  })
+
+  it('does not re-strand across consecutive ships (the 3× recurrence)', async () => {
+    const file = path.join(dir, 'CHANGELOG.md')
+    await fs.writeFile(file, `${'# Changelog'}\n\nKeep a Changelog\n\n## [Unreleased]\n\n`)
+    const svc = new ChangelogService(dir)
+
+    await svc.addFeature('2.0.0', 'first ship')
+    // A dev/process accumulates rich content under the fresh [Unreleased].
+    let c = await readChangelog()
+    c = c.replace(/## \[Unreleased\]\n/, '## [Unreleased]\n\n### Changed\n- accumulated work\n')
+    await fs.writeFile(file, c)
+    await svc.addFeature('2.1.0', 'second ship')
+
+    const final = await readChangelog()
+    expect((final.match(/^## \[Unreleased\]/gm) ?? []).length).toBe(1) // never piles up
+    expect(final).toContain('## [2.0.0]')
+    expect(final).toContain('## [2.1.0]')
+    // The accumulated work landed in 2.1.0, not stranded under [Unreleased].
+    const v210 = final.slice(final.indexOf('## [2.1.0]'))
+    expect(v210).toContain('accumulated work')
+    expect(final.indexOf('## [Unreleased]')).toBeLessThan(final.indexOf('## [2.1.0]'))
+  })
+
   it('handles generic markdown format (no Keep a Changelog markers)', async () => {
     const file = path.join(dir, 'CHANGELOG.md')
     await fs.writeFile(file, '# Changelog\n\n## 1.2.3 - 2025-01-01\n\n- old entry\n')

--- a/core/services/changelog-service.ts
+++ b/core/services/changelog-service.ts
@@ -141,24 +141,83 @@ export class ChangelogService {
 
   /**
    * Insert an entry in Keep a Changelog format.
-   * Looks for the first ## heading (version entry) and inserts before it.
-   * If no version heading exists, appends after the header block.
+   *
+   * ROOT-CAUSE FIX (mem_2895): the old version inserted the new
+   * `## [version]` block ABOVE the first `## ` heading. When the file
+   * followed proper Keep-a-Changelog (`## [Unreleased]` on top), that
+   * stranded `[Unreleased]` *below* the new release with its accumulated
+   * content never promoted — so every ship re-stranded it and the blocks
+   * piled up (needed manual consolidation 3×).
+   *
+   * Correct Keep-a-Changelog release: PROMOTE `## [Unreleased]` → the new
+   * `## [version] - date` (carrying its accumulated content + folding in
+   * this ship's feature, deduped), then put a fresh empty `## [Unreleased]`
+   * back on top. When there is no `[Unreleased]`, self-heal by adding one
+   * so the *next* ship promotes correctly.
    */
   private insertKeepAChangelogEntry(content: string, entry: ChangelogEntry, date: string): string {
-    const entryText = this.formatKeepAChangelogEntry(entry, date)
+    const lines = content.split('\n')
+    const unrelIdx = lines.findIndex((l) => /^##\s*\[Unreleased\]\s*$/i.test(l))
 
-    // Find the first version heading (## [...] or ## Unreleased)
-    const versionHeadingIndex = content.search(/^## /m)
+    if (unrelIdx !== -1) {
+      // [Unreleased] body = everything until the next "## " heading (or EOF).
+      let endIdx = lines.length
+      for (let i = unrelIdx + 1; i < lines.length; i++) {
+        if (/^##\s/.test(lines[i])) {
+          endIdx = i
+          break
+        }
+      }
+      const body = lines
+        .slice(unrelIdx + 1, endIdx)
+        .join('\n')
+        .trim()
+      const promoted = this.promoteUnreleasedBody(body, entry, date)
 
-    if (versionHeadingIndex !== -1) {
-      // Insert before the first version heading
-      const before = content.slice(0, versionHeadingIndex)
-      const after = content.slice(versionHeadingIndex)
-      return `${before + entryText}\n${after}`
+      const rebuilt = [
+        ...lines.slice(0, unrelIdx),
+        '## [Unreleased]',
+        '',
+        promoted,
+        '',
+        ...lines.slice(endIdx),
+      ].join('\n')
+      return `${rebuilt.replace(/\n{3,}/g, '\n\n').trimEnd()}\n`
     }
 
-    // No version headings - append after header
-    return `${content.trimEnd()}\n\n${entryText}`
+    // No [Unreleased] — self-heal: add a fresh one AND the version block so
+    // the next ship has something to promote.
+    const entryText = this.formatKeepAChangelogEntry(entry, date)
+    const versionHeadingIndex = content.search(/^## /m)
+    if (versionHeadingIndex !== -1) {
+      const before = content.slice(0, versionHeadingIndex)
+      const after = content.slice(versionHeadingIndex)
+      return `${before}## [Unreleased]\n\n${entryText}\n${after}`
+    }
+    return `${content.trimEnd()}\n\n## [Unreleased]\n\n${entryText}\n`
+  }
+
+  /**
+   * Build the promoted release section from the accumulated `[Unreleased]`
+   * body. The body (rich, hand/process-written) IS the release notes; the
+   * ship's thin auto-feature is folded into `### Added` only if its text
+   * isn't already present (dedupe). Empty body ⇒ the ship feature is the
+   * whole release.
+   */
+  private promoteUnreleasedBody(body: string, entry: ChangelogEntry, date: string): string {
+    if (!body) return this.formatKeepAChangelogEntry(entry, date)
+
+    const head = `## [${entry.version}] - ${date}`
+    const featureItems = entry.sections?.Added ?? (entry.description ? [entry.description] : [])
+    const missing = featureItems.filter((f) => !body.includes(f))
+
+    if (missing.length === 0) return `${head}\n\n${body}`
+
+    const bullets = missing.map((f) => `- ${f}`).join('\n')
+    const merged = /^###\s+Added\s*$/im.test(body)
+      ? body.replace(/^###\s+Added\s*$/im, (m) => `${m}\n${bullets}`)
+      : `### Added\n${bullets}\n\n${body}`
+    return `${head}\n\n${merged}`
   }
 
   /**


### PR DESCRIPTION
## Root cause (manual CHANGELOG consolidation was needed **3×** — mem_2895/mem_3135)

`ChangelogService.insertKeepAChangelogEntry` inserted the new `## [version]`
block **above the first `## ` heading**. With proper Keep-a-Changelog
(`## [Unreleased]` on top), that stranded `[Unreleased]` *below* every release
with its accumulated content never promoted → each ship re-stranded it and the
blocks piled up (the recurring `#343`-style cleanups).

## Fix

**Promote**, the canonical Keep-a-Changelog release move:
`## [Unreleased]` → `## [version] - date` (carry its accumulated content; fold
the ship's thin auto-feature in only if not already present — deduped), then a
**fresh empty `## [Unreleased]`** back on top. No `[Unreleased]` present →
self-heal by adding one so the *next* ship promotes correctly. Generic-markdown
and idempotency paths unchanged.

Also: the CI Release fallback (`release.yml` "Update CHANGELOG.md") had the
same insert-above-first-heading bug — minimal bash-safe tweak so it never
inserts above `## [Unreleased]`. It rarely fires (prjct ship writes first → CI
skips via the version guard); `ChangelogService` is the primary, tested fix.

## Tests

`changelog-service.test.ts` +2 regressions: promote-carries-content, and
no-re-strand-across-consecutive-ships (the 3× recurrence). **Both verified to
fail on the old impl.** Existing idempotency / generic-markdown tests still
green. Full suite **1199 / 0**; typecheck + biome + YAML clean.

Closes the recurring root cause (mem_2895 / mem_3135 / improvement-idea
mem_3026). Future ships keep CHANGELOG as a single clean `[Unreleased]` + clean
release history — no more manual consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)