### PR TITLE
fix: vault — one note per entry, reconnected legible graph (relaciones perdidas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.23.3] - 2026-05-18
+
+### Bug Fixes
+
+- vault: one note per memory entry → reconnected, human-legible Obsidian graph; titles not mem_N keys; idTypeIndex from full set; relation tags no longer fragment into orphan stubs (fixes "todas las relaciones se perdieron")
+
 ## [2.23.2] - 2026-05-18
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@
 
 - vault makes every mem_N navigable — Obsidian anchors + linkified cross-refs (mem_3233) (#356)
 
-
 ## [2.23.1] - 2026-05-18
 
 ### Bug Fixes
 
 - orchestrator triage-first — stop funneling every action through spec+reviewers (#355)
-
 
 ## [2.23.0] - 2026-05-18
 
@@ -24,13 +22,11 @@
 
 - make prjct upgrade bulletproof — no silent misroute, no stale-daemon, no downgrade (#353)
 
-
 ## [2.22.1] - 2026-05-18
 
 ### Bug Fixes
 
 - changelog generator PROMOTES [Unreleased] instead of stranding it (mem_2895 root cause) (#352)
-
 
 ## [2.22.0] - 2026-05-18
 
@@ -44,7 +40,6 @@
 - WS2b SQLite hardening — BEGIN IMMEDIATE txns, statement-cache + daemon-cache gating (#349)
 - WS3 P2 reliability — timer leak, backup clobber, daemon-exit, WAL checkpoint, duplicate-POST (#348)
 
-
 ## [2.21.1] - 2026-05-18
 
 ### Bug Fixes
@@ -53,8 +48,12 @@
 - optimistic CAS on StorageManager.update() — close the lost-update data race (#346)
 - gate workflow rules ingested from repo markdown (close clone-to-RCE) (#345)
 
-
 ## [Unreleased]
+
+## [2.23.3] - 2026-05-18
+
+### Added
+- vault: nota por entrada + grafo conectado legible (fix relaciones perdidas)
 
 ## [2.21.0] - 2026-05-17
 
@@ -77,7 +76,6 @@
 ### Fixed
 
 - **skill-miss-detector no longer false-positives after a crew run (#16 follow-up) (#339).** Crew implementer/reviewer run as isolated subagents in the *shared* working tree, so at the leader's Stop hook `getModifiedFiles()` saw their edits and path-overlap relevance fired — but the leader transcript never carries the memory references the subagent made in its own isolated transcript, producing a false skill-miss nag for every crew-touched file. Fix: `detectSkillMisses` collects the `files_touched` of crew runs whose `ended_at` is within `CREW_RUN_RECENCY_MS` (6h) via `crewRunStorage.list` and excludes them from path-overlap relevance; token-overlap detection stays active so non-crew work in the same session is still covered. Crew itself is unchanged (it was architecturally correct). Best-effort — any failure degrades to prior behavior. Tests: `core/__tests__/services/skill-miss-detector.test.ts`.
-
 
 ## [2.20.0] - 2026-05-17
 
@@ -180,13 +178,11 @@ Crew-mode persistence v7 (spec a50b32d1). SQLite becomes the single source of tr
 
 - Phase 1.6 — close the wire on Phase 1.5 (B1-B4) (#324)
 
-
 ## [2.18.1] - 2026-05-05
 
 ### Bug Fixes
 
 - make spec update --json a PATCH (shallow merge), not full replace (#323)
-
 
 ## [2.18.0] - 2026-05-05
 
@@ -194,13 +190,11 @@ Crew-mode persistence v7 (spec a50b32d1). SQLite becomes the single source of tr
 
 - auto-breakdown spec acceptance criteria into queue tasks on audit pass (#322)
 
-
 ## [2.17.0] - 2026-05-05
 
 ### Features
 
 - Phase 1.6 — brownfield-aware SDD (auto-context + codebase reviewers + inventory) (#321)
-
 
 ## [2.16.0] - 2026-05-04
 
@@ -211,7 +205,6 @@ Crew-mode persistence v7 (spec a50b32d1). SQLite becomes the single source of tr
 ### Bug Fixes
 
 - drop unused imports in entity-handlers (#320)
-
 
 ## [2.15.0] - 2026-05-03
 
@@ -259,13 +252,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 - split 1454-line wiki-generator into pure builders (#307)
 - introduce runHook<I> runner — DRY the hook quartet (#305)
 
-
 ## [2.14.0] - 2026-05-02
 
 ### Features
 
 - cleanup + friction-detection + proactive improvement loop (#302)
-
 
 ## [2.13.0] - 2026-05-02
 
@@ -273,13 +264,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - project CLAUDE.md routing + onboarding rewrite (UX phase 4+5) (#301)
 
-
 ## [2.12.0] - 2026-05-02
 
 ### Features
 
 - inject project state per turn (UX phase 3) (#300)
-
 
 ## [2.11.0] - 2026-05-02
 
@@ -287,13 +276,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - verb intent map + suggest/auto-execute protocol (UX phase 1+2) (#299)
 
-
 ## [2.10.1] - 2026-05-02
 
 ### Bug Fixes
 
 - zero-out every quality check (typecheck/lint/tests/knip) (#298)
-
 
 ## [2.10.0] - 2026-05-02
 
@@ -301,13 +288,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - prjct context-save / context-restore (gstack Fase D) (#296)
 
-
 ## [2.9.0] - 2026-05-02
 
 ### Features
 
 - prjct health — composite quality dashboard (gstack Fase C/5) (#295)
-
 
 ## [2.8.0] - 2026-05-02
 
@@ -315,13 +300,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - prjct retro — weekly engineering retrospective (gstack Fase C/6) (#294)
 
-
 ## [2.7.0] - 2026-05-02
 
 ### Features
 
 - gstack Fase B — question registry + 'stop asking me about X' (#293)
-
 
 ## [2.6.0] - 2026-05-02
 
@@ -329,13 +312,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - gstack Fase A — ethos preamble + memory dedupe (#292)
 
-
 ## [2.5.0] - 2026-05-02
 
 ### Features
 
 - adopt gstack patterns — subagent dispatch + audit orchestrator + decision-brief (#291)
-
 
 ## [2.4.43] - 2026-05-02
 
@@ -562,13 +543,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - feat(mcp): per-project MCP scoping — list, deny, allow
 
-
 ## [2.3.11] - 2026-05-02
 
 ### Bug Fixes
 
 - never silently re-run a command that may have partially run
-
 
 ## [2.3.10] - 2026-05-02
 
@@ -576,13 +555,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - upgrade every detected global install, not just one
 
-
 ## [2.3.9] - 2026-05-02
 
 ### Bug Fixes
 
 - remove orphaned context/CLAUDE.md checks; gate auto-update banner
-
 
 ## [2.3.8] - 2026-05-02
 
@@ -592,13 +569,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 - collapse legacy unmanaged duplicates on install
 - runtime-agnostic package manager handling
 
-
 ## [2.3.7] - 2026-05-01
 
 ### Bug Fixes
 
 - regression tests for bugs surfaced in 2.3.5 → 2.3.6
-
 
 ## [2.3.6] - 2026-05-01
 
@@ -606,13 +581,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - add `crew` to daemon-shim skip list
 
-
 ## [2.3.5] - 2026-05-01
 
 ### Refactoring
 
 - rename `harness` command to `crew` to avoid concept collision
-
 
 ## [2.3.4] - 2026-05-01
 
@@ -620,13 +593,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - switch to OIDC trusted publishing for npm releases
 
-
 ## [2.3.3] - 2026-05-01
 
 ### Bug Fixes
 
 - bump to 2.3.3 to recover from npm publish outage
-
 
 ## [2.3.2] - 2026-05-01
 
@@ -638,20 +609,17 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - drop dynamic node -e from update checker (scanner mitigation)
 
-
 ## [2.3.1] - 2026-05-01
 
 ### Bug Fixes
 
 - sync bun.lock with package.json (unblock --frozen-lockfile)
 
-
 ## [2.3.0] - 2026-04-30
 
 ### Features
 
 - opt-in multi-agent harness mode (#264)
-
 
 ## [2.2.18] - 2026-04-25
 
@@ -689,7 +657,6 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - silence Stop nag + drop variable content from SessionStart (cache stability) (#261)
 
-
 ## [2.2.11] - 2026-04-25
 
 ### Added
@@ -706,13 +673,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - replicate bare-verb auto-route to capture (#258)
 
-
 ## [2.2.8] - 2026-04-25
 
 ### Bug Fixes
 
 - re-export getActiveProvider (regression from #256) (#257)
-
 
 ## [2.2.7] - 2026-04-24
 
@@ -730,13 +695,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - seed main-branch gate + trailing newline in writeJson (#255)
 
-
 ## [2.2.4] - 2026-04-24
 
 ### Bug Fixes
 
 - stop hook counts ships/captures/tags as checkpoints (#254)
-
 
 ## [2.2.3] - 2026-04-23
 
@@ -744,13 +707,11 @@ prjct now ships an end-to-end SDD primitive. The canonical sequence is `spec →
 
 - workflow-first dispatcher + ambiguity gate (#253)
 
-
 ## [2.2.2] - 2026-04-22
 
 ### Bug Fixes
 
 - sandboxable config resolver + stop leaking to real config
-
 
 ## [2.2.1] - 2026-04-22
 
@@ -1335,7 +1296,6 @@ usable, not just carved out.
 
 - exclude .worktrees from indexing (#248)
 
-
 ## [1.56.11] - 2026-04-13
 
 ### Fixed
@@ -1348,7 +1308,6 @@ usable, not just carved out.
 
 - prefer direct Glob/Grep over Explore subagent (#247)
 - chore: dead code purge + architecture docs (v1.56.8) (#246)
-
 
 ## [1.56.9] - 2026-04-11
 
@@ -1430,7 +1389,6 @@ usable, not just carved out.
 
 - obsidian status neutral message when not configured (#242)
 
-
 ## [1.56.1] - 2026-04-06
 
 ### Fixed
@@ -1447,7 +1405,6 @@ usable, not just carved out.
 
 - biome lint + typecheck errors for clean push
 - revert accent to neutral, sidebar/tabs cleanup
-
 
 ## [1.54.2] - 2026-04-06
 
@@ -1489,7 +1446,6 @@ usable, not just carved out.
 - security hardening — command injection, CORS, path traversal, error disclosure (#235)
 - security hardening — command injection, CORS, path traversal, error disclosure
 
-
 ## [1.52.2] - 2026-03-07
 
 ### Added
@@ -1529,7 +1485,6 @@ usable, not just carved out.
 
 - context health system + clean --md output (#231)
 
-
 ## [1.50.3] - 2026-03-03
 
 ### Added
@@ -1540,7 +1495,6 @@ usable, not just carved out.
 ### Bug Fixes
 
 - guard against undefined decision.contexts in pattern-store (#230)
-
 
 ## [1.50.1] - 2026-03-02
 
@@ -1553,13 +1507,11 @@ usable, not just carved out.
 
 - auth UX overhaul — out.* utilities, branded browser page, auto-sync (#229)
 
-
 ## [1.49.0] - 2026-02-27
 
 ### Features
 
 - prjct login — browser-based OTP auth (#228)
-
 
 ## [1.48.1] - 2026-02-27
 
@@ -1567,20 +1519,17 @@ usable, not just carved out.
 
 - wire auth command in registry and bypass setup check (#227)
 
-
 ## [1.48.0] - 2026-02-27
 
 ### Features
 
 - CLI↔Web bidirectional sync (#226)
 
-
 ## [1.47.4] - 2026-02-26
 
 ### Refactoring
 
 - remove static context generation system (#225)
-
 
 ## [1.47.3] - 2026-02-26
 
@@ -1598,7 +1547,6 @@ usable, not just carved out.
 
 - centralize type definitions to core/types/ (#224)
 
-
 ## [1.47.0] - 2026-02-21
 
 ### Features
@@ -1615,13 +1563,11 @@ usable, not just carved out.
 - consolidate scattered types into core/types/
 - remove duplicate sorting logic and dead markdown-builder
 
-
 ## [1.46.7] - 2026-02-21
 
 ### Refactoring
 
 - extract context contract builder from workflow.ts (#222)
-
 
 ## [1.46.6] - 2026-02-21
 
@@ -1693,7 +1639,6 @@ usable, not just carved out.
 
 - multi-provider MCP setup + OAuth status fix (v1.45.9) (#216)
 
-
 ## [1.45.11] - 2026-02-16
 
 ### Added
@@ -1743,13 +1688,11 @@ usable, not just carved out.
 
 - p. workflow agentic natural language parsing (#213)
 
-
 ## [1.45.2] - 2026-02-17
 
 ### Bug Fixes
 
 - Jira/Linear MCP OAuth setup - guides user through mcp-remote auth (#212)
-
 
 ## [1.45.2] - 2026-02-16
 
@@ -1761,7 +1704,6 @@ usable, not just carved out.
 ### Bug Fixes
 
 - prjct update - daemon restart and latest version detection (#211)
-
 
 ## [1.45.1] - 2026-02-17
 
@@ -1809,20 +1751,17 @@ usable, not just carved out.
 
 - analyze shows actual report path (PRJ-348) (#208)
 
-
 ## [1.44.3] - 2026-02-16
 
 ### Bug Fixes
 
 - widen retry test timing tolerances (PRJ-346) (#207)
 
-
 ## [1.44.2] - 2026-02-16
 
 ### Bug Fixes
 
 - legacy previousTask not migrated to pausedTasks (PRJ-345) (#206)
-
 
 ## [1.44.3] - 2026-02-16
 
@@ -1842,7 +1781,6 @@ usable, not just carved out.
 
 - migrate sessions from JSON files to SQLite (#204)
 
-
 ## [1.43.1] - 2026-02-15
 
 ### Added
@@ -1858,7 +1796,6 @@ usable, not just carved out.
 
 - context file suggestion reinforcement learning (#202)
 
-
 ## [1.42.4] - 2026-02-15
 
 ### Added
@@ -1869,7 +1806,6 @@ usable, not just carved out.
 ### Bug Fixes
 
 - state storage updates preserve existing state to prevent data loss (#201)
-
 
 ## [1.42.4] - 2026-02-15
 
@@ -1894,7 +1830,6 @@ usable, not just carved out.
 
 - daemon commands ignore request.cwd causing cross-project contamination (#199)
 - pass request.cwd to analyze/cleanup/design in daemon
-
 
 ## [1.42.1] - 2026-02-15
 
@@ -1936,7 +1871,6 @@ usable, not just carved out.
 
 - sanitize SQLite bindings in JSON migration (#196)
 
-
 ## [1.40.1] - 2026-02-15
 
 ### Fixed
@@ -1947,7 +1881,6 @@ usable, not just carved out.
 ### Features
 
 - redesign prjct update as 3-phase system updater (#195)
-
 
 ## [1.39.0] - 2026-02-15
 
@@ -1996,7 +1929,6 @@ usable, not just carved out.
 
 - reconcile queue with Linear status on sync (#190)
 
-
 ## [1.38.3] - 2026-02-14
 
 ### Bug Fixes
@@ -2017,7 +1949,6 @@ usable, not just carved out.
 
 - auto-repair Codex router metadata during sync (#187)
 
-
 ## [1.38.1] - 2026-02-14
 
 ### Bug Fixes
@@ -2035,7 +1966,6 @@ usable, not just carved out.
 ### Bug Fixes
 
 - neutral banner colors + add Codex to provider selection (#185)
-
 
 ## [1.37.1] - 2026-02-14
 
@@ -2069,7 +1999,6 @@ usable, not just carved out.
 
 - Custom workflows with agentic auto-configuration (#183)
 
-
 ## [1.36.0] - 2026-02-13
 
 ### Features
@@ -2091,7 +2020,6 @@ usable, not just carved out.
 ### Features
 
 - add analysis rollback to restore previous sealed version (PRJ-276) (#181)
-
 
 ## [1.33.1] - 2026-02-12
 
@@ -2121,7 +2049,6 @@ usable, not just carved out.
 
 - exquisite terminal UX — rich markdown formatters + branded output (#179)
 
-
 ## [1.30.2] - 2026-02-12
 
 ### Added
@@ -2143,7 +2070,6 @@ usable, not just carved out.
 ### Features
 
 - enrich AI formatters with analysis data + add Codex support (#176)
-
 
 ## [1.29.0] - 2026-02-12
 
@@ -2168,20 +2094,17 @@ usable, not just carved out.
 
 - agentic Linear template without MCP dependency
 
-
 ## [1.27.1] - 2026-02-11
 
 ### Bug Fixes
 
 - exclude router files (p.md/p.toml) from subcommand installation
 
-
 ## [1.27.0] - 2026-02-11
 
 ### Features
 
 - dual-runtime SQLite — bun:sqlite + better-sqlite3 (#174)
-
 
 ## [1.27.6] - 2026-02-11
 
@@ -2290,7 +2213,6 @@ usable, not just carved out.
 ### Bug Fixes
 
 - strip shebangs in build via esbuild plugin (#171)
-
 
 ## [1.24.2] - 2026-02-10
 
@@ -2546,7 +2468,6 @@ Bridges the outcomes system to semantic memory. Previously, patterns from comple
 - add task-to-analysis feedback loop (PRJ-272) (#165)
 - add task history array with FIFO eviction (PRJ-281) (#164)
 
-
 ## [1.22.0] - 2026-02-10
 
 ### Features
@@ -2642,13 +2563,11 @@ Replaced single previousTask field with bounded task history array to enable pat
 **How to use:** No action needed — task history is automatic on `p. done`
 **Breaking changes:** None — fully backward compatible
 
-
 ## [1.20.0] - 2026-02-10
 
 ### Features
 
 - add retry with exponential backoff for agent and tool operations (#162)
-
 
 ## [1.20.0] - 2026-02-09
 
@@ -2816,7 +2735,6 @@ Modified:
 
 - implement incremental sync with file hashing (PRJ-305) (#160)
 
-
 ## [1.18.0] - 2026-02-09
 
 ### Features
@@ -2866,7 +2784,6 @@ Modified:
 ### Features
 
 - implement BM25 + import graph + git co-change for zero-cost file selection (PRJ-304) (#159)
-
 
 ## [1.17.0] - 2026-02-08
 
@@ -2944,7 +2861,6 @@ Modified:
 
 - replace hardcoded memory domain tags with semantic matching (PRJ-300) (#157)
 
-
 ## [1.14.1] - 2026-02-09
 
 ### Improved
@@ -2984,7 +2900,6 @@ Modified:
 ### Features
 
 - add sprint-based velocity calculation with trend detection (PRJ-296) (#156)
-
 
 ## [1.14.0] - 2026-02-09
 
@@ -3034,7 +2949,6 @@ Key changes:
 
 - inject sealed analysis into task prompt context (PRJ-260) (#155)
 
-
 ## [1.13.0] - 2026-02-09
 
 ### Features
@@ -3073,7 +2987,6 @@ Key changes:
 ### Features
 
 - make subtask output and handoff mandatory (PRJ-262) (#154)
-
 
 ## [1.11.0] - 2026-02-09
 
@@ -3139,7 +3052,6 @@ Key changes:
 
 - redesign prompt assembly with correct section ordering + anti-hallucination (PRJ-301) (#152)
 - add coordinated global token budget (PRJ-266) (#151)
-
 
 ## [1.12.0] - 2026-02-07
 

--- a/core/__tests__/commands/shipping.test.ts
+++ b/core/__tests__/commands/shipping.test.ts
@@ -7,7 +7,7 @@
  * `clarification` when the state is ambiguous.
  */
 
-import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -18,6 +18,12 @@ import pathManager from '../../infrastructure/path-manager'
 import { prjctDb } from '../../storage/database'
 import { shippedStorage } from '../../storage/shipped-storage'
 import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
+
+// Each test does a REAL ship: temp project + DB init + workflow
+// dispatch + vault regen + cleanup. That exceeds bun's 5s default
+// under CI load (flaky timeout at exactly 5001ms). Match the repo
+// convention for heavy real-I/O command tests (update-cleanup.test.ts).
+setDefaultTimeout(60_000)
 
 // Mirrors the (module-local) marker key in shipping.ts.
 const SHIP_MARKER_KEY = 'ship:in_progress'

--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -13,7 +13,13 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import pathManager from '../../infrastructure/path-manager'
-import { formatMemoryMd, type MemoryEntry, projectMemory } from '../../memory/project-memory'
+import {
+  deriveTitle,
+  formatMemoryMd,
+  linkifyMemRefs,
+  type MemoryEntry,
+  projectMemory,
+} from '../../memory/project-memory'
 import prjctDb from '../../storage/database'
 
 /**
@@ -232,12 +238,16 @@ describe('formatMemoryMd — vault makes every mem_N navigable (mem_3233)', () =
     expect(out).toContain('resolves=[[gotcha#^mem-3135|mem_3135]]')
   })
 
-  it('vault mode: UNKNOWN id → bare [[mem_N]] (clickable, not dead text)', () => {
+  it('vault mode: UNKNOWN id → muted code, not a fake dangling node', () => {
+    // Supersedes the old mem_3233 "bare [[mem_N]] clickable" rule: at
+    // graph scale that produced the orphan-dot dust the user reported.
+    // A deleted id is not knowledge — render it as honest muted text.
     const out = formatMemoryMd([mk({ id: 'mem_3247', content: 'see mem_999 for context' })], {
       vault: true,
       idTypeIndex: new Map(),
     })
-    expect(out).toContain('see [[mem_999]] for context')
+    expect(out).toContain('see `mem_999` for context')
+    expect(out).not.toContain('[[mem_999]]')
   })
 
   it('vault mode: inline content mentions are linkified too, not just the meta tail', () => {
@@ -253,5 +263,101 @@ describe('formatMemoryMd — vault makes every mem_N navigable (mem_3233)', () =
     const entries = [mk({ id: 'mem_3247', content: 'refs mem_1', tags: { relates: 'mem_2' } })]
     const cli = formatMemoryMd(entries)
     expect(cli).not.toMatch(/\^mem-|\[\[/)
+  })
+})
+
+describe('deriveTitle — deterministic, legible, no DB keys', () => {
+  const mk = (over: Partial<MemoryEntry> & { id: string }): MemoryEntry => ({
+    type: 'decision',
+    content: '',
+    tags: {},
+    rememberedAt: '2026-05-17T00:00:00.000Z',
+    provenance: 'declared',
+    ...over,
+  })
+
+  it('cuts at the first strong clause boundary', () => {
+    const t = deriveTitle(
+      mk({ id: 'mem_3247', content: 'Triage-before-spec enforced in skill body: root cause was…' })
+    )
+    expect(t).toBe('Triage-before-spec enforced in skill body')
+  })
+
+  it('strips a leading mem ref / wikilink so the title starts on the statement', () => {
+    const t = deriveTitle(
+      mk({
+        id: 'mem_3264',
+        content: '[[feedback#^mem-3233|mem_3233]] opaque pointers FIXED. detail',
+      })
+    )
+    expect(t).toBe('opaque pointers FIXED')
+  })
+
+  it('appends (PR #N) from the pr tag when not already present', () => {
+    const t = deriveTitle(
+      mk({ id: 'mem_1', content: 'Release debounce job added to CI', tags: { pr: '351' } })
+    )
+    expect(t).toBe('Release debounce job added to CI (PR #351)')
+  })
+
+  it('truncates long titles on a word boundary with an ellipsis', () => {
+    const t = deriveTitle(mk({ id: 'mem_1', content: `${'a'.repeat(40)} ${'b'.repeat(40)}` }))
+    expect(t.length).toBeLessThanOrEqual(74)
+    expect(t.endsWith('…')).toBe(true)
+  })
+
+  it('falls back to "<type> <id>" when content yields no usable title', () => {
+    expect(deriveTitle(mk({ id: 'mem_9', type: 'gotcha', content: '...' }))).toBe('gotcha mem_9')
+  })
+
+  it('is pure: same entry → same title', () => {
+    const e = mk({ id: 'mem_5', content: 'Stable title here. body' })
+    expect(deriveTitle(e)).toBe(deriveTitle(e))
+  })
+})
+
+describe('linkifyMemRefs — legible labels + alias resolution (additive)', () => {
+  it('per-entry type → alias link [[mem_N|title]] (resolves via aliases:)', () => {
+    const out = linkifyMemRefs('resolves=mem_3135', {
+      idTypeIndex: new Map([['mem_3135', 'gotcha']]),
+      idTitleIndex: new Map([['mem_3135', 'CHANGELOG Unreleased stranding']]),
+      perEntryTypes: new Set(['gotcha']),
+    })
+    expect(out).toBe('resolves=[[mem_3135|CHANGELOG Unreleased stranding]]')
+  })
+
+  it('aggregated type → block-anchor link with legible label', () => {
+    const out = linkifyMemRefs('see mem_42', {
+      idTypeIndex: new Map([['mem_42', 'inbox']]),
+      idTitleIndex: new Map([['mem_42', 'upgrade noise item']]),
+      perEntryTypes: new Set(['decision']),
+    })
+    expect(out).toBe('see [[inbox#^mem-42|upgrade noise item]]')
+  })
+
+  it('unknown id with no title → muted `mem_N` code (no fake node)', () => {
+    expect(linkifyMemRefs('ref mem_999', { idTypeIndex: new Map() })).toBe('ref `mem_999`')
+  })
+
+  it('author-written [[mem_N]] is normalized through the same resolver', () => {
+    // deleted id → muted code, NOT the broken [[`mem_N`]]
+    expect(linkifyMemRefs('violates [[mem_2620]]', { idTypeIndex: new Map() })).toBe(
+      'violates `mem_2620`'
+    )
+    // known id → legible alias link
+    expect(
+      linkifyMemRefs('see [[mem_42]]', {
+        idTypeIndex: new Map([['mem_42', 'gotcha']]),
+        idTitleIndex: new Map([['mem_42', 'busy_timeout CAS retry']]),
+        perEntryTypes: new Set(['gotcha']),
+      })
+    ).toBe('see [[mem_42|busy_timeout CAS retry]]')
+  })
+
+  it('backward compatible: no idTitleIndex → legacy mem_N label', () => {
+    const out = linkifyMemRefs('resolves=mem_3135', {
+      idTypeIndex: new Map([['mem_3135', 'gotcha']]),
+    })
+    expect(out).toBe('resolves=[[gotcha#^mem-3135|mem_3135]]')
   })
 })

--- a/core/__tests__/services/memory-builder.test.ts
+++ b/core/__tests__/services/memory-builder.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Vault memory builder — per-entry notes + connected, legible graph.
+ *
+ * Regression cover for the "all relationships lost in the vault" bug:
+ * entries must be individual notes (Obsidian graph nodes = files),
+ * cross-refs must be legible alias links (not `mem_N` keys, not
+ * dangling), and relation tags must NOT fragment into orphan tag pages.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { MemoryEntry } from '../../memory/project-memory'
+import {
+  buildMemoryFiles,
+  buildTagFiles,
+  PER_ENTRY_TYPES,
+} from '../../services/wiki/memory-builder'
+
+const mk = (over: Partial<MemoryEntry> & { id: string }): MemoryEntry => ({
+  type: 'decision',
+  content: '',
+  tags: {},
+  rememberedAt: '2026-05-17T00:00:00.000Z',
+  provenance: 'declared',
+  ...over,
+})
+
+describe('buildMemoryFiles — one note per entry', () => {
+  const entries = [
+    mk({
+      id: 'mem_3264',
+      type: 'decision',
+      content: 'Opaque mem pointers fixed. resolves the dangling class',
+      tags: { topic: 'memory-ux', pr: '356', resolves: 'mem_3233' },
+    }),
+    mk({
+      id: 'mem_3233',
+      type: 'feedback',
+      content: 'mem_NNNN are opaque pointers: not resolvable by human or LLM',
+      tags: { topic: 'memory-ux' },
+    }),
+  ]
+  const files = buildMemoryFiles(entries, entries)
+  const keys = [...files.keys()]
+
+  it('emits a per-entry note at memory/<type>/<slug>.md', () => {
+    const decisionNote = keys.find((k) => k.startsWith('memory/decision/'))
+    expect(decisionNote).toBeTruthy()
+    expect(decisionNote).not.toContain('mem_3264.md') // human slug, not the key
+  })
+
+  it('note carries aliases:[mem_N] + block anchor for stable resolution', () => {
+    const note = [...files.entries()].find(([k]) => k.startsWith('memory/decision/'))?.[1] ?? ''
+    expect(note).toContain('aliases: ["mem_3264"]')
+    expect(note).toContain('^mem-3264')
+    expect(note).toMatch(/^# decision: /m)
+  })
+
+  it('cross-ref renders as a legible alias link, never a bare key', () => {
+    const note = [...files.entries()].find(([k]) => k.startsWith('memory/decision/'))?.[1] ?? ''
+    // resolves=mem_3233 → [[mem_3233|<title of 3233>]] (feedback is per-entry)
+    expect(note).toContain('## Relations')
+    expect(note).toMatch(/\[\[mem_3233\|[^\]]*opaque[^\]]*\]\]/i)
+    expect(note).not.toContain('|mem_3233]]') // label is the title, not the key
+  })
+
+  it('memory/<type>.md is a MOC that wikilinks every entry note', () => {
+    const moc = files.get('memory/decision.md') ?? ''
+    expect(moc).toContain('# DECISION')
+    expect(moc).toMatch(/- \[\[mem_3264\|[^\]]+\]\]/)
+  })
+
+  it('no dangling [[mem_N]] for an id present in the full set', () => {
+    for (const body of files.values()) {
+      expect(body).not.toMatch(/\[\[mem_3233\]\]/) // must be the labelled alias form
+    }
+  })
+})
+
+describe('buildMemoryFiles — Defect B: refs to non-rendered ids still resolve', () => {
+  it('an old referenced entry gets a note so [[mem_N|title]] is not dangling', () => {
+    const rendered = [
+      mk({
+        id: 'mem_3300',
+        content: 'New decision that resolves an old one',
+        tags: { resolves: 'mem_2609' },
+      }),
+    ]
+    const all = [
+      ...rendered,
+      mk({ id: 'mem_2609', content: 'Closed mem_2525 daemon restart follow-up shipped' }),
+    ]
+    const files = buildMemoryFiles(all, all)
+    // mem_2609 must exist as a note carrying its alias
+    const has2609 = [...files.values()].some((b) => b.includes('aliases: ["mem_2609"]'))
+    expect(has2609).toBe(true)
+    const newNote = [...files.entries()].find(([k]) => k.startsWith('memory/decision/'))?.[1] ?? ''
+    expect(newNote).toMatch(/\[\[mem_2609\|/) // legible, resolvable
+  })
+})
+
+describe('buildTagFiles — Defect C: relation tags are NOT tag pages', () => {
+  const entries = [
+    mk({
+      id: 'mem_3205',
+      content: 'changelog root cause fixed',
+      tags: { topic: 'release', resolves: 'mem_3135', relates: 'mem_2895', closes: 'mem_2604' },
+    }),
+  ]
+  const files = buildTagFiles(entries, entries)
+  const keys = [...files.keys()]
+
+  it('does not emit tags/relates|resolves|closes/* orphan stubs', () => {
+    expect(keys.some((k) => k.startsWith('tags/relates/'))).toBe(false)
+    expect(keys.some((k) => k.startsWith('tags/resolves/'))).toBe(false)
+    expect(keys.some((k) => k.startsWith('tags/closes/'))).toBe(false)
+  })
+
+  it('still emits real category tag pages (topic)', () => {
+    expect(keys.some((k) => k.startsWith('tags/topic/'))).toBe(true)
+  })
+})
+
+describe('PER_ENTRY_TYPES contract', () => {
+  it('covers substantive types, excludes ephemeral GTD (inbox/todo/idea)', () => {
+    expect(PER_ENTRY_TYPES.has('decision')).toBe(true)
+    expect(PER_ENTRY_TYPES.has('gotcha')).toBe(true)
+    expect(PER_ENTRY_TYPES.has('inbox')).toBe(false)
+    expect(PER_ENTRY_TYPES.has('todo')).toBe(false)
+    expect(PER_ENTRY_TYPES.has('idea')).toBe(false)
+  })
+
+  it('ephemeral types stay aggregated (no per-entry note dir)', () => {
+    const entries = [mk({ id: 'mem_1', type: 'inbox', content: 'a stray thought to triage' })]
+    const files = buildMemoryFiles(entries, entries)
+    expect([...files.keys()].some((k) => k.startsWith('memory/inbox/'))).toBe(false)
+    expect(files.has('memory/inbox.md')).toBe(true)
+  })
+})

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -368,6 +368,33 @@ export const projectMemory = {
   },
 
   /**
+   * EVERY entry — no limit, no topic/type filter, no latest-winner
+   * dedupe. The vault link layer needs this: `recall()` collapses
+   * `(type, key)` duplicates and caps results, so an older entry that
+   * a current one still references (`resolves=mem_2609`) vanishes from
+   * the index and its links rot to a dangling `[[mem_2609]]`. Building
+   * the `mem_N → {type,title}` index from the full set is what keeps
+   * every cross-reference resolvable (the mem_3233 dangling class, at
+   * graph scale). Read-only, best-effort.
+   */
+  allEntriesForIndex(projectId: string): MemoryEntry[] {
+    try {
+      const rows = prjctDb.query<EventRow>(
+        projectId,
+        'SELECT id, type, data, timestamp FROM events WHERE type LIKE ? ORDER BY id DESC',
+        `${REMEMBER_EVENT_PREFIX}%`
+      )
+      const shipped = prjctDb.query<ShippedRow>(
+        projectId,
+        'SELECT id, name, type, shipped_at, data FROM shipped_features ORDER BY shipped_at DESC'
+      )
+      return [...rows.map(rowToEntry), ...shipped.map(shippedRowToEntry)]
+    } catch {
+      return []
+    }
+  },
+
+  /**
    * Lightweight similarity: share any keyword from the description. Good
    * enough to surface "we already shipped this" nudges; Phase 5 can layer
    * embeddings on top without changing the API.
@@ -409,16 +436,96 @@ export const projectMemory = {
  */
 export interface FormatMemoryMdOptions {
   vault?: boolean
+  /** `mem_N → type` so a cross-ref resolves to the right vault target. */
   idTypeIndex?: Map<string, string>
+  /**
+   * `mem_N → human title` (from {@link deriveTitle}). When present the
+   * wikilink display text is the title, not the opaque `mem_N` — the
+   * graph reads as knowledge for a human and an LLM, not DB keys.
+   * Additive: absent → legacy `mem_N` display (CLI lock unaffected).
+   */
+  idTitleIndex?: Map<string, string>
+  /**
+   * Types rendered as their own per-entry note (carrying
+   * `aliases: [mem_N]`). Refs to these resolve via the stable alias
+   * `[[mem_N|title]]`; everything else uses the aggregated-file block
+   * anchor `[[type#^mem-N|title]]`. Absent → legacy block-anchor form.
+   */
+  perEntryTypes?: ReadonlySet<string>
 }
 
-/** `mem_3135` / `mem-3135` → `[[decision#^mem-3135|mem_3135]]` (or `[[mem_3135]]` if type unknown). */
-function linkifyMemRefs(text: string, idTypeIndex?: Map<string, string>): string {
-  return text.replace(/\bmem[_-](\d+)\b/g, (_m, n: string) => {
-    const canonical = `mem_${n}`
-    const type = idTypeIndex?.get(canonical)
-    return type ? `[[${type}#^mem-${n}|${canonical}]]` : `[[${canonical}]]`
-  })
+const TITLE_MAX = 72
+
+/** Make a title safe as Obsidian wikilink display text. */
+function linkLabel(s: string): string {
+  return s
+    .replace(/[[\]|]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Deterministic, LLM-free human title for an entry, derived from its
+ * content. Used as the per-entry note filename slug, H1, and every
+ * wikilink's display text so the vault graph is legible knowledge, not
+ * `mem_3247` keys. Pure + stable: same entry → same title.
+ */
+export function deriveTitle(entry: Pick<MemoryEntry, 'content' | 'type' | 'id' | 'tags'>): string {
+  let raw = (entry.content ?? '').trim()
+  raw = raw.replace(/^(?:[-*•]\s+|\s+)+/, '')
+  raw = raw.replace(/^(?:\[\[[^\]]*\]\]|mem[_-]\d+)[\s:,-]*/i, '').trim()
+  let cut = raw.length
+  for (const b of [/\n/, /\.\s/, /:\s/, /;\s/, /\s—\s/, /\s\(/]) {
+    const m = raw.match(b)
+    if (m && m.index !== undefined && m.index > 4 && m.index < cut) cut = m.index
+  }
+  let title = raw.slice(0, cut).replace(/\s+/g, ' ').trim()
+  title = title
+    .replace(/\[\[[^\]|]*\|([^\]]*)\]\]/g, '$1')
+    .replace(/\[\[([^\]]*)\]\]/g, '$1')
+    .trim()
+  if (title.length > TITLE_MAX) {
+    const slice = title.slice(0, TITLE_MAX)
+    const sp = slice.lastIndexOf(' ')
+    title = `${(sp > 40 ? slice.slice(0, sp) : slice).trim()}…`
+  }
+  if (title.length < 6) title = `${entry.type} ${entry.id}`
+  const pr = entry.tags?.pr
+  if (pr && !new RegExp(`\\b#?${pr}\\b`).test(title)) title = `${title} (PR #${pr})`
+  return title
+}
+
+/**
+ * `mem_3135` → `[[mem_3135|<title>]]` (per-entry note, via alias) or
+ * `[[gotcha#^mem-3135|<title>]]` (aggregated file block anchor).
+ *
+ * When the id is NOT in the index it no longer exists (forgotten /
+ * pre-history). The old mem_3233 fix linked it anyway (`[[mem_N]]`,
+ * "clickable not dead text") — but at graph scale that IS the bug the
+ * user reported: every deleted ref became an orphan dangling node, a
+ * dust of `mem_N` dots. An unresolvable id is not knowledge; render it
+ * as muted inline-code text (honest, no fake node, no graph noise).
+ */
+export function linkifyMemRefs(text: string, opts?: FormatMemoryMdOptions): string {
+  // Author-written bare `[[mem_N]]` wikilinks (common in spec free-text)
+  // must go through the SAME resolver — otherwise an unresolvable one
+  // renders as the broken `[[\`mem_N\`]]`. Collapse the exact shape
+  // (no pipe, no #) back to a token first.
+  return text
+    .replace(/\[\[(mem[_-]\d+)\]\]/gi, '$1')
+    .replace(/\bmem[_-](\d+)\b/g, (_m, n: string) => {
+      const canonical = `mem_${n}`
+      const type = opts?.idTypeIndex?.get(canonical)
+      const title = opts?.idTitleIndex?.get(canonical)
+      const display = title ? linkLabel(title) : canonical
+      if (type && opts?.perEntryTypes?.has(type)) {
+        return `[[${canonical}|${display}]]`
+      }
+      if (type) {
+        return `[[${type}#^mem-${n}|${display}]]`
+      }
+      return title ? `[[${canonical}|${display}]]` : `\`${canonical}\``
+    })
 }
 
 export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOptions): string {
@@ -474,10 +581,8 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
       // (`^mem-N`) so it is a real navigable target (mem_3233 — the
       // dangling-pointer class is closed where the user actually reads:
       // Obsidian).
-      const content = opts?.vault ? linkifyMemRefs(e.content, opts.idTypeIndex) : e.content
-      const tagSuffix = tags
-        ? `  _(${opts?.vault ? linkifyMemRefs(tags, opts.idTypeIndex) : tags})_`
-        : ''
+      const content = opts?.vault ? linkifyMemRefs(e.content, opts) : e.content
+      const tagSuffix = tags ? `  _(${opts?.vault ? linkifyMemRefs(tags, opts) : tags})_` : ''
       const rowid = e.id.replace(/^mem[_-]/, '')
       const anchor = opts?.vault ? ` ^mem-${rowid}` : ''
       lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${content}${tagSuffix}${anchor}`)

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -57,7 +57,12 @@ import {
   sweepStaleFiles,
   writeFile,
 } from './wiki/manifest'
-import { buildMemoryFiles, buildTagFiles, formatShipBody } from './wiki/memory-builder'
+import {
+  buildMemoryFiles,
+  buildTagFiles,
+  buildVaultOpts,
+  formatShipBody,
+} from './wiki/memory-builder'
 import { buildReleasesFiles } from './wiki/release-builder'
 import { buildSpecFiles } from './wiki/spec-builder'
 import { buildWorkflowFiles } from './wiki/workflow-builder'
@@ -136,7 +141,11 @@ export async function generateWiki(
   const [ships, entries, analysis, llmAnalysis, workflowRules, specs, queueTasks] =
     await Promise.all([
       shippedStorage.getAll(projectId),
-      Promise.resolve(projectMemory.recall(projectId, { limit: 5000 })),
+      // Full set — no recall cap / latest-winner dedupe. The vault is a
+      // knowledge GRAPH: every entry a current one still references must
+      // exist as a navigable note, or its `[[mem_N|title]]` link rots to
+      // a dangling node (mem_3233, at graph scale).
+      Promise.resolve(projectMemory.allEntriesForIndex(projectId)),
       analysisStorage.getActive(projectId).catch(() => null),
       Promise.resolve(llmAnalysisStorage.getActive(projectId)).catch(() => null),
       Promise.resolve(workflowRuleStorage.getAllRules(projectId)).catch(() => [] as WorkflowRule[]),
@@ -165,9 +174,10 @@ export async function generateWiki(
   for (const ship of ships) {
     files.set(`ships/${slugify(ship.name)}.md`, formatShipBody(ship))
   }
-  for (const [rel, body] of buildMemoryFiles(declared)) files.set(rel, body)
-  for (const [rel, body] of buildTagFiles(declared)) files.set(rel, body)
-  for (const [rel, body] of buildSpecFiles(specs, queueTasks)) files.set(rel, body)
+  for (const [rel, body] of buildMemoryFiles(declared, entries)) files.set(rel, body)
+  for (const [rel, body] of buildTagFiles(declared, entries)) files.set(rel, body)
+  const vaultLinkOpts = buildVaultOpts(entries)
+  for (const [rel, body] of buildSpecFiles(specs, queueTasks, vaultLinkOpts)) files.set(rel, body)
 
   // crew-runs/<slug>-<ts>.md — one file per recorded crew session.
   // Isolated via runBuilder so a malformed run row doesn't take down

--- a/core/services/wiki/_shared.ts
+++ b/core/services/wiki/_shared.ts
@@ -61,9 +61,18 @@ export type ReleaseEntry = {
   body: string
 }
 
+/**
+ * Strip diacritics so accented words slug cleanly:
+ * "función detección" → "funcion deteccion" (not "funci-n detecci-n").
+ * NFD splits a letter from its combining mark, then we drop the marks.
+ */
+export function deburr(value: string): string {
+  return value.normalize('NFD').replace(/[̀-ͯ]/g, '')
+}
+
 export function slugify(value: string): string {
   return (
-    value
+    deburr(value)
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')

--- a/core/services/wiki/memory-builder.ts
+++ b/core/services/wiki/memory-builder.ts
@@ -4,25 +4,97 @@
  * Pure functions: take memory entries / shipped features in, return a
  * `{ relPath: body }` map ready for the orchestrator to diff against
  * the on-disk manifest. No I/O.
+ *
+ * Vault model (mem_3233 at graph scale): substantive memory types get
+ * ONE note per entry (`memory/<type>/<slug>.md`) so Obsidian — whose
+ * graph nodes are *files*, not block anchors — renders a connected web
+ * of entries. Each note carries `aliases: [mem_N]` so `[[mem_N|title]]`
+ * resolves regardless of the (human, content-derived) filename, and the
+ * displayed label is always a legible title, never the `mem_N` DB key.
  */
 
 import {
+  deriveTitle,
   type FormatMemoryMdOptions,
   formatMemoryMd,
+  linkifyMemRefs,
   type MemoryEntry,
 } from '../../memory/project-memory'
 import type { ShippedFeature } from '../../types/storage'
 import { chunkEntries, slugify } from './_shared'
 
 /**
- * Global `mem_N → type` index across ALL entries so a cross-ref in
- * one type's file (`resolves=mem_X` where mem_X is a gotcha) links to
- * the correct per-type vault file. Built once per builder call.
+ * Types rendered as their own per-entry note. Ephemeral GTD types
+ * (`inbox`/`todo`/`idea`) stay aggregated — they churn and would just
+ * add noise nodes — but still resolve via the index (block anchor).
  */
-function vaultOpts(entries: MemoryEntry[]): FormatMemoryMdOptions {
+export const PER_ENTRY_TYPES: ReadonlySet<string> = new Set([
+  'decision',
+  'learning',
+  'gotcha',
+  'pattern',
+  'anti-pattern',
+  'fact',
+  'insight',
+  'spec',
+  'feedback',
+  'improvement-idea',
+  'improvement-signal',
+  'question',
+  'source',
+  'person',
+])
+
+/**
+ * Tag keys that encode an entry→entry RELATION, not a category. These
+ * must NOT spawn `tags/<rel>/<value>.md` pages (that fragmented the
+ * graph into orphan stubs); they become real wikilink edges in each
+ * note's `## Relations` section instead.
+ */
+const RELATION_KEYS: ReadonlySet<string> = new Set([
+  'relates',
+  'resolves',
+  'closes',
+  'supersedes',
+  'duplicates',
+  'blocks',
+  'depends',
+])
+
+/**
+ * Global `mem_N → type` and `mem_N → title` indexes across ALL entries
+ * (not the recall-capped/deduped render set) so every cross-ref
+ * resolves and shows a legible label. See
+ * `projectMemory.allEntriesForIndex`.
+ */
+export function buildIndexMaps(allEntries: MemoryEntry[]): {
+  idTypeIndex: Map<string, string>
+  idTitleIndex: Map<string, string>
+} {
   const idTypeIndex = new Map<string, string>()
-  for (const e of entries) idTypeIndex.set(e.id, e.type)
-  return { vault: true, idTypeIndex }
+  const idTitleIndex = new Map<string, string>()
+  for (const e of allEntries) {
+    idTypeIndex.set(e.id, e.type)
+    idTitleIndex.set(e.id, deriveTitle(e))
+  }
+  return { idTypeIndex, idTitleIndex }
+}
+
+function vaultOpts(
+  idTypeIndex: Map<string, string>,
+  idTitleIndex: Map<string, string>
+): FormatMemoryMdOptions {
+  return { vault: true, idTypeIndex, idTitleIndex, perEntryTypes: PER_ENTRY_TYPES }
+}
+
+/**
+ * Shared vault linkify options built once from the FULL entry set —
+ * so every builder (memory, tags, specs) resolves `mem_N` refs to the
+ * same legible alias links instead of dangling pointers.
+ */
+export function buildVaultOpts(allEntries: MemoryEntry[]): FormatMemoryMdOptions {
+  const { idTypeIndex, idTitleIndex } = buildIndexMaps(allEntries)
+  return vaultOpts(idTypeIndex, idTitleIndex)
 }
 
 export function formatShipBody(ship: ShippedFeature): string {
@@ -42,10 +114,105 @@ export function formatShipBody(ship: ShippedFeature): string {
   return `${lines.join('\n')}\n`
 }
 
+function rowId(id: string): string {
+  return id.replace(/^mem[_-]/, '')
+}
+
+function dateOnly(iso: string): string {
+  const m = (iso || '').match(/^(\d{4}-\d{2}-\d{2})/)
+  return m ? m[1] : ''
+}
+
+/** YAML flow map of tags with quoted values; '' when no tags. */
+function frontmatterTags(tags: Record<string, string>): string {
+  const pairs = Object.entries(tags)
+  if (pairs.length === 0) return ''
+  const body = pairs.map(([k, v]) => `${k}: ${JSON.stringify(String(v))}`).join(', ')
+  return `tags: { ${body} }`
+}
+
+/**
+ * `## Relations` edges from RELATION_KEYS tags. `mem_N` values become
+ * wikilinks (the graph edge); non-mem values (e.g.
+ * `resolves=improvement-signal`) are listed as plain context.
+ */
+function relationsSection(entry: MemoryEntry, opts: FormatMemoryMdOptions): string[] {
+  const rels: string[] = []
+  for (const [k, raw] of Object.entries(entry.tags)) {
+    if (!RELATION_KEYS.has(k)) continue
+    for (const v of String(raw)
+      .split(/[\s,]+/)
+      .filter(Boolean)) {
+      if (/^mem[_-]\d+$/i.test(v)) {
+        rels.push(`- ${k} ${linkifyMemRefs(v.replace('-', '_'), opts)}`)
+      } else {
+        rels.push(`- ${k} \`${v}\``)
+      }
+    }
+  }
+  if (rels.length === 0) return []
+  return ['', '## Relations', ...rels]
+}
+
+/**
+ * One note per substantive entry. Filename is the human slug; the
+ * stable join key `mem_N` lives only in `aliases:` + a muted block
+ * anchor so the CLI/grep and legacy `#^mem-N` refs still resolve.
+ */
+export function buildMemoryEntryNotes(
+  entries: MemoryEntry[],
+  opts: FormatMemoryMdOptions
+): {
+  files: Map<string, string>
+  titleByType: Map<string, Array<{ id: string; title: string }>>
+} {
+  const files = new Map<string, string>()
+  const titleByType = new Map<string, Array<{ id: string; title: string }>>()
+  const usedSlugs = new Map<string, Set<string>>() // type → slugs
+
+  for (const e of entries) {
+    if (!PER_ENTRY_TYPES.has(e.type)) continue
+    const title = deriveTitle(e)
+    const seen = usedSlugs.get(e.type) ?? new Set<string>()
+    let slug = slugify(title)
+    if (seen.has(slug)) slug = `${slug}-${rowId(e.id)}`.slice(0, 80)
+    seen.add(slug)
+    usedSlugs.set(e.type, seen)
+
+    const created = dateOnly(e.rememberedAt)
+    const fm: string[] = ['---', `aliases: [${JSON.stringify(e.id)}]`, `type: ${e.type}`]
+    fm.push(`provenance: ${e.provenance}`)
+    if (created) fm.push(`created: ${created}`)
+    const ftags = frontmatterTags(e.tags)
+    if (ftags) fm.push(ftags)
+    fm.push('---')
+
+    const body: string[] = [
+      fm.join('\n'),
+      '',
+      `# ${e.type}: ${title}`,
+      '',
+      `> \`${e.id}\`  ^mem-${rowId(e.id)}`,
+      '',
+      linkifyMemRefs(e.content, opts).trim(),
+    ]
+    body.push(...relationsSection(e, opts))
+    files.set(`memory/${e.type}/${slug}.md`, `${body.join('\n')}\n`)
+
+    const bucket = titleByType.get(e.type) ?? []
+    bucket.push({ id: e.id, title })
+    titleByType.set(e.type, bucket)
+  }
+
+  return { files, titleByType }
+}
+
 function groupByTagPair(entries: MemoryEntry[]): Map<string, Map<string, MemoryEntry[]>> {
   const byKey = new Map<string, Map<string, MemoryEntry[]>>()
   for (const entry of entries) {
     for (const [k, v] of Object.entries(entry.tags)) {
+      // Relation tags are graph edges (see ## Relations), not categories.
+      if (RELATION_KEYS.has(k)) continue
       let byValue = byKey.get(k)
       if (!byValue) {
         byValue = new Map()
@@ -59,12 +226,17 @@ function groupByTagPair(entries: MemoryEntry[]): Map<string, Map<string, MemoryE
   return byKey
 }
 
-export function buildMemoryFiles(entries: MemoryEntry[]): Map<string, string> {
-  // Emit `memory/<type>.md` as an index + `memory/<type>/chunk-N.md` when
-  // a type bucket exceeds CHUNK_SIZE. Small buckets inline their entries
-  // in the index file directly to save a hop.
+export function buildMemoryFiles(
+  entries: MemoryEntry[],
+  allEntries: MemoryEntry[] = entries
+): Map<string, string> {
+  // Substantive types → one note per entry + a `memory/<type>.md` MOC
+  // that wikilinks every note (the hub node). Ephemeral types keep the
+  // aggregated/chunked file. Index maps are built from the FULL entry
+  // set so every cross-ref resolves (Defect B).
   const files = new Map<string, string>()
-  const opts = vaultOpts(entries)
+  const { idTypeIndex, idTitleIndex } = buildIndexMaps(allEntries)
+  const opts = vaultOpts(idTypeIndex, idTitleIndex)
 
   const byType = new Map<string, MemoryEntry[]>()
   for (const e of entries) {
@@ -73,14 +245,32 @@ export function buildMemoryFiles(entries: MemoryEntry[]): Map<string, string> {
     byType.set(e.type, bucket)
   }
 
+  const { files: noteFiles, titleByType } = buildMemoryEntryNotes(entries, opts)
+  for (const [rel, body] of noteFiles) files.set(rel, body)
+
   for (const [type, items] of byType) {
+    if (PER_ENTRY_TYPES.has(type)) {
+      // MOC: links every entry note via its stable alias, legible label.
+      const links = titleByType.get(type) ?? []
+      const moc = [
+        `# ${type.toUpperCase()}`,
+        '',
+        `_${links.length} ${links.length === 1 ? 'entry' : 'entries'} — newest first._`,
+        '',
+        ...links.map(({ id, title }) => `- [[${id}|${title.replace(/[[\]|]/g, '')}]]`),
+        '',
+      ]
+      files.set(`memory/${type}.md`, `${moc.join('\n')}\n`)
+      continue
+    }
+
+    // Ephemeral type — aggregated, chunked when large (legacy behavior).
     const chunks = chunkEntries(items)
     if (chunks.length === 1) {
       const body = [`# ${type.toUpperCase()}`, '', formatMemoryMd(items, opts), ''].join('\n')
       files.set(`memory/${type}.md`, body)
       continue
     }
-
     const indexLines = [
       `# ${type.toUpperCase()}`,
       '',
@@ -104,11 +294,16 @@ export function buildMemoryFiles(entries: MemoryEntry[]): Map<string, string> {
   return files
 }
 
-export function buildTagFiles(entries: MemoryEntry[]): Map<string, string> {
+export function buildTagFiles(
+  entries: MemoryEntry[],
+  allEntries: MemoryEntry[] = entries
+): Map<string, string> {
   // One page per distinct tag pair (`tags/<key>/<value>.md`) + an index
-  // per tag key (`tags/<key>.md`). Glob-discoverable by the agent.
+  // per tag key (`tags/<key>.md`). Relation tags are excluded — they're
+  // graph edges, not categories (Defect C).
   const files = new Map<string, string>()
-  const opts = vaultOpts(entries)
+  const { idTypeIndex, idTitleIndex } = buildIndexMaps(allEntries)
+  const opts = vaultOpts(idTypeIndex, idTitleIndex)
   const byPair = groupByTagPair(entries)
 
   for (const [key, byValue] of byPair) {

--- a/core/services/wiki/spec-builder.ts
+++ b/core/services/wiki/spec-builder.ts
@@ -11,11 +11,16 @@
  * stream alone wouldn't carry.
  */
 
+import { type FormatMemoryMdOptions, linkifyMemRefs } from '../../memory/project-memory'
 import type { QueueTask } from '../../schemas/state'
 import { SPEC_REVIEWERS, type Spec } from '../../types/spec'
 import { slugify } from './_shared'
 
-export function buildSpecFiles(specs: Spec[], queueTasks: QueueTask[] = []): Map<string, string> {
+export function buildSpecFiles(
+  specs: Spec[],
+  queueTasks: QueueTask[] = [],
+  vaultOpts?: FormatMemoryMdOptions
+): Map<string, string> {
   const files = new Map<string, string>()
 
   if (specs.length === 0) return files
@@ -30,7 +35,8 @@ export function buildSpecFiles(specs: Spec[], queueTasks: QueueTask[] = []): Map
   for (const spec of specs) {
     const slug = slugify(spec.title) || spec.id.slice(0, 8)
     const rel = `specs/${slug}.md`
-    files.set(rel, formatSpecBody(spec, taskById))
+    const body = formatSpecBody(spec, taskById)
+    files.set(rel, vaultOpts ? linkifyMemRefs(body, vaultOpts) : body)
     indexEntries.push({ slug, spec })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.23.2",
+  "version": "2.23.3",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Context

All users reported the Obsidian Graph view of their prjct vault lost every connection — a dust of disconnected nodes instead of a linked memory web. The vault is the first thing the human sees; it must be legible and correctly linked, with context (not opaque `mem_xxxx` DB keys) for both humans and LLMs.

## Root cause (3 coupled defects)

- **A — graph topology (primary):** entries were bullets in ~8 aggregated `memory/<type>.md` files. Obsidian graph nodes are *files*, not block anchors → the whole memory layer collapsed to ≤8 nodes.
- **B — dangling idTypeIndex:** built only from the recall-capped, deduped, non-`shipped` set → ~42% of cross-refs (mem_2609 ×24, …) degraded to dangling `[[mem_N]]`, hidden by `hideUnresolved`.
- **C — relation-as-tag fragmentation:** `relates/resolves/closes` spawned orphan `tags/<rel>/mem-N.md` stubs instead of edges.

## Fix

- **One note per substantive entry** (`memory/<type>/<slug>.md`); ephemeral GTD types stay aggregated.
- **Deterministic, content-derived human title** (no LLM) = filename slug, H1, every wikilink's display text, graph label. `mem_N` survives only as invisible stable join key (`aliases:` + `^mem-N`).
- **idTypeIndex/idTitleIndex from the FULL entry set** (`allEntriesForIndex` — no cap/dedupe).
- **Relation tags → real `## Relations` wikilink edges**, excluded from tag pages.
- Truly-deleted ids → muted `` `mem_N` `` text (honest, no fake node). Spec free-text refs run through the same resolver.
- **CLI `--md` byte-identical** — all changes gated behind `opts.vault` (regression-locked, PR #356 contract intact).

## Verification (real vault regen, ~/Documents/prjct/prjct-cli/_generated/)

| Metric | Before | After |
|---|---|---|
| Per-entry notes | 0 (8 aggregated) | 147 |
| Dangling `[[mem_N]]` | 73 | 0 |
| Resolved `[[mem_N\|title]]` | 0 | 199 |
| Relation-tag orphan dirs | yes | 0 |

- typecheck ✓ · full suite **1230 pass / 0 fail** ✓ · biome check ✓ · CLI regression-lock intact ✓

## Note

`prjct ship`'s `changelog:add` step silently no-op'd again (recurring CHANGELOG stranding — mem_2895/mem_3135/mem_3205 lineage); the v2.23.3 entry was added in a follow-up commit. Worth a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)