### PR TITLE
feat: embeddings ON by default (local, universal) + English content convention (RAG #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@
 
 ## [Unreleased]
 
+## [2.32.4] - 2026-05-31
+
+### Added
+- embeddings ON por defecto (local subword, universal, cero-dep) + auto-upgrade + convención de contenido en inglés (RAG #2)
+
 ## [2.32.3] - 2026-05-30
 
 ### Added

--- a/core/__tests__/services/embeddings.test.ts
+++ b/core/__tests__/services/embeddings.test.ts
@@ -1,9 +1,11 @@
 /**
- * Optional semantic-search layer — offline tests against a fake provider.
+ * Semantic-search layer — offline tests.
  *
- * Pins: disabled-by-default (no provider → inert), cosine math, store +
- * cosine-ranked semanticSearch, and backfill idempotency. No network: the
- * provider is injected, so these never touch a real embeddings endpoint.
+ * Pins: provider resolution (explicit endpoint vs the always-on local
+ * default), the local subword embedder (determinism, normalization,
+ * morphological ranking, end-to-end), cosine math, cosine-ranked
+ * semanticSearch, and backfill idempotency. No network: the HTTP path uses an
+ * injected fake; the local path is pure-JS.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -16,6 +18,9 @@ import {
   cosineSimilarity,
   type EmbeddingProvider,
   embeddingService,
+  LOCAL_EMBEDDING_MODEL,
+  LocalSubwordEmbeddingProvider,
+  resolveActiveProvider,
   resolveProvider,
 } from '../../services/embeddings'
 import prjctDb from '../../storage/database'
@@ -72,8 +77,8 @@ afterEach(async () => {
   await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
 })
 
-describe('embeddings — disabled by default', () => {
-  it('resolveProvider is null without config / provider / model', () => {
+describe('embeddings — provider resolution', () => {
+  it('resolveProvider (explicit only) is null without config / provider / model', () => {
     expect(resolveProvider(null)).toBeNull()
     expect(resolveProvider({ projectId: 'x', dataPath: '' } as LocalConfig)).toBeNull()
     expect(
@@ -81,17 +86,65 @@ describe('embeddings — disabled by default', () => {
     ).toBeNull()
   })
 
-  it('isEnabled false without a provider; true when configured', () => {
-    expect(embeddingService.isEnabled(null)).toBe(false)
+  it('resolveActiveProvider falls back to the local default (never null)', () => {
+    expect(resolveActiveProvider(null)).toBeInstanceOf(LocalSubwordEmbeddingProvider)
+    expect(resolveActiveProvider(null).model).toBe(LOCAL_EMBEDDING_MODEL)
+    // An explicit endpoint upgrades over the local default.
+    expect(resolveActiveProvider(enabledConfig).model).toBe('fake-1')
+  })
+
+  it('isEnabled is always true (semantic on for everyone)', () => {
+    expect(embeddingService.isEnabled(null)).toBe(true)
     expect(embeddingService.isEnabled(enabledConfig)).toBe(true)
   })
 
-  it('semanticSearch returns [] when disabled', async () => {
+  it('semanticSearch returns [] when nothing is embedded yet (lexical fallback)', async () => {
     const out = await embeddingService.semanticSearch(projectId, 'anything', {
       projectId: 'x',
       dataPath: '',
     } as LocalConfig)
     expect(out).toHaveLength(0)
+  })
+})
+
+describe('LocalSubwordEmbeddingProvider', () => {
+  const local = new LocalSubwordEmbeddingProvider()
+
+  it('produces a deterministic, L2-normalized 256-dim vector', async () => {
+    const [a] = await local.embed(['authentication flow'])
+    const [b] = await local.embed(['authentication flow'])
+    expect(a).toHaveLength(256)
+    expect(a).toEqual(b!) // deterministic
+    const norm = Math.sqrt(a!.reduce((s, x) => s + x * x, 0))
+    expect(norm).toBeCloseTo(1, 5)
+  })
+
+  it('scores morphologically-related text above unrelated text', async () => {
+    const [q] = await local.embed(['authentication'])
+    const [near] = await local.embed(['authenticate the user'])
+    const [far] = await local.embed(['banana pricing spreadsheet'])
+    expect(cosineSimilarity(q!, near!)).toBeGreaterThan(cosineSimilarity(q!, far!))
+  })
+
+  it('end-to-end: backfill + semanticSearch with the local default ranks the related entry first', async () => {
+    const target = write('decision', 'migrate the sqlite database schema with a new migration')
+    write('decision', 'style the react frontend button component')
+
+    // No provider passed → uses the local default via resolveActiveProvider.
+    const r = await embeddingService.backfill(
+      projectId,
+      { projectId, dataPath: '' } as LocalConfig,
+      NOW
+    )
+    expect(r.embedded).toBe(2)
+
+    const hits = await embeddingService.semanticSearch(
+      projectId,
+      'database migrations',
+      { projectId, dataPath: '' } as LocalConfig,
+      5
+    )
+    expect(hits[0]?.id).toBe(target)
   })
 })
 

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -130,17 +130,16 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
           }
         }
 
-        // Semantic index maintenance (opt-in): when an embeddings provider is
-        // configured, embed memory entries written this session so semantic
-        // recall stays current. Best-effort and — in daemon mode — detached,
-        // so the network round-trip never blocks session end. No-op (and no
-        // network) when embeddings are disabled or the index is current.
-        if (embeddingService.isEnabled(config)) {
-          try {
-            await embeddingService.backfill(p, config, new Date().toISOString())
-          } catch {
-            /* never block session end on index maintenance */
-          }
+        // Semantic index maintenance: embed memory entries written this
+        // session so semantic recall stays current. The default provider is
+        // the in-process local embedder (no network, no key), so this runs for
+        // every project; a configured HTTP endpoint transparently takes over.
+        // Best-effort, idempotent (only un-embedded entries are touched), and
+        // must never block session end.
+        try {
+          await embeddingService.backfill(p, config, new Date().toISOString())
+        } catch {
+          /* never block session end on index maintenance */
         }
 
         await regenerateWikiDeferred(p, config.projectId).catch(() => undefined)

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -1,18 +1,20 @@
 /**
- * Optional semantic-search layer (phase 3).
+ * Semantic-search layer.
  *
  * Design constraints that shaped this:
- *   - OFF by default. With no `config.embeddings.provider`, every export
- *     here is inert and recall stays pure BM25/keyword — zero new runtime
- *     dependencies, zero network, zero behavior change.
+ *   - ON by default, universally, with ZERO new dependency. The default
+ *     provider is a pure-JS local embedder (feature-hashed character n-grams,
+ *     see LocalSubwordEmbeddingProvider) — no model download, no native addon,
+ *     no API key, no network. So "vectorized to the DB" is true for every user
+ *     out of the box, not just those who configured an endpoint.
+ *   - AUTO-UPGRADE: when a project configures an OpenAI-compatible endpoint
+ *     (OpenAI, Ollama at `http://localhost:11434/v1`, LM Studio, …) that real
+ *     model takes over — higher quality, same pipeline. The local embedder is
+ *     the floor, not the ceiling.
  *   - NO vector database / native dependency. Vectors are packed Float32
- *     BLOBs in SQLite (`memory_embeddings`) and ranked with in-process
- *     cosine. For a project's hundreds–thousands of memory entries this is
- *     trivially fast and keeps prjct's fragile native-dep story unchanged.
- *   - Provider is an OpenAI-compatible `/embeddings` HTTP endpoint (OpenAI,
- *     Ollama, LM Studio, …) called with plain `fetch` — no SDK in the
- *     bundle. The API key, when needed, comes from the environment, never
- *     from committed config.
+ *     BLOBs in SQLite (`memory_embeddings`) and ranked with in-process cosine.
+ *     For a project's hundreds–thousands of entries this is trivially fast and
+ *     keeps prjct's zero-native-dep story intact.
  *
  * The provider is injectable so tests run fully offline against a fake.
  */
@@ -24,6 +26,12 @@ import type { LocalConfig } from '../../types/config'
 /** Produces one vector per input string, order-preserving. */
 export interface EmbeddingProvider {
   readonly model: string
+  /**
+   * True for providers that compute in-process with no network/cost, so the
+   * caller may embed inline (e.g. on every capture) instead of deferring to a
+   * batched backfill. Remote/HTTP providers leave this falsy.
+   */
+  readonly isLocal?: boolean
   embed(texts: string[]): Promise<number[][]>
 }
 
@@ -71,6 +79,91 @@ export class HttpEmbeddingProvider implements EmbeddingProvider {
   }
 }
 
+// Local default provider — zero-dependency subword embedding.
+
+/** Model tag stamped on locally-computed vectors. Bump the suffix to
+ *  invalidate every local vector if the algorithm below changes. */
+export const LOCAL_EMBEDDING_MODEL = 'local-subword-v1'
+const LOCAL_DIM = 256
+const MAX_TOKENS = 800 // cap work on pathologically long entries
+
+/** FNV-1a 32-bit — small, fast, well-distributed string hash. */
+function fnv1a(str: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/** Character n-grams of `s` for n in [min,max]; falls back to the whole
+ *  string when it is shorter than `min`. */
+function charNGrams(s: string, min: number, max: number): string[] {
+  const grams: string[] = []
+  if (s.length < min) {
+    grams.push(s)
+    return grams
+  }
+  for (let n = min; n <= max; n++) {
+    for (let i = 0; i + n <= s.length; i++) grams.push(s.slice(i, i + n))
+  }
+  return grams
+}
+
+/**
+ * Embed one string into an L2-normalized LOCAL_DIM vector via the hashing
+ * trick over boundary-wrapped character n-grams (n=3..5) plus the whole token.
+ * Memory content is English by convention (see the skill's CONTENT LANGUAGE
+ * rule), which keeps semantics clean; the tokenizer stays Unicode-safe so code
+ * identifiers (file paths, function names) and any stray non-English token
+ * still contribute. A signed hash spreads collisions across buckets.
+ */
+function embedLocal(text: string): number[] {
+  const acc = new Float64Array(LOCAL_DIM)
+  const tokens = (text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []).slice(0, MAX_TOKENS)
+  for (const tok of tokens) {
+    const grams = charNGrams(`<${tok}>`, 3, 5)
+    grams.push(tok) // whole-token feature in addition to its n-grams
+    for (const g of grams) {
+      const h = fnv1a(g)
+      const bucket = h % LOCAL_DIM
+      const sign = h & 0x10000 ? 1 : -1 // sign bit independent of the bucket bits
+      acc[bucket] += sign
+    }
+  }
+  let norm = 0
+  for (let i = 0; i < LOCAL_DIM; i++) norm += acc[i] * acc[i]
+  norm = Math.sqrt(norm) || 1
+  const out = new Array<number>(LOCAL_DIM)
+  for (let i = 0; i < LOCAL_DIM; i++) out[i] = acc[i] / norm
+  return out
+}
+
+/**
+ * The always-available default provider. Pure-JS, deterministic, no network.
+ * Captures morphological / substring similarity (auth≈authentication,
+ * sqlite≈SQLite) that exact-token BM25 misses, and yields a continuous score
+ * for ranking + the vector substrate the bidirectional-vault pipeline needs.
+ * NOT deep synonymy — that is what the HTTP auto-upgrade buys.
+ */
+export class LocalSubwordEmbeddingProvider implements EmbeddingProvider {
+  readonly model = LOCAL_EMBEDDING_MODEL
+  readonly isLocal = true
+  async embed(texts: string[]): Promise<number[][]> {
+    return texts.map((t) => embedLocal(t))
+  }
+}
+
+/**
+ * The provider actually used at runtime: a configured HTTP endpoint when the
+ * project opted into one, otherwise the local default. Unlike `resolveProvider`
+ * this NEVER returns null — semantic search is on for everyone.
+ */
+export function resolveActiveProvider(config: LocalConfig | null | undefined): EmbeddingProvider {
+  return resolveProvider(config) ?? new LocalSubwordEmbeddingProvider()
+}
+
 // Vector <-> BLOB packing (Float32 little-endian).
 
 function packVector(v: number[]): Buffer {
@@ -104,9 +197,13 @@ interface EmbeddingRow {
 }
 
 export const embeddingService = {
-  /** True when this project has opted into a provider. */
-  isEnabled(config: LocalConfig | null | undefined): boolean {
-    return resolveProvider(config) !== null
+  /**
+   * Always true now: the local default provider makes semantic search
+   * available to every project. Kept as a method so callers read intent
+   * ("is semantic available?") and so a future kill-switch has one home.
+   */
+  isEnabled(_config: LocalConfig | null | undefined): boolean {
+    return true
   },
 
   /** Store one entry's vector (upsert). */
@@ -157,8 +254,7 @@ export const embeddingService = {
     nowIso: string,
     opts: { provider?: EmbeddingProvider; batchSize?: number } = {}
   ): Promise<{ embedded: number; skipped: number; total: number }> {
-    const provider = opts.provider ?? resolveProvider(config)
-    if (!provider) return { embedded: 0, skipped: 0, total: 0 }
+    const provider = opts.provider ?? resolveActiveProvider(config)
     const batchSize = opts.batchSize ?? 64
     const all = projectMemory.allEntriesForIndex(projectId)
     const have = this.embeddedIds(projectId, provider.model)
@@ -195,8 +291,8 @@ export const embeddingService = {
     limit = 10,
     provider?: EmbeddingProvider
   ): Promise<MemoryEntry[]> {
-    const p = provider ?? resolveProvider(config)
-    if (!p || !query.trim()) return []
+    const p = provider ?? resolveActiveProvider(config)
+    if (!query.trim()) return []
     let qv: number[] | undefined
     try {
       ;[qv] = await p.embed([query])

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -141,6 +141,8 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '',
     'The user does NOT type prjct commands. You do. On every turn, ask: "what is the user trying to accomplish?" Match the answer to one of the verbs below. If multiple match, pick the most specific and surface the rest as alternatives. Bilingual (es/en) — the verbs are language-agnostic, the intent isn\'t.',
     '',
+    "**CONTENT LANGUAGE — author every stored memory in ENGLISH**, regardless of the conversation language. When you `capture`/`remember`, translate the intent into a clean English entry (the user may speak Spanish; the persisted knowledge is English). Reason: LLMs comprehend English better and embeddings/vectorization stay high-quality and noise-free in one canonical language (mixed-language content produces cross-language retrieval noise). The verbs and the user's intent are bilingual; the knowledge you write down is not.",
+    '',
     "These are *signals*, not phrase templates. Read them as descriptions of moments in the user's flow.",
     '',
     '### `task` — "I\'m starting a piece of work" (THE DEFAULT — try this first)',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.32.3",
+  "version": "2.32.4",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## RAG #2 — semantic search ON by default, universally

Second lever from the RAG analysis. Embeddings were opt-in (off unless you configured an OpenAI endpoint + key). Now every project gets semantic recall out of the box — the substrate the bidirectional-vault vision needs.

### Changes
- **`LocalSubwordEmbeddingProvider`** (`core/services/embeddings`) — pure-JS embedding via feature-hashed character n-grams (subword, fastText-style, no trained weights). 256-dim, L2-normalized. **Zero dependency, zero native addon, zero API key, zero download/network.** Captures morphology (auth≈authentication, sqlite≈SQLite) that exact-token BM25 misses.
- **`resolveActiveProvider()`** — never null: falls back to the local default. `resolveProvider` stays explicit-only (existing tests intact). `isEnabled()` is now always true.
- **Auto-upgrade** — a configured OpenAI-compatible endpoint (Ollama `localhost:11434/v1`, LM Studio, OpenAI) transparently takes over the same pipeline.
- **Backfill on the Stop hook** runs for every project now (local is cheap + idempotent), so memory written each session gets vectorized.
- **English content convention** — the generated skill now instructs agents to author every stored memory in English regardless of conversation language. Reason: better LLM comprehension + clean, noise-free embeddings (mixed-language content produced cross-language retrieval noise). Friction-detector verbatim quotes are the documented exception.

### Verified (real DB)
- 85 memories vectorized (local-subword-v1, 256-dim)
- Morphological query "vectorizando memoria" surfaced entries BM25 missed
- `typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1365 tests** ✓ (+ local-provider tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)