### PR TITLE
feat: resolvable + legible memory references (no more opaque mem_NNNN)

### DIFF
--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -166,3 +166,32 @@ describe('projectMemory.recall — dedupeByKey', () => {
     expect(entries[1].content).toBe('v1')
   })
 })
+
+describe('projectMemory.getById — resolve an opaque mem_N reference', () => {
+  it('resolves a mem_<id> (and bare numeric) to the full entry', async () => {
+    await writeMemoryEntry({
+      type: 'decision',
+      content: 'pick Bun over Node',
+      tags: { topic: 'rt' },
+    })
+    const [e] = projectMemory.recall(projectId, { types: ['decision'] })
+    expect(e.id).toMatch(/^mem_\d+$/)
+
+    const byMem = projectMemory.getById(projectId, e.id)
+    expect(byMem).not.toBeNull()
+    expect(byMem?.content).toBe('pick Bun over Node')
+    expect(byMem?.type).toBe('decision')
+    expect(byMem?.tags).toEqual({ topic: 'rt' })
+
+    // Bare numeric and mem- variants resolve the same row.
+    const bare = projectMemory.getById(projectId, e.id.replace('mem_', ''))
+    expect(bare?.id).toBe(e.id)
+    expect(projectMemory.getById(projectId, e.id.replace('_', '-'))?.id).toBe(e.id)
+  })
+
+  it('returns null for a non-existent / malformed id (no throw)', () => {
+    expect(projectMemory.getById(projectId, 'mem_999999')).toBeNull()
+    expect(projectMemory.getById(projectId, 'not-an-id')).toBeNull()
+    expect(projectMemory.getById(projectId, '')).toBeNull()
+  })
+})

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -341,6 +341,33 @@ export const projectMemory = {
   },
 
   /**
+   * Resolve a single memory entry by its `mem_<rowid>` id (or a bare
+   * numeric id). This is the legibility fix: every `mem_NNNN` reference
+   * the topical-memory injection / a memory body cites (`relates=mem_X`,
+   * `resolves=mem_Y`) is otherwise an opaque dangling pointer that
+   * neither a human (in Obsidian) nor an LLM can resolve. Returns null
+   * if the id doesn't exist or isn't a remember-event row.
+   */
+  getById(projectId: string, id: string): MemoryEntry | null {
+    const m = String(id)
+      .trim()
+      .match(/^(?:mem[_-])?(\d+)$/i)
+    if (!m) return null
+    const rowId = Number(m[1])
+    try {
+      const row = prjctDb.get<EventRow>(
+        projectId,
+        'SELECT id, type, data, timestamp FROM events WHERE id = ? AND type LIKE ?',
+        rowId,
+        `${REMEMBER_EVENT_PREFIX}%`
+      )
+      return row ? rowToEntry(row) : null
+    } catch {
+      return null
+    }
+  },
+
+  /**
    * Lightweight similarity: share any keyword from the description. Good
    * enough to surface "we already shipped this" nudges; Phase 5 can layer
    * embeddings on top without changing the API.
@@ -416,7 +443,11 @@ export function formatMemoryMd(entries: MemoryEntry[]): string {
         .join(' ')
       const tagSuffix = tags ? `  _(${tags})_` : ''
       const prov = PROV_PREFIX[e.provenance]
-      lines.push(`- \`${prov}\` [${e.id}] ${e.content}${tagSuffix}`)
+      // `[mem_N · type]` not bare `[mem_N]`: a reference now says WHAT it
+      // is at a glance, and `mem_N` stays plain text so Obsidian search /
+      // grep resolves it. The full entry is one command away:
+      // `prjct context memory mem_N`.
+      lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${e.content}${tagSuffix}`)
     }
     lines.push('')
   }

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -164,6 +164,33 @@ async function runMemoryTool(
       .join(' ')
       .trim() || undefined
 
+  // Resolve-by-ID: `prjct context memory mem_3209` (or `--id mem_3209`)
+  // returns that exact entry. Makes every `mem_NNNN` reference (topical
+  // injection, `relates=`/`resolves=` cross-refs) resolvable instead of a
+  // dangling opaque pointer "nobody — including an LLM — can read".
+  const idArg = (() => {
+    const flag = args.find((a) => a.startsWith('--id'))
+    if (flag) {
+      const v = flag.includes('=') ? flag.split('=')[1] : args[args.indexOf(flag) + 1]
+      if (v) return v
+    }
+    return topic && /^mem[_-]?\d+$/i.test(topic) ? topic : undefined
+  })()
+
+  if (idArg) {
+    const entry = projectMemory.getById(projectId, idArg)
+    return {
+      tool: opts.kind,
+      result: {
+        markdown: entry
+          ? formatMemoryMd([entry])
+          : `> No memory entry with id \`${idArg}\` (it may have aged out or never existed).`,
+        entryCount: entry ? 1 : 0,
+        topic: idArg,
+      },
+    }
+  }
+
   // `learnings` is a typed slice of memory focused on what the project
   // has *learned* the hard way. Everything else comes through `memory`.
   const LEARNINGS_TYPES: MemoryType[] = ['learning', 'anti-pattern', 'gotcha']


### PR DESCRIPTION
## Problem (user-reported)

`mem_NNNN` ids are everywhere — the topical-memory injection, and
`relates=`/`resolves=` cross-refs inside entry bodies — but were **opaque
dangling pointers**: `prjct context memory mem_3209` treated it as a *topic*
(no resolver), and the vault didn't surface ids legibly. Nobody — **including
an LLM** — could tell what an id referred to. That breaks the whole compounding
-memory value prop.

## Fix (the 3 the user asked for)

1. **Resolve by ID (CLI).** `projectMemory.getById(projectId, id)` resolves
   `mem_<rowid>` (also bare numeric / `mem-` variant) → full entry; `null` on
   miss, never throws. Wired into `prjct context memory mem_3209` and
   `--id mem_3209`. Every reference is now one command from its content.
2. **Vault legibility.** No code change needed: `buildMemoryFiles` already
   renders every type incl. `inbox` from `recall({limit:5000})` — the earlier
   "not in Obsidian" was vault **staleness** (regenerates on sync/Stop/ship),
   not missing rendering. With #3 the id is present + labeled wherever the
   vault regenerates (grep / Obsidian search resolves it).
3. **Legible reference.** `formatMemoryMd` now renders `[mem_N · type]` not
   bare `[mem_N]` — a reference says *what it is* at a glance, everywhere it's
   emitted (injection + vault), `mem_N` stays plain-text searchable.

## Tests

`project-memory.test.ts`: `getById` resolves `mem_`/bare/`mem-` to the right
row; non-existent / malformed → `null` (no throw). Full suite **1201 / 0**;
typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)