### PR TITLE
feat(memory): traverse the relationship graph on recall (phase 3)

### DIFF
--- a/core/__tests__/memory/expand-links.test.ts
+++ b/core/__tests__/memory/expand-links.test.ts
@@ -1,0 +1,95 @@
+/**
+ * projectMemory.expandWithLinks — one-hop relationship-graph traversal.
+ *
+ * The cross-reference graph (`resolves=`/`relates=`/`supersedes=` tags and
+ * inline `mem_N` mentions) existed only as rendered wikilinks; no retrieval
+ * path followed it. These tests pin that recalling an entry can now surface
+ * the entries it points to — deduped against the seed and capped.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { projectMemory } from '../../memory/project-memory'
+import prjctDb from '../../storage/database'
+
+let tmpRoot: string
+let projectId: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+/** Write a memory entry and return its `mem_<rowid>` id. */
+function write(type: string, content: string, tags: Record<string, string> = {}): string {
+  prjctDb.appendEvent(projectId, `memory.remember.${type}`, {
+    content,
+    tags,
+    provenance: 'declared',
+  })
+  // Newest-first recall → the entry we just wrote is first.
+  const latest = projectMemory.recall(projectId, { limit: 1, dedupeByKey: false })
+  return latest[0]?.id ?? ''
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-expand-links-'))
+  projectId = `test-expand-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+  pathManager.getStoragePath = (id: string, filename: string) =>
+    path.join(tmpRoot, id, 'storage', filename)
+  pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+    path.join(tmpRoot, id, layer, filename)
+})
+
+afterEach(async () => {
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('projectMemory.expandWithLinks', () => {
+  it('follows a `resolves=` tag to the referenced entry', () => {
+    const a = write('decision', 'use npm as the package manager')
+    const b = write('decision', 'switched to bun for speed', { resolves: a })
+    const seed = projectMemory.getById(projectId, b)!
+    const linked = projectMemory.expandWithLinks(projectId, [seed])
+    expect(linked.map((e) => e.id)).toContain(a)
+  })
+
+  it('follows an inline `mem_N` mention in the content body', () => {
+    const a = write('gotcha', 'WAL mode locks under iCloud sync')
+    const c = write('learning', `root cause traced back to ${a} — same locking class`)
+    const seed = projectMemory.getById(projectId, c)!
+    const linked = projectMemory.expandWithLinks(projectId, [seed])
+    expect(linked.map((e) => e.id)).toContain(a)
+  })
+
+  it('never returns an entry already in the seed set (no self/dup)', () => {
+    const a = write('decision', 'alpha')
+    const b = write('decision', 'beta resolves alpha', { resolves: a })
+    const seedA = projectMemory.getById(projectId, a)!
+    const seedB = projectMemory.getById(projectId, b)!
+    const linked = projectMemory.expandWithLinks(projectId, [seedA, seedB])
+    // Both are already seeds — nothing new to surface.
+    expect(linked).toHaveLength(0)
+  })
+
+  it('respects the cap', () => {
+    const targets = [write('fact', 'one'), write('fact', 'two'), write('fact', 'three')]
+    const hub = write('decision', `relates to ${targets.join(' and ')}`)
+    const seed = projectMemory.getById(projectId, hub)!
+    const linked = projectMemory.expandWithLinks(projectId, [seed], 2)
+    expect(linked.length).toBe(2)
+  })
+
+  it('returns [] for an empty seed or a non-positive cap', () => {
+    expect(projectMemory.expandWithLinks(projectId, [])).toHaveLength(0)
+    const a = write('fact', 'solo')
+    const seed = projectMemory.getById(projectId, a)!
+    expect(projectMemory.expandWithLinks(projectId, [seed], 0)).toHaveLength(0)
+  })
+})

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -467,6 +467,49 @@ export const projectMemory = {
   },
 
   /**
+   * Follow each seed entry's cross-references ONE hop and return the linked
+   * entries (deduped against the seed, capped).
+   *
+   * The relationship graph already exists as text — a decision captured with
+   * `--tags resolves:mem_2609` (or an inline `mem_2609` mention) renders as a
+   * wikilink in the vault — but no RETRIEVAL path ever traversed it. So
+   * recalling "the decision that resolved X" left X itself (the superseded
+   * decision, the bug it fixed, the spec it implements) invisible to the
+   * agent unless it manually looked it up. This surfaces those one hop out so
+   * a single recall carries its own context. Bounded by `cap` so a densely
+   * linked entry can't balloon the injected context.
+   */
+  expandWithLinks(projectId: string, seed: MemoryEntry[], cap = 5): MemoryEntry[] {
+    if (seed.length === 0 || cap <= 0) return []
+    const refRe = /\bmem[_-](\d+)\b/g
+    // Tag keys whose values name a related entry. Kept explicit (not "any
+    // tag") so an arbitrary `mem_N`-looking tag value can't pull noise.
+    const relKeys = ['resolves', 'relates', 'supersedes', 'superseded-by', 'duplicates', 'spec']
+    const seen = new Set(seed.map((e) => e.id))
+    const linked: MemoryEntry[] = []
+
+    for (const entry of seed) {
+      if (linked.length >= cap) break
+      const refs = new Set<string>()
+      for (const key of relKeys) {
+        const v = entry.tags?.[key]
+        if (!v) continue
+        for (const m of String(v).matchAll(refRe)) refs.add(`mem_${m[1]}`)
+      }
+      for (const m of entry.content.matchAll(refRe)) refs.add(`mem_${m[1]}`)
+
+      for (const ref of refs) {
+        if (linked.length >= cap) break
+        if (seen.has(ref)) continue
+        seen.add(ref)
+        const e = projectMemory.getById(projectId, ref)
+        if (e) linked.push(e)
+      }
+    }
+    return linked
+  },
+
+  /**
    * EVERY entry — no limit, no topic/type filter, no latest-winner
    * dedupe. The vault link layer needs this: `recall()` collapses
    * `(type, key)` duplicates and caps results, so an older entry that

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -180,13 +180,17 @@ async function runMemoryTool(
 
   if (idArg) {
     const entry = projectMemory.getById(projectId, idArg)
+    // Resolving one entry by id is exactly when its relationships matter
+    // most ("show me mem_3209" → also show what it resolves / supersedes).
+    const linked = entry ? projectMemory.expandWithLinks(projectId, [entry], 5) : []
+    const resolved = entry ? [entry, ...linked] : []
     return {
       tool: opts.kind,
       result: {
         markdown: entry
-          ? formatMemoryMd([entry])
+          ? formatMemoryMd(resolved)
           : `> No memory entry with id \`${idArg}\` (it may have aged out or never existed).`,
-        entryCount: entry ? 1 : 0,
+        entryCount: resolved.length,
         topic: idArg,
       },
     }
@@ -222,6 +226,13 @@ async function runMemoryTool(
       entries.push(e)
       if (entries.length >= LIMIT) break
     }
+  }
+  // One hop of relationship-graph traversal: append entries the results
+  // resolve / relate to / supersede so a recall carries its own context
+  // instead of dangling `mem_N` pointers the agent must chase manually.
+  if (entries.length > 0) {
+    const linked = projectMemory.expandWithLinks(projectId, entries, 5)
+    if (linked.length > 0) entries = entries.concat(linked)
   }
   return {
     tool: opts.kind,


### PR DESCRIPTION
## Summary
The cross-reference graph already existed as text — a decision captured with `--tags resolves:mem_2609`, or an inline `mem_2609` mention, renders as a wikilink in the vault — but **no retrieval path ever followed it**. Recalling "the decision that resolved X" left X itself (the superseded decision, the bug it fixed, the spec it implements) invisible unless the agent manually chased the `mem_N` pointer.

`projectMemory.expandWithLinks(projectId, seed, cap)` follows each seed entry's cross-refs **one hop** — `resolves` / `relates` / `supersedes` / `superseded-by` / `duplicates` / `spec` tag values plus inline `mem_N` mentions — and returns the linked entries, **deduped against the seed and capped** so a densely-linked entry can't balloon injected context.

## Wiring
- CLI/MCP `context memory` path (generous 30-entry budget): topic search **and** resolve-by-id — `prjct context memory mem_N` now also surfaces what that entry resolves/supersedes.
- **Not** wired into the UserPromptSubmit hook — its tight token budget stays lean.

## Tests
`core/__tests__/memory/expand-links.test.ts`: tag refs, inline mentions, seed-dedup, cap, empty/zero guards. Full suite green (1316), typecheck + knip clean.

## Phase 3 status
This is the first, no-new-dependency slice of "world-class memory." Still ahead: **memory decay/compaction** (superseded-entry pruning, age-weighting) and **semantic/embedding search** (the latter has a local-vs-API fork worth deciding deliberately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)