### PR TITLE
feat(memory): author-declared compaction in recall (phase 3)

### DIFF
--- a/core/__tests__/memory/supersede-decay.test.ts
+++ b/core/__tests__/memory/supersede-decay.test.ts
@@ -1,0 +1,99 @@
+/**
+ * projectMemory.recall — author-declared compaction (supersede / duplicate).
+ *
+ * Stale entries the author explicitly retired must drop out of recall so the
+ * agent isn't handed an obsolete decision next to the one that replaced it.
+ * Author-declared, not heuristic: nothing is pruned unless the relationship
+ * was written down. The link/index layer can opt out so retired entries stay
+ * resolvable (their wikilinks must not rot).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { projectMemory } from '../../memory/project-memory'
+import prjctDb from '../../storage/database'
+
+let tmpRoot: string
+let projectId: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+function write(type: string, content: string, tags: Record<string, string> = {}): string {
+  prjctDb.appendEvent(projectId, `memory.remember.${type}`, {
+    content,
+    tags,
+    provenance: 'declared',
+  })
+  // Keep pruning/dedupe OFF here so we always get the id of the entry we
+  // just wrote, even when it self-declares `superseded-by`.
+  const latest = projectMemory.recall(projectId, {
+    limit: 1,
+    dedupeByKey: false,
+    pruneSuperseded: false,
+  })
+  return latest[0]?.id ?? ''
+}
+
+const ids = (entries: { id: string }[]) => entries.map((e) => e.id)
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-supersede-'))
+  projectId = `test-sup-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+  pathManager.getStoragePath = (id: string, filename: string) =>
+    path.join(tmpRoot, id, 'storage', filename)
+  pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+    path.join(tmpRoot, id, layer, filename)
+})
+
+afterEach(async () => {
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('projectMemory.recall — supersede/duplicate compaction', () => {
+  it('drops an entry retired by a newer `supersedes:` entry', () => {
+    const old = write('decision', 'use npm')
+    write('decision', 'use bun instead', { supersedes: old })
+    const got = ids(projectMemory.recall(projectId, { types: ['decision'] }))
+    expect(got).not.toContain(old)
+    expect(got.length).toBe(1)
+  })
+
+  it('drops an entry that self-declares `superseded-by:`', () => {
+    const a = write('decision', 'legacy approach', { 'superseded-by': 'mem_99999' })
+    const got = ids(projectMemory.recall(projectId, { types: ['decision'] }))
+    expect(got).not.toContain(a)
+  })
+
+  it('drops an entry retired via `duplicates:`', () => {
+    const orig = write('gotcha', 'WAL lock under iCloud')
+    write('gotcha', 'iCloud sync lock (dupe)', { duplicates: orig })
+    const got = ids(projectMemory.recall(projectId, { types: ['gotcha'] }))
+    expect(got).not.toContain(orig)
+  })
+
+  it('keeps retired entries when pruneSuperseded:false (link/index layer)', () => {
+    const old = write('decision', 'use npm')
+    write('decision', 'use bun instead', { supersedes: old })
+    const got = ids(
+      projectMemory.recall(projectId, { types: ['decision'], pruneSuperseded: false })
+    )
+    expect(got).toContain(old)
+    expect(got.length).toBe(2)
+  })
+
+  it('leaves unrelated entries untouched', () => {
+    write('decision', 'alpha')
+    write('decision', 'beta')
+    const got = projectMemory.recall(projectId, { types: ['decision'] })
+    expect(got.length).toBe(2)
+  })
+})

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -103,6 +103,15 @@ interface RecallOpts {
    * `gstack-learnings-search` (garrytan/gstack).
    */
   dedupeByKey?: boolean
+
+  /**
+   * Drop entries the author explicitly marked obsolete — an entry tagged
+   * `supersedes:mem_X` / `duplicates:mem_X` retires X, and an entry tagged
+   * `superseded-by:…` retires itself. Author-declared compaction, not a
+   * heuristic. Default: true. Set false for the link/index layer, which
+   * must keep retired entries resolvable so their wikilinks don't rot.
+   */
+  pruneSuperseded?: boolean
 }
 
 const DEFAULT_RECALL_LIMIT = 25
@@ -210,6 +219,34 @@ function dedupeLatestByKey(entries: MemoryEntry[]): MemoryEntry[] {
     out.push(entry)
   }
   return out
+}
+
+const MEM_REF_RE = /\bmem[_-](\d+)\b/g
+
+/**
+ * Collect the ids that the author has explicitly declared obsolete, from
+ * the relationships present in `entries`:
+ *   - an entry tagged `supersedes:mem_X` (or `duplicates:mem_X`) marks X dead
+ *     — the newer/canonical entry replaces it;
+ *   - an entry tagged `superseded-by:…` marks ITSELF dead — it points forward
+ *     to its replacement.
+ *
+ * This is author-declared compaction, not a heuristic: nothing is pruned
+ * unless someone wrote the relationship down. Scoped to the supplied window
+ * (no extra query on the recall hot path); the superseding entry is almost
+ * always newer than — and thus recalled alongside — the one it replaces.
+ */
+function collectSupersededIds(entries: MemoryEntry[]): Set<string> {
+  const dead = new Set<string>()
+  for (const entry of entries) {
+    if (entry.tags['superseded-by']) dead.add(entry.id)
+    for (const key of ['supersedes', 'duplicates']) {
+      const v = entry.tags[key]
+      if (!v) continue
+      for (const m of String(v).matchAll(MEM_REF_RE)) dead.add(`mem_${m[1]}`)
+    }
+  }
+  return dead
 }
 
 export const projectMemory = {
@@ -434,6 +471,15 @@ export const projectMemory = {
     // sort so the first match per group is the newest.
     if (opts.dedupeByKey !== false) {
       entries = dedupeLatestByKey(entries)
+    }
+
+    // Author-declared compaction: drop entries explicitly retired via
+    // supersedes / superseded-by / duplicates. Runs before the slice so a
+    // retired entry never consumes a result slot. Opt out (link/index layer)
+    // to keep retired entries resolvable.
+    if (opts.pruneSuperseded !== false) {
+      const dead = collectSupersededIds(entries)
+      if (dead.size > 0) entries = entries.filter((e) => !dead.has(e.id))
     }
 
     return entries.slice(0, limit)


### PR DESCRIPTION
## Summary
The decay/compaction half of phase 3. Stale entries the author explicitly retired now drop out of recall, so the agent isn't handed an obsolete decision next to the one that replaced it. **Author-declared, not a heuristic** — nothing is pruned unless the relationship was written down.

`recall` (default on, opt-out via `pruneSuperseded: false`) drops:
- an entry tagged `supersedes:mem_X` / `duplicates:mem_X` → retires X
- an entry tagged `superseded-by:…` → retires itself

## Safety / scope
- Scoped to the fetched window (no extra query on the hot path); the superseding entry is newer than — and recalled alongside — the one it replaces. Pruning runs **before the limit slice** so a retired entry never consumes a slot.
- The **link/index layer is unaffected**: it builds from `allEntriesForIndex` (full scan, not `recall`), so retired entries stay resolvable and wikilinks don't rot.
- Every agent-facing recall caller (context tool, prompt hook, friction/skill-miss detectors, spec inference, `similar`) gets compaction for free.

## Tests
`core/__tests__/memory/supersede-decay.test.ts`: supersedes, superseded-by, duplicates, opt-out, unrelated-untouched. Full suite green (1326), typecheck + knip clean.

## Phase 3 status
✅ relationship-graph traversal (#383) · ✅ decay/compaction (this) · ⬜ semantic/embedding search (local-vs-API-vs-pluggable fork still pending your decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)