### PR TITLE
fix: hook output can emit lone UTF-16 surrogate → API 400 'no low surrogate in string'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.23.7] - 2026-05-18
+
+### Added
+- current work
+
 ## [2.23.6] - 2026-05-18
 
 ### Added

--- a/core/__tests__/hooks/hook-schema.test.ts
+++ b/core/__tests__/hooks/hook-schema.test.ts
@@ -13,7 +13,13 @@
  */
 
 import { describe, expect, test } from 'bun:test'
-import { buildHookOutput } from '../../hooks/_shared'
+import { buildHookOutput, safeTruncate, stripLoneSurrogates } from '../../hooks/_shared'
+
+/** True iff `s` round-trips through UTF-8 — i.e. contains no unpaired
+ *  surrogate. A lone surrogate encodes to U+FFFD, so the round-trip
+ *  differs. This is exactly the property the Anthropic API requires of
+ *  the request body; a string failing it triggers the 400 we fix here. */
+const isWellFormedUtf8 = (s: string): boolean => Buffer.from(s, 'utf8').toString('utf8') === s
 
 describe('buildHookOutput routes per Claude Code schema', () => {
   test('SessionStart uses hookSpecificOutput.additionalContext', () => {
@@ -73,6 +79,54 @@ describe('buildHookOutput routes per Claude Code schema', () => {
     ]) {
       expect(buildHookOutput(event, null)).toEqual({})
     }
+  })
+
+  // Regression: API 400 "no low surrogate in string" — hook output that
+  // ends in a lone UTF-16 high surrogate makes the model request body
+  // un-encodable. Root cause was `s.slice(0, n)` cutting between an
+  // emoji's surrogate pair during truncation.
+  test('buildHookOutput scrubs an unpaired surrogate from context', () => {
+    // U+1F916 🤖 = high D83E + low DD16. Keep only the high half.
+    const corrupted = `state line with a split emoji \uD83E`
+    expect(isWellFormedUtf8(corrupted)).toBe(false) // precondition: it IS broken
+    const out = buildHookOutput('UserPromptSubmit', corrupted)
+    expect(isWellFormedUtf8(out.hookSpecificOutput?.additionalContext ?? '')).toBe(true)
+  })
+
+  test('buildHookOutput scrubs an unpaired LOW surrogate too (systemMessage path)', () => {
+    const corrupted = `\uDD16 nudge with a leading orphan low surrogate`
+    const out = buildHookOutput('Stop', corrupted)
+    expect(isWellFormedUtf8(out.systemMessage ?? '')).toBe(true)
+  })
+
+  test('stripLoneSurrogates preserves valid astral pairs, kills only orphans', () => {
+    const ok = 'robot 🤖 fire 🔥 done'
+    expect(stripLoneSurrogates(ok)).toBe(ok)
+    expect(stripLoneSurrogates(`${ok}\uD83E`)).toBe(`${ok}�`)
+  })
+
+  test('safeTruncate never splits a surrogate pair at the cut boundary', () => {
+    // Build a string where an emoji straddles the truncation point for a
+    // range of caps — the naive slice would leave a lone high surrogate.
+    const head = 'x'.repeat(40)
+    const s = `${head}🤖${'y'.repeat(40)}`
+    for (let max = 30; max <= 60; max++) {
+      const t = safeTruncate(s, max, '…')
+      expect(isWellFormedUtf8(t)).toBe(true)
+      expect(t.length).toBeLessThanOrEqual(max)
+    }
+    // Naive slice at the splitting index really would be ill-formed —
+    // pins that the test is exercising the actual failure mode.
+    const splitAt = head.length + 1 // between high and low surrogate
+    expect(isWellFormedUtf8(s.slice(0, splitAt))).toBe(false)
+  })
+
+  test('safeTruncate is a no-op under budget and respects the marker', () => {
+    expect(safeTruncate('short', 100)).toBe('short')
+    const long = 'a'.repeat(500)
+    const out = safeTruncate(long, 50, '\n… [truncated]')
+    expect(out.endsWith('\n… [truncated]')).toBe(true)
+    expect(out.length).toBeLessThanOrEqual(50)
   })
 
   test('emitted JSON only contains top-level fields Claude Code accepts', () => {

--- a/core/hooks/_shared.ts
+++ b/core/hooks/_shared.ts
@@ -124,10 +124,47 @@ export function extractKeywords(text: string, maxCount = 8): string[] {
   return out
 }
 
+/**
+ * Replace any unpaired UTF-16 surrogate with U+FFFD.
+ *
+ * JS strings are UTF-16; an astral character (emoji, non-BMP CJK) is a
+ * high+low surrogate pair. A lone surrogate — a high not followed by a
+ * low, or a low not preceded by a high — is a well-formed JS string but
+ * NOT representable in UTF-8. When Claude Code forwards our injected
+ * context into the model request body, the Anthropic API rejects it
+ * with `400 ... no low surrogate in string`, killing the user's turn.
+ *
+ * Two ways a lone surrogate reaches us: (1) truncation cutting between a
+ * pair — handled at the source by `safeTruncate` — and (2) corrupted
+ * source content captured by a user. This scrub at the single emit
+ * choke point (`buildHookOutput`) defends against both, for every hook.
+ */
+export function stripLoneSurrogates(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '�')
+}
+
+/**
+ * Truncate `s` to at most `max` UTF-16 units, appending `marker`, WITHOUT
+ * ever splitting a surrogate pair. A naive `s.slice(0, n)` can land
+ * between a high and low surrogate, leaving a trailing lone high
+ * surrogate that makes the API request body invalid JSON (see
+ * `stripLoneSurrogates`). If the last retained unit is a high surrogate
+ * we drop it, so the cut always lands on a code-point boundary.
+ */
+export function safeTruncate(s: string, max: number, marker = '\n… [truncated]'): string {
+  if (s.length <= max) return s
+  let end = Math.max(0, max - marker.length)
+  const last = s.charCodeAt(end - 1)
+  if (last >= 0xd800 && last <= 0xdbff) end -= 1 // trailing high surrogate → drop it
+  return s.slice(0, Math.max(0, end)) + marker
+}
+
 export function buildHookOutput(event: string, context: string | null): HookOutput {
   if (!context) return {}
+  const safe = stripLoneSurrogates(context)
   if (ADDITIONAL_CONTEXT_EVENTS.has(event)) {
-    return { hookSpecificOutput: { hookEventName: event, additionalContext: context } }
+    return { hookSpecificOutput: { hookEventName: event, additionalContext: safe } }
   }
-  return { systemMessage: context }
+  return { systemMessage: safe }
 }

--- a/core/hooks/pre-commit.ts
+++ b/core/hooks/pre-commit.ts
@@ -16,6 +16,7 @@ import { execSync } from 'node:child_process'
 import configManager from '../infrastructure/config-manager'
 import { formatMemoryMd, type MemoryEntry, projectMemory } from '../memory/project-memory'
 import { runHook } from './_runner'
+import { safeTruncate } from './_shared'
 
 const MAX_CHARS = 1200
 const MAX_ENTRIES = 3
@@ -100,7 +101,7 @@ async function buildPreCommitContext(projectPath: string): Promise<string | null
   lines.push('')
   lines.push('> Nudge, not block. Proceed if you think it still applies.')
   const body = lines.join('\n')
-  return body.length > MAX_CHARS ? `${body.slice(0, MAX_CHARS - 20)}\n… [truncated]` : body
+  return safeTruncate(body, MAX_CHARS)
 }
 
 export function runPreCommitHook(projectPath: string = process.cwd()): Promise<void> {

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -22,7 +22,7 @@ import { stateStorage } from '../storage/state-storage'
 import { execFileAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
 import { runHook } from './_runner'
-import { extractKeywords } from './_shared'
+import { extractKeywords, safeTruncate } from './_shared'
 
 const MAX_CHARS = 1800
 const MAX_ENTRIES = 4
@@ -75,7 +75,7 @@ async function buildPromptContext(projectPath: string, prompt: string): Promise<
   lines.push('')
   lines.push('> Exposed as state. Use if relevant; ignore if not.')
   const body = lines.join('\n')
-  return body.length > MAX_CHARS ? `${body.slice(0, MAX_CHARS - 20)}\n… [truncated]` : body
+  return safeTruncate(body, MAX_CHARS)
 }
 
 /**
@@ -306,9 +306,7 @@ export function runPromptHook(projectPath: string = process.cwd()): Promise<void
       const blocks = [state, signals, memory].filter((b): b is string => Boolean(b))
       if (blocks.length === 0) return null
       const context = blocks.join('\n\n')
-      return context.length > MAX_CHARS
-        ? `${context.slice(0, MAX_CHARS - 20)}\n… [truncated]`
-        : context
+      return safeTruncate(context, MAX_CHARS)
     },
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.23.6",
+  "version": "2.23.7",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Hook context truncation used `String.slice(0, MAX_CHARS - 20)`, which operates on **UTF-16 code units**. When the cut landed between an emoji's surrogate pair (e.g. 🤖 = `D83E`+`DD16` — common in captured memory content), it left a **trailing lone high surrogate**. The string is valid JS but cannot encode to UTF-8; Claude Code forwards it into the model request body → Anthropic API `400 The request body is not valid JSON: no low surrogate in string`, killing the user's turn.

This existed in triplicate: `core/hooks/prompt.ts` (×2) and `core/hooks/pre-commit.ts` (×1).

## Fix — two layers

1. **`safeTruncate()`** (new, `core/hooks/_shared.ts`) — if the last retained UTF-16 unit is a high surrogate, drop it so the cut always lands on a code-point boundary. Replaces all 3 ad-hoc truncations.
2. **`stripLoneSurrogates()`** applied in **`buildHookOutput()`** — the single emit choke point for **all 7 hooks** — replaces any unpaired surrogate with `�`. Layer 1 stops the systematic generator; layer 2 is the universal net (also covers corrupted captured source content).

## Tests

5 new regression tests in `core/__tests__/hooks/hook-schema.test.ts`, including a precondition assert that pins the actual failure mode (the naive `slice` IS ill-formed at the splitting index).

- `bun test core/__tests__/hooks/` → **36 pass / 0 fail**
- `npm run typecheck` clean · `npm run lint` no new errors

## Risk areas

Hook output path only. No behavior change for well-formed content (`safeTruncate` is a no-op under budget; `stripLoneSurrogates` is identity on well-formed strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)