### PR TITLE
docs: persist agent autonomy contract

### DIFF
--- a/core/__tests__/services/skill-generator.test.ts
+++ b/core/__tests__/services/skill-generator.test.ts
@@ -179,7 +179,16 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
       const content = await fs.readFile(result.generated[0].path, 'utf-8')
       expect(content).toContain('## Use when')
       expect(content).toContain("## What's here")
+      expect(content).toContain('### Agent contract')
       expect(content).toContain('## Gotchas')
+    })
+
+    it('states the portable agent contract for Claude and GPT', async () => {
+      const result = await generator.generateAndInstall(makeSyncResult())
+      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      expect(content).toContain('prjct remembers project state and shows the path')
+      expect(content).toContain('Claude, GPT, and other agents decide the concrete HOW')
+      expect(content).toContain('Treat prjct output as durable signals')
     })
 
     it('exposes primitives (capture, remember, context, workflow, seed)', async () => {

--- a/core/infrastructure/command-installer/global-config.ts
+++ b/core/infrastructure/command-installer/global-config.ts
@@ -20,6 +20,8 @@ const GLOBAL_CLAUDE_MD_CONTENT = `<!-- prjct:start - DO NOT REMOVE THIS MARKER -
 
 prjct stores project memory (decisions, learnings, gotchas, patterns, ships, analyses) per project and regenerates a readable Markdown vault. **Use it — don't re-read source from scratch.**
 
+prjct remembers and shows the path; it does not own execution. Treat prjct output as durable signals (task state, memories, specs, workflows, risks, recent learnings). Claude, GPT, and other agents decide the concrete HOW with their own native tools and judgment, then persist meaningful outcomes back to prjct.
+
 You are in a prjct project when any of these signs are present: \`~/Documents/prjct/<slug>/_generated/\` exists, OR \`.prjct/\` is in cwd, OR \`~/.prjct-cli/projects/\` has an entry for the current path.
 
 ## Lookup FIRST, source LAST

--- a/core/services/skill-generator.ts
+++ b/core/services/skill-generator.ts
@@ -77,6 +77,10 @@ function buildSkillContent(def: SkillDefinition, ctx: SkillContext): string {
   return `${buildFrontmatter(def, ctx)}\n\n${def.body(ctx)}`
 }
 
+function homeDir(): string {
+  return process.env.HOME || os.homedir()
+}
+
 // ============================================================================
 // SKILL GENERATOR
 // ============================================================================
@@ -128,7 +132,7 @@ class SkillGenerator {
       userPatterns: richContext?.userPatterns ?? [],
     }
 
-    const skillsDir = path.join(os.homedir(), '.claude', 'skills')
+    const skillsDir = path.join(homeDir(), '.claude', 'skills')
 
     for (const def of SKILL_DEFINITIONS) {
       if (!def.condition(conditionContext)) {

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -14,7 +14,7 @@ import { formatProjectHeader, formatRichContext } from './formatters'
 import type { SkillContext } from './types'
 
 export const PRJCT_SKILL_DESCRIPTION =
-  'Project-memory + spec-driven runtime. TRIAGE FIRST, every turn — is this simple or complex? MOST work is SIMPLE (≈1 file, known cause, bug/config/copy/doc, reversible, or the user says fix/hoy/rápido/directo): go DIRECT — `prjct task` → implement → `qa`/`review` → `ship`. NO spec, NO audit-spec, NO reviewer subagents. Spec is the EXCEPTION, ONLY for genuinely complex / high-stakes work (multi-file + new behavior, ambiguous scope, irreversible, or the user frames goals/acceptance/risks): then `spec` → `audit-spec` → `task --spec` → `ship`. Over-routing simple work through spec+reviewers is THE failure mode (burns time/tokens, zero protection on a one-file fix) — when unsure prefer DIRECT and ask one line; never default to spec. Recognize intent in any language (es/en) and run the verb yourself — never make the user type commands. Routine captures (capture/remember/tag) auto-execute, one-line confirm; destructive verbs (ship, status done) suggest-and-confirm; heavy reviews (audit/review/security/investigate) dispatch parallel subagents ONLY when the diff/scope warrants. Lookup-first: vault before re-reading source.'
+  'Project-memory + spec-driven runtime. prjct remembers and shows the path; the agent decides how to execute with its own tools. TRIAGE FIRST, every turn — is this simple or complex? MOST work is SIMPLE (≈1 file, known cause, bug/config/copy/doc, reversible, or the user says fix/hoy/rápido/directo): go DIRECT — `prjct task` → implement → `qa`/`review` → `ship`. NO spec, NO audit-spec, NO reviewer subagents. Spec is the EXCEPTION, ONLY for genuinely complex / high-stakes work (multi-file + new behavior, ambiguous scope, irreversible, or the user frames goals/acceptance/risks): then `spec` → `audit-spec` → `task --spec` → `ship`. Over-routing simple work through spec+reviewers is THE failure mode (burns time/tokens, zero protection on a one-file fix) — when unsure prefer DIRECT and ask one line; never default to spec. Recognize intent in any language (es/en) and run the verb yourself — never make the user type commands. Routine captures (capture/remember/tag) auto-execute, one-line confirm; destructive verbs (ship, status done) suggest-and-confirm; heavy reviews (audit/review/security/investigate) dispatch parallel subagents ONLY when the diff/scope warrants. Lookup-first: vault before re-reading source.'
 
 export const PRJCT_SKILL_ALLOWED_TOOLS = [
   'Bash',
@@ -88,6 +88,13 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     formatProjectHeader(ctx),
     '',
     formatRichContext(ctx),
+    '',
+    '### Agent contract',
+    '',
+    '- prjct remembers project state and shows the path; it does not own the execution.',
+    '- Treat prjct output as durable signals: active task, memories, workflows, specs, risks, and recent learnings.',
+    '- Claude, GPT, and other agents decide the concrete HOW with their own native tools and judgment.',
+    '- Persist meaningful outcomes back through `prjct remember`, `prjct capture`, `prjct task`, and `prjct ship` so the next interaction starts smarter.',
     '',
     '### Primitives',
     '',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,8 +165,12 @@ register memory types, name workflow slots, and declare hook signals — but
 never ship bash pipelines. Scripts are authored on demand by the human or
 the agent, using `projectMemory` + MCP as signal sources.
 
-This is the "prjct exposes the WHAT, the agent decides the HOW" invariant:
-zero numbered steps, zero prescriptive pipelines, zero harness.
+This is the "prjct remembers and shows the path; the agent decides the HOW"
+invariant. prjct persists project state, emits signals, and exposes recall
+surfaces. Claude, GPT, and other agents use their own native tools and judgment
+to execute, then persist outcomes back through prjct. The compatibility target
+is semantic events and durable memory, not a prescriptive harness: zero numbered
+steps, zero fixed pipelines.
 
 ## Testing
 

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -15,6 +15,8 @@ Flow: idea → roadmap → next → task → done → ship → next (cycle until
 
 Rules:
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
+- prjct remembers and shows the path; the agent decides how to execute with its own tools
+- Treat prjct output as signals, not a prescriptive harness
 - All commits include footer: `Generated with [p/](https://www.prjct.app/)`
 - All storage through `prjct` CLI (SQLite internally)
 - Start code tasks with `p. task` and follow Context Contract from CLI output

--- a/templates/global/ANTIGRAVITY.md
+++ b/templates/global/ANTIGRAVITY.md
@@ -8,6 +8,8 @@ Flow: idea → roadmap → next → task → done → ship → next (cycle until
 
 Data:
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
+- prjct remembers and shows the path; the agent decides how to execute with its own native tools
+- Treat prjct output as signals, not a prescriptive harness
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)

--- a/templates/global/CURSOR.mdc
+++ b/templates/global/CURSOR.mdc
@@ -13,6 +13,8 @@ Flow: idea → roadmap → next → task → done → ship → next (cycle until
 
 Data:
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
+- prjct remembers and shows the path; the agent decides how to execute with its own native tools
+- Treat prjct output as signals, not a prescriptive harness
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)

--- a/templates/global/GEMINI.md
+++ b/templates/global/GEMINI.md
@@ -8,6 +8,8 @@ Flow: idea → roadmap → next → task → done → ship → next (cycle until
 
 Data:
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
+- prjct remembers and shows the path; the agent decides how to execute with its own native tools
+- Treat prjct output as signals, not a prescriptive harness
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)

--- a/templates/global/WINDSURF.md
+++ b/templates/global/WINDSURF.md
@@ -13,6 +13,8 @@ Flow: idea → roadmap → next → task → done → ship → next (cycle until
 
 Data:
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
+- prjct remembers and shows the path; the agent decides how to execute with its own native tools
+- Treat prjct output as signals, not a prescriptive harness
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)


### PR DESCRIPTION
## Summary
- add a persistent agent contract: prjct remembers and shows the path, while Claude/GPT decide the concrete how with native tools
- include the contract in generated prjct skills, Codex skill template, provider global templates, global CLAUDE config, and architecture docs
- fix skill generation to respect HOME in controlled environments so tests and agent installs write to the intended home

## Tests
- bun test core/__tests__/services/skill-generator.test.ts
- bun run format:check
- bun run lint
- bun run knip
- npm run build
- pre-push: tsc --noEmit -p core/tsconfig.json