### PR TITLE
fix: vault makes every mem_N navigable — Obsidian anchors + linkified cross-refs (mem_3233)

### DIFF
--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -13,7 +13,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import pathManager from '../../infrastructure/path-manager'
-import { projectMemory } from '../../memory/project-memory'
+import { formatMemoryMd, type MemoryEntry, projectMemory } from '../../memory/project-memory'
 import prjctDb from '../../storage/database'
 
 /**
@@ -193,5 +193,65 @@ describe('projectMemory.getById — resolve an opaque mem_N reference', () => {
     expect(projectMemory.getById(projectId, 'mem_999999')).toBeNull()
     expect(projectMemory.getById(projectId, 'not-an-id')).toBeNull()
     expect(projectMemory.getById(projectId, '')).toBeNull()
+  })
+})
+
+describe('formatMemoryMd — vault makes every mem_N navigable (mem_3233)', () => {
+  const mk = (over: Partial<MemoryEntry> & { id: string }): MemoryEntry => ({
+    type: 'decision',
+    content: '',
+    tags: {},
+    rememberedAt: '2026-05-18T00:00:00.000Z',
+    provenance: 'declared',
+    ...over,
+  })
+
+  it('CLI mode (no opts) is plain — no anchor, no wikilink', () => {
+    const out = formatMemoryMd([
+      mk({ id: 'mem_3247', content: 'fixed via resolves=mem_3135', tags: { pr: '355' } }),
+    ])
+    expect(out).toContain('[mem_3247 · decision]')
+    expect(out).not.toContain('^mem-3247') // no Obsidian block anchor in terminal
+    expect(out).not.toContain('[[') // no wikilink in terminal
+    expect(out).toContain('resolves=mem_3135') // stays plain text for grep
+  })
+
+  it('vault mode: every entry gets a ^mem-N block anchor', () => {
+    const out = formatMemoryMd([mk({ id: 'mem_3247', content: 'x' })], { vault: true })
+    // Anchor must be the LAST token on the bullet (Obsidian block-ref rule).
+    const line = out.split('\n').find((l) => l.includes('mem_3247'))
+    expect(line?.endsWith(' ^mem-3247')).toBe(true)
+  })
+
+  it('vault mode: cross-ref with KNOWN type → typed wikilink to its file', () => {
+    const idTypeIndex = new Map([['mem_3135', 'gotcha']])
+    const out = formatMemoryMd(
+      [mk({ id: 'mem_3247', content: 'done', tags: { resolves: 'mem_3135' } })],
+      { vault: true, idTypeIndex }
+    )
+    expect(out).toContain('resolves=[[gotcha#^mem-3135|mem_3135]]')
+  })
+
+  it('vault mode: UNKNOWN id → bare [[mem_N]] (clickable, not dead text)', () => {
+    const out = formatMemoryMd([mk({ id: 'mem_3247', content: 'see mem_999 for context' })], {
+      vault: true,
+      idTypeIndex: new Map(),
+    })
+    expect(out).toContain('see [[mem_999]] for context')
+  })
+
+  it('vault mode: inline content mentions are linkified too, not just the meta tail', () => {
+    const idTypeIndex = new Map([['mem_2895', 'feedback']])
+    const out = formatMemoryMd([mk({ id: 'mem_3247', content: 'supersedes mem_2895 entirely' })], {
+      vault: true,
+      idTypeIndex,
+    })
+    expect(out).toContain('supersedes [[feedback#^mem-2895|mem_2895]] entirely')
+  })
+
+  it('regression lock: vault syntax never leaks into the CLI/terminal path', () => {
+    const entries = [mk({ id: 'mem_3247', content: 'refs mem_1', tags: { relates: 'mem_2' } })]
+    const cli = formatMemoryMd(entries)
+    expect(cli).not.toMatch(/\^mem-|\[\[/)
   })
 })

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -397,7 +397,31 @@ export const projectMemory = {
  * Render memory entries as compact markdown grouped by type.
  * Designed to be short enough for Claude to read without tripping budgets.
  */
-export function formatMemoryMd(entries: MemoryEntry[]): string {
+/**
+ * Render options. `vault: true` makes the output Obsidian-navigable:
+ * every entry gets a block anchor (`^mem-N`) so it is a real link
+ * target, and every `mem_N` token (cross-refs like `resolves=mem_X`
+ * AND inline mentions) becomes a wikilink — closing the dangling-
+ * pointer class (mem_3233). `idTypeIndex` maps `mem_N → type` across
+ * ALL entries so a link can point at the right per-type file; unknown
+ * ids fall back to a bare `[[mem_N]]` (still clickable, not dead text).
+ * Without opts the output is byte-identical to before (CLI/terminal).
+ */
+export interface FormatMemoryMdOptions {
+  vault?: boolean
+  idTypeIndex?: Map<string, string>
+}
+
+/** `mem_3135` / `mem-3135` → `[[decision#^mem-3135|mem_3135]]` (or `[[mem_3135]]` if type unknown). */
+function linkifyMemRefs(text: string, idTypeIndex?: Map<string, string>): string {
+  return text.replace(/\bmem[_-](\d+)\b/g, (_m, n: string) => {
+    const canonical = `mem_${n}`
+    const type = idTypeIndex?.get(canonical)
+    return type ? `[[${type}#^mem-${n}|${canonical}]]` : `[[${canonical}]]`
+  })
+}
+
+export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOptions): string {
   if (entries.length === 0) return '> No matching memory entries.'
 
   const groups = new Map<MemoryType, MemoryEntry[]>()
@@ -441,13 +465,22 @@ export function formatMemoryMd(entries: MemoryEntry[]): string {
       const tags = Object.entries(e.tags)
         .map(([k, v]) => `${k}=${v}`)
         .join(' ')
-      const tagSuffix = tags ? `  _(${tags})_` : ''
       const prov = PROV_PREFIX[e.provenance]
-      // `[mem_N · type]` not bare `[mem_N]`: a reference now says WHAT it
-      // is at a glance, and `mem_N` stays plain text so Obsidian search /
-      // grep resolves it. The full entry is one command away:
-      // `prjct context memory mem_N`.
-      lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${e.content}${tagSuffix}`)
+      // `[mem_N · type]` not bare `[mem_N]`: a reference says WHAT it is
+      // at a glance. CLI/terminal: `mem_N` stays plain text so grep
+      // resolves it, full entry one command away (`prjct context memory
+      // mem_N`). Vault: every `mem_N` (cross-refs + inline mentions)
+      // becomes a wikilink and the entry gets an Obsidian block anchor
+      // (`^mem-N`) so it is a real navigable target (mem_3233 — the
+      // dangling-pointer class is closed where the user actually reads:
+      // Obsidian).
+      const content = opts?.vault ? linkifyMemRefs(e.content, opts.idTypeIndex) : e.content
+      const tagSuffix = tags
+        ? `  _(${opts?.vault ? linkifyMemRefs(tags, opts.idTypeIndex) : tags})_`
+        : ''
+      const rowid = e.id.replace(/^mem[_-]/, '')
+      const anchor = opts?.vault ? ` ^mem-${rowid}` : ''
+      lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${content}${tagSuffix}${anchor}`)
     }
     lines.push('')
   }

--- a/core/services/wiki/memory-builder.ts
+++ b/core/services/wiki/memory-builder.ts
@@ -6,9 +6,24 @@
  * the on-disk manifest. No I/O.
  */
 
-import { formatMemoryMd, type MemoryEntry } from '../../memory/project-memory'
+import {
+  type FormatMemoryMdOptions,
+  formatMemoryMd,
+  type MemoryEntry,
+} from '../../memory/project-memory'
 import type { ShippedFeature } from '../../types/storage'
 import { chunkEntries, slugify } from './_shared'
+
+/**
+ * Global `mem_N → type` index across ALL entries so a cross-ref in
+ * one type's file (`resolves=mem_X` where mem_X is a gotcha) links to
+ * the correct per-type vault file. Built once per builder call.
+ */
+function vaultOpts(entries: MemoryEntry[]): FormatMemoryMdOptions {
+  const idTypeIndex = new Map<string, string>()
+  for (const e of entries) idTypeIndex.set(e.id, e.type)
+  return { vault: true, idTypeIndex }
+}
 
 export function formatShipBody(ship: ShippedFeature): string {
   const lines: string[] = []
@@ -49,6 +64,7 @@ export function buildMemoryFiles(entries: MemoryEntry[]): Map<string, string> {
   // a type bucket exceeds CHUNK_SIZE. Small buckets inline their entries
   // in the index file directly to save a hop.
   const files = new Map<string, string>()
+  const opts = vaultOpts(entries)
 
   const byType = new Map<string, MemoryEntry[]>()
   for (const e of entries) {
@@ -60,7 +76,7 @@ export function buildMemoryFiles(entries: MemoryEntry[]): Map<string, string> {
   for (const [type, items] of byType) {
     const chunks = chunkEntries(items)
     if (chunks.length === 1) {
-      const body = [`# ${type.toUpperCase()}`, '', formatMemoryMd(items), ''].join('\n')
+      const body = [`# ${type.toUpperCase()}`, '', formatMemoryMd(items, opts), ''].join('\n')
       files.set(`memory/${type}.md`, body)
       continue
     }
@@ -76,7 +92,7 @@ export function buildMemoryFiles(entries: MemoryEntry[]): Map<string, string> {
       const body = [
         `# ${type.toUpperCase()} — chunk ${i + 1}/${chunks.length}`,
         '',
-        formatMemoryMd(chunks[i]),
+        formatMemoryMd(chunks[i], opts),
         '',
       ].join('\n')
       files.set(`memory/${chunkRel}`, body)
@@ -92,6 +108,7 @@ export function buildTagFiles(entries: MemoryEntry[]): Map<string, string> {
   // One page per distinct tag pair (`tags/<key>/<value>.md`) + an index
   // per tag key (`tags/<key>.md`). Glob-discoverable by the agent.
   const files = new Map<string, string>()
+  const opts = vaultOpts(entries)
   const byPair = groupByTagPair(entries)
 
   for (const [key, byValue] of byPair) {
@@ -103,7 +120,7 @@ export function buildTagFiles(entries: MemoryEntry[]): Map<string, string> {
       const valueSlug = slugify(value)
       const chunks = chunkEntries(items)
       if (chunks.length === 1) {
-        const body = [`# ${key}: ${value}`, '', formatMemoryMd(items), ''].join('\n')
+        const body = [`# ${key}: ${value}`, '', formatMemoryMd(items, opts), ''].join('\n')
         files.set(`tags/${keySlug}/${valueSlug}.md`, body)
         indexLines.push(`- [${value}](${keySlug}/${valueSlug}.md) — ${items.length} entries`)
       } else {
@@ -111,7 +128,7 @@ export function buildTagFiles(entries: MemoryEntry[]): Map<string, string> {
           const body = [
             `# ${key}: ${value} — chunk ${i + 1}/${chunks.length}`,
             '',
-            formatMemoryMd(chunks[i]),
+            formatMemoryMd(chunks[i], opts),
             '',
           ].join('\n')
           files.set(`tags/${keySlug}/${valueSlug}-${i + 1}.md`, body)


### PR DESCRIPTION
## `p.bug` / investigate — "sigo viendo cosas como mem_3000"

Opaque `mem_NNNN` pointers everywhere, unresolvable in the vault the user actually reads (Obsidian). This is **mem_3233**, still open after the prior partial fix.

### Root cause (code-traced)

`formatMemoryMd` (`core/memory/project-memory.ts:450`) renders plain bullets and is shared by **both** the CLI terminal **and** the Obsidian vault (`memory-builder.ts`). The prior session-fix only relabeled an entry's *own* id to `[mem_N · type]` — it never:
- made an entry a **navigable target** (a bullet is not a heading/anchor → `decision.md#mem_N` lands on nothing), nor
- touched the ids an entry **points to** — `resolves=mem_3135` / `relates=mem_2895` stayed **bare dead text** (the exact dangling-pointer mem_3233 names).

### Fix (DRY, opt-in at the boundary)

`formatMemoryMd` gains optional `{ vault, idTypeIndex }`:
- **CLI callers pass nothing → byte-identical output** (regression-locked by a test).
- **Vault mode** (`memory-builder` builds a global `mem_N→type` index across all entries):
  - every entry ends with an Obsidian block anchor `^mem-N` → a real link target;
  - every `mem_N` (cross-refs **and** inline mentions) → `[[<type>#^mem-N|mem_N]]`, or a clickable `[[mem_N]]` when the id is unknown/aged-out — **never dead text**.

Verified against the real regenerated `prjct-cli` vault: `^mem-3247` anchors present, `closes=[[inbox#^mem-2524|mem_2524]]` typed links resolve.

### Tests

6 new in `project-memory.test.ts` incl. a **regression lock** that vault syntax never leaks to the terminal path. Full suite **1209/0**; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)