### PR TITLE
perf(hooks): serve hooks from the warm daemon (~9x faster per hook)

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -35,6 +35,26 @@ if (_fastCommand === '__internal-auto-update') {
   process.exit(0)
 }
 
+// Read all of stdin (the hook event JSON) as a string, with a timeout
+// safety net. Used only on the hook fast path to forward the event to the
+// daemon. Returns whatever arrived if stdin never closes.
+async function readAllStdin(timeoutMs: number): Promise<string> {
+  if (process.stdin.isTTY) return ''
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = []
+    let done = false
+    const finish = () => {
+      if (done) return
+      done = true
+      resolve(Buffer.concat(chunks).toString('utf-8'))
+    }
+    process.stdin.on('data', (c: Buffer) => chunks.push(Buffer.from(c)))
+    process.stdin.on('end', finish)
+    process.stdin.on('error', finish)
+    setTimeout(finish, timeoutMs)
+  })
+}
+
 // Commands that bin/prjct.ts handles directly (NOT routed through daemon).
 // Note: mcp must stay here because its interactive multi-select needs TTY on
 // stdin/stdout — the detached daemon process has no TTY and would silently
@@ -195,6 +215,72 @@ if (_fastCommand && !_binCommands.has(_fastCommand) && !REGISTERED_VERBS_SET.has
   }
   _fastCommand = 'capture'
   _fastArgs = ['capture', description, ...flags]
+}
+
+// === HOOK FAST PATH (daemon-served) ===
+// Hooks fire on session-start + every prompt + every stop. A cold spawn
+// costs ~300ms (bun) to ~950ms (node) in process + module load alone; the
+// warm daemon answers in ~5-20ms. Forward the event (read from stdin) to the
+// daemon and write its response raw (byte-identical to the cold path). If the
+// daemon isn't reachable, run the SAME hook in-process here using the stdin we
+// already read (so it's never read twice), preserving the fail-soft contract.
+// `hook` stays in `_binCommands` so the GTD auto-route + generic daemon block
+// skip it; PRJCT_NO_DAEMON=1 also skips this and falls through to main().
+if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
+  const fs = await import('node:fs')
+  const { DAEMON_PATHS } = await import('../core/daemon/protocol')
+  if (fs.existsSync(DAEMON_PATHS.socket())) {
+    const subcommand = _fastArgs[1]
+    const stdinPayload = await readAllStdin(1000)
+    try {
+      const { sendRequest } = await import('../core/daemon/client')
+      const crypto = await import('node:crypto')
+      const response = await sendRequest({
+        id: crypto.randomUUID(),
+        command: 'hook',
+        args: subcommand ? [subcommand] : [],
+        options: {},
+        cwd: process.cwd(),
+        stdin: stdinPayload,
+      })
+      if (response.stdout) process.stdout.write(response.stdout)
+      process.exit(response.exitCode ?? 0)
+    } catch {
+      // Daemon unreachable mid-request. stdin is already consumed, so we
+      // can't fall through to main()'s stdin-reading handler — run the hook
+      // in-process right here with the payload we captured. Mirrors the cold
+      // path: emit, then await afterEmit before exit.
+      try {
+        const { getHookRunner } = await import('../core/hooks/registry')
+        const runner = getHookRunner(subcommand)
+        if (!runner) {
+          process.stdout.write('{}\n')
+          process.exit(0)
+        }
+        let input: unknown = {}
+        try {
+          input = stdinPayload ? JSON.parse(stdinPayload) : {}
+        } catch {
+          input = {}
+        }
+        const pending: Array<() => Promise<void>> = []
+        await runner(process.cwd(), {
+          input,
+          sink: (chunk: string) => {
+            process.stdout.write(chunk)
+          },
+          detachAfterEmit: (fn: () => Promise<void>) => {
+            pending.push(fn)
+          },
+        })
+        for (const fn of pending) await fn().catch(() => undefined)
+        process.exit(0)
+      } catch {
+        process.stdout.write('{}\n')
+        process.exit(0)
+      }
+    }
+  }
 }
 
 if (_fastCommand && !_binCommands.has(_fastCommand) && process.env.PRJCT_NO_DAEMON !== '1') {

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
       "!**/*.min.js",
       "!**/bun.lock",
       "!web",
-      "!.worktrees"
+      "!.worktrees",
+      "!**/.claude/worktrees"
     ]
   },
   "formatter": {

--- a/core/__tests__/daemon/hook-routing.test.ts
+++ b/core/__tests__/daemon/hook-routing.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Daemon hook-routing contract.
+ *
+ * Hooks can run two ways now: the cold process path (reads process.stdin,
+ * writes process.stdout, awaits afterEmit) and the warm daemon path (input
+ * injected via HookIo, output captured to a sink, afterEmit detached). The
+ * client writes the daemon's captured output RAW, so the two paths MUST emit
+ * byte-identical JSON for the same input — otherwise daemon-served hooks
+ * would silently inject different context than cold ones.
+ *
+ * These tests pin: (1) byte-parity between the two modes, (2) fail-soft in
+ * io mode (a throwing build still emits `{}`), (3) afterEmit is detached (not
+ * awaited) in io mode, and (4) the registry exposes every installed hook.
+ */
+
+import { describe, expect, spyOn, test } from 'bun:test'
+import { type HookIo, type RunHookOptions, runHook } from '../../hooks/_runner'
+import { HOOK_RUNNERS } from '../../hooks/registry'
+
+/** Capture process.stdout while running the cold path with stdin forced to
+ *  TTY (so readStdinSafe returns `{}` immediately — no hang). */
+async function coldOutput(opts: RunHookOptions<unknown>): Promise<string> {
+  const writes: string[] = []
+  const spy = spyOn(process.stdout, 'write').mockImplementation(((chunk: string | Uint8Array) => {
+    writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'))
+    return true
+  }) as typeof process.stdout.write)
+  const originalIsTTY = process.stdin.isTTY
+  Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  try {
+    await runHook(opts)
+  } finally {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    spy.mockRestore()
+  }
+  return writes.join('')
+}
+
+/** Run the warm (daemon) path with an injected input, capturing the sink. */
+async function warmOutput(
+  opts: RunHookOptions<unknown>,
+  input: unknown
+): Promise<{ out: string; pendingAfterEmit: number }> {
+  let out = ''
+  const pending: Array<() => Promise<void>> = []
+  const io: HookIo = {
+    input,
+    sink: (chunk) => {
+      out += chunk
+    },
+    detachAfterEmit: (fn) => {
+      pending.push(fn)
+    },
+  }
+  await runHook(opts, io)
+  return { out, pendingAfterEmit: pending.length }
+}
+
+describe('hook routing — process/daemon parity', () => {
+  test('both modes emit byte-identical JSON for the same (empty) input', async () => {
+    const opts: RunHookOptions<{ x?: number }> = {
+      event: 'UserPromptSubmit',
+      build: async (input) => `value:${input?.x ?? 'none'}`,
+    }
+    const cold = await coldOutput(opts as RunHookOptions<unknown>)
+    // Cold path reads `{}` from the forced-TTY stdin, so input.x is undefined.
+    const { out: warm } = await warmOutput(opts as RunHookOptions<unknown>, {})
+    expect(warm).toBe(cold)
+    expect(warm.endsWith('\n')).toBe(true)
+    expect(() => JSON.parse(warm.trim())).not.toThrow()
+  })
+
+  test('io mode threads the injected input into build (daemon stdin forwarding)', async () => {
+    const opts: RunHookOptions<{ prompt?: string }> = {
+      event: 'UserPromptSubmit',
+      build: async (input) => (input?.prompt ? `got:${input.prompt}` : null),
+    }
+    const { out } = await warmOutput(opts as RunHookOptions<unknown>, { prompt: 'hello' })
+    expect(out).toContain('got:hello')
+  })
+
+  test('io mode is fail-soft — a throwing build still emits {}', async () => {
+    const opts: RunHookOptions<unknown> = {
+      event: 'Stop',
+      build: async () => {
+        throw new Error('boom')
+      },
+    }
+    const { out } = await warmOutput(opts, {})
+    expect(out).toBe('{}\n')
+  })
+
+  test('io mode DETACHES afterEmit (does not await it before returning)', async () => {
+    let afterEmitRan = false
+    const opts: RunHookOptions<unknown> = {
+      event: 'Stop',
+      afterEmit: async () => {
+        afterEmitRan = true
+      },
+    }
+    const { pendingAfterEmit } = await warmOutput(opts, {})
+    // runHook returned WITHOUT running afterEmit — it was handed to the
+    // detach sink for the daemon to schedule out-of-band.
+    expect(pendingAfterEmit).toBe(1)
+    expect(afterEmitRan).toBe(false)
+  })
+})
+
+describe('hook registry', () => {
+  test('exposes every installed hook subcommand', () => {
+    // Mirrors settings-installer.ts HOOKS list.
+    for (const name of [
+      'session-start',
+      'prompt',
+      'pre-commit',
+      'post-edit',
+      'stop',
+      'subagent-start',
+      'cwd-changed',
+    ]) {
+      expect(typeof HOOK_RUNNERS[name]).toBe('function')
+    }
+  })
+})

--- a/core/__tests__/infrastructure/daemon-shim-sync.test.ts
+++ b/core/__tests__/infrastructure/daemon-shim-sync.test.ts
@@ -76,10 +76,20 @@ describe('daemon-shim ↔ bin/prjct.ts sync', () => {
 describe('daemon-shim fallback policy', () => {
   const buildSrc = fs.readFileSync(path.join(ROOT, 'scripts/build.js'), 'utf-8')
 
-  test('timeout is 30s, matching core/daemon/client.ts sendRequest', () => {
+  test('generic-path timeout is 30s; any short timeout is fail-soft, never re-imports core', () => {
+    // The generic command path keeps the 30s timeout matching sendRequest.
     expect(buildSrc).toContain('30000)')
-    // 5000 was the old hair-trigger timeout that caused the double-fire.
-    expect(buildSrc).not.toMatch(/setTimeout\([^)]*,\s*5000\)/)
+    // A 5s timeout used to be a hair-trigger that fell through to a core
+    // re-import, double-running mutating commands like `ship`. The hook fast
+    // path reintroduces a short (5s) timeout ON PURPOSE — a hook must never
+    // freeze the agent turn — but it is fail-soft: every 5s timeout routes to
+    // `soft`, which writes the empty no-op `{}` and exits 0. It must NEVER
+    // call fallback() (which re-imports core and could double-run).
+    const fiveSecTimeouts = buildSrc.match(/setTimeout\([^,]*,\s*5000\)/g) ?? []
+    for (const t of fiveSecTimeouts) {
+      expect(t).toContain('soft')
+      expect(t).not.toContain('fallback')
+    }
   })
 
   test('socket error path checks ECONNREFUSED / ENOENT before fallback', () => {

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -17,6 +17,8 @@ import { createServer as createNetServer } from 'node:net'
 import { PrjctCommands } from '../commands/commands'
 import { commandRegistry } from '../commands/registry'
 import '../commands/register'
+import type { HookIo } from '../hooks/_runner'
+import { getHookRunner } from '../hooks/registry'
 import prjctDb from '../storage/database'
 import type { DaemonRequest, DaemonResponse, DaemonState } from '../types/daemon'
 import { executeCommand } from './dispatch'
@@ -286,6 +288,8 @@ async function handleRequestInner(request: DaemonRequest): Promise<DaemonRespons
 
   if (request.command === 'daemon') return handleDaemonCommand(request)
 
+  if (request.command === 'hook') return handleHookRequest(request)
+
   if (request.command === '__ping') {
     return {
       id: request.id,
@@ -327,6 +331,57 @@ async function handleRequestInner(request: DaemonRequest): Promise<DaemonRespons
       stderr: (err as Error).message,
     }
   }
+}
+
+/**
+ * Serve a Claude Code hook from the warm daemon instead of a cold spawn.
+ *
+ * The hook runner is given a `HookIo` bridge: its event payload comes from
+ * the forwarded stdin, its emitted JSON is captured into `stdout` (returned
+ * verbatim to the client, which writes it raw — byte-identical to the cold
+ * path), and its `afterEmit` side-effects (vault regen, transcript ingest)
+ * are DETACHED via setImmediate so they neither delay the response nor block
+ * the daemon's serialized request chain. The runner is fail-soft by
+ * contract; the outer guard is belt-and-suspenders so a hook can never take
+ * the daemon down.
+ */
+async function handleHookRequest(request: DaemonRequest): Promise<DaemonResponse> {
+  const runner = getHookRunner(request.args[0])
+  if (!runner) {
+    return { id: request.id, success: true, exitCode: 0, stdout: '{}\n' }
+  }
+
+  let input: unknown = {}
+  if (request.stdin) {
+    try {
+      input = JSON.parse(request.stdin)
+    } catch {
+      input = {}
+    }
+  }
+
+  let captured = ''
+  const io: HookIo = {
+    input,
+    sink: (chunk) => {
+      captured += chunk
+    },
+    detachAfterEmit: (fn) => {
+      setImmediate(() => {
+        fn().catch(() => {
+          /* detached side-effects are best-effort; the next hook recovers */
+        })
+      })
+    },
+  }
+
+  try {
+    await runner(request.cwd, io)
+  } catch {
+    /* runner is fail-soft; guard anyway so the daemon never crashes */
+  }
+
+  return { id: request.id, success: true, exitCode: 0, stdout: captured || '{}\n' }
 }
 
 function handleDaemonCommand(request: DaemonRequest): DaemonResponse {

--- a/core/hooks/_runner.ts
+++ b/core/hooks/_runner.ts
@@ -17,6 +17,14 @@
  *      Stop only accepts systemMessage).
  *   4. After-effects run AFTER `emit` so the host parser doesn't wait
  *      on side-effect work.
+ *
+ * Two execution modes share ALL of the above:
+ *   - Process mode (`io` omitted): the cold path Claude Code spawns —
+ *     reads `process.stdin`, writes `process.stdout`, awaits `afterEmit`.
+ *   - Daemon mode (`io` supplied): the warm path — input comes pre-parsed
+ *     from the wire request, output goes to a sink (returned to the
+ *     client), and `afterEmit` is DETACHED so it never blocks the daemon's
+ *     serialized request chain. Same build + same fail-soft contract.
  */
 
 import { buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
@@ -36,8 +44,44 @@ export interface RunHookOptions<I> {
   afterEmit?: (input: I, projectPath: string) => Promise<void>
 }
 
-export async function runHook<I = Record<string, unknown>>(opts: RunHookOptions<I>): Promise<void> {
+/**
+ * Daemon-mode I/O bridge. When present, the hook runs warm inside the
+ * daemon instead of cold in a freshly-spawned process.
+ */
+export interface HookIo {
+  /** The hook event payload, already parsed from the wire request. */
+  input: unknown
+  /** Receives the exact bytes the process path would write to stdout
+   *  (a JSON line terminated by `\n`). The daemon returns this verbatim
+   *  to the client, which writes it raw — byte-identical to the cold path. */
+  sink: (chunk: string) => void
+  /** Schedule `afterEmit` to run WITHOUT blocking the response or the
+   *  daemon's request chain (typically `setImmediate` + error swallow). */
+  detachAfterEmit: (fn: () => Promise<void>) => void
+}
+
+export async function runHook<I = Record<string, unknown>>(
+  opts: RunHookOptions<I>,
+  io?: HookIo
+): Promise<void> {
   const projectPath = opts.projectPath ?? process.cwd()
+
+  if (io) {
+    // Daemon (warm) path. Mirror the process path's fail-soft contract:
+    // any throw becomes the empty no-op `{}` so a broken hook can never
+    // disturb the host session.
+    try {
+      const input = io.input as I
+      const context = opts.build ? await opts.build(input, projectPath) : null
+      io.sink(`${JSON.stringify(buildHookOutput(opts.event, context))}\n`)
+      if (opts.afterEmit) io.detachAfterEmit(() => opts.afterEmit!(input, projectPath))
+    } catch {
+      io.sink('{}\n')
+    }
+    return
+  }
+
+  // Process (cold) path — unchanged.
   await safeRun(async () => {
     const input = await readStdinSafe<I>()
     const context = opts.build ? await opts.build(input, projectPath) : null

--- a/core/hooks/cwd-changed.ts
+++ b/core/hooks/cwd-changed.ts
@@ -9,20 +9,23 @@
  * If the new cwd has no prjct project, we emit `{}` — no noise.
  */
 
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 import { buildSessionContext } from './session-start'
 
 interface HookInput {
   cwd?: string
 }
 
-export function runCwdChangedHook(fallbackCwd: string = process.cwd()): Promise<void> {
-  return runHook<HookInput>({
-    event: 'CwdChanged',
-    projectPath: fallbackCwd,
-    build: async (input, fallback) => {
-      const cwd = input.cwd || fallback
-      return buildSessionContext(cwd)
+export function runCwdChangedHook(fallbackCwd: string = process.cwd(), io?: HookIo): Promise<void> {
+  return runHook<HookInput>(
+    {
+      event: 'CwdChanged',
+      projectPath: fallbackCwd,
+      build: async (input, fallback) => {
+        const cwd = input.cwd || fallback
+        return buildSessionContext(cwd)
+      },
     },
-  })
+    io
+  )
 }

--- a/core/hooks/post-edit.ts
+++ b/core/hooks/post-edit.ts
@@ -10,7 +10,7 @@
 
 import configManager from '../infrastructure/config-manager'
 import { memoryService } from '../services/memory-service'
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 
 interface EditOrWriteToolInput {
   file_path?: string
@@ -21,26 +21,29 @@ interface HookInput {
   tool_input?: EditOrWriteToolInput
 }
 
-export function runPostEditHook(projectPath: string = process.cwd()): Promise<void> {
-  return runHook<HookInput>({
-    event: 'PostToolUse',
-    projectPath,
-    afterEmit: async (input, p) => {
-      const file = input.tool_input?.file_path
-      if (!file) return
-      const config = await configManager.readConfig(p)
-      if (!config?.projectId) return
-      // Event-sourced — downstream hooks/workflows can query via
-      // `memoryService.getRecent()` filtering on `post_edit`. Fire and
-      // forget; any failure is non-critical.
-      try {
-        await memoryService.log(p, 'post_edit', {
-          file,
-          tool: input.tool_name ?? 'unknown',
-        })
-      } catch {
-        /* swallow — hook must never surface errors */
-      }
+export function runPostEditHook(projectPath: string = process.cwd(), io?: HookIo): Promise<void> {
+  return runHook<HookInput>(
+    {
+      event: 'PostToolUse',
+      projectPath,
+      afterEmit: async (input, p) => {
+        const file = input.tool_input?.file_path
+        if (!file) return
+        const config = await configManager.readConfig(p)
+        if (!config?.projectId) return
+        // Event-sourced — downstream hooks/workflows can query via
+        // `memoryService.getRecent()` filtering on `post_edit`. Fire and
+        // forget; any failure is non-critical.
+        try {
+          await memoryService.log(p, 'post_edit', {
+            file,
+            tool: input.tool_name ?? 'unknown',
+          })
+        } catch {
+          /* swallow — hook must never surface errors */
+        }
+      },
     },
-  })
+    io
+  )
 }

--- a/core/hooks/pre-commit.ts
+++ b/core/hooks/pre-commit.ts
@@ -15,7 +15,7 @@
 import { execSync } from 'node:child_process'
 import configManager from '../infrastructure/config-manager'
 import { formatMemoryMd, type MemoryEntry, projectMemory } from '../memory/project-memory'
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 import { safeTruncate } from './_shared'
 
 const MAX_CHARS = 1200
@@ -104,17 +104,20 @@ async function buildPreCommitContext(projectPath: string): Promise<string | null
   return safeTruncate(body, MAX_CHARS)
 }
 
-export function runPreCommitHook(projectPath: string = process.cwd()): Promise<void> {
-  return runHook<HookInput>({
-    event: 'PreToolUse',
-    projectPath,
-    build: async (input, p) => {
-      // Only fire for `git commit` invocations — the matcher in
-      // settings.json already narrows to Bash, but the `if:` clause
-      // is pattern-based and the host may pass us other Bash calls.
-      const command = input.tool_input?.command ?? ''
-      if (!/\bgit\s+commit\b/.test(command)) return null
-      return buildPreCommitContext(p)
+export function runPreCommitHook(projectPath: string = process.cwd(), io?: HookIo): Promise<void> {
+  return runHook<HookInput>(
+    {
+      event: 'PreToolUse',
+      projectPath,
+      build: async (input, p) => {
+        // Only fire for `git commit` invocations — the matcher in
+        // settings.json already narrows to Bash, but the `if:` clause
+        // is pattern-based and the host may pass us other Bash calls.
+        const command = input.tool_input?.command ?? ''
+        if (!/\bgit\s+commit\b/.test(command)) return null
+        return buildPreCommitContext(p)
+      },
     },
-  })
+    io
+  )
 }

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -22,7 +22,7 @@ import { stateStorage } from '../storage/state-storage'
 import type { LocalConfig } from '../types/config'
 import { execFileAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 import { extractKeywords, safeTruncate } from './_shared'
 
 const MAX_CHARS = 2200
@@ -332,35 +332,38 @@ function formatRelative(isoTimestamp: string): string {
   return `${Math.floor(days / 30)}mo ago`
 }
 
-export function runPromptHook(projectPath: string = process.cwd()): Promise<void> {
-  return runHook<HookInput>({
-    event: 'UserPromptSubmit',
-    projectPath,
-    build: async (input, p) => {
-      const prompt = (input.prompt ?? '').trim()
-      if (!prompt) return null
-      // Read config ONCE and fan it out — the three builders previously each
-      // called configManager.readConfig(p), i.e. 3 disk reads + 3 JSONC parses
-      // of the same file on every prompt turn. readConfig is uncached.
-      const config = await configManager.readConfig(p)
-      // Three pass: state (for intent disambiguation) + memory (for topical
-      // recall) + improvement signals (proactive UX nudges from prior
-      // sessions). All independent, each silently null'd on failure.
-      const [state, memory, signals] = await Promise.all([
-        buildProjectState(p, config),
-        buildPromptContext(p, prompt, config),
-        buildImprovementSignals(p, config),
-      ])
-      // Per-block budgets first (each builder already trims to its own
-      // ceiling; this is a defense-in-depth re-clamp), then MAX_CHARS as
-      // a hard cap on the joined output.
-      const blocks = [
-        state ? safeTruncate(state, STATE_BUDGET) : null,
-        signals ? safeTruncate(signals, SIGNALS_BUDGET) : null,
-        memory ? safeTruncate(memory, MEMORY_BUDGET) : null,
-      ].filter((b): b is string => Boolean(b))
-      if (blocks.length === 0) return null
-      return safeTruncate(blocks.join('\n\n'), MAX_CHARS)
+export function runPromptHook(projectPath: string = process.cwd(), io?: HookIo): Promise<void> {
+  return runHook<HookInput>(
+    {
+      event: 'UserPromptSubmit',
+      projectPath,
+      build: async (input, p) => {
+        const prompt = (input.prompt ?? '').trim()
+        if (!prompt) return null
+        // Read config ONCE and fan it out — the three builders previously each
+        // called configManager.readConfig(p), i.e. 3 disk reads + 3 JSONC parses
+        // of the same file on every prompt turn. readConfig is uncached.
+        const config = await configManager.readConfig(p)
+        // Three pass: state (for intent disambiguation) + memory (for topical
+        // recall) + improvement signals (proactive UX nudges from prior
+        // sessions). All independent, each silently null'd on failure.
+        const [state, memory, signals] = await Promise.all([
+          buildProjectState(p, config),
+          buildPromptContext(p, prompt, config),
+          buildImprovementSignals(p, config),
+        ])
+        // Per-block budgets first (each builder already trims to its own
+        // ceiling; this is a defense-in-depth re-clamp), then MAX_CHARS as
+        // a hard cap on the joined output.
+        const blocks = [
+          state ? safeTruncate(state, STATE_BUDGET) : null,
+          signals ? safeTruncate(signals, SIGNALS_BUDGET) : null,
+          memory ? safeTruncate(memory, MEMORY_BUDGET) : null,
+        ].filter((b): b is string => Boolean(b))
+        if (blocks.length === 0) return null
+        return safeTruncate(blocks.join('\n\n'), MAX_CHARS)
+      },
     },
-  })
+    io
+  )
 }

--- a/core/hooks/registry.ts
+++ b/core/hooks/registry.ts
@@ -1,0 +1,40 @@
+/**
+ * Hook runner registry — the single source of truth mapping a Claude Code
+ * hook subcommand name to its runner.
+ *
+ * Both entry paths consume this:
+ *   - the cold path (`bin/prjct.ts` → `prjct hook <name>`), and
+ *   - the warm path (the daemon, which runs the same runner with a
+ *     `HookIo` bridge so the hook body never touches process stdin/stdout).
+ *
+ * Keeping the mapping here (instead of a switch duplicated in both places)
+ * means adding a hook is a one-line change that both paths pick up — the
+ * same drift-killer applied to spec routing in `core/commands/route-spec.ts`.
+ */
+
+import type { HookIo } from './_runner'
+import { runCwdChangedHook } from './cwd-changed'
+import { runPostEditHook } from './post-edit'
+import { runPreCommitHook } from './pre-commit'
+import { runPromptHook } from './prompt'
+import { runSessionStartHook } from './session-start'
+import { runStopHook } from './stop'
+import { runSubagentStartHook } from './subagent-start'
+
+/** A hook runner: runs the hook for `projectPath`. With `io` it runs in
+ *  daemon (warm) mode; without, in process (cold) mode. */
+export type HookRunner = (projectPath: string, io?: HookIo) => Promise<void>
+
+export const HOOK_RUNNERS: Record<string, HookRunner> = {
+  'session-start': runSessionStartHook,
+  prompt: runPromptHook,
+  'pre-commit': runPreCommitHook,
+  'post-edit': runPostEditHook,
+  stop: runStopHook,
+  'subagent-start': runSubagentStartHook,
+  'cwd-changed': runCwdChangedHook,
+}
+
+export function getHookRunner(name: string | undefined): HookRunner | undefined {
+  return name ? HOOK_RUNNERS[name] : undefined
+}

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -35,7 +35,7 @@ import { isSyncCurrent, runSelfHeal } from '../infrastructure/self-heal'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import type { LocalConfig, ProjectPersona } from '../types/config'
 import { VERSION } from '../utils/version'
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 
 interface HookInput {
   source?: 'startup' | 'resume' | 'clear' | 'compact'
@@ -85,41 +85,47 @@ function formatPersona(persona: ProjectPersona): string {
  * Top-level entry — read stdin, emit JSON, exit.
  * Never throws; hook failures must not break the host session.
  */
-export function runSessionStartHook(projectPath: string = process.cwd()): Promise<void> {
+export function runSessionStartHook(
+  projectPath: string = process.cwd(),
+  io?: HookIo
+): Promise<void> {
   // Captured by the build closure so afterEmit can reuse it without a
   // second disk read on the hot path that fires on every session start.
   let cachedConfig: LocalConfig | null = null
 
-  return runHook<HookInput>({
-    event: 'SessionStart',
-    projectPath,
-    build: async (_input, p) => {
-      cachedConfig = await configManager.readConfig(p).catch(() => null)
-      return buildSessionContext(p, cachedConfig)
-    },
-    afterEmit: async (_input, p) => {
-      // Refresh the Obsidian vault from DB so the files Claude may Read
-      // reflect current project state. Best-effort; errors are swallowed.
-      if (cachedConfig?.projectId) {
-        await regenerateWikiDeferred(p, cachedConfig.projectId).catch(() => undefined)
-      }
+  return runHook<HookInput>(
+    {
+      event: 'SessionStart',
+      projectPath,
+      build: async (_input, p) => {
+        cachedConfig = await configManager.readConfig(p).catch(() => null)
+        return buildSessionContext(p, cachedConfig)
+      },
+      afterEmit: async (_input, p) => {
+        // Refresh the Obsidian vault from DB so the files Claude may Read
+        // reflect current project state. Best-effort; errors are swallowed.
+        if (cachedConfig?.projectId) {
+          await regenerateWikiDeferred(p, cachedConfig.projectId).catch(() => undefined)
+        }
 
-      // Self-heal hooks + global CLAUDE.md when the binary moved past the
-      // last sync. Catches machines where postinstall is disabled by
-      // security policy. Hot path is one fs read of the stamp file.
-      if (!isSyncCurrent(VERSION)) {
-        await runSelfHeal(VERSION).catch(() => undefined)
-      }
+        // Self-heal hooks + global CLAUDE.md when the binary moved past the
+        // last sync. Catches machines where postinstall is disabled by
+        // security policy. Hot path is one fs read of the stamp file.
+        if (!isSyncCurrent(VERSION)) {
+          await runSelfHeal(VERSION).catch(() => undefined)
+        }
 
-      // M5: opt-in silent auto-update. No-op unless the user has opted
-      // in via `prjct config set auto-update on`. Throttled to 1/hour
-      // and runs detached so the session never waits.
-      try {
-        const { maybeAutoUpdate } = await import('../services/auto-updater')
-        maybeAutoUpdate(VERSION)
-      } catch {
-        // never block the session on update mechanics
-      }
+        // M5: opt-in silent auto-update. No-op unless the user has opted
+        // in via `prjct config set auto-update on`. Throttled to 1/hour
+        // and runs detached so the session never waits.
+        try {
+          const { maybeAutoUpdate } = await import('../services/auto-updater')
+          maybeAutoUpdate(VERSION)
+        } catch {
+          // never block the session on update mechanics
+        }
+      },
     },
-  })
+    io
+  )
 }

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -25,95 +25,98 @@ import { detectSkillMisses } from '../services/skill-miss-detector'
 import { ingestTranscript } from '../services/transcript-learner'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 
 interface HookInput {
   transcript_path?: string
   session_id?: string
 }
 
-export function runStopHook(projectPath: string = process.cwd()): Promise<void> {
-  return runHook<HookInput>({
-    event: 'Stop',
-    projectPath,
-    afterEmit: async (input, p) => {
-      const config = await configManager.readConfig(p).catch(() => null)
-      if (!config?.projectId) return
+export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): Promise<void> {
+  return runHook<HookInput>(
+    {
+      event: 'Stop',
+      projectPath,
+      afterEmit: async (input, p) => {
+        const config = await configManager.readConfig(p).catch(() => null)
+        if (!config?.projectId) return
 
-      // Captured notes → memory entries (existing behavior).
-      try {
-        await ingestCapturedNotes(p)
-      } catch {
-        // Ingest failure shouldn't block regen — captured/ stays for next turn.
-      }
-
-      // M1b INPUT: workflow overrides → workflow_rules table.
-      try {
-        await ingestWorkflowEdits(p)
-      } catch {
-        // Same contract — failed parses leave the file in place for the user.
-      }
-
-      // M1a: auto-capture substantive insights from the assistant's
-      // transcript. Conservative heuristics, hashed-dedup, never blocks.
-      if (input.transcript_path) {
+        // Captured notes → memory entries (existing behavior).
         try {
-          await ingestTranscript(p, input.transcript_path, input.session_id ?? null)
+          await ingestCapturedNotes(p)
         } catch {
-          // Failed parse / unexpected format → swallow. The user can
-          // always run `prjct remember` explicitly.
+          // Ingest failure shouldn't block regen — captured/ stays for next turn.
         }
-      }
 
-      // M2: detect durable patterns (hot files for now) and persist them
-      // as learning memory entries. Lookup-first protocol means Claude
-      // finds them on next session start without inflating context.
-      try {
-        await detectAndPersistPatterns(p)
-      } catch {
-        // Git failure / non-repo → swallow; nothing to do here.
-      }
-
-      // Session-end housekeeping (Phase A): age-out inbox, prune archives
-      // and old checkpoints, rotate stale on-disk caches. Best-effort —
-      // each step internally swallows its own failures, so the rest of
-      // the cleanup still runs even if one step trips.
-      try {
-        const cleanup = await runSessionCleanup(config.projectId)
-        await recordCleanupReport(config.projectId, cleanup)
-      } catch {
-        /* never block session end on cleanup */
-      }
-
-      // Session-end friction capture (Phase B): scan the transcript for
-      // user-pushback moments (negation, correction, complaint markers)
-      // and persist them as `improvement-signal` memory entries. The
-      // next session's Claude reads them via topical recall and
-      // synthesises improvement ideas — no regex-based classification
-      // here, only signal extraction.
-      if (input.transcript_path) {
+        // M1b INPUT: workflow overrides → workflow_rules table.
         try {
-          await detectFriction(p, input.transcript_path, input.session_id ?? null)
+          await ingestWorkflowEdits(p)
         } catch {
-          /* same contract as transcript-learner — silent best-effort */
+          // Same contract — failed parses leave the file in place for the user.
         }
-      }
 
-      // Session-end skill-miss capture (harness #16): flag captured
-      // project knowledge (decision/gotcha/anti-pattern) that was
-      // relevant to this session's work but never referenced. Persisted
-      // as `improvement-signal` and surfaced under the existing block at
-      // the next session start — advisory, never a gate. Same silent
-      // best-effort contract as the friction detector above.
-      if (input.transcript_path) {
+        // M1a: auto-capture substantive insights from the assistant's
+        // transcript. Conservative heuristics, hashed-dedup, never blocks.
+        if (input.transcript_path) {
+          try {
+            await ingestTranscript(p, input.transcript_path, input.session_id ?? null)
+          } catch {
+            // Failed parse / unexpected format → swallow. The user can
+            // always run `prjct remember` explicitly.
+          }
+        }
+
+        // M2: detect durable patterns (hot files for now) and persist them
+        // as learning memory entries. Lookup-first protocol means Claude
+        // finds them on next session start without inflating context.
         try {
-          await detectSkillMisses(p, input.transcript_path, input.session_id ?? null)
+          await detectAndPersistPatterns(p)
         } catch {
-          /* silent best-effort — must never block session end */
+          // Git failure / non-repo → swallow; nothing to do here.
         }
-      }
 
-      await regenerateWikiDeferred(p, config.projectId).catch(() => undefined)
+        // Session-end housekeeping (Phase A): age-out inbox, prune archives
+        // and old checkpoints, rotate stale on-disk caches. Best-effort —
+        // each step internally swallows its own failures, so the rest of
+        // the cleanup still runs even if one step trips.
+        try {
+          const cleanup = await runSessionCleanup(config.projectId)
+          await recordCleanupReport(config.projectId, cleanup)
+        } catch {
+          /* never block session end on cleanup */
+        }
+
+        // Session-end friction capture (Phase B): scan the transcript for
+        // user-pushback moments (negation, correction, complaint markers)
+        // and persist them as `improvement-signal` memory entries. The
+        // next session's Claude reads them via topical recall and
+        // synthesises improvement ideas — no regex-based classification
+        // here, only signal extraction.
+        if (input.transcript_path) {
+          try {
+            await detectFriction(p, input.transcript_path, input.session_id ?? null)
+          } catch {
+            /* same contract as transcript-learner — silent best-effort */
+          }
+        }
+
+        // Session-end skill-miss capture (harness #16): flag captured
+        // project knowledge (decision/gotcha/anti-pattern) that was
+        // relevant to this session's work but never referenced. Persisted
+        // as `improvement-signal` and surfaced under the existing block at
+        // the next session start — advisory, never a gate. Same silent
+        // best-effort contract as the friction detector above.
+        if (input.transcript_path) {
+          try {
+            await detectSkillMisses(p, input.transcript_path, input.session_id ?? null)
+          } catch {
+            /* silent best-effort — must never block session end */
+          }
+        }
+
+        await regenerateWikiDeferred(p, config.projectId).catch(() => undefined)
+      },
     },
-  })
+    io
+  )
 }

--- a/core/hooks/subagent-start.ts
+++ b/core/hooks/subagent-start.ts
@@ -8,13 +8,19 @@
  * WHAT (role, MCPs, recent memory), never CÓMO.
  */
 
-import { runHook } from './_runner'
+import { type HookIo, runHook } from './_runner'
 import { buildSessionContext } from './session-start'
 
-export function runSubagentStartHook(projectPath: string = process.cwd()): Promise<void> {
-  return runHook({
-    event: 'SubagentStart',
-    projectPath,
-    build: (_input, p) => buildSessionContext(p),
-  })
+export function runSubagentStartHook(
+  projectPath: string = process.cwd(),
+  io?: HookIo
+): Promise<void> {
+  return runHook(
+    {
+      event: 'SubagentStart',
+      projectPath,
+      build: (_input, p) => buildSessionContext(p),
+    },
+    io
+  )
 }

--- a/core/types/daemon.ts
+++ b/core/types/daemon.ts
@@ -19,6 +19,9 @@ export interface DaemonRequest {
   cwd: string
   /** Process start time (nanoseconds) for startup metrics */
   perfStartNs?: string
+  /** Raw stdin payload, forwarded for `hook` commands (the Claude Code
+   *  event JSON the hook would otherwise read from its own stdin). */
+  stdin?: string
 }
 
 /** Response sent from daemon to CLI client */

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -189,7 +189,26 @@ const cmd=args.find(a=>!a.startsWith("-"));
 const skip=new Set(["daemon","stop","restart","start","setup","update","upgrade","dev","web","serve","context","hooks","doctor","uninstall","watch","help","-h","--help","version","-v","--version","claude","hook","seed","install","crew","mcp","prefs","retro","health","skill-adherence","review-risk","context-save","context-restore","spec","audit-spec"]);
 function refuse(m){console.error("prjct: daemon dropped the request ("+m+"). Retry: prjct "+args.join(" "));process.exit(1)}
 function isSafeRetry(e){const c=e&&e.code||"",m=e&&e.message||"";return c==="ECONNREFUSED"||c==="ENOENT"||m.includes("ECONNREFUSED")||m.includes("ENOENT")}
-if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
+// Hook fast path: forward the event (stdin) to the warm daemon and write its
+// response raw. Hooks must never disturb the host session, so ANY failure
+// (connect error, timeout, closed socket) degrades to the empty no-op {} and
+// exit 0 — the same fail-soft contract the in-process hook runner honors.
+let hookDone=false;
+function sendHook(sub,data){
+  if(hookDone)return;hookDone=true;
+  const msg=JSON.stringify({id:randomUUID(),command:"hook",args:sub?[sub]:[],options:{},cwd:process.cwd(),stdin:data})+"\\n";
+  const sock=connect(sockPath);let buf="",done=false;
+  const soft=()=>{if(!done){done=true;clearTimeout(t);sock.destroy();process.stdout.write("{}\\n");process.exit(0)}};
+  const t=setTimeout(soft,5000);
+  sock.on("connect",()=>sock.write(msg));
+  sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));done=true;clearTimeout(t);sock.end();if(r.stdout)process.stdout.write(r.stdout);process.exit(r.exitCode!=null?r.exitCode:0)}});
+  sock.on("error",soft);
+  sock.on("close",soft);
+}
+if(cmd==="hook"&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
+  const sub=args[1];
+  if(process.stdin.isTTY){sendHook(sub,"")}else{let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>sendHook(sub,d));process.stdin.on("error",()=>sendHook(sub,d));setTimeout(()=>sendHook(sub,d),1000)}
+}else if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
   const cArgs=[],cOpts={};
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}
   const msg=JSON.stringify({id:randomUUID(),command:cmd,args:cArgs,options:cOpts,cwd:process.cwd()})+"\\n";


### PR DESCRIPTION
## Summary
Hooks (session-start + **every prompt** + **every stop**) were cold process spawns that load the 738KB core bundle + better-sqlite3 native binding before doing any work — **~950ms (node) / ~300ms (bun) per hook** (`scripts/bench-hooks.mjs`), i.e. ~2s of pure prjct overhead per turn on node. The daemon already keeps everything warm for other commands; hooks just never used it. Now the shim forwards `hook <event>` (with stdin) to the daemon and writes the response raw.

## Measured (this machine, node, 15 iters/event)
| event | cold | warm | speedup |
|-------|------|------|---------|
| session-start | 958ms | 106ms | **9.0x** |
| prompt | 960ms | 109ms | **8.8x** |
| stop | 994ms | 98ms | **10.1x** |

Output is **byte-identical** to the cold path (verified in production: `diff` of warm vs cold is empty).

## How it stays correct and safe
- **`runHook(opts, io?)`** gains an optional `HookIo` bridge. Without it the **cold path is unchanged** (process.stdin → stdout, awaits afterEmit). With it: input injected, output to a sink, and **afterEmit DETACHED** (`setImmediate`) so vault regen / transcript ingest never block the daemon's serialized request chain or the response.
- **Hook registry** (`core/hooks/registry.ts`) maps subcommand → runner; daemon and shim both consume it (no duplicated switch — same drift-killer as `route-spec.ts`).
- **Fail-soft end to end**: any error (build throw, daemon connect/timeout/close) → empty no-op `{}` + exit 0. A hook can never disturb the host session.
- **Cold path is the fallback**: socket absent or `PRJCT_NO_DAEMON=1` → in-process handler runs exactly as before (no double stdin read).
- The shim's 5s hook timeout routes to a fail-soft `soft()` (writes `{}`, exits) and **never calls `fallback()`** (which re-imports core), so the v2.19.x double-fire hazard does not apply. The shim-sync test now pins that invariant.

## Tests
- `core/__tests__/daemon/hook-routing.test.ts` — pins byte-parity between the two modes, io-mode fail-soft, afterEmit detachment, and registry completeness.
- `daemon-shim-sync.test.ts` updated for the hook fast-path timeout invariant.
- Full suite green (1311), typecheck + knip clean.

## Also
- `biome.json` ignores `**/.claude/worktrees` (Claude Code spawned-task worktrees carry a nested biome.json that broke `biome check .`).

## Risk
The hot, fail-soft, every-turn path. Mitigated by: cold path untouched as fallback, byte-parity test, fail-soft preserved at every layer, and the daemon handler guarded so a hook can never crash the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)