### PR TITLE
fix: vault — link by note slug, not alias (Obsidian graph was empty)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.23.4] - 2026-05-18
+
+### Bug Fixes
+
+- vault: link cross-references by the note's real slug/basename, not the `mem_N` frontmatter alias — Obsidian's Graph view resolves links by path/basename and ignores aliases, so v2.23.3's alias-only links were graph-invisible (with `hideUnresolved` the relations disappeared entirely). Relations now render as actual graph edges.
+
 ## [2.23.3] - 2026-05-18
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@
 
 ## [Unreleased]
 
+## [2.23.4] - 2026-05-18
+
+### Added
+- vault: link by note slug not alias — fix Obsidian graph (alias links graph-invisible)
+
 ## [2.23.3] - 2026-05-18
 
 ### Added

--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -316,17 +316,21 @@ describe('deriveTitle — deterministic, legible, no DB keys', () => {
   })
 })
 
-describe('linkifyMemRefs — legible labels + alias resolution (additive)', () => {
-  it('per-entry type → alias link [[mem_N|title]] (resolves via aliases:)', () => {
+describe('linkifyMemRefs — slug-targeted links (graph-visible) + legible labels', () => {
+  it('per-entry type → links the note BASENAME [[slug|title]] (graph draws it)', () => {
+    // The v2.23.3 regression: [[mem_N|title]] resolved only via alias,
+    // invisible to Obsidian's graph. Must target the real slug.
     const out = linkifyMemRefs('resolves=mem_3135', {
       idTypeIndex: new Map([['mem_3135', 'gotcha']]),
       idTitleIndex: new Map([['mem_3135', 'CHANGELOG Unreleased stranding']]),
+      idSlugIndex: new Map([['mem_3135', 'changelog-unreleased-stranding']]),
       perEntryTypes: new Set(['gotcha']),
     })
-    expect(out).toBe('resolves=[[mem_3135|CHANGELOG Unreleased stranding]]')
+    expect(out).toBe('resolves=[[changelog-unreleased-stranding|CHANGELOG Unreleased stranding]]')
+    expect(out).not.toContain('[[mem_3135') // never alias-only
   })
 
-  it('aggregated type → block-anchor link with legible label', () => {
+  it('aggregated type (no slug) → block-anchor link with legible label', () => {
     const out = linkifyMemRefs('see mem_42', {
       idTypeIndex: new Map([['mem_42', 'inbox']]),
       idTitleIndex: new Map([['mem_42', 'upgrade noise item']]),
@@ -344,14 +348,15 @@ describe('linkifyMemRefs — legible labels + alias resolution (additive)', () =
     expect(linkifyMemRefs('violates [[mem_2620]]', { idTypeIndex: new Map() })).toBe(
       'violates `mem_2620`'
     )
-    // known id → legible alias link
+    // known per-entry id → slug link, graph-visible
     expect(
       linkifyMemRefs('see [[mem_42]]', {
         idTypeIndex: new Map([['mem_42', 'gotcha']]),
         idTitleIndex: new Map([['mem_42', 'busy_timeout CAS retry']]),
+        idSlugIndex: new Map([['mem_42', 'busy-timeout-cas-retry']]),
         perEntryTypes: new Set(['gotcha']),
       })
-    ).toBe('see [[mem_42|busy_timeout CAS retry]]')
+    ).toBe('see [[busy-timeout-cas-retry|busy_timeout CAS retry]]')
   })
 
   it('backward compatible: no idTitleIndex → legacy mem_N label', () => {

--- a/core/__tests__/services/memory-builder.test.ts
+++ b/core/__tests__/services/memory-builder.test.ts
@@ -55,29 +55,43 @@ describe('buildMemoryFiles — one note per entry', () => {
     expect(note).toMatch(/^# decision: /m)
   })
 
-  it('cross-ref renders as a legible alias link, never a bare key', () => {
+  it('cross-ref links the target NOTE by basename, not the mem_N alias', () => {
     const note = [...files.entries()].find(([k]) => k.startsWith('memory/decision/'))?.[1] ?? ''
-    // resolves=mem_3233 → [[mem_3233|<title of 3233>]] (feedback is per-entry)
     expect(note).toContain('## Relations')
-    expect(note).toMatch(/\[\[mem_3233\|[^\]]*opaque[^\]]*\]\]/i)
-    expect(note).not.toContain('|mem_3233]]') // label is the title, not the key
+    // resolves=mem_3233 → [[<slug-of-3233>|title]] — slug, NOT [[mem_3233|…]]
+    expect(note).not.toMatch(/\[\[mem_3233\b/) // alias-only link defeats the graph
+    expect(note).toMatch(/\[\[[a-z0-9-]+\|[^\]]*opaque[^\]]*\]\]/i)
   })
 
-  it('memory/<type>.md is a MOC that wikilinks every entry note', () => {
+  it('GRAPH INVARIANT: every [[target|label]] resolves to a real note basename', () => {
+    // The v2.23.3 regression: links resolved only via frontmatter alias,
+    // which Obsidian's graph ignores. Every link target must be an
+    // emitted note's basename (or a type MOC) so the edge is drawn.
+    const basenames = new Set<string>()
+    for (const k of keys) {
+      const m = k.match(/^memory\/[^/]+\/(.+)\.md$/)
+      if (m) basenames.add(m[1])
+      const moc = k.match(/^memory\/([^/]+)\.md$/)
+      if (moc) basenames.add(moc[1]) // type MOC, also block-anchor host
+    }
+    for (const body of files.values()) {
+      for (const [, target] of body.matchAll(/\[\[([^|\]#]+)(?:#[^|\]]+)?\|[^\]]+\]\]/g)) {
+        if (/^mem_\d+$/.test(target)) throw new Error(`alias-only link: [[${target}]]`)
+        expect(basenames.has(target)).toBe(true)
+      }
+    }
+  })
+
+  it('memory/<type>.md is a MOC that wikilinks each note by slug', () => {
     const moc = files.get('memory/decision.md') ?? ''
     expect(moc).toContain('# DECISION')
-    expect(moc).toMatch(/- \[\[mem_3264\|[^\]]+\]\]/)
-  })
-
-  it('no dangling [[mem_N]] for an id present in the full set', () => {
-    for (const body of files.values()) {
-      expect(body).not.toMatch(/\[\[mem_3233\]\]/) // must be the labelled alias form
-    }
+    expect(moc).not.toMatch(/\[\[mem_\d+\|/) // not alias links
+    expect(moc).toMatch(/- \[\[[a-z0-9-]+\|[^\]]+\]\]/)
   })
 })
 
 describe('buildMemoryFiles — Defect B: refs to non-rendered ids still resolve', () => {
-  it('an old referenced entry gets a note so [[mem_N|title]] is not dangling', () => {
+  it('an old referenced entry gets a note + a slug link the graph can draw', () => {
     const rendered = [
       mk({
         id: 'mem_3300',
@@ -87,14 +101,18 @@ describe('buildMemoryFiles — Defect B: refs to non-rendered ids still resolve'
     ]
     const all = [
       ...rendered,
-      mk({ id: 'mem_2609', content: 'Closed mem_2525 daemon restart follow-up shipped' }),
+      mk({ id: 'mem_2609', content: 'Closed an old daemon restart follow-up shipped' }),
     ]
     const files = buildMemoryFiles(all, all)
-    // mem_2609 must exist as a note carrying its alias
-    const has2609 = [...files.values()].some((b) => b.includes('aliases: ["mem_2609"]'))
-    expect(has2609).toBe(true)
+    // mem_2609 exists as a note (alias kept for CLI/click) AND its
+    // basename is the link target so the graph edge is drawn.
+    const note2609 = [...files.entries()].find(([, b]) => b.includes('aliases: ["mem_2609"]'))
+    expect(note2609).toBeDefined()
+    const slug2609 = note2609?.[0].match(/^memory\/[^/]+\/(.+)\.md$/)?.[1] ?? ''
+    expect(slug2609).not.toBe('')
     const newNote = [...files.entries()].find(([k]) => k.startsWith('memory/decision/'))?.[1] ?? ''
-    expect(newNote).toMatch(/\[\[mem_2609\|/) // legible, resolvable
+    expect(newNote).not.toMatch(/\[\[mem_2609\b/) // not alias-only
+    expect(newNote).toContain(`[[${slug2609}|`) // links the real note basename
   })
 })
 

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -446,12 +446,22 @@ export interface FormatMemoryMdOptions {
    */
   idTitleIndex?: Map<string, string>
   /**
-   * Types rendered as their own per-entry note (carrying
-   * `aliases: [mem_N]`). Refs to these resolve via the stable alias
-   * `[[mem_N|title]]`; everything else uses the aggregated-file block
+   * Types rendered as their own per-entry note. Combined with
+   * {@link idSlugIndex}, refs to these link by the note's real basename
+   * `[[<slug>|title]]`; everything else uses the aggregated-file block
    * anchor `[[type#^mem-N|title]]`. Absent → legacy block-anchor form.
    */
   perEntryTypes?: ReadonlySet<string>
+  /**
+   * `mem_N → note basename (slug, no extension)` for per-entry notes.
+   * The link MUST target the real file, not the `mem_N` alias:
+   * Obsidian's GRAPH view resolves links by path/basename and ignores
+   * frontmatter `aliases` (backlinks/click honor aliases; the graph
+   * does not). With `hideUnresolved:true` an alias-only link is treated
+   * as unresolved and hidden → no edge. Linking by slug is what makes
+   * the relations actually appear in the graph (the v2.23.3 regression).
+   */
+  idSlugIndex?: Map<string, string>
 }
 
 const TITLE_MAX = 72
@@ -517,9 +527,12 @@ export function linkifyMemRefs(text: string, opts?: FormatMemoryMdOptions): stri
       const canonical = `mem_${n}`
       const type = opts?.idTypeIndex?.get(canonical)
       const title = opts?.idTitleIndex?.get(canonical)
+      const slug = opts?.idSlugIndex?.get(canonical)
       const display = title ? linkLabel(title) : canonical
-      if (type && opts?.perEntryTypes?.has(type)) {
-        return `[[${canonical}|${display}]]`
+      // Per-entry note → link the REAL basename so the graph draws the
+      // edge (alias-only links are invisible to Obsidian's graph).
+      if (slug && type && opts?.perEntryTypes?.has(type)) {
+        return `[[${slug}|${display}]]`
       }
       if (type) {
         return `[[${type}#^mem-${n}|${display}]]`

--- a/core/services/wiki/memory-builder.ts
+++ b/core/services/wiki/memory-builder.ts
@@ -70,31 +70,54 @@ const RELATION_KEYS: ReadonlySet<string> = new Set([
 export function buildIndexMaps(allEntries: MemoryEntry[]): {
   idTypeIndex: Map<string, string>
   idTitleIndex: Map<string, string>
+  idSlugIndex: Map<string, string>
 } {
   const idTypeIndex = new Map<string, string>()
   const idTitleIndex = new Map<string, string>()
+  const idSlugIndex = new Map<string, string>()
+  // SINGLE SOURCE OF TRUTH for per-entry note basenames. The link
+  // target (linkifyMemRefs) and the emitted filename
+  // (buildMemoryEntryNotes) MUST be byte-identical or the graph edge
+  // breaks. Slugs are made vault-UNIQUE (global seen-set, not per-type)
+  // so `[[<slug>|title]]` resolves unambiguously by basename. Order is
+  // deterministic (allEntriesForIndex → id DESC).
+  const usedSlugs = new Set<string>()
   for (const e of allEntries) {
     idTypeIndex.set(e.id, e.type)
-    idTitleIndex.set(e.id, deriveTitle(e))
+    const title = deriveTitle(e)
+    idTitleIndex.set(e.id, title)
+    if (PER_ENTRY_TYPES.has(e.type)) {
+      let slug = slugify(title)
+      if (usedSlugs.has(slug)) slug = `${slug}-${rowId(e.id)}`.slice(0, 80)
+      usedSlugs.add(slug)
+      idSlugIndex.set(e.id, slug)
+    }
   }
-  return { idTypeIndex, idTitleIndex }
+  return { idTypeIndex, idTitleIndex, idSlugIndex }
 }
 
 function vaultOpts(
   idTypeIndex: Map<string, string>,
-  idTitleIndex: Map<string, string>
+  idTitleIndex: Map<string, string>,
+  idSlugIndex: Map<string, string>
 ): FormatMemoryMdOptions {
-  return { vault: true, idTypeIndex, idTitleIndex, perEntryTypes: PER_ENTRY_TYPES }
+  return {
+    vault: true,
+    idTypeIndex,
+    idTitleIndex,
+    idSlugIndex,
+    perEntryTypes: PER_ENTRY_TYPES,
+  }
 }
 
 /**
  * Shared vault linkify options built once from the FULL entry set —
  * so every builder (memory, tags, specs) resolves `mem_N` refs to the
- * same legible alias links instead of dangling pointers.
+ * same slug-targeted, legible links (graph-visible, not alias-only).
  */
 export function buildVaultOpts(allEntries: MemoryEntry[]): FormatMemoryMdOptions {
-  const { idTypeIndex, idTitleIndex } = buildIndexMaps(allEntries)
-  return vaultOpts(idTypeIndex, idTitleIndex)
+  const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
+  return vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
 }
 
 export function formatShipBody(ship: ShippedFeature): string {
@@ -164,20 +187,18 @@ export function buildMemoryEntryNotes(
   opts: FormatMemoryMdOptions
 ): {
   files: Map<string, string>
-  titleByType: Map<string, Array<{ id: string; title: string }>>
+  titleByType: Map<string, Array<{ id: string; title: string; slug: string }>>
 } {
   const files = new Map<string, string>()
-  const titleByType = new Map<string, Array<{ id: string; title: string }>>()
-  const usedSlugs = new Map<string, Set<string>>() // type → slugs
+  const titleByType = new Map<string, Array<{ id: string; title: string; slug: string }>>()
 
   for (const e of entries) {
     if (!PER_ENTRY_TYPES.has(e.type)) continue
     const title = deriveTitle(e)
-    const seen = usedSlugs.get(e.type) ?? new Set<string>()
-    let slug = slugify(title)
-    if (seen.has(slug)) slug = `${slug}-${rowId(e.id)}`.slice(0, 80)
-    seen.add(slug)
-    usedSlugs.set(e.type, seen)
+    // Slug comes from the shared index (buildIndexMaps) so the filename
+    // is byte-identical to every link target. Fallback only if an entry
+    // somehow isn't in the index.
+    const slug = opts.idSlugIndex?.get(e.id) ?? `${slugify(title)}-${rowId(e.id)}`.slice(0, 80)
 
     const created = dateOnly(e.rememberedAt)
     const fm: string[] = ['---', `aliases: [${JSON.stringify(e.id)}]`, `type: ${e.type}`]
@@ -200,7 +221,7 @@ export function buildMemoryEntryNotes(
     files.set(`memory/${e.type}/${slug}.md`, `${body.join('\n')}\n`)
 
     const bucket = titleByType.get(e.type) ?? []
-    bucket.push({ id: e.id, title })
+    bucket.push({ id: e.id, title, slug })
     titleByType.set(e.type, bucket)
   }
 
@@ -235,8 +256,8 @@ export function buildMemoryFiles(
   // aggregated/chunked file. Index maps are built from the FULL entry
   // set so every cross-ref resolves (Defect B).
   const files = new Map<string, string>()
-  const { idTypeIndex, idTitleIndex } = buildIndexMaps(allEntries)
-  const opts = vaultOpts(idTypeIndex, idTitleIndex)
+  const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
+  const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
 
   const byType = new Map<string, MemoryEntry[]>()
   for (const e of entries) {
@@ -250,14 +271,15 @@ export function buildMemoryFiles(
 
   for (const [type, items] of byType) {
     if (PER_ENTRY_TYPES.has(type)) {
-      // MOC: links every entry note via its stable alias, legible label.
+      // MOC: links every entry note by its real basename (slug) so the
+      // graph draws the hub→note edge; label stays the legible title.
       const links = titleByType.get(type) ?? []
       const moc = [
         `# ${type.toUpperCase()}`,
         '',
         `_${links.length} ${links.length === 1 ? 'entry' : 'entries'} — newest first._`,
         '',
-        ...links.map(({ id, title }) => `- [[${id}|${title.replace(/[[\]|]/g, '')}]]`),
+        ...links.map(({ slug, title }) => `- [[${slug}|${title.replace(/[[\]|]/g, '')}]]`),
         '',
       ]
       files.set(`memory/${type}.md`, `${moc.join('\n')}\n`)
@@ -302,8 +324,8 @@ export function buildTagFiles(
   // per tag key (`tags/<key>.md`). Relation tags are excluded — they're
   // graph edges, not categories (Defect C).
   const files = new Map<string, string>()
-  const { idTypeIndex, idTitleIndex } = buildIndexMaps(allEntries)
-  const opts = vaultOpts(idTypeIndex, idTitleIndex)
+  const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
+  const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
   const byPair = groupByTagPair(entries)
 
   for (const [key, byValue] of byPair) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.23.3",
+  "version": "2.23.4",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Context

User reported v2.23.3 **still** showed no relations in Obsidian's Graph view ("sigue sin crear las relaciones") despite the on-disk vault having 214 valid cross-links and 0 dangling.

## Root cause (confirmed, structural)

**Obsidian's Graph view resolves links by file path/basename and IGNORES frontmatter `aliases`.** Backlinks panel and Ctrl+click honor aliases; the graph does not. v2.23.3 linked every cross-reference as `[[mem_N|title]]` resolving *only* via the target note's `aliases: [mem_N]` — so to the graph engine all 214 links were unresolved, and with the user's `graph.json` `hideUnresolved: true` they were hidden entirely → empty graph. The "link by stable alias" design was itself the defect.

## Fix

- Links now target the note's real **slug/basename**: `[[changelog-root-cause-fixed-pr-352|CHANGELOG root cause FIXED (PR #352)]]`. Obsidian resolves it by basename → **the graph draws the edge**.
- `aliases: [mem_N]` kept (CLI/grep/click resolution unchanged).
- `buildIndexMaps` is the single source of truth for slugs (vault-unique, global seen-set) → emitted filename == every link target, byte-identical. `linkifyMemRefs`, MOCs, Relations, spec-builder all use it.
- Aggregated types (inbox/todo/idea) keep `[[type#^mem-N|title]]` (resolves to the real `type.md`). Deleted ids → muted `` `mem_N` ``. CLI `--md` byte-identical (gated behind `opts.vault`).

## Verification (real regenerated vault)

| | result |
|---|---|
| alias-only `[[mem_N\|…]]` links | **0** (was 214 — all graph-invisible) |
| real cross-links resolving to a note basename | **all** |
| per-entry notes | 142 |
| suite | **1230 / 0** · biome ✓ · CLI lock intact |

New regression test: **`GRAPH INVARIANT: every [[target|label]] resolves to a real note basename`** — fails on any alias-only link.

## Note

`prjct ship` `changelog:add` silently no-op'd again (mem_3373 / mem_2895 lineage) — v2.23.4 entry added in a follow-up commit. Still pending a separate investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)