### PR TITLE
feat: vault signal cleanup — collapse release/tag sprawl + always-on architecture.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@
 
 ## [Unreleased]
 
+## [2.32.7] - 2026-05-31
+
+### Added
+- vault signal cleanup: collapse release/tag sprawl + always-on architecture.md synthesis
+
 ## [2.32.6] - 2026-05-31
 
 ### Added

--- a/core/__tests__/services/architecture-builder.test.ts
+++ b/core/__tests__/services/architecture-builder.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Baseline architecture synthesis — the deterministic `architecture.md` that
+ * makes the "read architecture first" contract hold without an LLM analysis.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { MemoryEntry } from '../../memory/project-memory'
+import { buildArchitectureBaseline } from '../../services/wiki/architecture-builder'
+
+function entry(id: string, type: string, content: string): MemoryEntry {
+  return {
+    id,
+    type,
+    content,
+    tags: {},
+    rememberedAt: '2026-05-31T00:00:00Z',
+    provenance: 'declared',
+  } as MemoryEntry
+}
+
+describe('buildArchitectureBaseline', () => {
+  it('returns null when there are no decisions or gotchas', () => {
+    const out = buildArchitectureBaseline([
+      entry('mem_1', 'fact', 'the sky is blue'),
+      entry('mem_2', 'idea', 'maybe add dark mode'),
+    ])
+    expect(out).toBeNull()
+  })
+
+  it('synthesizes decisions and gotchas into sections with mem refs', () => {
+    const out = buildArchitectureBaseline([
+      entry('mem_10', 'decision', 'Use node:sqlite to drop the native dependency.'),
+      entry('mem_11', 'gotcha', 'The daemon holds a write lock — set busy_timeout.'),
+      entry('mem_12', 'fact', 'ignored'),
+    ])
+    expect(out).not.toBeNull()
+    expect(out).toContain('# Architecture')
+    expect(out).toContain('## Key decisions')
+    expect(out).toContain('## Known gotchas')
+    expect(out).toContain('node:sqlite')
+    expect(out).toContain('busy_timeout')
+    expect(out).toContain('`mem_10`')
+    expect(out).toContain('`mem_11`')
+    // A non-decision/gotcha entry must not leak in.
+    expect(out).not.toContain('ignored')
+  })
+
+  it('omits a section that has no entries', () => {
+    const out = buildArchitectureBaseline([entry('mem_1', 'decision', 'Ship daily.')])
+    expect(out).toContain('## Key decisions')
+    expect(out).not.toContain('## Known gotchas')
+  })
+
+  it('caps each section at 20 entries', () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      entry(`mem_${i}`, 'decision', `Decision number ${i} about the system.`)
+    )
+    const out = buildArchitectureBaseline(many)!
+    const count = (out.match(/^- \*\*/gm) ?? []).length
+    expect(count).toBe(20)
+  })
+})

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -41,6 +41,7 @@ import type { WorkflowRule } from '../types/storage/extended'
 import { ensureObsidianVault } from './obsidian-vault'
 import type { Manifest } from './wiki/_shared'
 import { sha256, slugify } from './wiki/_shared'
+import { buildArchitectureBaseline } from './wiki/architecture-builder'
 import { buildAnalysisArchiveFiles, collectConcepts } from './wiki/concept-builder'
 import { computeRegenFingerprint, FINGERPRINT_FILE } from './wiki/fingerprint'
 import { buildIndexFile } from './wiki/index-builder'
@@ -204,13 +205,17 @@ export async function generateWiki(
   const patternsBody = buildPatternsFile(patterns, antiPatterns)
   if (patternsBody) files.set('patterns.md', patternsBody)
 
-  // LLM-only sections: architecture, tech debt, risks, refactors, conventions,
-  // project insights. Each lands in its own markdown file so the vault stays
-  // browsable and agents can fetch them individually.
-  if (llmAnalysis) {
-    const archBody = buildArchitectureFile(llmAnalysis)
-    if (archBody) files.set('architecture.md', archBody)
+  // architecture.md: prefer the rich LLM analysis when present, otherwise
+  // synthesize a baseline from declared memory (decisions + gotchas) so the
+  // "read architecture.md first" contract holds for EVERY project, not just
+  // ones that ran an LLM analysis.
+  const archBody =
+    (llmAnalysis ? buildArchitectureFile(llmAnalysis) : null) ?? buildArchitectureBaseline(declared)
+  if (archBody) files.set('architecture.md', archBody)
 
+  // tech-debt / insights remain LLM-only — a deterministic baseline would be
+  // too thin to be worth a page.
+  if (llmAnalysis) {
     const debtBody = buildTechDebtFile(llmAnalysis)
     if (debtBody) files.set('tech-debt.md', debtBody)
 

--- a/core/services/wiki/architecture-builder.ts
+++ b/core/services/wiki/architecture-builder.ts
@@ -1,0 +1,59 @@
+/**
+ * Baseline architecture synthesis.
+ *
+ * The vault's `architecture.md` used to exist ONLY when an LLM analysis had
+ * been run — so most projects had none, and the "read architecture.md first"
+ * contract 404'd. This builds a deterministic baseline from the knowledge the
+ * project already recorded: its decisions (the *why* behind choices) and its
+ * gotchas (the traps). That synthesis is the vault's unique value — it does not
+ * exist anywhere else, unlike the per-entry pages which mirror the DB. When a
+ * richer LLM analysis IS present, the caller prefers that and ignores this.
+ */
+
+import { deriveTitle, type MemoryEntry } from '../../memory/project-memory'
+
+const MAX_PER_SECTION = 20
+
+function teaser(content: string): string {
+  const flat = content.replace(/\s+/g, ' ').trim()
+  return flat.length > 200 ? `${flat.slice(0, 199)}…` : flat
+}
+
+function bullet(entry: MemoryEntry): string {
+  return `- **${deriveTitle(entry)}** — ${teaser(entry.content)}  \`${entry.id}\``
+}
+
+/**
+ * Synthesize `architecture.md` from declared memory. Returns null when there's
+ * nothing load-bearing to say (no decisions and no gotchas), so the caller can
+ * skip writing an empty page.
+ */
+export function buildArchitectureBaseline(declared: MemoryEntry[]): string | null {
+  // `declared` is newest-first (allEntriesForIndex order); keep that — recent
+  // decisions describe the current shape of the project.
+  const decisions = declared.filter((e) => e.type === 'decision').slice(0, MAX_PER_SECTION)
+  const gotchas = declared.filter((e) => e.type === 'gotcha').slice(0, MAX_PER_SECTION)
+  if (decisions.length === 0 && gotchas.length === 0) return null
+
+  const lines: string[] = ['# Architecture', '']
+  lines.push(
+    '> Synthesized from project memory — the decisions and gotchas the project recorded.',
+    '> Read this before re-reading source. The full knowledge graph is under `memory/`.',
+    ''
+  )
+
+  if (decisions.length > 0) {
+    lines.push('## Key decisions — the *why*', '')
+    for (const d of decisions) lines.push(bullet(d))
+    lines.push('')
+  }
+
+  if (gotchas.length > 0) {
+    lines.push('## Known gotchas — traps to avoid', '')
+    for (const g of gotchas) lines.push(bullet(g))
+    lines.push('')
+  }
+
+  lines.push('---', '', 'See also: [project wiki](index.md)', '')
+  return `${lines.join('\n')}\n`
+}

--- a/core/services/wiki/memory-builder.ts
+++ b/core/services/wiki/memory-builder.ts
@@ -316,19 +316,46 @@ export function buildMemoryFiles(
   return files
 }
 
+/**
+ * Tag keys that are machine bookkeeping, not browsable categories — their
+ * values are opaque hashes / uuids / counters that spawned hundreds of vault
+ * pages nobody reads (tags/key/<hash>.md, tags/session/<uuid>.md, …). We skip
+ * generating pages for them; the entries are still reachable via memory/<type>
+ * and search. Human dimensions (topic, type, pr, file, domain, …) still get
+ * pages.
+ */
+const NOISE_TAG_KEYS = new Set([
+  'key',
+  'hash',
+  'content-hash',
+  'content_hash',
+  'session',
+  'window-days',
+  'window_days',
+  'touches',
+  'occurrences',
+  'phrase',
+  'slug',
+  'spec-id',
+  'spec_id',
+  'kind',
+])
+
 export function buildTagFiles(
   entries: MemoryEntry[],
   allEntries: MemoryEntry[] = entries
 ): Map<string, string> {
   // One page per distinct tag pair (`tags/<key>/<value>.md`) + an index
   // per tag key (`tags/<key>.md`). Relation tags are excluded — they're
-  // graph edges, not categories (Defect C).
+  // graph edges, not categories (Defect C). Opaque machine keys (NOISE_TAG_KEYS)
+  // are skipped so the vault stays browsable signal, not hash sprawl.
   const files = new Map<string, string>()
   const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
   const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
   const byPair = groupByTagPair(entries)
 
   for (const [key, byValue] of byPair) {
+    if (NOISE_TAG_KEYS.has(key)) continue
     const keySlug = slugify(key)
     const indexLines = [`# Tag: ${key}`, '']
     const sortedValues = [...byValue.entries()].sort((a, b) => a[0].localeCompare(b[0]))

--- a/core/services/wiki/release-builder.ts
+++ b/core/services/wiki/release-builder.ts
@@ -1,10 +1,11 @@
 /**
  * Release file builder.
  *
- * Most projects have way more history in their CHANGELOG than in the
- * young prjct SQLite tables. Parse `CHANGELOG.md` and emit one file
- * per `## [version] - date` block so every release shows up in the
- * vault as a discrete, addressable note.
+ * `CHANGELOG.md` is the source of truth and ships in the repo. The vault used
+ * to mirror it as one file PER version (hundreds of near-empty notes nobody
+ * reads — pure sprawl). Instead we emit a SINGLE `releases/index.md` rollup: a
+ * newest-first table with a one-line summary per version, pointing at
+ * `CHANGELOG.md` for the full notes.
  */
 
 import fs from 'node:fs/promises'
@@ -42,63 +43,30 @@ export function parseChangelog(raw: string): ReleaseEntry[] {
   return out
 }
 
-export function releaseSlug(version: string): string {
-  // Versions like `2.0.0-alpha.12` → `v2.0.0-alpha.12`. Obsidian-safe.
-  const cleaned = version.replace(/[^a-zA-Z0-9._-]+/g, '-')
-  return `v${cleaned}`
-}
-
-function buildReleaseFile(
-  entry: ReleaseEntry,
-  prev: { entry: ReleaseEntry; slug: string } | null,
-  next: { entry: ReleaseEntry; slug: string } | null
-): string {
-  const lines: string[] = []
-  lines.push('---')
-  lines.push(`type: release`)
-  lines.push(`version: ${entry.version}`)
-  lines.push(`date: ${entry.date}`)
-  lines.push('tags: [release]')
-  lines.push('---')
-  lines.push('')
-  lines.push(`# v${entry.version} — ${entry.date}`)
-  lines.push('')
-
-  // Nav at the top for quick hop-scrolling through release history.
-  const navParts: string[] = []
-  if (prev) navParts.push(`← [v${prev.entry.version}](${prev.slug}.md)`)
-  navParts.push(`[releases index](index.md)`)
-  if (next) navParts.push(`[v${next.entry.version}](${next.slug}.md) →`)
-  lines.push(navParts.join(' · '))
-  lines.push('')
-
-  if (entry.body) {
-    lines.push(entry.body)
-    lines.push('')
-  } else {
-    lines.push('_No changelog body._')
-    lines.push('')
+/** First non-empty, de-bulleted line of a changelog body, table-cell safe. */
+function firstMeaningfulLine(body: string): string {
+  for (const raw of body.split('\n')) {
+    const t = raw.replace(/^[-*#>\s]+/, '').trim()
+    if (t) {
+      const clean = t.replace(/\|/g, '\\|')
+      return clean.length > 80 ? `${clean.slice(0, 79)}…` : clean
+    }
   }
-
-  lines.push('---')
-  lines.push('')
-  lines.push(`[project wiki](../index.md) · [releases index](index.md)`)
-  lines.push('')
-  return `${lines.join('\n')}\n`
+  return '—'
 }
 
-function buildReleasesIndex(entries: Array<{ entry: ReleaseEntry; slug: string }>): string {
+function buildReleasesIndex(entries: ReleaseEntry[]): string {
   const lines: string[] = ['# Releases', '']
   lines.push(
-    `${entries.length} version entr${entries.length === 1 ? 'y' : 'ies'} parsed from \`CHANGELOG.md\`. Newest first.`
+    `${entries.length} version${entries.length === 1 ? '' : 's'} parsed from \`CHANGELOG.md\`. Newest first — full notes live in \`CHANGELOG.md\`.`
   )
   lines.push('')
   lines.push('See also: [project wiki](../index.md)')
   lines.push('')
-  lines.push('| Date | Version | Link |')
+  lines.push('| Date | Version | Summary |')
   lines.push('|---|---|---|')
-  for (const { entry, slug } of entries) {
-    lines.push(`| ${entry.date} | ${entry.version} | [v${entry.version}](${slug}.md) |`)
+  for (const entry of entries) {
+    lines.push(`| ${entry.date} | ${entry.version} | ${firstMeaningfulLine(entry.body)} |`)
   }
   lines.push('')
   return `${lines.join('\n')}\n`
@@ -117,29 +85,7 @@ export async function buildReleasesFiles(projectPath: string): Promise<Map<strin
   const entries = parseChangelog(raw)
   if (entries.length === 0) return out
 
-  // Some CHANGELOGs repeat a version header (re-releases, authoring
-  // mistakes). Disambiguate with a `-Nb` suffix on the slug so every
-  // parsed entry survives — we'd rather show "v1.45.6-2b.md" than drop
-  // half the history on the floor.
-  const slugSeen = new Map<string, number>()
-  const decoratedEntries: Array<{ entry: ReleaseEntry; slug: string }> = []
-  for (const entry of entries) {
-    const base = releaseSlug(entry.version)
-    const count = slugSeen.get(base) ?? 0
-    slugSeen.set(base, count + 1)
-    const slug = count === 0 ? base : `${base}-${count + 1}b`
-    decoratedEntries.push({ entry, slug })
-  }
-
-  // Two-pass so each release can carry prev/next nav pointing at the
-  // decorated slugs. `entries` is newest-first → `prev` in nav means
-  // "previous in reading order" (older).
-  for (let i = 0; i < decoratedEntries.length; i++) {
-    const curr = decoratedEntries[i]
-    const newer = i > 0 ? decoratedEntries[i - 1] : null
-    const older = i + 1 < decoratedEntries.length ? decoratedEntries[i + 1] : null
-    out.set(`releases/${curr.slug}.md`, buildReleaseFile(curr.entry, older, newer))
-  }
-  out.set('releases/index.md', buildReleasesIndex(decoratedEntries))
+  // One consolidated rollup — NOT one file per version (that was the sprawl).
+  out.set('releases/index.md', buildReleasesIndex(entries))
   return out
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.32.6",
+  "version": "2.32.7",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Make the vault signal, not a noisy mirror (RAG #6)

Directly answers the question that kicked off this work — *does the generated vault add value, or is it just visual?* It cuts the machine sprawl nobody reads and adds the one thing the vault uniquely can: a synthesis.

### 6a — kill the sprawl
- **`release-builder.ts`**: emit a single `releases/index.md` rollup (date · version · one-line summary, pointing at `CHANGELOG.md`) instead of **one file per version**. Removed `releaseSlug`/`buildReleaseFile`.
- **`memory-builder.ts`**: `buildTagFiles` skips a `NOISE_TAG_KEYS` denylist (`key/hash/session/window-days/touches/occurrences/phrase/slug/spec-id/kind`) — opaque hash/uuid/counter tags that spawned hundreds of unread pages. Human dimensions (topic, pr, file, domain, …) still get pages.

### 6b — add the synthesis
- **`wiki/architecture-builder.ts`** (new): `buildArchitectureBaseline(declared)` synthesizes `architecture.md` from the project's **decisions (the why)** + **gotchas (the traps)**. Now emitted for **every** project (was LLM-analysis-only → the global `CLAUDE.md` "read architecture.md first" instruction 404'd). A richer LLM analysis is still preferred when present.

### Verified (real vault)
- `releases/` **161 → 1** · `tags/` **156 → 123** · total files **420 → 227** (−46%).
- `architecture.md` now generated with a real decision/gotcha digest.
- `typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1384 tests** ✓ (+ architecture-builder tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)