### PR TITLE
feat(memory): ship-success attribution — strongest reinforcement signal

### DIFF
--- a/core/__tests__/services/usefulness.test.ts
+++ b/core/__tests__/services/usefulness.test.ts
@@ -117,3 +117,43 @@ describe('usefulnessService.rerank', () => {
     expect(reranked[0]?.id).toBe('mem_0')
   })
 })
+
+describe('usefulnessService — ship-success attribution', () => {
+  it('credits surfaced entries on ship and clears the log', () => {
+    usefulnessService.recordSurfaced(projectId, ['mem_10', 'mem_11'], 'task-1', T0_ISO)
+    const credited = usefulnessService.creditShippedTask(projectId, 'task-1', T0_ISO)
+    expect(credited).toBe(2)
+
+    const scores = usefulnessService.decayedScores(projectId, T0)
+    // Ship credit (2.5) is the strongest signal — stronger than a reference.
+    expect(scores.get('mem_10')).toBeCloseTo(2.5, 5)
+    expect(scores.get('mem_11')).toBeCloseTo(2.5, 5)
+
+    // Log cleared → a second credit finds nothing.
+    expect(usefulnessService.creditShippedTask(projectId, 'task-1', T0_ISO)).toBe(0)
+  })
+
+  it('only credits the shipped task, leaving other tasks pending', () => {
+    usefulnessService.recordSurfaced(projectId, ['mem_20'], 'task-a', T0_ISO)
+    usefulnessService.recordSurfaced(projectId, ['mem_21'], 'task-b', T0_ISO)
+    usefulnessService.creditShippedTask(projectId, 'task-a', T0_ISO)
+
+    const scores = usefulnessService.decayedScores(projectId, T0)
+    expect(scores.get('mem_20')).toBeCloseTo(2.5, 5)
+    expect(scores.has('mem_21')).toBe(false) // task-b never shipped → no credit yet
+    // task-b's surface row survives for a later ship.
+    expect(usefulnessService.creditShippedTask(projectId, 'task-b', T0_ISO)).toBe(1)
+  })
+
+  it('adds ship credit on top of an existing usefulness score', () => {
+    usefulnessService.recordFetch(projectId, 'mem_30', T0_ISO) // 0.4
+    usefulnessService.recordSurfaced(projectId, ['mem_30'], 'task-x', T0_ISO)
+    usefulnessService.creditShippedTask(projectId, 'task-x', T0_ISO)
+    expect(usefulnessService.decayedScores(projectId, T0).get('mem_30')).toBeCloseTo(2.9, 5)
+  })
+
+  it('is a no-op for an empty task id or no surfaced rows', () => {
+    expect(usefulnessService.creditShippedTask(projectId, '', T0_ISO)).toBe(0)
+    expect(usefulnessService.creditShippedTask(projectId, 'never-surfaced', T0_ISO)).toBe(0)
+  })
+})

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -255,6 +255,19 @@ export class ShippingCommands extends PrjctCommandsBase {
         showNextSteps('ship')
       }
 
+      // Ship-success reinforcement: every memory surfaced during this task
+      // just fed work that actually shipped — give it the strong usefulness
+      // credit so it ranks higher in future recall. Best-effort; a completed
+      // ship must never fail on reinforcement bookkeeping.
+      if (currentTask?.id) {
+        try {
+          const { usefulnessService } = await import('../services/usefulness')
+          usefulnessService.creditShippedTask(projectId, currentTask.id)
+        } catch {
+          /* best-effort */
+        }
+      }
+
       return { success: true, feature: featureName, version: newVersion }
     } catch (error) {
       out.fail(getErrorMessage(error))

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -30,6 +30,9 @@ import prjctDb from '../../storage/database'
 const HALF_LIFE_DAYS = 45
 const REF_WEIGHT = 1.0
 const FETCH_WEIGHT = 0.4
+/** Strongest signal: this entry was surfaced during work that actually
+ *  shipped. A real outcome, not just a citation. */
+const SHIP_WEIGHT = 2.5
 const MS_PER_DAY = 86_400_000
 
 /** Tag keys whose values name a related entry (mirrors expandWithLinks). */
@@ -101,6 +104,71 @@ export const usefulnessService = {
       bump(projectId, memoryId, FETCH_WEIGHT, 'fetch_count', nowIso)
     } catch {
       /* best-effort */
+    }
+  },
+
+  /**
+   * Note that `memoryIds` were surfaced during `taskId`. Kept in a transient
+   * log; credited (or dropped) when the task ships (or is abandoned). At most
+   * one row per (memory, task).
+   */
+  recordSurfaced(
+    projectId: string,
+    memoryIds: string[],
+    taskId: string,
+    nowIso: string = new Date().toISOString()
+  ): void {
+    if (!taskId || memoryIds.length === 0) return
+    try {
+      for (const id of memoryIds) {
+        prjctDb.run(
+          projectId,
+          `INSERT OR IGNORE INTO memory_surface_log (memory_id, task_id, created_at)
+           VALUES (?, ?, ?)`,
+          id,
+          taskId,
+          nowIso
+        )
+      }
+    } catch {
+      /* best-effort — surfacing telemetry must never break a recall */
+    }
+  },
+
+  /**
+   * A task shipped successfully: credit every entry surfaced during it with
+   * the strong ship-success weight, then clear the task's surface rows.
+   * Returns how many entries were credited. Best-effort.
+   */
+  creditShippedTask(
+    projectId: string,
+    taskId: string,
+    nowIso: string = new Date().toISOString()
+  ): number {
+    if (!taskId) return 0
+    try {
+      const rows = prjctDb.query<{ memory_id: string }>(
+        projectId,
+        'SELECT memory_id FROM memory_surface_log WHERE task_id = ?',
+        taskId
+      )
+      for (const r of rows) {
+        prjctDb.run(
+          projectId,
+          `INSERT INTO memory_usefulness (memory_id, score, last_used_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(memory_id) DO UPDATE SET
+             score = score + ?, last_used_at = excluded.last_used_at`,
+          r.memory_id,
+          SHIP_WEIGHT,
+          nowIso,
+          SHIP_WEIGHT
+        )
+      }
+      prjctDb.run(projectId, 'DELETE FROM memory_surface_log WHERE task_id = ?', taskId)
+      return rows.length
+    } catch {
+      return 0
     }
   },
 

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -752,4 +752,25 @@ export const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 24,
+    name: 'memory-surface-log',
+    up: (db: SqliteDatabase) => {
+      // Ship-success attribution: which memory entries were SURFACED during a
+      // task. `context memory` records the entries it shows here, keyed by the
+      // active task; when that task reaches a successful `prjct ship`, every
+      // surfaced entry gets a strong usefulness boost — "knowledge that fed
+      // work which actually shipped." Rows are deleted once credited, so this
+      // stays a small, transient working set. (memory_id, task_id) is unique
+      // so a memory is recorded at most once per task.
+      db.run(`
+        CREATE TABLE IF NOT EXISTS memory_surface_log (
+          memory_id   TEXT NOT NULL,
+          task_id     TEXT NOT NULL,
+          created_at  TEXT NOT NULL,
+          PRIMARY KEY (memory_id, task_id)
+        )
+      `)
+    },
+  },
 ]

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../../memory/project-memory'
 import { embeddingService } from '../../services/embeddings'
 import { usefulnessService } from '../../services/usefulness'
+import { stateStorage } from '../../storage/state-storage'
 import type { ContextToolOutput } from '../../types/context-tools'
 import { getErrorMessage } from '../../types/fs'
 
@@ -268,6 +269,24 @@ async function runMemoryTool(
     const linked = projectMemory.expandWithLinks(projectId, entries, 5)
     if (linked.length > 0) entries = entries.concat(linked)
   }
+
+  // Ship-success attribution: note that these entries were surfaced during the
+  // active task. If that task reaches a successful `prjct ship`, each earns the
+  // strong ship-credit (see usefulnessService.creditShippedTask). No active
+  // task → nothing recorded.
+  try {
+    const task = await stateStorage.getCurrentTask(projectId)
+    if (task?.id) {
+      usefulnessService.recordSurfaced(
+        projectId,
+        entries.map((e) => e.id),
+        task.id
+      )
+    }
+  } catch {
+    /* best-effort — attribution telemetry must never break a recall */
+  }
+
   return {
     tool: opts.kind,
     result: {


### PR DESCRIPTION
## Summary
Completes the "learn from hits and misses" loop. The usefulness ledger (#386) learned from **references** (citations) and **fetches** (by-id pulls), with time-decay as the disuse signal. This adds the strongest positive signal of all: a real **outcome** — knowledge that fed work which actually **shipped**.

## How it works (attributed by task)
Attributed by **task**, not session id — ship is already task-scoped, so no cross-process plumbing.
- `context memory` records the entries it surfaces into a transient log (migration 24, `memory_surface_log`) keyed by the **active task** — at most one row per (memory, task).
- On a successful `prjct ship`, `creditShippedTask` credits every entry surfaced during that task with the strong ship weight (**2.5** vs 1.0 reference / 0.4 fetch), then clears the task's rows.
- A task that never ships keeps its rows pending; only the **shipped** task's knowledge is rewarded.

The memories that recur in work that ships rise to the top of recall over time; the rest decay — exactly "smarter the more it's used, learning from what works."

## Safety
Best-effort end to end: surfacing can't break a recall, crediting can't fail a completed ship (both wrapped, dynamic import to avoid cycles).

## Tests
`core/__tests__/services/usefulness.test.ts`: credit + clear, per-task isolation, stacking on existing score, empty/no-rows no-ops. Full suite green (1346), typecheck + knip clean.

## The reinforcement loop, now complete
references + fetches + **ship-success** (positive) · time-decay (disuse). Recall blends 5 signals: relevance (BM25+semantic) + graph + compaction + learned usefulness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)