### PR TITLE
fix(crew): leader templates no longer grant blanket .prjct/ write permission (v2.23.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.23.8] - 2026-05-19
+
+### Bug Fixes
+- crew leader templates no longer grant blanket `.prjct/` write permission — the previous "Edits to `.prjct/` … you may edit directly" line let the leader create `.prjct/audits/`, `.prjct/CHECKPOINTS.md`, `.prjct/deploy/RAILWAY-CHECKLIST.md` in client repos, violating the absolute-persistence rule. Allowlist now scoped to `.prjct/prjct.config.json`; added explicit "Hard persistence rule" section in both `templates/crew/agents/leader.md` and `templates/crew/CLAUDE-leader-mode.md`. Guard test extended (`FORBIDDEN` += audits/deploy/CHECKPOINTS paths, plus positive assertion that the canonical config path is named as the only edit-allowed file under `.prjct/`).
+
 ## [2.23.7] - 2026-05-18
 
 ### Added

--- a/core/__tests__/commands/crew-templates-no-disk-writes.test.ts
+++ b/core/__tests__/commands/crew-templates-no-disk-writes.test.ts
@@ -2,11 +2,16 @@
  * Architecture guard: shipped crew templates must not instruct subagents to
  * write reports into the customer's working tree.
  *
- * A real customer reported `.prjct/sessions/<task>/<role>.md` files dirtying
- * their repo because the crew templates told the leader/implementer/reviewer
- * to persist output there. The product invariant is: SQLite + regenerated
- * vault are the only allowed persistence surfaces. This test fails fast if
- * any template under templates/crew/ reintroduces the pattern.
+ * Customer #1 (pre-2.19.7): `.prjct/sessions/<task>/<role>.md` ghost files
+ * because templates told subagents to persist output there.
+ * Customer #2 (post-2.23.7): `.prjct/audits/*.md`, `.prjct/CHECKPOINTS.md`,
+ * `.prjct/deploy/RAILWAY-CHECKLIST.md` because the leader template said
+ * "Edits to `.prjct/` ... you may edit directly" — the leader treated the
+ * whole .prjct/ subtree as a free-write zone.
+ *
+ * Product invariant: SQLite + regenerated vault are the only allowed
+ * persistence surfaces. The ONLY hand-editable file under .prjct/ is
+ * .prjct/prjct.config.json.
  */
 
 import { describe, expect, test } from 'bun:test'
@@ -15,7 +20,7 @@ import path from 'node:path'
 
 const REPO_ROOT = path.resolve(__dirname, '../../..')
 const CREW_DIR = path.join(REPO_ROOT, 'templates', 'crew')
-const FORBIDDEN = ['.prjct/sessions/']
+const FORBIDDEN = ['.prjct/sessions/', '.prjct/audits/', '.prjct/deploy/', '.prjct/CHECKPOINTS.md']
 
 async function collectFiles(dir: string): Promise<string[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true })
@@ -39,13 +44,39 @@ describe('crew templates: no disk-write instructions', () => {
     const offenders: Array<{ file: string; needle: string }> = []
     for (const file of files) {
       const content = await fs.readFile(file, 'utf-8')
+      // Allow the CHECKPOINTS bundled template itself (it is the canonical
+      // checkpoints content, not a path instruction). Everything else that
+      // mentions a forbidden path is an offender.
+      const isCheckpointsBundle = file.endsWith(path.join('crew', 'CHECKPOINTS.md'))
       for (const needle of FORBIDDEN) {
-        if (content.includes(needle)) {
-          offenders.push({ file: path.relative(REPO_ROOT, file), needle })
-        }
+        if (!content.includes(needle)) continue
+        if (isCheckpointsBundle && needle === '.prjct/CHECKPOINTS.md') continue
+        offenders.push({ file: path.relative(REPO_ROOT, file), needle })
       }
     }
 
     expect(offenders).toEqual([])
+  })
+
+  test('leader templates scope the .prjct/ edit-allowlist to prjct.config.json', async () => {
+    // Regression guard for the post-2.23.7 client report: the leader and
+    // CLAUDE-leader-mode templates previously said "Edits to `.prjct/`,
+    // docs, configuration, or this file itself → you may edit directly"
+    // which the leader read as license to write audits/checklists/deploys
+    // anywhere under .prjct/. Two invariants every leader template must
+    // satisfy:
+    //   1. The canonical config file path is named as the allowlist scope.
+    //   2. The bad grant phrase "Edits to `.prjct/`," (broad, comma-grouped
+    //      with other targets) is gone.
+    const targets = [
+      path.join(CREW_DIR, 'agents', 'leader.md'),
+      path.join(CREW_DIR, 'CLAUDE-leader-mode.md'),
+    ]
+    for (const file of targets) {
+      const content = await fs.readFile(file, 'utf-8')
+      expect(content).toContain('`.prjct/prjct.config.json`')
+      expect(content).not.toContain('Edits to `.prjct/`,')
+      expect(content).not.toContain('Edits to `.prjct/`')
+    }
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.23.7",
+  "version": "2.23.8",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/crew/CLAUDE-leader-mode.md
+++ b/templates/crew/CLAUDE-leader-mode.md
@@ -21,5 +21,9 @@ If you need durable state that outlives the session, persist via `prjct` CLI ver
 ### When this role does NOT apply
 
 - Pure exploratory / read-only questions about the repo → answer directly.
-- Edits to `.prjct/`, docs, configuration, or this file → you may edit directly.
+- Edits to docs, configuration files (e.g. `.prjct/prjct.config.json`), or this file → you may edit directly.
+
+### Hard persistence rule
+
+Never write audit, checkpoint, review, deploy, or report markdown into any new file or subdirectory under the prjct state folder, and no scratch `.md` anywhere else in the worktree. The ONLY hand-editable file in that folder is `.prjct/prjct.config.json`. Everything else — checkpoints, audits, decisions, learnings, deploy notes — lives in SQLite + the regenerated vault, written through `prjct` CLI verbs (`prjct crew checkpoints set`, `prjct remember`, `prjct capture`, `prjct spec record-review`). If a subagent reports findings, persist them via `prjct remember` and cite the returned mem id; never tell a subagent to write to disk.
 <!-- prjct:crew:end - DO NOT REMOVE THIS MARKER -->

--- a/templates/crew/agents/leader.md
+++ b/templates/crew/agents/leader.md
@@ -91,4 +91,8 @@ If the reviewer replies `VERDICT: CHANGES_REQUESTED`, do not call `record-run` f
 ## When this role does NOT apply
 
 - Pure exploration / read-only questions about the repo → answer directly, no subagents.
-- Edits to `.prjct/`, docs, configuration, or this file itself → you may edit directly.
+- Edits to docs, configuration files (e.g. `.prjct/prjct.config.json`), or this file itself → you may edit directly.
+
+## Hard persistence rule
+
+Never write audit, checklist, review, deploy, or report markdown into any new file or subdirectory under the prjct state folder. The ONLY hand-editable file in that folder is `.prjct/prjct.config.json`. Durable state — checkpoints, audits, reviews, decisions, learnings — goes through `prjct` CLI verbs (`prjct crew checkpoints set`, `prjct remember`, `prjct capture`, `prjct spec record-review`). SQLite + the regenerated vault are the only allowed persistence surfaces.


### PR DESCRIPTION
## Summary
- Client reported `.prjct/audits/*.md ×24`, `.prjct/CHECKPOINTS.md`, `.prjct/deploy/RAILWAY-CHECKLIST.md` appearing in their repo — violating the absolute persistence rule (DB + regenerated vault only).
- Root cause: `templates/crew/agents/leader.md:94` and `templates/crew/CLAUDE-leader-mode.md:24` said *"Edits to `.prjct/`, docs, configuration, or this file itself → you may edit directly"*. The leader read the broad `.prjct/` mention as license to write audits/checklists/deploys anywhere under that directory — directly contradicting `templates/crew/agents/implementer.md:45` ("no subdirectory under `.prjct/`").
- Fix: scoped the allowlist to `.prjct/prjct.config.json` and added an explicit **Hard persistence rule** section to both templates. Guard test extended with the new forbidden paths plus a positive assertion that the canonical config path is named as the only edit-allowed file under `.prjct/`.

## Changes
- `templates/crew/agents/leader.md` — replaced blanket `.prjct/` allowance with `.prjct/prjct.config.json` only; added Hard persistence rule
- `templates/crew/CLAUDE-leader-mode.md` — same fix in the snippet installed into every client's `CLAUDE.md`
- `core/__tests__/commands/crew-templates-no-disk-writes.test.ts` — `FORBIDDEN` += `.prjct/audits/`, `.prjct/deploy/`, `.prjct/CHECKPOINTS.md`; new test asserts `.prjct/prjct.config.json` is named and `Edits to ` + `` `.prjct/` `` grant phrase is gone

## Test plan
- [x] `bun test core/__tests__/commands/crew-templates-no-disk-writes.test.ts` — 2 pass / 0 fail
- [x] Full suite: `bun test` — 1258 pass / 0 fail
- [x] `bun run build` regenerates `dist/templates.json` (148.1 KB, 63 files) with the new persistence rule prose
- [x] Verified the bundled templates carry the fix (grep tail of both files in dist/templates.json)

## Client impact
- Existing `.prjct/audits/`, `.prjct/deploy/RAILWAY-CHECKLIST.md`, etc. were created by the LLM following the broken template — NOT written by prjct-cli. After upgrading and running `prjct crew install` (which refreshes the `CLAUDE.md` snippet and the leader agent file), the leader will stop creating these.
- Existing legacy `.prjct/CHECKPOINTS.md` files are already migrated by `legacy-crew-sweep` (since v2.19.7); the client can safely delete the disk file after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)