### PR TITLE
feat(memory): reinforcement loop — recall gets smarter with use

### DIFF
--- a/core/__tests__/services/usefulness.test.ts
+++ b/core/__tests__/services/usefulness.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Memory reinforcement ledger — "smarter with use".
+ *
+ * Pins: reference/fetch signals accumulate a score, scores TIME-DECAY by
+ * half-life, and recall re-ranking gives a BOUNDED usefulness boost (a
+ * proven entry climbs, but relevance still leads and unscored entries keep
+ * their order). Time is injected so decay is deterministic.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import type { MemoryEntry } from '../../memory/project-memory'
+import { extractRefIds, usefulnessService } from '../../services/usefulness'
+import prjctDb from '../../storage/database'
+
+let tmpRoot: string
+let projectId: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+const T0 = Date.parse('2026-01-01T00:00:00.000Z')
+const T0_ISO = new Date(T0).toISOString()
+const DAY = 86_400_000
+
+const fakeEntry = (id: string): MemoryEntry =>
+  ({
+    id,
+    type: 'decision',
+    content: id,
+    tags: {},
+    rememberedAt: T0_ISO,
+    provenance: 'declared',
+  }) as MemoryEntry
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-useful-'))
+  projectId = `test-useful-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+  pathManager.getStoragePath = (id: string, filename: string) =>
+    path.join(tmpRoot, id, 'storage', filename)
+  pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+    path.join(tmpRoot, id, layer, filename)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0') // force migrations
+})
+
+afterEach(async () => {
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('extractRefIds', () => {
+  it('pulls ids from relationship tags and inline mentions', () => {
+    const ids = extractRefIds('builds on mem_7 and mem_8', { resolves: 'mem_3', other: 'x' })
+    expect(new Set(ids)).toEqual(new Set(['mem_3', 'mem_7', 'mem_8']))
+  })
+  it('returns [] when there are no refs', () => {
+    expect(extractRefIds('no references here', {})).toHaveLength(0)
+  })
+})
+
+describe('usefulnessService — accumulation + decay', () => {
+  it('credits referenced ids and exposes their score', () => {
+    usefulnessService.recordReferences(projectId, 'see mem_5', {}, T0_ISO)
+    const scores = usefulnessService.decayedScores(projectId, T0)
+    expect(scores.get('mem_5')).toBeCloseTo(1.0, 5)
+  })
+
+  it('a reference outweighs a fetch', () => {
+    usefulnessService.recordReferences(projectId, 'mem_1', {}, T0_ISO)
+    usefulnessService.recordFetch(projectId, 'mem_2', T0_ISO)
+    const s = usefulnessService.decayedScores(projectId, T0)
+    expect(s.get('mem_1')!).toBeGreaterThan(s.get('mem_2')!)
+  })
+
+  it('decays to ~half after one half-life (45d)', () => {
+    usefulnessService.recordReferences(projectId, 'mem_9', {}, T0_ISO)
+    const decayed = usefulnessService.decayedScores(projectId, T0 + 45 * DAY)
+    expect(decayed.get('mem_9')).toBeCloseTo(0.5, 2)
+  })
+
+  it('accumulates repeated references', () => {
+    usefulnessService.recordReferences(projectId, 'mem_4', {}, T0_ISO)
+    usefulnessService.recordReferences(projectId, 'mem_4 again', {}, T0_ISO)
+    expect(usefulnessService.decayedScores(projectId, T0).get('mem_4')).toBeCloseTo(2.0, 5)
+  })
+})
+
+describe('usefulnessService.rerank', () => {
+  it('lifts a proven entry above an unused one ranked just ahead of it', () => {
+    // Give mem_2 a strong score; it starts BELOW mem_1 in relevance order.
+    for (let i = 0; i < 5; i++) usefulnessService.recordReferences(projectId, 'mem_2', {}, T0_ISO)
+    const ordered = [fakeEntry('mem_1'), fakeEntry('mem_2'), fakeEntry('mem_3')]
+    const reranked = usefulnessService.rerank(projectId, ordered, T0)
+    expect(reranked[0]?.id).toBe('mem_2')
+  })
+
+  it('is a no-op when nothing has a score (preserves order)', () => {
+    const ordered = [fakeEntry('mem_1'), fakeEntry('mem_2'), fakeEntry('mem_3')]
+    const reranked = usefulnessService.rerank(projectId, ordered, T0)
+    expect(reranked.map((e) => e.id)).toEqual(['mem_1', 'mem_2', 'mem_3'])
+  })
+
+  it('boost is bounded — a tiny score cannot leap a far-more-relevant entry', () => {
+    usefulnessService.recordFetch(projectId, 'mem_99', T0_ISO) // weak, single fetch
+    // mem_99 is dead last in a long relevance-ordered list.
+    const ordered = Array.from({ length: 10 }, (_, i) => fakeEntry(`mem_${i}`))
+    ordered.push(fakeEntry('mem_99'))
+    const reranked = usefulnessService.rerank(projectId, ordered, T0)
+    // It may climb a few slots but must NOT reach the top.
+    expect(reranked[0]?.id).toBe('mem_0')
+  })
+})

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -310,6 +310,19 @@ export const projectMemory = {
       }
     }
 
+    // Reinforcement loop: credit the entries this new one references — they
+    // just proved load-bearing (the project is building on them). Feeds the
+    // usefulness ranking so proven knowledge surfaces first over time.
+    // Best-effort; dynamic import avoids a static service cycle.
+    if (logResult?.projectId) {
+      try {
+        const { usefulnessService } = await import('../services/usefulness')
+        usefulnessService.recordReferences(logResult.projectId, args.content, tags)
+      } catch {
+        /* never block a capture on reinforcement bookkeeping */
+      }
+    }
+
     // Phase 1.5 / B1: also publish to the sync queue so prjct-cloud
     // mirrors memories. memoryService.log writes to the local events
     // table, but it doesn't enqueue a SyncEvent for push — that's

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -1,0 +1,161 @@
+/**
+ * Memory reinforcement ledger — "prjct gets smarter the more it's used."
+ *
+ * Recall already ranks by relevance (BM25 / semantic) and recency. What it
+ * lacked was a memory of WHICH knowledge actually pays off. This service
+ * accumulates a per-entry `usefulness` score from deterministic usage
+ * signals and feeds it back into the ranking:
+ *
+ *   - reference  — a newly captured entry cites an older `mem_N`
+ *                  (resolves / relates / supersedes / inline mention). The
+ *                  cited entry is load-bearing knowledge the project keeps
+ *                  building on → strong positive signal.
+ *   - fetch      — an entry was pulled by id on purpose
+ *                  (`prjct context memory mem_N`) → weaker positive signal.
+ *
+ * Scores TIME-DECAY (half-life): knowledge that stops being used fades from
+ * the ranking boost on its own, so the system tracks what is useful NOW, not
+ * what was useful once. That decay is how it "learns from" disuse — the
+ * negative half of the loop — without ever deleting anything.
+ *
+ * Best-effort throughout: a failure here must never break a capture or a
+ * recall. Time is injectable so tests are deterministic.
+ */
+
+import type { MemoryEntry } from '../../memory/project-memory'
+import prjctDb from '../../storage/database'
+
+/** Days for a usefulness contribution to halve. ~6 weeks: a decision cited
+ *  last month still counts, one cited last year barely does. */
+const HALF_LIFE_DAYS = 45
+const REF_WEIGHT = 1.0
+const FETCH_WEIGHT = 0.4
+const MS_PER_DAY = 86_400_000
+
+/** Tag keys whose values name a related entry (mirrors expandWithLinks). */
+const REL_KEYS = ['resolves', 'relates', 'supersedes', 'superseded-by', 'duplicates', 'spec']
+const MEM_REF_RE = /\bmem[_-](\d+)\b/g
+
+/** Collect the `mem_N` ids a new entry points at (relationship tags + inline). */
+export function extractRefIds(content: string, tags: Record<string, string>): string[] {
+  const ids = new Set<string>()
+  for (const key of REL_KEYS) {
+    const v = tags[key]
+    if (!v) continue
+    for (const m of String(v).matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
+  }
+  for (const m of content.matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
+  return [...ids]
+}
+
+interface UsefulnessRow {
+  memory_id: string
+  score: number
+  last_used_at: string
+}
+
+function bump(
+  projectId: string,
+  memoryId: string,
+  weight: number,
+  column: 'ref_count' | 'fetch_count',
+  nowIso: string
+): void {
+  prjctDb.run(
+    projectId,
+    `INSERT INTO memory_usefulness (memory_id, score, ${column}, last_used_at)
+     VALUES (?, ?, 1, ?)
+     ON CONFLICT(memory_id) DO UPDATE SET
+       score = score + ?, ${column} = ${column} + 1, last_used_at = excluded.last_used_at`,
+    memoryId,
+    weight,
+    nowIso,
+    weight
+  )
+}
+
+export const usefulnessService = {
+  /** Credit every entry that `content`/`tags` reference (a capture happened). */
+  recordReferences(
+    projectId: string,
+    content: string,
+    tags: Record<string, string>,
+    nowIso: string = new Date().toISOString()
+  ): void {
+    try {
+      for (const id of extractRefIds(content, tags)) {
+        bump(projectId, id, REF_WEIGHT, 'ref_count', nowIso)
+      }
+    } catch {
+      /* best-effort — never block a capture */
+    }
+  },
+
+  /** Credit an entry pulled deliberately by id. */
+  recordFetch(
+    projectId: string,
+    memoryId: string,
+    nowIso: string = new Date().toISOString()
+  ): void {
+    try {
+      bump(projectId, memoryId, FETCH_WEIGHT, 'fetch_count', nowIso)
+    } catch {
+      /* best-effort */
+    }
+  },
+
+  /**
+   * Current time-decayed usefulness per memory id. A score recorded `age`
+   * days ago is worth `score * 0.5^(age / HALF_LIFE_DAYS)` today.
+   */
+  decayedScores(projectId: string, nowMs: number = Date.now()): Map<string, number> {
+    const out = new Map<string, number>()
+    let rows: UsefulnessRow[]
+    try {
+      rows = prjctDb.query<UsefulnessRow>(
+        projectId,
+        'SELECT memory_id, score, last_used_at FROM memory_usefulness'
+      )
+    } catch {
+      return out
+    }
+    for (const r of rows) {
+      const last = Date.parse(r.last_used_at)
+      const factor = Number.isNaN(last)
+        ? 1
+        : 0.5 ** (Math.max(0, nowMs - last) / MS_PER_DAY / HALF_LIFE_DAYS)
+      out.set(r.memory_id, r.score * factor)
+    }
+    return out
+  },
+
+  /**
+   * Re-rank a relevance-ordered list with a BOUNDED usefulness boost: a
+   * proven-useful entry can climb a few slots, but relevance still leads
+   * (the boost only reorders near-equals). Stable for entries with no score.
+   * Returns a new array; never throws.
+   */
+  rerank(projectId: string, entries: MemoryEntry[], nowMs: number = Date.now()): MemoryEntry[] {
+    if (entries.length < 2) return entries
+    let scores: Map<string, number>
+    try {
+      scores = this.decayedScores(projectId, nowMs)
+    } catch {
+      return entries
+    }
+    if (scores.size === 0) return entries
+
+    const max = Math.max(1, ...scores.values())
+    // Max slots a maximally-useful entry may climb. Small so relevance leads.
+    const BOOST = 4
+    const n = entries.length
+    const ranked = entries.map((entry, i) => {
+      const norm = (scores.get(entry.id) ?? 0) / max // 0..1
+      // Higher rankScore = earlier. Relevance contributes (n - i); usefulness
+      // adds up to BOOST. Index keeps the sort stable on ties.
+      return { entry, i, rankScore: n - i + BOOST * norm }
+    })
+    ranked.sort((a, b) => b.rankScore - a.rankScore || a.i - b.i)
+    return ranked.map((r) => r.entry)
+  },
+}

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -729,4 +729,27 @@ export const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 23,
+    name: 'memory-usefulness-ledger',
+    up: (db: SqliteDatabase) => {
+      // Reinforcement ledger: prjct gets smarter with use by tracking which
+      // memory entries actually prove useful. A row accumulates a decayed
+      // `score` from real usage signals — `ref_count` (a later entry cited
+      // this one: load-bearing knowledge) and `fetch_count` (it was pulled by
+      // id on purpose). `last_used_at` drives time-decay at read time, so
+      // knowledge that stops being used fades from the ranking boost on its
+      // own. Recall blends this score so proven-useful entries surface first.
+      // Keyed by the same `mem_<id>` as the rest of the memory layer.
+      db.run(`
+        CREATE TABLE IF NOT EXISTS memory_usefulness (
+          memory_id    TEXT PRIMARY KEY,
+          score        REAL NOT NULL DEFAULT 0,
+          ref_count    INTEGER NOT NULL DEFAULT 0,
+          fetch_count  INTEGER NOT NULL DEFAULT 0,
+          last_used_at TEXT NOT NULL
+        )
+      `)
+    },
+  },
 ]

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -20,6 +20,7 @@ import {
   projectMemory,
 } from '../../memory/project-memory'
 import { embeddingService } from '../../services/embeddings'
+import { usefulnessService } from '../../services/usefulness'
 import type { ContextToolOutput } from '../../types/context-tools'
 import { getErrorMessage } from '../../types/fs'
 
@@ -181,6 +182,8 @@ async function runMemoryTool(
 
   if (idArg) {
     const entry = projectMemory.getById(projectId, idArg)
+    // Deliberate by-id pull = a usefulness signal; reinforce it.
+    if (entry) usefulnessService.recordFetch(projectId, entry.id)
     // Resolving one entry by id is exactly when its relationships matter
     // most ("show me mem_3209" → also show what it resolves / supersedes).
     const linked = entry ? projectMemory.expandWithLinks(projectId, [entry], 5) : []
@@ -248,6 +251,14 @@ async function runMemoryTool(
     } catch {
       /* best-effort — lexical results stand */
     }
+  }
+
+  // Reinforcement: nudge proven-useful entries up (bounded — relevance still
+  // leads). This is how recall gets smarter with use: knowledge the project
+  // keeps referencing / pulling rises over time; unused knowledge decays out
+  // of the boost on its own.
+  if (entries.length > 1) {
+    entries = usefulnessService.rerank(projectId, entries)
   }
 
   // One hop of relationship-graph traversal: append entries the results


### PR DESCRIPTION
## Summary
Direct answer to "prjct should get smarter the more it's used, learning from its hits and misses." Recall ranked by relevance + recency but had **no memory of which entries actually prove useful** — a load-bearing decision the project keeps building on ranked the same as a one-off note. Now it learns.

## The loop
A usefulness ledger (migration 23, `memory_usefulness`) accumulates a per-entry score from **deterministic usage signals**:
- **reference** (w 1.0): a newly captured entry cites an older `mem_N` (resolves/relates/supersedes/inline) — recorded in `projectMemory.remember`. The cited entry is knowledge the project is *building on*.
- **fetch** (w 0.4): an entry pulled by id (`context memory mem_N`) — recorded in the CLI/MCP path.

Scores **time-decay** (45-day half-life), so the ranking tracks what's useful **now**; knowledge that stops being used fades from the boost on its own. That decay is the "learn from disuse" half of the loop — **nothing is ever deleted**.

`context memory` re-ranks with a **bounded** boost: a proven entry climbs a few slots, but relevance still leads and a tiny score can't leap a far-more-relevant hit.

## Why this is the right shape
- **Deterministic, no attribution guesswork** — references and by-id pulls are hard signals, not heuristics about "did this help."
- Pairs with phase-3: graph traversal (connected) + compaction (supersede) + this (proven + current) → the knowledge that rises is connected, proven, and current; stale/superseded sinks.
- **Best-effort everywhere** — reinforcement bookkeeping can never break a capture or recall.

## Tests
`core/__tests__/services/usefulness.test.ts`: extract, accumulate, half-life decay, bounded re-rank, no-op-when-unscored. Time injected → deterministic. Full suite green (1342), typecheck + knip clean.

## Future signals (same ledger, later PRs)
ship-success attribution (memories recalled in a session that shipped), friction/skill-miss as negative signals, surfacing a "most valuable knowledge" view in `prjct retro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)