### PR TITLE
feat: binary ingest extractors — zero-dep auto-detect (PDF/Office/images)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@
 
 ## [Unreleased]
 
+## [2.32.6] - 2026-05-31
+
+### Added
+- binary ingest extractors: zero-dep auto-detect (textutil/pdftotext/tesseract) for PDF/Office/images
+
 ## [2.32.5] - 2026-05-31
 
 ### Added

--- a/core/__tests__/services/ingest-extractors.test.ts
+++ b/core/__tests__/services/ingest-extractors.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Ingest extractors — selection logic, offline.
+ *
+ * The real extractors shell out to textutil/pdftotext/tesseract, which may or
+ * may not exist on a given machine. To stay deterministic we inject fake
+ * extractors and assert the registry's contract: first matching extractor that
+ * yields non-empty text wins; absent (throwing) or empty ones fall through;
+ * null when nothing handles it. The static metadata (extensions, hints) is
+ * pinned directly.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  EXTRACTABLE_EXTENSIONS,
+  type Extractor,
+  extractHint,
+  extractText,
+} from '../../services/ingest-extractors'
+
+const ok = (label: string, ext: string, text: string): Extractor => ({
+  label,
+  exts: new Set([ext]),
+  extract: async () => text,
+})
+const boom = (ext: string): Extractor => ({
+  label: 'gone',
+  exts: new Set([ext]),
+  extract: async () => {
+    throw new Error('ENOENT: tool not installed')
+  },
+})
+
+describe('extractText — selection', () => {
+  it('returns text + tool from the first matching extractor', async () => {
+    const r = await extractText('/tmp/doc.pdf', [ok('pdftotext', '.pdf', 'hello pdf')])
+    expect(r).toEqual({ text: 'hello pdf', tool: 'pdftotext' })
+  })
+
+  it('falls through an absent (throwing) extractor to the next one', async () => {
+    const r = await extractText('/tmp/doc.pdf', [boom('.pdf'), ok('backup', '.pdf', 'recovered')])
+    expect(r?.tool).toBe('backup')
+    expect(r?.text).toBe('recovered')
+  })
+
+  it('skips an extractor that yields only whitespace', async () => {
+    const r = await extractText('/tmp/doc.pdf', [
+      ok('blank', '.pdf', '   \n  '),
+      ok('real', '.pdf', 'text'),
+    ])
+    expect(r?.tool).toBe('real')
+  })
+
+  it('trims extracted text', async () => {
+    const r = await extractText('/tmp/doc.pdf', [ok('t', '.pdf', '  spaced  ')])
+    expect(r?.text).toBe('spaced')
+  })
+
+  it('returns null when no extractor matches the extension', async () => {
+    const r = await extractText('/tmp/img.png', [ok('pdftotext', '.pdf', 'x')])
+    expect(r).toBeNull()
+  })
+
+  it('returns null when every matching extractor fails', async () => {
+    const r = await extractText('/tmp/doc.pdf', [boom('.pdf'), boom('.pdf')])
+    expect(r).toBeNull()
+  })
+
+  it('matches case-insensitively on extension', async () => {
+    const r = await extractText('/tmp/DOC.PDF', [ok('t', '.pdf', 'x')])
+    expect(r?.text).toBe('x')
+  })
+})
+
+describe('extractor metadata', () => {
+  it('advertises the binary/rich formats it can handle', () => {
+    for (const ext of ['.pdf', '.docx', '.png', '.jpg', '.rtf']) {
+      expect(EXTRACTABLE_EXTENSIONS.has(ext)).toBe(true)
+    }
+    expect(EXTRACTABLE_EXTENSIONS.has('.txt')).toBe(false) // plain text is not "extracted"
+  })
+
+  it('gives a format-specific install hint', () => {
+    expect(extractHint('.pdf')).toContain('poppler')
+    expect(extractHint('.png')).toContain('tesseract')
+    expect(extractHint('.docx')).toContain('textutil')
+  })
+})

--- a/core/__tests__/services/wiki-ingest.test.ts
+++ b/core/__tests__/services/wiki-ingest.test.ts
@@ -252,8 +252,10 @@ describe('Wiki Ingest — raw documents', () => {
     expect(recallAll().every((e) => e.type === 'source')).toBe(true)
   })
 
-  test('ignores unsupported (binary) extensions', async () => {
-    await dropNote('diagram.png', 'not-really-an-image-but-wrong-ext')
+  test('ignores extensions that are neither text nor extractable', async () => {
+    // .zip is not in the text allowlist nor handled by any extractor → it is
+    // never even listed, so no ingest, no skip entry, no noise.
+    await dropNote('archive.zip', 'PK binary junk')
     const result = await ingestCapturedNotes(projectPath)
     expect(result.ingested).toBe(0)
     expect(result.skipped).toEqual([])
@@ -283,6 +285,21 @@ describe('Wiki Ingest — raw documents', () => {
     const [entry] = recallAll()
     expect(entry.tags.part).toBeUndefined()
     expect(entry.tags.doc).toBeUndefined()
+  })
+
+  test('a binary drop with no available extractor is skipped with an actionable hint (never lost)', async () => {
+    // `.pdf` is in the dropzone allowlist but needs poppler. Whether or not
+    // this machine has pdftotext, the file must be ACCOUNTED FOR — ingested or
+    // skipped-with-reason, never silently dropped or crashed.
+    const filePath = await dropNote('scan.pdf', '%PDF-1.4 not real pdf bytes')
+    const result = await ingestCapturedNotes(projectPath)
+    expect(result.errors).toEqual([])
+    expect(result.ingested + result.skipped.length).toBe(1)
+    if (result.skipped.length === 1) {
+      expect(result.skipped[0].reason).toMatch(/extract|poppler/i)
+      // Left in the inbox so a re-sync after installing the tool picks it up.
+      await expect(fs.stat(filePath)).resolves.toBeTruthy()
+    }
   })
 })
 

--- a/core/services/ingest-extractors.ts
+++ b/core/services/ingest-extractors.ts
@@ -1,0 +1,131 @@
+/**
+ * Ingest extractors — turn a binary/rich document into plain text using
+ * EXTERNAL tools that are already on the machine, then feed that text through
+ * the normal capture pipeline (chunk → `source` memory → vectorized).
+ *
+ * Design (mirrors the embeddings tiering): ZERO bundled dependency. We never
+ * ship a PDF/OCR library — instead we shell out to a tool IF the user has it,
+ * exactly like embeddings use a local engine when one is present:
+ *   - `.docx/.doc/.rtf/.html/.pages/…` → `textutil` (built into macOS)
+ *   - `.pdf`                            → `pdftotext` (poppler)
+ *   - images `.png/.jpg/…`             → `tesseract` (OCR)
+ *
+ * A tool that is absent simply throws ENOENT on exec; we catch, try the next
+ * extractor, and ultimately return null so the caller can skip the file with
+ * an actionable "install X" hint. Nothing here is reached unless the user
+ * dropped a non-text file, so the common path pays zero cost.
+ *
+ * Safety: every tool is invoked with `execFile` (no shell, argv array) on a
+ * user-supplied path, with a timeout and a generous maxBuffer. The extracted
+ * text still runs through the secret/prompt-injection scanners in wiki-ingest.
+ */
+
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const EXEC_OPTS = { timeout: 30_000, maxBuffer: 64 * 1024 * 1024 } as const
+
+export interface Extractor {
+  /** Stamped onto the memory as `extracted:<label>` for provenance. */
+  label: string
+  exts: Set<string>
+  /** Resolve to the document's text. Throw (e.g. ENOENT) when the tool is
+   *  absent or the file has no extractable text — the caller falls through. */
+  extract(absPath: string): Promise<string>
+}
+
+/** macOS built-in. Handles Office/rich-text/HTML without any install. */
+const textutilExtractor: Extractor = {
+  label: 'textutil',
+  exts: new Set([
+    '.docx',
+    '.doc',
+    '.rtf',
+    '.rtfd',
+    '.html',
+    '.htm',
+    '.odt',
+    '.pages',
+    '.webarchive',
+  ]),
+  async extract(absPath) {
+    if (process.platform !== 'darwin') throw new Error('textutil is macOS-only')
+    const { stdout } = await execFileAsync(
+      'textutil',
+      ['-convert', 'txt', '-stdout', absPath],
+      EXEC_OPTS
+    )
+    return stdout
+  },
+}
+
+/** poppler. The de-facto PDF→text tool; `-` writes to stdout. */
+const pdftotextExtractor: Extractor = {
+  label: 'pdftotext',
+  exts: new Set(['.pdf']),
+  async extract(absPath) {
+    const { stdout } = await execFileAsync('pdftotext', ['-q', '-nopgbrk', absPath, '-'], EXEC_OPTS)
+    return stdout
+  },
+}
+
+/** Tesseract OCR for images. `stdout` is its special "write to stdout" target. */
+const tesseractExtractor: Extractor = {
+  label: 'tesseract',
+  exts: new Set(['.png', '.jpg', '.jpeg', '.tif', '.tiff', '.bmp', '.webp']),
+  async extract(absPath) {
+    const { stdout } = await execFileAsync('tesseract', [absPath, 'stdout'], EXEC_OPTS)
+    return stdout
+  },
+}
+
+export const DEFAULT_EXTRACTORS: Extractor[] = [
+  textutilExtractor,
+  pdftotextExtractor,
+  tesseractExtractor,
+]
+
+/** Every extension some extractor could handle — used to widen the ingest
+ *  dropzone's file allowlist beyond plain text. */
+export const EXTRACTABLE_EXTENSIONS: Set<string> = new Set(
+  DEFAULT_EXTRACTORS.flatMap((e) => [...e.exts])
+)
+
+/** Static, availability-free hint for the skip message when extraction yields
+ *  nothing — so the user knows which tool unlocks the format. */
+export function extractHint(ext: string): string {
+  const e = ext.toLowerCase()
+  if (e === '.pdf')
+    return 'install poppler (`brew install poppler`) for PDF text, or convert it to .txt'
+  if (['.png', '.jpg', '.jpeg', '.tif', '.tiff', '.bmp', '.webp'].includes(e)) {
+    return 'install tesseract (`brew install tesseract`) for image OCR, or add a sidecar .txt note'
+  }
+  if (['.docx', '.doc', '.rtf', '.odt', '.pages', '.html', '.htm', '.webarchive'].includes(e)) {
+    return 'rich-doc extraction needs macOS `textutil`; on other platforms convert to .txt/.md'
+  }
+  return 'convert it to a supported text format (.txt/.md)'
+}
+
+/**
+ * Extract text from a non-text file, or null if no available tool produced
+ * any. `extractors` is injectable so tests run without real binaries.
+ */
+export async function extractText(
+  absPath: string,
+  extractors: Extractor[] = DEFAULT_EXTRACTORS
+): Promise<{ text: string; tool: string } | null> {
+  const ext = path.extname(absPath).toLowerCase()
+  for (const e of extractors) {
+    if (!e.exts.has(ext)) continue
+    try {
+      const text = (await e.extract(absPath)).trim()
+      if (text) return { text, tool: e.label }
+    } catch {
+      // Tool absent (ENOENT) or failed on this file — try the next extractor.
+    }
+  }
+  return null
+}

--- a/core/services/wiki-ingest.ts
+++ b/core/services/wiki-ingest.ts
@@ -35,6 +35,7 @@ import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { WorkflowRule } from '../types/storage/extended'
 import { scanForPromptInjection } from '../utils/prompt-injection'
 import { scanForSecrets } from '../utils/secret-scanner'
+import { EXTRACTABLE_EXTENSIONS, extractHint, extractText } from './ingest-extractors'
 import { resolveVaultRoot } from './wiki-migration'
 
 const CAPTURED_SUBDIR = 'captured'
@@ -110,8 +111,22 @@ export async function ingestCapturedNotes(
   for (const absPath of files) {
     const relName = path.basename(absPath)
     try {
-      const raw = await fs.readFile(absPath, 'utf-8')
-      const built = buildEntries(relName, raw)
+      const ext = path.extname(relName).toLowerCase()
+      let built: BuildResult
+      if (TEXT_EXTENSIONS.has(ext)) {
+        built = buildEntries(relName, await fs.readFile(absPath, 'utf-8'))
+      } else {
+        // Binary / rich document → external extractor (textutil / pdftotext /
+        // tesseract) IF the user has one. Absent → skip with an install hint;
+        // the file stays in the inbox so a re-sync after install picks it up.
+        const extracted = await extractText(absPath)
+        built = extracted
+          ? {
+              ok: true,
+              entries: buildDocEntries(relName, extracted.text, { extracted: extracted.tool }),
+            }
+          : { ok: false, error: `no text extracted from ${ext} — ${extractHint(ext)}` }
+      }
       if (!built.ok) {
         result.skipped.push({ file: relName, reason: built.error })
         continue
@@ -184,21 +199,30 @@ function buildEntries(relName: string, raw: string): BuildResult {
 
   const text = raw.trim()
   if (!text) return { ok: false, error: 'empty file' }
+  return { ok: true, entries: buildDocEntries(relName, text) }
+}
 
-  const baseTags: Record<string, string> = { file: relName, origin: 'ingest' }
-  const chunks = chunkText(text)
+/**
+ * A raw document (frontmatter-less text, or text extracted from a binary) →
+ * `source` memory entries, chunked when long. `extraTags` carries provenance
+ * like `extracted: pdftotext`. Callers guarantee non-empty text.
+ */
+function buildDocEntries(
+  relName: string,
+  text: string,
+  extraTags: Record<string, string> = {}
+): ParsedNote[] {
+  const baseTags: Record<string, string> = { file: relName, origin: 'ingest', ...extraTags }
+  const chunks = chunkText(text.trim())
   if (chunks.length === 1) {
-    return { ok: true, entries: [{ type: DEFAULT_DOC_TYPE, tags: baseTags, content: chunks[0]! }] }
+    return [{ type: DEFAULT_DOC_TYPE, tags: baseTags, content: chunks[0]! }]
   }
   const docSlug = slugifyName(relName)
-  return {
-    ok: true,
-    entries: chunks.map((content, i) => ({
-      type: DEFAULT_DOC_TYPE,
-      tags: { ...baseTags, doc: docSlug, part: `${i + 1}/${chunks.length}` },
-      content,
-    })),
-  }
+  return chunks.map((content, i) => ({
+    type: DEFAULT_DOC_TYPE,
+    tags: { ...baseTags, doc: docSlug, part: `${i + 1}/${chunks.length}` },
+    content,
+  }))
 }
 
 /**
@@ -295,8 +319,12 @@ ${MEMORY_TYPES.map((t) => `- \`${t}\``).join('\n')}
   skipped — they ingest as raw documents.
 - \`tags\` is optional — a flat \`key: value\` map.
 - Supported text formats: \`.md .markdown .mdx .txt .text .json .yaml .yml
-  .csv .tsv .log .rst .org\`. (Binary formats like PDF/images are not yet
-  extracted.)
+  .csv .tsv .log .rst .org\`.
+- Binary / rich docs are extracted via tools you already have (zero bundled
+  dependency): \`.docx/.doc/.rtf/.html/.pages\` → \`textutil\` (macOS);
+  \`.pdf\` → \`pdftotext\` (\`brew install poppler\`); images → \`tesseract\`
+  (\`brew install tesseract\`). Without the tool, the file is left here with a
+  hint so a re-sync after install picks it up.
 - Raw documents keep their original language; agent-authored memory is English.
 - Secret-like content (API keys, JWTs) is refused unless you pass
   \`--force\` to \`prjct context wiki sync\`.
@@ -317,7 +345,8 @@ async function listNoteFiles(capturedRoot: string): Promise<string[]> {
     if (name.startsWith('.')) continue
     if (name === INGESTED_SUBDIR) continue
     if (name === README_FILENAME) continue
-    if (!TEXT_EXTENSIONS.has(path.extname(name).toLowerCase())) continue
+    const fileExt = path.extname(name).toLowerCase()
+    if (!TEXT_EXTENSIONS.has(fileExt) && !EXTRACTABLE_EXTENSIONS.has(fileExt)) continue
     files.push(path.join(capturedRoot, name))
   }
   return files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.32.5",
+  "version": "2.32.6",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Binary ingest extractors — RAG #4 (zero-dependency auto-detect)

Completes the ingest pipeline for binary / rich documents, using the **same tiering philosophy as embeddings**: ship NO PDF/OCR library — shell out to a tool the user already has, if present.

### `core/services/ingest-extractors.ts` (new)
- `extractText(absPath)` tries matching extractors in order:
  - `.docx/.doc/.rtf/.html/.pages/.odt` → **textutil** (built into macOS)
  - `.pdf` → **pdftotext** (poppler)
  - images `.png/.jpg/.tiff/.webp/…` → **tesseract** (OCR)
- A missing tool throws ENOENT → caught → next extractor → `null` when none yield text.
- `execFile` (no shell, argv array) + 30s timeout + 64MB buffer; extractor list is injectable for tests.

### `wiki-ingest.ts`
- Non-text drops route through `extractText`: got text → `buildDocEntries` (chunked `source`, tagged `extracted:<tool>`); none → **skip with an actionable install hint** (`brew install poppler/tesseract`), file stays in the inbox so a re-sync after install picks it up.
- Extracted text still passes the secret / prompt-injection scanners.

### Verified
- Real `.rtf` on macOS → textutil extracted → `source` memory tagged `extracted:textutil` → vectorized.
- `typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1380 tests** ✓ (new extractor unit tests + tolerant binary-routing test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)