### PR TITLE
feat: memory dedup en capture + heal histórico (RAG #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@
 
 ## [Unreleased]
 
+## [2.32.3] - 2026-05-30
+
+### Added
+- memory dedup en capture + heal histórico (RAG #1): content-fingerprint, dedup net en remember(), fix friction-detector 64-vs-12, migración v25 backfill+purga
+
 ## [2.32.2] - 2026-05-30
 
 ### Added

--- a/core/__tests__/memory/content-fingerprint.test.ts
+++ b/core/__tests__/memory/content-fingerprint.test.ts
@@ -1,0 +1,31 @@
+/**
+ * content-fingerprint — the normalization contract shared by the dedup net
+ * (projectMemory.remember) and the heal migration (memory-dedup-content-hash).
+ * If these two ever disagree, historical dups stop being recognized, so the
+ * normalization rules are pinned here.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { memoryFingerprint } from '../../memory/content-fingerprint'
+
+describe('memoryFingerprint', () => {
+  it('is stable for identical content', () => {
+    expect(memoryFingerprint('use bun runtime')).toBe(memoryFingerprint('use bun runtime'))
+  })
+
+  it('ignores case', () => {
+    expect(memoryFingerprint('Use Bun Runtime')).toBe(memoryFingerprint('use bun runtime'))
+  })
+
+  it('collapses internal whitespace runs and trims edges', () => {
+    expect(memoryFingerprint('  use   bun\n\truntime  ')).toBe(memoryFingerprint('use bun runtime'))
+  })
+
+  it('distinguishes genuinely different content', () => {
+    expect(memoryFingerprint('use bun')).not.toBe(memoryFingerprint('use node'))
+  })
+
+  it('returns a 64-char hex sha256', () => {
+    expect(memoryFingerprint('anything')).toMatch(/^[a-f0-9]{64}$/)
+  })
+})

--- a/core/__tests__/storage/memory-dedup-migration.test.ts
+++ b/core/__tests__/storage/memory-dedup-migration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Migration `memory-dedup-content-hash` (v25) — backfills memories.content_hash
+ * and purges historical verbatim duplicates from BOTH memory tables.
+ *
+ * The migration is idempotent, so the test seeds duplicates into a
+ * fully-migrated DB and re-invokes the migration's `up()` directly — this
+ * exercises the heal logic deterministically without depending on whether the
+ * fresh-DB path happened to leave dups behind.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { prjctDb } from '../../storage/database'
+import { migrations } from '../../storage/database/migrations'
+
+const migration25 = migrations.find((m) => m.version === 25)
+if (!migration25) throw new Error('migration v25 not found')
+
+let tmpRoot: string
+let projectId: string
+
+const originalGetGlobalProjectPath = pathManager.getGlobalProjectPath.bind(pathManager)
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-dedup-mig-'))
+  projectId = 'dedup-mig-test'
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+  await fs.mkdir(path.join(tmpRoot, projectId), { recursive: true })
+})
+
+afterEach(async () => {
+  prjctDb.close()
+  pathManager.getGlobalProjectPath = originalGetGlobalProjectPath
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+function seedMemory(id: string, type: string, content: string): void {
+  // content_hash left NULL on purpose: simulates a row that landed before the
+  // dedup net existed. created_at irrelevant to the (numeric-id) keep-earliest.
+  prjctDb.run(
+    projectId,
+    `INSERT INTO memories
+       (id, project_id, title, content, tags, type, provenance, user_triggered,
+        created_at, updated_at)
+     VALUES (?, ?, ?, ?, '{}', ?, 'declared', 0, ?, ?)`,
+    id,
+    projectId,
+    content.slice(0, 80),
+    content,
+    type,
+    '2026-01-01T00:00:00Z',
+    '2026-01-01T00:00:00Z'
+  )
+}
+
+describe('migration v25 — memory dedup + content_hash backfill', () => {
+  it('backfills content_hash, keeps the earliest dup, soft-deletes the rest', () => {
+    const db = prjctDb.getDb(projectId) // runs all migrations on a clean DB
+
+    // Three verbatim copies (differing only in whitespace/case) + one distinct.
+    seedMemory('mem_5', 'improvement-signal', 'No,   THIS is broken')
+    seedMemory('mem_9', 'improvement-signal', 'no, this is broken')
+    seedMemory('mem_12', 'improvement-signal', 'no, this is broken')
+    seedMemory('mem_7', 'improvement-signal', 'a different signal entirely')
+
+    migration25.up(db)
+
+    // content_hash backfilled on every row.
+    const hashed = prjctDb.query<{ id: string; content_hash: string | null }>(
+      projectId,
+      'SELECT id, content_hash FROM memories'
+    )
+    expect(hashed.every((r) => !!r.content_hash)).toBe(true)
+
+    // The three normalized-equal copies collapse to the earliest (mem_5);
+    // mem_9 and mem_12 are soft-deleted. The distinct one survives.
+    const live = prjctDb.query<{ id: string }>(
+      projectId,
+      'SELECT id FROM memories WHERE deleted_at IS NULL ORDER BY id'
+    )
+    const liveIds = live.map((r) => r.id).sort()
+    expect(liveIds).toEqual(['mem_5', 'mem_7'])
+
+    // Soft, not hard — the demoted rows are still resolvable by id.
+    const total = prjctDb.query<{ n: number }>(projectId, 'SELECT COUNT(*) AS n FROM memories')
+    expect(total[0]!.n).toBe(4)
+  })
+
+  it('hard-deletes duplicate remember-events, keeping the earliest', () => {
+    const db = prjctDb.getDb(projectId)
+
+    // events carries the vault-index source; dup signals must not spawn files.
+    const ins = (id: number, content: string) =>
+      db
+        .prepare(
+          `INSERT INTO events (id, type, data, timestamp)
+           VALUES (?, 'memory.remember.improvement-signal', ?, '2026-01-01T00:00:00Z')`
+        )
+        .run(id, JSON.stringify({ content }))
+    ins(5, 'no, this is broken')
+    ins(9, 'no, this is broken')
+    ins(12, 'NO, this   is broken') // normalized-equal
+    ins(7, 'a unique learning')
+
+    migration25.up(db)
+
+    const rows = prjctDb.query<{ id: number }>(
+      projectId,
+      "SELECT id FROM events WHERE type LIKE 'memory.remember.%' ORDER BY id"
+    )
+    expect(rows.map((r) => r.id)).toEqual([5, 7])
+  })
+
+  it('is idempotent (a second run is a no-op)', () => {
+    const db = prjctDb.getDb(projectId)
+    seedMemory('mem_5', 'gotcha', 'same trap')
+    seedMemory('mem_9', 'gotcha', 'same trap')
+
+    migration25.up(db)
+    const after1 = prjctDb.query<{ n: number }>(
+      projectId,
+      'SELECT COUNT(*) AS n FROM memories WHERE deleted_at IS NULL'
+    )[0]!.n
+    migration25.up(db)
+    const after2 = prjctDb.query<{ n: number }>(
+      projectId,
+      'SELECT COUNT(*) AS n FROM memories WHERE deleted_at IS NULL'
+    )[0]!.n
+
+    expect(after1).toBe(1)
+    expect(after2).toBe(1)
+  })
+})

--- a/core/memory/content-fingerprint.ts
+++ b/core/memory/content-fingerprint.ts
@@ -1,0 +1,21 @@
+/**
+ * Stable content fingerprint for memory duplicate detection.
+ *
+ * Normalizes away trivial formatting noise — case, leading/trailing space, and
+ * internal whitespace runs — so two captures of the same knowledge collapse to
+ * the same hash. Two consumers MUST agree on this normalization, so it lives
+ * here (one tiny module, only `node:crypto`) and is imported by both:
+ *   - `projectMemory.remember()` — skips a verbatim re-capture (the dedup net)
+ *   - migration `memory-dedup-content-hash` — backfills `memories.content_hash`
+ *     and purges the historical duplicates that landed before the net existed
+ *
+ * Keep this dependency-free to avoid an import cycle through the storage layer.
+ */
+
+import crypto from 'node:crypto'
+
+/** sha256 of the case- and whitespace-normalized content. */
+export function memoryFingerprint(content: string): string {
+  const normalized = content.toLowerCase().replace(/\s+/g, ' ').trim()
+  return crypto.createHash('sha256').update(normalized).digest('hex')
+}

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -24,6 +24,7 @@
 import { memoryService } from '../services/memory-service'
 import prjctDb from '../storage/database'
 import { escapeMarkdownInline } from '../utils/prompt-injection'
+import { memoryFingerprint } from './content-fingerprint'
 import { REMEMBER_ACTION_PREFIX, REMEMBER_EVENT_PREFIX } from './events'
 
 /**
@@ -267,6 +268,31 @@ export const projectMemory = {
   ): Promise<void> {
     const tags = args.tags ?? {}
     const provenance = args.provenance ?? 'declared'
+    const contentHash = memoryFingerprint(args.content)
+
+    // Dedup net: a verbatim re-capture of the same (type, content) adds no
+    // knowledge — it only dilutes recall and burns slots in the fixed-size
+    // injection budget. Skip it. This is the universal guard behind EVERY
+    // capture path (manual `remember`, the friction / skill-miss detectors,
+    // wiki-ingest), so a single detector re-firing each session can't spam the
+    // store. Best-effort: any lookup failure falls through to a normal write —
+    // a dedup miss is cheaper than a dropped capture.
+    try {
+      const { default: cfgMgr } = await import('../infrastructure/config-manager')
+      const dedupProjectId = (await cfgMgr.readConfig(projectPath))?.projectId
+      if (dedupProjectId) {
+        const dup = prjctDb.get<{ id: string }>(
+          dedupProjectId,
+          'SELECT id FROM memories WHERE content_hash = ? AND type = ? AND deleted_at IS NULL LIMIT 1',
+          contentHash,
+          args.type
+        )
+        if (dup) return
+      }
+    } catch {
+      /* fall through — never block a capture on the dedup check */
+    }
+
     const logResult = await memoryService.log(
       projectPath,
       `${REMEMBER_ACTION_PREFIX}${args.type}`,
@@ -291,9 +317,9 @@ export const projectMemory = {
         prjctDb.run(
           logResult.projectId,
           `INSERT OR IGNORE INTO memories
-             (id, project_id, title, content, tags, type, provenance, user_triggered,
-              created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             (id, project_id, title, content, tags, type, provenance, content_hash,
+              user_triggered, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           memId,
           logResult.projectId,
           title,
@@ -301,6 +327,7 @@ export const projectMemory = {
           JSON.stringify(tags),
           args.type,
           provenance,
+          contentHash,
           0,
           now,
           now

--- a/core/services/friction-detector.ts
+++ b/core/services/friction-detector.ts
@@ -108,8 +108,12 @@ export async function detectFriction(
   let recorded = 0
   let skipped = 0
   for (const signal of signals.slice(0, MAX_SIGNALS_PER_SESSION)) {
-    const hash = hashSignal(signal.excerpt)
-    if (existing.has(hash)) {
+    // `existing` holds the 12-char keys stored on prior signals (see
+    // projectMemoryHashes), so the comparison unit MUST be the same 12-char
+    // slice — comparing the full 64-char hash here silently never matched,
+    // re-recording the same pushback every session (the 5-9× dup bloat).
+    const dedupKey = hashSignal(signal.excerpt).slice(0, 12)
+    if (existing.has(dedupKey)) {
       skipped++
       continue
     }
@@ -121,7 +125,7 @@ export async function detectFriction(
           source: SOURCE_TAG,
           category: signal.category,
           ...(sessionId ? { session: sessionId } : {}),
-          key: hash.slice(0, 12), // dedup key for the (type, key) latest-winner rule
+          key: dedupKey, // dedup key for the (type, key) latest-winner rule
         },
         provenance: 'extracted',
       })

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -6,6 +6,7 @@
  * migration with the next sequential version number.
  */
 
+import { memoryFingerprint } from '../../memory/content-fingerprint'
 import type { Migration } from '../../types/storage/extended'
 import { INITIAL_SCHEMA_SQL } from './initial-schema.sql'
 import type { SqliteDatabase } from './sqlite-compat'
@@ -771,6 +772,85 @@ export const migrations: Migration[] = [
           PRIMARY KEY (memory_id, task_id)
         )
       `)
+    },
+  },
+  {
+    version: 25,
+    name: 'memory-dedup-content-hash',
+    up: (db: SqliteDatabase) => {
+      // Backfill `memories.content_hash` and purge historical verbatim
+      // duplicates from BOTH memory tables.
+      //
+      // Until now nothing populated `memories.content_hash`, and a
+      // friction-detector key bug (a 64-char hash compared against a 12-char
+      // stored key — they never matched) re-recorded the same user-pushback
+      // every session, leaving 5-9 identical copies per signal. Those dups
+      // dilute `searchFts` (reads `memories`) and the vault index (reads
+      // `events`), and waste slots in the fixed-size recall-injection budget.
+      //
+      // Going forward `projectMemory.remember()` dedups on `content_hash`
+      // before writing; this migration heals what already landed and seeds the
+      // hash on every existing row so that guard recognizes them. Idempotent —
+      // safe to re-run (NULL backfill only, keep-earliest is deterministic).
+      const numOf = (id: string): number => Number(String(id).replace(/^mem[_-]/i, '')) || 0
+
+      // 1) Backfill content_hash wherever it's missing.
+      const memAll = db.prepare('SELECT id, content, content_hash FROM memories').all() as Array<{
+        id: string
+        content: string
+        content_hash: string | null
+      }>
+      const setHash = db.prepare('UPDATE memories SET content_hash = ? WHERE id = ?')
+      for (const r of memAll) {
+        if (!r.content_hash) setHash.run(memoryFingerprint(r.content ?? ''), r.id)
+      }
+
+      // 2) Soft-delete duplicate `memories` rows: keep the earliest (smallest
+      //    mem_<id>) per (type, content_hash); mark the rest deleted so
+      //    searchFts — which filters `deleted_at IS NULL` — stops returning
+      //    them. Soft, not hard: the row stays resolvable by id.
+      const memLive = db
+        .prepare('SELECT id, type, content_hash FROM memories WHERE deleted_at IS NULL')
+        .all() as Array<{ id: string; type: string | null; content_hash: string | null }>
+      const canonicalMem = new Map<string, number>() // group key -> min numeric id
+      for (const r of memLive) {
+        if (!r.content_hash) continue
+        const k = `${r.type ?? ''}::${r.content_hash}`
+        const n = numOf(r.id)
+        const cur = canonicalMem.get(k)
+        if (cur === undefined || n < cur) canonicalMem.set(k, n)
+      }
+      const nowIso = new Date().toISOString()
+      const softDelete = db.prepare('UPDATE memories SET deleted_at = ? WHERE id = ?')
+      for (const r of memLive) {
+        if (!r.content_hash) continue
+        const k = `${r.type ?? ''}::${r.content_hash}`
+        if (canonicalMem.get(k) !== numOf(r.id)) softDelete.run(nowIso, r.id)
+      }
+
+      // 3) Hard-delete duplicate remember-events: keep the earliest per
+      //    (type, normalized content). `events` feeds recall() and the vault
+      //    index (allEntriesForIndex), neither of which dedups non-keyed
+      //    entries — so the dup rows (and the vault files they spawn) only
+      //    disappear when the rows do. These are verbatim duplicate signals
+      //    with no audit value. ORDER BY id ASC ⇒ first seen = earliest = kept.
+      const evRows = db
+        .prepare(
+          `SELECT id, type, json_extract(data, '$.content') AS content
+             FROM events WHERE type LIKE 'memory.remember.%' ORDER BY id ASC`
+        )
+        .all() as Array<{ id: number; type: string; content: string | null }>
+      const seenEv = new Set<string>()
+      const delEv = db.prepare('DELETE FROM events WHERE id = ?')
+      for (const r of evRows) {
+        if (r.content == null) continue
+        const k = `${r.type}::${memoryFingerprint(r.content)}`
+        if (seenEv.has(k)) {
+          delEv.run(r.id)
+          continue
+        }
+        seenEv.add(k)
+      }
     },
   },
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.32.2",
+  "version": "2.32.3",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## RAG #1 — dedup en capture

Primera palanca del análisis "hacer prjct el mejor RAG": eliminar el ruido de memorias duplicadas que diluía recall, el ledger de usefulness y el budget fijo de inyección.

### Cambios
- **`core/memory/content-fingerprint.ts`** (nuevo) — `memoryFingerprint()`: sha256 de contenido normalizado (lowercase + colapsa whitespace). Fuente única compartida por el net y la migración.
- **`projectMemory.remember()`** — net universal: salta una re-captura verbatim de `(type, content)` antes de escribir, y ahora **sí puebla `content_hash`** (la columna existía pero nadie la llenaba). Cubre remember manual, friction-detector, skill-miss y wiki-ingest.
- **`friction-detector.ts`** — bug raíz: comparaba un hash de **64 chars** contra un set de keys de **12 chars** (`hash.slice(0,12)`) → nunca hacía match → re-grababa el mismo pushback cada sesión (bloat 5–9×). Corregido.
- **Migración v25 `memory-dedup-content-hash`** — backfill de `content_hash` en filas existentes + purga histórica de duplicados en **ambas** tablas: soft-delete en `memories` (arregla `searchFts`) y hard-delete de eventos remember dup en `events` (arregla `recall()` + el índice del vault). Idempotente; auto-corre en cada DB al actualizar.

### Verificado (DB real)
- improvement-signal **27→7** filas · events **32→7** · `content_hash` **70/70** · 25 soft-deleted · **0 grupos dup**
- Prevención en vivo: captura idéntica 2× → 1 fila; variante MAYÚS+espacios también colapsa
- Vault healed: archivos improvement-signal ~27→7
- `typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1360 tests** ✓ (+ tests nuevos: content-fingerprint, migration v25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)