### PR TITLE
fix(ci): include chore/build/ci commits in auto-changelog Maintenance section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,11 +257,16 @@ jobs:
             RANGE="HEAD"
           fi
 
-          # Categorize commits
+          # Categorize commits. The release gate (above) only fires on
+          # feat/fix/perf/refactor/BREAKING — but a release that's triggered
+          # by, say, a fix often also ships chore/build/ci commits that
+          # landed since the last tag. Without a Maintenance bucket those
+          # silently vanish from the changelog.
           FEATURES=$(git log $RANGE --pretty=format:"- %s" --grep="^feat" 2>/dev/null | sed 's/^- feat[^:]*: /- /' || echo "")
           FIXES=$(git log $RANGE --pretty=format:"- %s" --grep="^fix" 2>/dev/null | sed 's/^- fix[^:]*: /- /' || echo "")
           PERF=$(git log $RANGE --pretty=format:"- %s" --grep="^perf" 2>/dev/null | sed 's/^- perf[^:]*: /- /' || echo "")
           REFACTOR=$(git log $RANGE --pretty=format:"- %s" --grep="^refactor" 2>/dev/null | sed 's/^- refactor[^:]*: /- /' || echo "")
+          MAINTENANCE=$(git log $RANGE --pretty=format:"- %s" --grep="^chore\|^build\|^ci" 2>/dev/null | sed -E 's/^- (chore|build|ci)[^:]*: /- /' || echo "")
 
           if [ -n "$FEATURES" ]; then
             ENTRY+="### Features"$'\n\n'"$FEATURES"$'\n\n'
@@ -277,6 +282,10 @@ jobs:
 
           if [ -n "$REFACTOR" ]; then
             ENTRY+="### Refactoring"$'\n\n'"$REFACTOR"$'\n\n'
+          fi
+
+          if [ -n "$MAINTENANCE" ]; then
+            ENTRY+="### Maintenance"$'\n\n'"$MAINTENANCE"$'\n\n'
           fi
 
           # Save for release notes


### PR DESCRIPTION
## Summary

The release gate fires on `feat|fix|perf|refactor|BREAKING` — correct, `chore:` shouldn't trigger a release on its own. But when a release IS triggered, the auto-changelog categorizer (in the same workflow) dropped any `chore`/`build`/`ci` commits that had landed since the last tag, because they had no matching bucket.

Add a `### Maintenance` section to pick them up. The gate itself is unchanged — this only fixes the changelog accuracy bug downstream.

## Why this matters

PR #376 was a 310-line cleanup mislabeled as `chore:`. Per project convention (mem_271), tech-debt cleanup is `fix:` and `chore:` is reserved for true infra-only changes. The next legitimate `fix:`/`feat:` release that ships will batch all commits since the last tag — without this fix, #376's cleanup would still be invisible in v2.24.1's release notes even though it's in the diff.

Going forward: cleanup PRs labeled correctly as `fix:` show up in **Bug Fixes**; pure infra commits show up in **Maintenance**; nothing vanishes.

## Test plan

- [x] YAML syntax valid
- [x] Grep pattern manually traced against the `chore: dead _-prefixed defs round 2…` subject from #376 — matches
- [ ] On merge: release job triggers (this commit is `fix:`), v2.24.1 cut, changelog shows both **Bug Fixes** (this PR) and **Maintenance** (#376)

🤖 Generated with [Claude Code](https://claude.com/claude-code)