### PR TITLE
feat(memory): negative reinforcement — learn from mistakes too

### DIFF
--- a/core/__tests__/services/usefulness.test.ts
+++ b/core/__tests__/services/usefulness.test.ts
@@ -157,3 +157,34 @@ describe('usefulnessService — ship-success attribution', () => {
     expect(usefulnessService.creditShippedTask(projectId, 'never-surfaced', T0_ISO)).toBe(0)
   })
 })
+
+describe('usefulnessService — negative signal (corrections)', () => {
+  it('a `corrects:` tag drives the marked entry NEGATIVE', () => {
+    usefulnessService.recordCorrection(projectId, { corrects: 'mem_40' }, T0_ISO)
+    expect(usefulnessService.decayedScores(projectId, T0).get('mem_40')).toBeCloseTo(-2.5, 5)
+  })
+
+  it('`contradicts:` works the same and only acts on explicit tags', () => {
+    // Inline mention in CONTENT must NOT penalize — corrections are tags-only.
+    usefulnessService.recordReferences(projectId, 'builds on mem_41', {}, T0_ISO) // +1.0
+    usefulnessService.recordCorrection(projectId, { contradicts: 'mem_42' }, T0_ISO)
+    const s = usefulnessService.decayedScores(projectId, T0)
+    expect(s.get('mem_41')).toBeCloseTo(1.0, 5) // referenced, not corrected
+    expect(s.get('mem_42')).toBeCloseTo(-2.5, 5) // corrected
+  })
+
+  it('a correction can flip a previously-useful entry net-negative', () => {
+    usefulnessService.recordReferences(projectId, 'mem_43', {}, T0_ISO) // +1.0
+    usefulnessService.recordCorrection(projectId, { corrects: 'mem_43' }, T0_ISO) // -2.5
+    expect(usefulnessService.decayedScores(projectId, T0).get('mem_43')).toBeCloseTo(-1.5, 5)
+  })
+
+  it('rerank SINKS a corrected entry below its relevance position', () => {
+    usefulnessService.recordCorrection(projectId, { corrects: 'mem_50' }, T0_ISO)
+    // mem_50 leads on relevance but is a known mistake; mem_51/52 are neutral.
+    const ordered = [fakeEntry('mem_50'), fakeEntry('mem_51'), fakeEntry('mem_52')]
+    const reranked = usefulnessService.rerank(projectId, ordered, T0)
+    expect(reranked[0]?.id).not.toBe('mem_50')
+    expect(reranked.at(-1)?.id).toBe('mem_50')
+  })
+})

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -318,6 +318,9 @@ export const projectMemory = {
       try {
         const { usefulnessService } = await import('../services/usefulness')
         usefulnessService.recordReferences(logResult.projectId, args.content, tags)
+        // Negative half of the loop: an entry tagged corrects:/contradicts:
+        // marks the referenced one as a mistake → demote it in recall.
+        usefulnessService.recordCorrection(logResult.projectId, tags)
       } catch {
         /* never block a capture on reinforcement bookkeeping */
       }

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -33,10 +33,18 @@ const FETCH_WEIGHT = 0.4
 /** Strongest signal: this entry was surfaced during work that actually
  *  shipped. A real outcome, not just a citation. */
 const SHIP_WEIGHT = 2.5
+/** Negative signal: a later entry declared this one WRONG (`corrects:` /
+ *  `contradicts:`). The project learned this knowledge was a mistake, so it
+ *  sinks in recall — but is never deleted (the record + the correction's
+ *  context stay resolvable). Magnitude mirrors a ship credit, inverted. */
+const CORRECTION_WEIGHT = -2.5
 const MS_PER_DAY = 86_400_000
 
 /** Tag keys whose values name a related entry (mirrors expandWithLinks). */
 const REL_KEYS = ['resolves', 'relates', 'supersedes', 'superseded-by', 'duplicates', 'spec']
+/** Tag keys that mark the referenced entry as an ERROR. Tags ONLY (never
+ *  inline content) so a passing `mem_N` mention can't accidentally demote. */
+const CORRECTION_KEYS = ['corrects', 'contradicts']
 const MEM_REF_RE = /\bmem[_-](\d+)\b/g
 
 /** Collect the `mem_N` ids a new entry points at (relationship tags + inline). */
@@ -48,6 +56,17 @@ export function extractRefIds(content: string, tags: Record<string, string>): st
     for (const m of String(v).matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
   }
   for (const m of content.matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
+  return [...ids]
+}
+
+/** Collect the `mem_N` ids a new entry marks as WRONG (correction tags only). */
+export function extractCorrectionIds(tags: Record<string, string>): string[] {
+  const ids = new Set<string>()
+  for (const key of CORRECTION_KEYS) {
+    const v = tags[key]
+    if (!v) continue
+    for (const m of String(v).matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
+  }
   return [...ids]
 }
 
@@ -77,6 +96,21 @@ function bump(
   )
 }
 
+/** Adjust only the score (no count column) by `delta`, which may be negative. */
+function addScore(projectId: string, memoryId: string, delta: number, nowIso: string): void {
+  prjctDb.run(
+    projectId,
+    `INSERT INTO memory_usefulness (memory_id, score, last_used_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(memory_id) DO UPDATE SET
+       score = score + ?, last_used_at = excluded.last_used_at`,
+    memoryId,
+    delta,
+    nowIso,
+    delta
+  )
+}
+
 export const usefulnessService = {
   /** Credit every entry that `content`/`tags` reference (a capture happened). */
   recordReferences(
@@ -88,6 +122,25 @@ export const usefulnessService = {
     try {
       for (const id of extractRefIds(content, tags)) {
         bump(projectId, id, REF_WEIGHT, 'ref_count', nowIso)
+      }
+    } catch {
+      /* best-effort — never block a capture */
+    }
+  },
+
+  /**
+   * Penalize entries a new capture marks WRONG via `corrects:` / `contradicts:`
+   * tags — the negative half of the loop. Demotes them in recall without
+   * deleting them. Best-effort.
+   */
+  recordCorrection(
+    projectId: string,
+    tags: Record<string, string>,
+    nowIso: string = new Date().toISOString()
+  ): void {
+    try {
+      for (const id of extractCorrectionIds(tags)) {
+        addScore(projectId, id, CORRECTION_WEIGHT, nowIso)
       }
     } catch {
       /* best-effort — never block a capture */
@@ -153,17 +206,7 @@ export const usefulnessService = {
         taskId
       )
       for (const r of rows) {
-        prjctDb.run(
-          projectId,
-          `INSERT INTO memory_usefulness (memory_id, score, last_used_at)
-           VALUES (?, ?, ?)
-           ON CONFLICT(memory_id) DO UPDATE SET
-             score = score + ?, last_used_at = excluded.last_used_at`,
-          r.memory_id,
-          SHIP_WEIGHT,
-          nowIso,
-          SHIP_WEIGHT
-        )
+        addScore(projectId, r.memory_id, SHIP_WEIGHT, nowIso)
       }
       prjctDb.run(projectId, 'DELETE FROM memory_surface_log WHERE task_id = ?', taskId)
       return rows.length


### PR DESCRIPTION
## Summary
Closes the reinforcement loop on the **error** side. It already learned from hits (references, fetches, ship-success) and disuse (time-decay). Now it learns from being **wrong**: a new entry tagged `corrects:mem_X` / `contradicts:mem_X` gives the marked entry a strong negative usefulness adjustment (**-2.5**, the ship credit inverted) → it sinks in recall, so knowledge the project found to be a mistake stops surfacing first.

## Deliberate design
- **Author-declared, tags ONLY** (never inline `mem_N`) — a passing reference can't accidentally demote real knowledge.
- **Demote, don't delete** — the entry stays for the record and so the correction's own context stays resolvable (distinct from `supersedes`, which compaction drops).
- Negative scores flow through the same decayed-score rerank: a corrected entry drops below its relevance position; a correction can flip a previously-useful entry net-negative.
- Wired in `projectMemory.remember` next to the positive signal; best-effort, never blocks a capture.

## Tests
`core/__tests__/services/usefulness.test.ts`: corrects/contradicts go negative, tags-only (inline doesn't penalize), flip-to-negative, rerank sinks corrected entry to the bottom. Full suite green (1350), typecheck + knip clean.

## The loop, complete 🔄
**positive** references + fetches + ship-success · **negative** corrections · **disuse** time-decay. Recall blends relevance (BM25+semantic) + graph + compaction + this learned usefulness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)