### PR TITLE
fix: make prjct upgrade bulletproof — no silent misroute, no stale-daemon, no downgrade

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -177,8 +177,22 @@ if (_fastCommand && !_selfHealSkip.has(_fastCommand) && process.env.PRJCT_NO_SEL
 // wanted a task (branch/worktree), they type `prjct task "..."`
 // explicitly.
 if (_fastCommand && !_binCommands.has(_fastCommand) && !REGISTERED_VERBS_SET.has(_fastCommand)) {
-  const description = _fastArgs.filter((a) => !a.startsWith('-')).join(' ')
+  const positionals = _fastArgs.filter((a) => !a.startsWith('-'))
+  const description = positionals.join(' ')
   const flags = _fastArgs.filter((a) => a.startsWith('-'))
+  // A single command-shaped token (e.g. `prjct upgrade`) is almost never a
+  // GTD note — it's a MISROUTED command: a typo, or a stale parallel
+  // install / long-lived daemon that predates the verb. Silently turning it
+  // into an inbox capture buries it with zero feedback (same silent-no-op
+  // class as the WS1 exit-0 bug). Still capture (don't break free-text GTD)
+  // but make it LOUD + actionable so it's never a silent surprise.
+  if (positionals.length === 1 && /^[a-z][a-z0-9:-]+$/.test(positionals[0])) {
+    process.stderr.write(
+      `prjct: '${positionals[0]}' is not a known command in this install — ` +
+        'saving it to the inbox instead. If you meant the command, this prjct ' +
+        'may be stale: run `prjct update`.\n'
+    )
+  }
   _fastCommand = 'capture'
   _fastArgs = ['capture', description, ...flags]
 }

--- a/core/__tests__/e2e/cli-lifecycle.e2e.test.ts
+++ b/core/__tests__/e2e/cli-lifecycle.e2e.test.ts
@@ -41,6 +41,24 @@ describe('e2e: unconfigured project fails LOUD (regression)', () => {
     expect(r.code).toBe(0)
     expect(r.stdout + r.stderr).toContain(REPO_VERSION)
   })
+
+  // A misrouted single command-shaped token (typo / stale parallel install
+  // or daemon that predates a verb like `upgrade`) must NOT be silently
+  // swallowed into the inbox — it has to say so, loudly + actionably.
+  test('an unknown command-shaped token is captured LOUDLY, not silently', async () => {
+    const r = await sb.cli(['definitelynotacommand'])
+    const out = (r.stdout + r.stderr).toLowerCase()
+    expect(out).toContain('not a known command')
+    expect(out).toContain('prjct update')
+  })
+
+  // Free-text GTD capture (multi-word, first token not a verb) stays silent
+  // — the advisory is only for a LONE command-shaped token, so quick notes
+  // aren't nagged.
+  test('multi-word free-text capture stays silent (GTD preserved)', async () => {
+    const r = await sb.cli(['buy', 'more', 'coffee', 'beans'])
+    expect((r.stdout + r.stderr).toLowerCase()).not.toContain('not a known command')
+  })
 })
 
 describe('e2e: CLI lifecycle (hermetic fake project)', () => {

--- a/core/commands/update.ts
+++ b/core/commands/update.ts
@@ -69,6 +69,24 @@ export class UpdateCommands extends PrjctCommandsBase {
     }
 
     try {
+      // ── Phase 0: stop any running daemon FIRST ──
+      // A daemon from a previous (now-stale) version keeps serving old code
+      // for its whole lifetime — it never learned new verbs/aliases (e.g.
+      // `upgrade`) and would mis-handle them (silently inbox-capturing the
+      // command). Tear it down before doing anything; phase 3 spawns a
+      // fresh one from the just-installed code.
+      if (!dryRun) {
+        try {
+          const { isDaemonRunning, stopDaemon, forceKillDaemon } = await import('../daemon/client')
+          if (await isDaemonRunning()) {
+            const ok = await stopDaemon()
+            if (!ok) forceKillDaemon()
+          }
+        } catch {
+          // best-effort — never block the update on daemon teardown
+        }
+      }
+
       // ── Phase 1: Package Update ──
       if (!md) out.step(1, 3, 'Updating package...')
       results.phase1 = await this.phasePackageUpdate(dryRun)
@@ -173,6 +191,19 @@ export class UpdateCommands extends PrjctCommandsBase {
         targets = [selectPackageManager()]
       }
 
+      // Resolve the TRUE latest from the npm registry and PIN it. `@latest`
+      // is resolved by each PM from its own metadata cache — pnpm's is
+      // frequently stale and silently resolves an OLD version, so a plain
+      // `pnpm add -g prjct-cli@latest` can *downgrade* the install. Pinning
+      // the exact registry version makes the upgrade deterministic.
+      let pinnedSpec: string | null = null
+      try {
+        const v = (await new UpdateChecker().getLatestVersion())?.trim()
+        if (v && /^\d+\.\d+\.\d+/.test(v)) pinnedSpec = `prjct-cli@${v}`
+      } catch {
+        // registry unreachable — fall back to each PM's @latest
+      }
+
       for (const pm of targets) {
         if (!isOnPath(pm.name)) {
           result.errors.push(
@@ -182,10 +213,13 @@ export class UpdateCommands extends PrjctCommandsBase {
           continue
         }
         try {
-          // Use install @latest (rather than `update`) to bypass semver range
-          // constraints and always fetch the true latest from the registry.
-          execSync([pm.name, ...pm.installArgs].join(' '), { stdio: 'pipe' })
-          result.details.push(`${pm.name} install complete`)
+          // Pin the exact registry latest (bypasses semver ranges AND each
+          // PM's stale @latest cache — see pinnedSpec above).
+          const args = pinnedSpec
+            ? pm.installArgs.map((a) => (a === 'prjct-cli@latest' ? pinnedSpec : a))
+            : pm.installArgs
+          execSync([pm.name, ...args].join(' '), { stdio: 'pipe' })
+          result.details.push(`${pm.name} install complete${pinnedSpec ? ` (${pinnedSpec})` : ''}`)
         } catch (err) {
           result.errors.push(`${pm.name}: ${getErrorMessage(err)}`)
         }


### PR DESCRIPTION
## Found by dogfooding `prjct upgrade` on a real machine

The v2.22.1 bundle **did** have the `upgrade` alias wired correctly (verified
`dist/bin/prjct-core.mjs`: `_binCommands` has `"update","upgrade"`, routing,
banner) — so these are **robustness** bugs, not missing wiring:

| # | Bug | Fix |
|---|---|---|
| 1 🔴 | A single command-shaped token that isn't a known verb (typo, or a **stale parallel install / long-lived daemon predating the verb**) was **silently** turned into an inbox capture — zero feedback (same class as the WS1 exit-0 bug; it junked the inbox with `mem_3209`/`mem_3216`="upgrade"). | Still captures (free-text GTD preserved) but prints a **LOUD actionable stderr advisory**; multi-word free-text stays silent. |
| 2 🟠 | A daemon from a prior version serves old code for its whole lifetime — never learns new verbs/aliases. | `prjct update`/`upgrade` now **stops any running daemon in a new Phase 0** (before package update), not just restarting at phase 3. |
| 3 🟠 | `phasePackageUpdate` used each PM's `prjct-cli@latest`; pnpm resolves `@latest` from a **stale local cache and silently downgrades** (observed 2.22.1 → 2.19.9). | Resolve the **true latest from the npm registry** (`UpdateChecker.getLatestVersion`) and **pin the exact version** for every PM. |

## Tests

e2e: an unknown command-shaped token is captured **loudly** (advisory +
`prjct update`); multi-word free-text capture stays silent (GTD preserved).
Full suite **1199 / 0**; typecheck + biome clean.

Note: `mem_3209`/`mem_3216` ("upgrade") are junk inbox items created by bug #1
during the dogfooding — noise, safe to ignore/triage (no public memory-forget
verb yet, mem_2612).

🤖 Generated with [Claude Code](https://claude.com/claude-code)