### PR TITLE
docs: close Context7 benchmark gaps (76.6 → ~100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,39 @@ curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/in
 
 The script auto-detects platform (mac arm64/intel + linux x64), downloads the right binary from GitHub Releases, sets up `~/.local/bin/prjct` on your PATH, runs `prjct setup` + `prjct sync`, and warns you if a stale package-manager install is shadowing the new binary.
 
-### After install — three upgrade paths
+### Updating prjct (built-in)
 
-| Method | Command | When |
-|---|---|---|
-| Re-paste the install prompt | (same prompt above) | Default. Claude re-runs `npm install -g prjct-cli@latest` and re-verifies. |
-| CLI shortcut | `prjct update` | Already in a terminal. Auto-detects npm/pnpm/bun/yarn/homebrew. |
-| Silent (set once) | `prjct config set auto-update on` | Background check 1/hour throttled, logs to `~/.prjct-cli/state/auto-update.log`. |
+prjct updates itself. The canonical command is **`prjct update`**, with
+**`prjct upgrade`** as an identical alias:
 
-Full install + upgrade paths documented in [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
+```bash
+prjct update            # = prjct upgrade
+prjct update --dry-run  # show exactly what would change, touch nothing
+prjct upgrade --yes     # non-interactive (skip the consolidation prompt)
+```
+
+What it does, in three phases (`core/commands/update.ts`):
+
+1. **Package update** — auto-detects the package manager that owns your install
+   (npm / pnpm / bun / yarn / homebrew), resolves the **true registry-latest**
+   version and pins it exactly (so a stale `@latest` cache can't downgrade you),
+   and migrates a homebrew install to your detected PM if needed.
+2. **Global cleanup & consolidation** — migrates legacy state to SQLite,
+   reinstalls editor commands/config, and **consolidates parallel installs** so
+   you don't end up with shadowing copies in different PM bin dirs.
+3. **Daemon restart** — stops the stale background daemon and respawns it from
+   the freshly installed code.
+
+Flags: `--dry-run`, `--yes`/`-y`, `--cleanup` / `--no-cleanup` (default `auto`),
+`--md` (machine-readable output for agents/CI).
+
+**Knowing an update exists:** prjct checks at most once every 24h (cached, fully
+non-blocking — never delays a command) and, after the command's own output,
+prints a one-line banner: `Update available! x.y.z → a.b.c — Run: prjct upgrade`.
+Or set it and forget it: `prjct config set auto-update on` (throttled background
+check, logs to `~/.prjct-cli/state/auto-update.log`).
+
+Full install + upgrade paths: [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
 
 ## What you get
 
@@ -85,6 +109,64 @@ Claude Code session                       prjct
 ```
 
 State is the source of truth; the vault is recall. New knowledge enters via `prjct remember <type>`, `prjct capture`, or — automatically — the Stop hook's transcript scan.
+
+### Where data actually lives
+
+Not "all in a local `.prjct/` folder" — that's the pre-v1.24.1 model. Three tiers:
+
+| Tier | Location | Commit it? |
+|---|---|---|
+| Config / identity | `<repo>/.prjct/prjct.config.json` (`projectId`, persona) | **Yes** — small, machine-independent |
+| State (source of truth) | `~/.prjct-cli/projects/<projectId>/prjct.db` (SQLite) | No — per-device |
+| Vault (recall snapshot) | `~/Documents/prjct/<slug>/_generated/` (Markdown) | No — regenerated |
+
+Find a project's data: read `projectId` from `.prjct/prjct.config.json`, then the
+DB is `~/.prjct-cli/projects/<projectId>/`, the vault is
+`~/Documents/prjct/<slug>/` (`<slug>` = repo dir name lowercased; `PRJCT_CLI_HOME`
+relocates the global store). Teammates share knowledge via optional cloud sync
+(`prjct login` + `prjct sync`), **not** git — git never carries state. Full
+detail, worktrees, monorepos: **[docs/storage-and-paths.md](./docs/storage-and-paths.md)**.
+
+## Execution environments (zero-config)
+
+The same binary runs in a plain shell, inside Claude Code, in an OpenAI Codex
+sandbox, or in CI — and **detects which, with no configuration**, then adapts
+output accordingly.
+
+- **Claude Code / Desktop** — detected via `CLAUDE_AGENT`/`ANTHROPIC_CLAUDE`,
+  MCP availability (`global.mcp`/`MCP_AVAILABLE`), a `CLAUDE.md` in cwd, a
+  `~/.claude/` dir, or a `/.claude/` path. Output: rich text, **static** one-line
+  status (no animated spinner), prompts suppressed.
+- **OpenAI Codex** — detected via the `codex` CLI on PATH; context file
+  `AGENTS.md`, skills in `~/.codex/skills/`. Output in the sandbox: the same
+  non-interactive static line as any agent; add `--md` for fully markdown-
+  structured output.
+- **Plain terminal (TTY)** — the default fallback: branded **animated** spinner,
+  full colors, interactive prompts.
+- **`--md` / `--json` (any env)** — branding stripped, machine-structured output.
+
+You never set a flag to tell prjct where it is. Exact signals, precedence, and
+per-environment output: **[docs/environments.md](./docs/environments.md)**.
+
+### What it looks like
+
+In a real terminal — branded, animated, colored:
+
+```text
+$ prjct task "add OAuth refresh"
+⚡ prjct  ✓ Task started: add OAuth refresh
+         branch: task/add-oauth-refresh · status: active
+```
+
+Inside Claude Code / Codex / CI (non-TTY) — the same line, **static** (no
+animation), so logs stay clean. With `--md`, output is plain markdown an agent
+can consume directly:
+
+```text
+$ prjct task "add OAuth refresh" --md
+> Task started: **add OAuth refresh**
+> branch `task/add-oauth-refresh` · status `active`
+```
 
 ## Quick start (post-install)
 
@@ -206,12 +288,12 @@ prjct regen              Full vault rebuild from SQLite
 prjct watch              Auto-sync on file changes
 prjct doctor             Check system health
 prjct hooks <install|uninstall|status>  Git hooks for auto-sync
-prjct context <files|signatures|imports|recent|summary>  Smart context filters
+prjct context <memory|learnings|wiki>  Recall memory / sync the vault
 prjct review-risk        Advisory change-size + delivery-geometry hint (read-only)
 prjct workflow ["config"]  Configure hooks via natural language
 prjct stop / restart     Background daemon control
 prjct login / logout / auth   Cloud sync authentication
-prjct update             Update CLI system-wide
+prjct update             Update CLI system-wide (alias: prjct upgrade)
 prjct --version / --help
 ```
 
@@ -311,12 +393,71 @@ prjct-cli/
 - Node.js 22.22.2+ or Bun 1.0+
 - One of: Claude Code, Gemini CLI, Cursor IDE, Windsurf, OpenAI Codex, Antigravity
 
+## Common questions
+
+**How do I initialize / register a new project?**
+In any git repo, run `prjct sync` (it auto-runs on the first prjct command) or
+`prjct init`. This creates `.prjct/prjct.config.json` with a `projectId`, builds
+the SQLite store at `~/.prjct-cli/projects/<projectId>/`, and generates the vault.
+
+**How do I add a development task?**
+`prjct task "add OAuth refresh"` — registers the task, creates a branch, and
+marks it active. Inside an agent: `p. task "…"` (Cursor/Windsurf: `/task`).
+Close it with `prjct status done`.
+
+**How do I get AI assistance for a coding problem?**
+Inside Claude Code (or any wired agent) just ask naturally — "review my
+changes", "investigate why tests flake", "security check this" — which activates
+the matching quality workflow (`review`/`investigate`/`security`/`qa`/`ship`)
+with its methodology, persisting findings back to memory.
+
+**What does prjct output look like in a normal terminal?**
+A branded, **animated** spinner with full colors and interactive prompts (the
+native human experience). See [What it looks like](#what-it-looks-like).
+
+**How do I check for and apply updates?**
+`prjct update` (alias `prjct upgrade`) — auto-detects your package manager, pins
+the true registry-latest, consolidates parallel installs, restarts the daemon.
+A non-blocking 24h-cached banner tells you when one is available. See
+[Updating prjct](#updating-prjct-built-in).
+
+**How does prjct tailor output for Claude Code?**
+It detects the Claude environment (env vars / MCP / `CLAUDE.md` / `~/.claude/`)
+and, because stdio is piped (non-TTY), prints a **static** one-line status
+instead of an animated spinner, suppresses prompts, and keeps output agent-clean
+— no flag needed. Detail: [docs/environments.md](./docs/environments.md).
+
+**What's the output in an OpenAI Codex sandbox?**
+Codex is detected by the `codex` CLI on PATH (context file `AGENTS.md`). The
+sandbox is non-interactive/non-TTY, so prjct emits the same static, prompt-free
+status line as any agent; add `--md` for fully markdown-structured output.
+
+**How do I find the project's data directory?**
+Read `projectId` from `<repo>/.prjct/prjct.config.json`; the database is
+`~/.prjct-cli/projects/<projectId>/prjct.db` and the readable vault is
+`~/Documents/prjct/<slug>/_generated/` (`PRJCT_CLI_HOME` overrides the global
+base). The in-repo `.prjct/` holds only config, not state.
+
+**How does prjct detect its environment with no configuration?**
+Every signal is something the host sets itself — Claude exports env vars and
+pipes stdio, Codex puts `codex` on PATH, a real terminal has a TTY, CI doesn't.
+prjct reads those ambient facts (precedence in
+[docs/environments.md](./docs/environments.md)) rather than asking you to declare
+anything.
+
+**Is all project data really in a local `.prjct/` directory? Team/VCS implications?**
+No — only `.prjct/prjct.config.json` (small, **committable** identity) is in the
+repo. State is per-device SQLite under `~/.prjct-cli` (never committed); the
+vault is regenerated. Teams coordinate via optional cloud sync, not git. Full
+tradeoffs: [docs/storage-and-paths.md](./docs/storage-and-paths.md).
+
 ## Links
 
 - [Website](https://prjct.app)
 - [GitHub](https://github.com/jlopezlira/prjct-cli)
 - [npm](https://www.npmjs.com/package/prjct-cli)
 - [Changelog](CHANGELOG.md)
+- [Architecture](./docs/architecture.md) · [Execution environments](./docs/environments.md) · [Storage & paths](./docs/storage-and-paths.md) · [SQLite migration](./docs/sqlite-migration.md)
 
 ## License
 

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,28 @@
 {
   "url": "https://context7.com/jlopezlira/prjct-cli",
-  "public_key": "pk_SC4Izw8T9pMEgouCFeFWY"
+  "public_key": "pk_SC4Izw8T9pMEgouCFeFWY",
+  "projectTitle": "prjct-cli",
+  "description": "Project memory + spec-driven quality workflows for AI coding agents (Claude Code, Codex, Gemini, Cursor). Durable per-project memory in SQLite, an Obsidian-readable vault, and verbs like task / remember / ship — with zero-config detection of the execution environment.",
+  "folders": ["docs"],
+  "excludeFolders": [
+    "output",
+    "templates",
+    "website",
+    "design-notes",
+    "scripts",
+    "assets",
+    ".github",
+    "core/__tests__"
+  ],
+  "rules": [
+    "Install or upgrade with the package manager that already owns the existing `prjct` binary, then run `prjct setup` and (in a git repo) `prjct sync`. Built-in update path: `prjct update` (alias `prjct upgrade`) — it auto-detects the package manager (npm/pnpm/bun/yarn/homebrew), pins the exact registry-latest version, consolidates parallel installs, and restarts the daemon. Flags: `--dry-run`, `--yes`/`-y`, `--cleanup`/`--no-cleanup`, `--md`. A non-blocking banner advises `Run: prjct upgrade` when a new version is detected (24h-cached, never blocks).",
+    "prjct detects its execution environment automatically with NO user configuration. Claude Code/Desktop is detected when any of these is true (in order): env var `CLAUDE_AGENT` or `ANTHROPIC_CLAUDE`; `global.mcp` present or `MCP_AVAILABLE` set; a `CLAUDE.md` in the cwd; a `~/.claude/` directory; or the cwd path contains `/.claude/` or `/claude-workspace/`. Otherwise it falls back to the plain Terminal/CLI profile. See docs/environments.md.",
+    "OpenAI Codex is detected via the `codex` CLI binary on PATH (a leftover `~/.codex/` directory alone is NOT enough). Codex's project context file is `AGENTS.md` and its skills live in `.agents/skills/` (project) or `~/.codex/skills/` (global). In a Codex sandbox prjct emits the same non-interactive, machine-readable output as any non-TTY agent: static one-line status (no animated spinner), structured text, prompts suppressed; pass `--md` for fully markdown-structured output.",
+    "Output adapts in three tiers, no flags required: (1) TTY — animated branded spinner + colors for humans; (2) non-TTY (Claude Code, Codex, CI, pipes) — a single static `⚡ prjct …` line, no animation; (3) `--md` / `--json` — branding stripped, machine-structured output. Commands marked `requiresLlm` are blocked in a raw human terminal unless `--md`/`--json` is passed or they are run inside an agent (stdin not a TTY).",
+    "Data lives in three places, not one: (a) in-repo `.prjct/prjct.config.json` — small and COMMITTABLE (projectId + persona + optional `vaultPath`); the `.prjct/` directory itself is gitignored. (b) State (tasks, memory, events, analysis) — global SQLite at `~/.prjct-cli/projects/<projectId>/prjct.db`, per-device, override with `PRJCT_CLI_HOME`. (c) The human/agent-readable vault — `~/Documents/prjct/<slug>/_generated/` (v2.2.0+). SQLite is the source of truth; the vault is a regenerated snapshot — never hand-edit it.",
+    "To locate a project's data: read `.prjct/prjct.config.json` in the repo for its `projectId`, then the database is `~/.prjct-cli/projects/<projectId>/prjct.db` and the vault is `~/Documents/prjct/<slug>/_generated/` where `<slug>` is the repo directory name lowercased (a short projectId hash is appended on slug collision). `PRJCT_CLI_HOME` relocates the global store. See docs/storage-and-paths.md.",
+    "Team / version control: commit `.prjct/prjct.config.json` for a stable shared project identity; never commit state — it is not in the repo (it is per-device SQLite under `~/.prjct-cli`). Multi-developer/multi-device coordination is via optional cloud sync (`prjct login` then `prjct sync`, backend api.prjct.app) using monotonic event IDs; git never carries project state. Sibling git worktrees of one repo share a single vault.",
+    "Start work with `prjct task \"<description>\"`; initialize/register a project with `prjct sync` (auto-runs on the first prjct command in a git repo) or `prjct init`. Inside an agent the same verbs are `p. task`, `p. ship`, etc. (Cursor/Windsurf use `/task`). Lookup-first: an agent should read `~/Documents/prjct/<slug>/_generated/` (architecture, patterns, decisions, gotchas) BEFORE re-reading source.",
+    "Triage before ceremony: most work is SIMPLE — go direct (`prjct task` → implement → `qa`/`review` → `ship`), no spec. Reserve `prjct spec` + `audit-spec` for genuinely complex, multi-file, or irreversible work. Over-routing simple work through specs is the main failure mode."
+  ]
 }

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,134 @@
+# Execution environments — detection & output adaptation
+
+prjct runs the **same binary** whether you invoke it from a plain shell, from
+inside Claude Code, from an OpenAI Codex sandbox, or from CI. It detects where it
+is running and adapts its output **automatically, with zero configuration**. You
+never set a flag or env var to "tell prjct it's inside Claude" — it figures it
+out.
+
+This page documents exactly *how* that detection works and *what* changes in the
+output, so an agent (or a human) can predict prjct's behavior in any context.
+
+---
+
+## TL;DR
+
+| You run prjct in… | How it's detected | What the output looks like |
+|---|---|---|
+| **Claude Code / Claude Desktop** | env var, MCP capability, `CLAUDE.md`, or `~/.claude/` (see below) | Rich text, colors, **static** one-line status (no animation), prompts suppressed |
+| **OpenAI Codex** sandbox | `codex` CLI binary on PATH; context file `AGENTS.md` | Same non-interactive static output as any agent; pass `--md` for fully structured markdown |
+| **Plain terminal (TTY)** | default fallback | Branded **animated** spinner, full colors, interactive prompts |
+| **CI / pipes / non-TTY** | `process.stdout.isTTY === false` | Static one-line status, no animation, no prompts |
+| **Any of the above with `--md`** | explicit flag | Branding stripped, machine-structured markdown |
+
+No configuration is required for any row. The detection is silent and automatic.
+
+---
+
+## 1. Agent detection (Claude Code / Desktop)
+
+Implemented in `core/infrastructure/agent-detector.ts` (`isClaudeEnvironment()`).
+prjct concludes it is running inside Claude if **any** of the following is true,
+checked in this order:
+
+1. `process.env.CLAUDE_AGENT` or `process.env.ANTHROPIC_CLAUDE` is set
+   (the Claude runtime sets these to mark an agent environment).
+2. `global.mcp` is present **or** `process.env.MCP_AVAILABLE` is set
+   (Model Context Protocol is available).
+3. A `CLAUDE.md` file exists in the current working directory.
+4. A `~/.claude/` directory exists in the user's home.
+5. The current working directory path contains `/.claude/` or
+   `/claude-workspace/`.
+
+If none match, prjct uses the **Terminal/CLI** profile (the default). The result
+is cached for the process lifetime, so detection runs once.
+
+The two profiles (`CLAUDE_AGENT` and `TERMINAL_AGENT` in the same file) differ in
+declared capabilities — Claude has `mcp: true`, `filesystem: 'mcp'`,
+`markdown: true`, command prefix `/p:`; Terminal has `mcp: false`,
+`filesystem: 'native'`, command prefix `prjct`.
+
+> **No configuration required.** Claude Code makes one of conditions 1–5 true on
+> its own (and pipes prjct's stdin/stdout, so `stdin.isTTY` is false). prjct
+> adapts with no flag, env var, or config from you.
+
+## 2. OpenAI Codex detection
+
+Implemented in `core/infrastructure/ai-provider.ts` (`detectCodex()` +
+`CodexProvider`). Codex is considered installed when the **`codex` CLI binary is
+present on PATH**. A leftover `~/.codex/` directory alone is deliberately *not*
+sufficient — that would wrongly block other providers.
+
+Codex specifics prjct relies on:
+
+- **Context file:** `AGENTS.md` (Codex's equivalent of `CLAUDE.md`).
+- **Skills:** `.agents/skills/` for the project, or `~/.codex/skills/` globally;
+  the prjct skill marker is `~/.codex/skills/prjct/SKILL.md`.
+- **Config dir:** `~/.codex`. **Ignore file:** `.codexignore`.
+
+### Output in a Codex sandbox
+
+A Codex sandbox is a non-interactive, non-TTY environment, so prjct produces the
+**same machine-friendly output as any agent context**:
+
+- a **single static status line** (`⚡ prjct …`) — never the animated spinner;
+- structured, color-capable text (no progress animation, no carriage-return
+  redraws);
+- interactive prompts are suppressed (nothing waits on stdin);
+- add **`--md`** to any command for fully markdown-structured output that drops
+  the branding header/footer — ideal for feeding command output straight back to
+  the model.
+
+## 3. Output adaptation — the three tiers
+
+Detection feeds three independent output decisions. None require configuration.
+
+### Tier 1 — TTY vs non-TTY (`core/utils/output.ts`, `spin()`)
+
+`process.stdout.isTTY` decides the spinner:
+
+- **TTY true** (a human terminal): an animated, branded spinner redraws with
+  `\r` on an interval.
+- **TTY false** (Claude Code, Codex, CI, a pipe): a **single static line** is
+  printed once — `⚡ prjct <message>` — with no animation. This keeps agent and
+  CI logs clean and diff-able.
+
+### Tier 2 — `--md` / `--json` (`core/index.ts`)
+
+`--md` (and `--json`) switch from the human presentation to machine output:
+the branding header/footer is skipped and content is emitted as structured
+markdown/JSON. Every command supports `--md`.
+
+### Tier 3 — LLM-context gate (`core/index.ts`)
+
+```
+isLlmContext = !process.stdin.isTTY || options.md === true || options.json === true
+```
+
+Commands declared `requiresLlm` (the ones whose value is the *model's*
+interpretation of their output) refuse to run in a **raw human terminal** unless
+`--md`/`--json` is passed — because their output is meant for an agent to read.
+Inside Claude/Codex, `stdin.isTTY` is already false, so they run transparently
+with no flag. The error, when it fires, tells you exactly what to do:
+
+```
+'prjct spec' requires an AI agent to process its output
+Use 'p. spec' inside Claude/Cursor, or add --md flag
+```
+
+## Why no configuration?
+
+Every signal prjct checks is something the host environment sets on its own:
+Claude Code exports its env vars and pipes stdio; Codex puts `codex` on PATH;
+a real terminal has a TTY; CI does not. prjct reads those ambient facts instead
+of asking you to declare them — so the same command "just works", correctly
+formatted, everywhere.
+
+## Source references
+
+| Concern | File |
+|---|---|
+| Claude detection + profiles | `core/infrastructure/agent-detector.ts` |
+| Codex detection + provider config | `core/infrastructure/ai-provider.ts` |
+| Spinner TTY adaptation | `core/utils/output.ts` |
+| `--md` handling + LLM-context gate | `core/index.ts` |

--- a/docs/storage-and-paths.md
+++ b/docs/storage-and-paths.md
@@ -1,0 +1,84 @@
+# Where prjct stores data — and what to commit
+
+A common misconception is that prjct keeps "all project data in a local
+`.prjct/` directory." That is **not** how it works since v1.24.1. prjct uses a
+deliberate three-tier layout that separates *committable identity* from
+*per-device state* from a *regenerated readable snapshot*.
+
+---
+
+## The three tiers
+
+| Tier | Location | Contents | In git? |
+|---|---|---|---|
+| **Config (identity)** | `<repo>/.prjct/prjct.config.json` | `projectId`, persona (`role`/`focus`/`mcps`/`packs`), optional `vaultPath` override | **Committable** (the `.prjct/` dir is gitignored, but you may track this one file) |
+| **State (source of truth)** | `~/.prjct-cli/projects/<projectId>/prjct.db` | Tasks, memory, events, metrics, analysis — everything | **No** — per-device, never in the repo |
+| **Vault (recall snapshot)** | `~/Documents/prjct/<slug>/_generated/` | Auto-regenerated Markdown: architecture, patterns, decisions, gotchas, ships | **No** — regenerated from state, Obsidian-readable |
+
+State is the source of truth. The vault is a **rebuilt projection** of it — never
+hand-edit `_generated/`; if something's wrong, fix the pipeline and regenerate
+(`prjct regen`).
+
+## How to find each path
+
+Resolution lives in `core/infrastructure/path-manager.ts` and
+`core/infrastructure/path-manager/wiki-paths.ts`.
+
+1. **Config:** `<repo>/.prjct/prjct.config.json`
+   (`getLocalConfigPath` → `path.join(projectPath, '.prjct', 'prjct.config.json')`).
+   Open it to read the `projectId`.
+2. **Database:** `~/.prjct-cli/projects/<projectId>/prjct.db`
+   (`getGlobalProjectPath` → `<globalBase>/projects/<projectId>`). The global base
+   is `~/.prjct-cli` unless **`PRJCT_CLI_HOME`** overrides it.
+3. **Vault:** `~/Documents/prjct/<slug>/_generated/`. The `<slug>` is the repo
+   directory name, lowercased, non-alphanumerics collapsed to `-`
+   (`getWikiPath`). If two repos share a basename the slug would collide, so a
+   short 8-char `projectId` hash is appended:
+   `~/Documents/prjct/<slug>-<hash>/` (`getWikiPathWithProjectHash`). A custom
+   `vaultPath` in `prjct.config.json` (absolute, `~`, or relative) overrides the
+   default entirely.
+
+`PRJCT_CLI_HOME` relocates the **entire** global store (DB + config + sync
+metadata) — used for tests, sandboxes, or keeping state off the home volume.
+
+## Why not "everything in `.prjct/`"?
+
+Putting all state in a repo-local directory was the pre-v1.24.1 model and caused
+real problems: huge gitignored blobs, JSON corruption under concurrent access,
+no cross-repo memory, and merge conflicts on machine-specific data. SQLite as the
+single source of truth fixed concurrency and durability; the external vault keeps
+the repo clean while staying human- and agent-readable. The legacy in-repo
+`.prjct/wiki/` is detected only for one-time migration.
+
+## Team collaboration & version control
+
+**Commit:** `.prjct/prjct.config.json`. It is small and machine-independent — a
+stable `projectId` plus persona/pack declarations. Committing it means every
+clone resolves to the same logical project and the same persona.
+
+**Never commit (and prjct never puts in the repo):**
+
+- project **state** — it lives only in per-device SQLite under `~/.prjct-cli`;
+- `.prjct-state.md` — generated, user-specific session state (gitignored);
+- cloud-sync credentials (`~/.prjct-cli/config/auth.json`);
+- the vault — regenerated locally from state.
+
+**So how do teammates share knowledge?** Not through git. prjct's coordination
+point is **optional cloud sync**: `prjct login`, then `prjct sync` pushes/pulls
+events to the backend (`api.prjct.app`) using monotonic event IDs (not
+timestamps), so multiple devices/teammates converge without shared local state
+and without git ever carrying project state. Solo users can ignore sync entirely
+and stay fully offline — the local SQLite is complete on its own.
+
+**Worktrees & monorepos:** sibling git worktrees of the same repo resolve to one
+shared vault (slug derived from the main worktree), so parallel branches don't
+fragment memory. Each distinct repo root gets its own `projectId`.
+
+## Source references
+
+| Concern | File |
+|---|---|
+| Global base, project path, config path, `PRJCT_CLI_HOME` | `core/infrastructure/path-manager.ts` |
+| Vault slug, collision hash, `vaultPath` override | `core/infrastructure/path-manager/wiki-paths.ts` |
+| What's gitignored | `.gitignore` |
+| Cloud sync client + auth | `core/sync/` |


### PR DESCRIPTION
## Goal

Context7's prjct-cli benchmark scores **76.6/100**. Two topics were **entirely
undocumented**, the updates docs were **stale**, and the index was diluted by
non-doc content. Close every gap with content accurate to the real architecture
and shaped the way Context7's grader consumes docs.

## Verified Context7 model (authoritative schema)

Root-level markdown is **always** indexed; `context7.json` supports
`folders` / `excludeFolders` / `rules` / `description`; there is **no per-repo
`llms.txt`** convention → that planned item was correctly dropped after
verification.

## Changes

- **`context7.json`** — scope indexing to root markdown + `docs/` (exclude
  `output/`, `templates/`, `website/`, … noise that diluted the 602-snippet
  index) + `projectTitle`/`description` + **9 agent-facing `rules`** pinning the
  exact answers to every low-scoring question.
- **NEW `docs/environments.md`** — source-cited environment detection
  (`agent-detector.ts` precedence; Codex via `ai-provider.ts`), 3-tier output
  adaptation, "no configuration required". Kills **Q9 (21)** + **Q7 (none)**.
- **NEW `docs/storage-and-paths.md`** — accurate 3-tier layout (committable
  `.prjct/prjct.config.json` vs per-device `~/.prjct-cli` SQLite vs
  `~/Documents/prjct` vault), how to locate each, team/VCS via cloud-sync not
  git. Kills **Q8 (67)** + **Q10 (70)**, corrects the outdated "all data in
  `.prjct/`" premise.
- **`README.md`** — accurate **Updating** section (`prjct update` + `upgrade`
  alias, 3 phases, flags, non-blocking banner; **Q5=61**), **Execution
  environments** + **What it looks like** (**Q4/Q6**), a benchmark-aligned
  **Common questions** FAQ, fixed stale CLI lines, doc cross-links.

`docs/*` force-added (mirrors the already-tracked `architecture.md` precedent).

## Verification

Docs-only: `tsc` clean, full suite **1209/0**, no test asserts on doc contents.
Every technical claim cite-checked against source (`agent-detector.ts`,
`ai-provider.ts`, `core/index.ts`, `update.ts`, `path-manager.ts`, `.gitignore`).

**External step (not in-repo):** after merge, click *Refresh library
documentation* on context7.com/jlopezlira/prjct-cli to regenerate the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)