### PR TITLE
fix(memory): a correction must not credit its own inline reference

### DIFF
--- a/core/__tests__/services/usefulness.test.ts
+++ b/core/__tests__/services/usefulness.test.ts
@@ -195,6 +195,17 @@ describe('usefulnessService — negative signal (corrections)', () => {
     expect(s.get('mem_42')).toBeCloseTo(-2.5, 5) // corrected
   })
 
+  it('does NOT credit an inline reference to an id the same entry corrects', () => {
+    // Real-world shape found in live testing: a correction names the entry it
+    // corrects in its own text ("mem_70 was wrong"). The inline mention must
+    // not earn a +1.0 reference that cancels the -2.5 penalty.
+    const corrector = 'REINFORCE: mem_70 turned out wrong'
+    usefulnessService.recordReferences(projectId, corrector, { corrects: 'mem_70' }, T0_ISO)
+    usefulnessService.recordCorrection(projectId, { corrects: 'mem_70' }, T0_ISO)
+    // Pure -2.5, NOT -2.5 + 1.0.
+    expect(usefulnessService.decayedScores(projectId, T0).get('mem_70')).toBeCloseTo(-2.5, 5)
+  })
+
   it('a correction can flip a previously-useful entry net-negative', () => {
     usefulnessService.recordReferences(projectId, 'mem_43', {}, T0_ISO) // +1.0
     usefulnessService.recordCorrection(projectId, { corrects: 'mem_43' }, T0_ISO) // -2.5

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -61,6 +61,11 @@ export function extractRefIds(content: string, tags: Record<string, string>): st
     for (const m of String(v).matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
   }
   for (const m of content.matchAll(MEM_REF_RE)) ids.add(`mem_${m[1]}`)
+  // A correction naturally NAMES the entry it corrects (inline or in the
+  // tag), which would otherwise credit a positive reference that cancels the
+  // penalty. An entry you're marking WRONG must not also be rewarded — drop
+  // any id this same entry corrects/contradicts from the positive set.
+  for (const cid of extractCorrectionIds(tags)) ids.delete(cid)
   return [...ids]
 }
 


### PR DESCRIPTION
## Found by real-DB testing (not mocks)
Exercising the reinforcement loop against the live prjct-cli DB surfaced this: a `corrects:mem_X` entry naturally **names** the entry it corrects in its own text ("mem_485 turned out wrong"). `recordReferences` counts inline `mem_N` mentions as a +1.0 reference, so the correction's **-2.5 penalty was partly cancelled** by a +1.0 self-reference — a corrected entry landed at **-0.1** instead of the intended ~-1.1, barely sinking.

## Fix
`extractRefIds` now drops any id the same entry corrects/contradicts from the positive set. You can't reward and penalize the same entry in one capture. Net penalty is the clean **-2.5** again.

## Why the unit tests missed it
They fed tag-only inputs with no inline mention — but real captures always mention the corrected id. Added a regression test in that real-world shape.

Full suite green (1353), typecheck + knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)