### PR TITLE
feat(memory): learn from mistakes automatically — no command needed

### DIFF
--- a/core/__tests__/services/usefulness.test.ts
+++ b/core/__tests__/services/usefulness.test.ts
@@ -158,6 +158,28 @@ describe('usefulnessService — ship-success attribution', () => {
   })
 })
 
+describe('usefulnessService — automatic friction penalty (no command)', () => {
+  it('demotes surfaced entries on friction but keeps the rows (task still open)', () => {
+    usefulnessService.recordSurfaced(projectId, ['mem_60', 'mem_61'], 'task-f', T0_ISO)
+    const nudged = usefulnessService.penalizeSurfaced(projectId, 'task-f', T0_ISO)
+    expect(nudged).toBe(2)
+
+    const scores = usefulnessService.decayedScores(projectId, T0)
+    expect(scores.get('mem_60')).toBeCloseTo(-0.5, 5)
+    expect(scores.get('mem_61')).toBeCloseTo(-0.5, 5)
+
+    // Rows are NOT cleared — a later ship can still credit the same task.
+    const credited = usefulnessService.creditShippedTask(projectId, 'task-f', T0_ISO)
+    expect(credited).toBe(2)
+    // Net per entry: -0.5 (friction) + 2.5 (ship) = 2.0.
+    expect(usefulnessService.decayedScores(projectId, T0).get('mem_60')).toBeCloseTo(2.0, 5)
+  })
+
+  it('is a no-op for an empty task id', () => {
+    expect(usefulnessService.penalizeSurfaced(projectId, '', T0_ISO)).toBe(0)
+  })
+})
+
 describe('usefulnessService — negative signal (corrections)', () => {
   it('a `corrects:` tag drives the marked entry NEGATIVE', () => {
     usefulnessService.recordCorrection(projectId, { corrects: 'mem_40' }, T0_ISO)

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -24,8 +24,10 @@ import { detectAndPersistPatterns } from '../services/pattern-detector'
 import { recordCleanupReport, runSessionCleanup } from '../services/session-cleanup'
 import { detectSkillMisses } from '../services/skill-miss-detector'
 import { ingestTranscript } from '../services/transcript-learner'
+import { usefulnessService } from '../services/usefulness'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
+import { stateStorage } from '../storage/state-storage'
 import { type HookIo, runHook } from './_runner'
 
 interface HookInput {
@@ -95,7 +97,20 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // here, only signal extraction.
         if (input.transcript_path) {
           try {
-            await detectFriction(p, input.transcript_path, input.session_id ?? null)
+            const friction = await detectFriction(
+              p,
+              input.transcript_path,
+              input.session_id ?? null
+            )
+            // AUTOMATIC negative reinforcement (no command): if the user
+            // pushed back this session, demote the memories that were in
+            // context for the active task. prjct learns from mistakes on its
+            // own — the explicit `corrects:` tag is now an optional override,
+            // not a requirement.
+            if (friction.signalsRecorded > 0) {
+              const task = await stateStorage.getCurrentTask(config.projectId)
+              if (task?.id) usefulnessService.penalizeSurfaced(config.projectId, task.id)
+            }
           } catch {
             /* same contract as transcript-learner — silent best-effort */
           }

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -38,6 +38,11 @@ const SHIP_WEIGHT = 2.5
  *  sinks in recall — but is never deleted (the record + the correction's
  *  context stay resolvable). Magnitude mirrors a ship credit, inverted. */
 const CORRECTION_WEIGHT = -2.5
+/** AUTOMATIC negative: the user pushed back (friction) while these memories
+ *  were in context. Smaller than an explicit correction — attribution is
+ *  fuzzy (the friction may be unrelated) — but it needs NO command, so prjct
+ *  learns from mistakes on its own. Bounded by decay + the rerank cap. */
+const FRICTION_WEIGHT = -0.5
 const MS_PER_DAY = 86_400_000
 
 /** Tag keys whose values name a related entry (mirrors expandWithLinks). */
@@ -185,6 +190,33 @@ export const usefulnessService = {
       }
     } catch {
       /* best-effort — surfacing telemetry must never break a recall */
+    }
+  },
+
+  /**
+   * AUTOMATIC negative reinforcement: the active task hit user friction this
+   * session, so gently demote the entries surfaced during it. Unlike
+   * `creditShippedTask`, this does NOT clear the surface rows — the task is
+   * still in flight and may yet ship. Returns how many entries were nudged.
+   * Best-effort. No command required — this is what makes prjct learn from
+   * mistakes on its own.
+   */
+  penalizeSurfaced(
+    projectId: string,
+    taskId: string,
+    nowIso: string = new Date().toISOString()
+  ): number {
+    if (!taskId) return 0
+    try {
+      const rows = prjctDb.query<{ memory_id: string }>(
+        projectId,
+        'SELECT memory_id FROM memory_surface_log WHERE task_id = ?',
+        taskId
+      )
+      for (const r of rows) addScore(projectId, r.memory_id, FRICTION_WEIGHT, nowIso)
+      return rows.length
+    } catch {
+      return 0
     }
   },
 


### PR DESCRIPTION
## The gap this closes
The negative signal required remembering to tag `corrects:mem_X`. **If you forget, it never learns from the error.** Now prjct learns from mistakes **on its own**, from a signal it already captures every session with zero user action.

## How
The Stop hook already runs the **friction detector** (user pushback — negation, correction, complaint markers in the transcript). When it fires, the memories that were in context for the active task (`memory_surface_log`) get an **automatic small demotion** (`FRICTION_WEIGHT` -0.5). No command. Smaller than the explicit `corrects:` correction (-2.5) because friction attribution is fuzzier.

It does **not** clear the surface rows — the task is still in flight, so a later successful ship can still credit the same entries (net: friction -0.5 then ship +2.5 = **+2.0**). The explicit `corrects:` tag stays as a strong manual override, but is **no longer required**.

## The loop is now fully automatic
Every session teaches prjct with **zero commands**:
- **raise**: references · fetches · ship-success
- **lower**: friction (automatic) · `corrects:` (optional manual override)
- **fade**: time-decay (disuse)

## Tests
`core/__tests__/services/usefulness.test.ts`: friction demotes + keeps rows for a later ship credit, empty-task no-op. Full suite green (1352), typecheck + knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)