### PR TITLE
feat: global BYOT embeddings — one securely-stored API key for all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,11 @@
 
 ## [Unreleased]
 
+## [2.32.8] - 2026-05-31
+
+### Added
+- global BYOT embeddings: one securely-stored API key (Keychain) for all projects + prjct embeddings command
+
 ## [2.32.7] - 2026-05-31
 
 ### Added

--- a/core/__tests__/services/secure-key.test.ts
+++ b/core/__tests__/services/secure-key.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Secure embeddings-key resolution — the env tier (deterministic, no Keychain
+ * / filesystem side effects). The Keychain + file tiers are exercised live;
+ * here we pin the precedence (env wins) and the per-process cache contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  _resetKeyCache,
+  EMBEDDINGS_API_KEY_ENV,
+  getEmbeddingsKey,
+  getKeyLocation,
+} from '../../services/embeddings/secure-key'
+
+const original = process.env[EMBEDDINGS_API_KEY_ENV]
+
+beforeEach(() => {
+  _resetKeyCache()
+})
+
+afterEach(() => {
+  if (original === undefined) delete process.env[EMBEDDINGS_API_KEY_ENV]
+  else process.env[EMBEDDINGS_API_KEY_ENV] = original
+  _resetKeyCache()
+})
+
+describe('secure-key — env tier', () => {
+  it('resolves the key from the env var', async () => {
+    process.env[EMBEDDINGS_API_KEY_ENV] = 'sk-from-env'
+    expect(await getEmbeddingsKey()).toBe('sk-from-env')
+  })
+
+  it('reports the env location when the env var is set', async () => {
+    process.env[EMBEDDINGS_API_KEY_ENV] = 'sk-from-env'
+    expect(await getKeyLocation()).toBe('env')
+  })
+
+  it('env takes precedence and the value is cached for the process', async () => {
+    process.env[EMBEDDINGS_API_KEY_ENV] = 'sk-first'
+    expect(await getEmbeddingsKey()).toBe('sk-first')
+    // Changing the env WITHOUT resetting the cache keeps the first value.
+    process.env[EMBEDDINGS_API_KEY_ENV] = 'sk-second'
+    expect(await getEmbeddingsKey()).toBe('sk-first')
+    // After an explicit reset, the new value resolves.
+    _resetKeyCache()
+    expect(await getEmbeddingsKey()).toBe('sk-second')
+  })
+
+  it('trims surrounding whitespace from the env value', async () => {
+    process.env[EMBEDDINGS_API_KEY_ENV] = '  sk-padded  '
+    expect(await getEmbeddingsKey()).toBe('sk-padded')
+  })
+})

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -460,6 +460,29 @@ export const COMMANDS: CommandMeta[] = [
     ],
   },
   {
+    name: 'embeddings',
+    group: 'core',
+    routing: { group: 'embeddings', method: 'embeddings' },
+    description:
+      'Configure the GLOBAL semantic-embeddings provider (BYOT) — one API key, stored securely, used by every project.',
+    usage: {
+      claude: '/p:embeddings status',
+      terminal:
+        'prjct embeddings <set|status|test|clear> [--key <K>] [--model <M>] [--base-url <U>]',
+    },
+    params: '[set|status|test|clear]',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: false,
+    features: [
+      'BYOT: bring your own embedding API key (OpenAI-compatible)',
+      'Key stored in the macOS Keychain (else a 0600 file), never in config',
+      'Global — applies to all projects; per-project config still overrides',
+      'Without a key, recall uses the always-on local subword embedder',
+      'Validate with: prjct embeddings test',
+    ],
+  },
+  {
     name: 'config',
     group: 'core',
     routing: { group: 'config', method: 'config' },

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -21,6 +21,7 @@ import { AnalysisCommands } from './analysis'
 import { CaptureCommands } from './capture'
 import { ConfigCommands } from './config'
 import { ContextCommands } from './context'
+import { EmbeddingsCommands } from './embeddings'
 import { InstallCommands } from './install'
 import { McpCommands } from './mcp'
 import { PlanningCommands } from './planning'
@@ -53,6 +54,7 @@ class PrjctCommands {
   private mcpCmds: McpCommands
   private teamCmds: TeamCommands
   private configCmds: ConfigCommands
+  private embeddingsCmds: EmbeddingsCommands
   private specCmds: SpecCommands
 
   // Shared state
@@ -76,6 +78,7 @@ class PrjctCommands {
     this.mcpCmds = new McpCommands()
     this.teamCmds = new TeamCommands()
     this.configCmds = new ConfigCommands()
+    this.embeddingsCmds = new EmbeddingsCommands()
     this.specCmds = new SpecCommands()
 
     this.agent = null
@@ -247,6 +250,14 @@ class PrjctCommands {
     options: MdOption = {}
   ): Promise<CommandResult> {
     return this.configCmds.config(input, projectPath, options)
+  }
+
+  async embeddings(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: MdOption & { key?: string; model?: string; baseUrl?: string } = {}
+  ): Promise<CommandResult> {
+    return this.embeddingsCmds.embeddings(input, projectPath, options)
   }
 
   // ========== Auth Commands ==========

--- a/core/commands/embeddings.ts
+++ b/core/commands/embeddings.ts
@@ -1,0 +1,153 @@
+/**
+ * `prjct embeddings` — configure the GLOBAL semantic-embeddings provider
+ * (BYOT). One key, stored securely (macOS Keychain, else a 0600 file), used by
+ * every project. Without it, recall uses the always-on local subword embedder.
+ *
+ * Subcommands:
+ *   set --key <K> [--model <M>] [--base-url <U>]   Store key + global settings
+ *   status                                          Show provider + key location
+ *   test                                            Embed a probe to validate
+ *   clear                                           Forget key + settings
+ */
+
+import {
+  clearGlobalEmbeddings,
+  DEFAULT_EMBEDDINGS_MODEL,
+  resolveActiveProvider,
+  resolveGlobalEmbeddings,
+  setGlobalEmbeddings,
+} from '../services/embeddings'
+import {
+  clearEmbeddingsKey,
+  getKeyLocation,
+  setEmbeddingsKey,
+} from '../services/embeddings/secure-key'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+interface EmbeddingsOptions {
+  md?: boolean
+  /** Flags parsed by the CLI arg parser (not left in the positional string). */
+  key?: string
+  model?: string
+  baseUrl?: string
+}
+
+function flag(parts: string[], name: string): string | undefined {
+  const i = parts.indexOf(`--${name}`)
+  if (i >= 0 && parts[i + 1]) return parts[i + 1]
+  const eq = parts.find((p) => p.startsWith(`--${name}=`))
+  return eq ? eq.slice(name.length + 3) : undefined
+}
+
+export class EmbeddingsCommands extends PrjctCommandsBase {
+  async embeddings(
+    input: string | null = null,
+    _projectPath: string = process.cwd(),
+    options: EmbeddingsOptions = {}
+  ): Promise<CommandResult> {
+    const parts = (input ?? '').trim().split(/\s+/).filter(Boolean)
+    const sub = parts[0] ?? 'status'
+    switch (sub) {
+      case 'set':
+        return this.set(parts.slice(1), options)
+      case 'status':
+        return this.status(options)
+      case 'test':
+        return this.test(options)
+      case 'clear':
+        return this.clear(options)
+      default:
+        return failHard(
+          `Unknown subcommand '${sub}'. Use: set --key <K> [--model <M>] [--base-url <U>] | status | test | clear`
+        )
+    }
+  }
+
+  private async set(parts: string[], options: EmbeddingsOptions): Promise<CommandResult> {
+    // CLI flags arrive in `options`; fall back to parsing the raw string so a
+    // direct programmatic call (or a test) works the same way.
+    const key = options.key ?? flag(parts, 'key')
+    const model = options.model ?? flag(parts, 'model')
+    const baseUrl = options.baseUrl ?? flag(parts, 'base-url') ?? flag(parts, 'baseUrl')
+    if (!key && !model && !baseUrl) {
+      return failHard(
+        'Nothing to set. Usage: prjct embeddings set --key <api-key> [--model <id>] [--base-url <url>]'
+      )
+    }
+
+    let location: 'keychain' | 'file' | undefined
+    if (key) {
+      try {
+        location = await setEmbeddingsKey(key)
+      } catch (error) {
+        return failHard(`Could not store the key securely: ${getErrorMessage(error)}`)
+      }
+    }
+    const settings = setGlobalEmbeddings({ model, baseUrl })
+
+    out.done('Global embeddings configured (applies to all projects)')
+    out.info(`provider: ${settings.provider}`)
+    out.info(`model:    ${settings.model}`)
+    out.info(`base URL: ${settings.baseUrl}`)
+    if (location)
+      out.info(
+        `api key:  stored in ${location === 'keychain' ? 'macOS Keychain' : '~/.prjct-cli/config/embeddings.key (0600)'}`
+      )
+    out.info(
+      'Each project re-vectorizes on its next session (Stop hook). Run `prjct embeddings test` to validate now.'
+    )
+    return { success: true }
+  }
+
+  private async status(_options: EmbeddingsOptions): Promise<CommandResult> {
+    const g = resolveGlobalEmbeddings()
+    const loc = await getKeyLocation()
+    if (!g) {
+      out.info('Global embeddings: not configured — using the built-in local subword embedder.')
+      out.info(`api key: ${loc === 'none' ? 'none' : `present (${loc})`}`)
+      out.info('Set one with: prjct embeddings set --key <api-key>')
+      return { success: true, configured: false }
+    }
+    out.done('Global embeddings: configured')
+    out.info(`provider: ${g.provider}`)
+    out.info(`model:    ${g.model}`)
+    out.info(`base URL: ${g.baseUrl}`)
+    out.info(
+      `api key:  ${loc === 'none' ? 'MISSING — set with `prjct embeddings set --key <api-key>`' : `present (${loc})`}`
+    )
+    return { success: true, configured: true }
+  }
+
+  private async test(_options: EmbeddingsOptions): Promise<CommandResult> {
+    const provider = resolveActiveProvider(null)
+    try {
+      const [vector] = await provider.embed(['prjct embeddings connectivity probe'])
+      if (!vector || vector.length === 0) {
+        return failHard(`Provider '${provider.model}' returned an empty vector.`)
+      }
+      out.done(`OK — '${provider.model}' returned a ${vector.length}-dim vector.`)
+      if (provider.isLocal) {
+        out.info(
+          'This is the local embedder. Set a key to upgrade: prjct embeddings set --key <api-key>'
+        )
+      }
+      return { success: true, model: provider.model, dims: vector.length }
+    } catch (error) {
+      return failHard(
+        `Embedding failed for '${provider.model}': ${getErrorMessage(error)}. Check the key and base URL.`
+      )
+    }
+  }
+
+  private async clear(_options: EmbeddingsOptions): Promise<CommandResult> {
+    await clearEmbeddingsKey()
+    clearGlobalEmbeddings()
+    out.done('Cleared global embeddings — semantic recall falls back to the local embedder.')
+    out.info(`(Default model when you reconfigure: ${DEFAULT_EMBEDDINGS_MODEL}.)`)
+    return { success: true }
+  }
+}

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -18,6 +18,7 @@ import { CaptureCommands } from './capture'
 import { CATEGORIES, COMMANDS } from './command-data'
 import { ConfigCommands } from './config'
 import { ContextCommands } from './context'
+import { EmbeddingsCommands } from './embeddings'
 import { InstallCommands } from './install'
 import { McpCommands } from './mcp'
 import { PlanningCommands } from './planning'
@@ -51,6 +52,7 @@ const groupInstances: Record<CommandRoutingGroup, object> = {
   uninstall: new UninstallCommands(),
   update: new UpdateCommands(),
   spec: new SpecCommands(),
+  embeddings: new EmbeddingsCommands(),
 }
 
 function registerCategories(): void {

--- a/core/index.ts
+++ b/core/index.ts
@@ -264,6 +264,14 @@ async function main(): Promise<void> {
           }),
         // Per-project MCP scoping
         mcp: (p) => commands.mcp(p, process.cwd(), { md }),
+        // Global BYOT embeddings config
+        embeddings: (p) =>
+          commands.embeddings(p, process.cwd(), {
+            md,
+            key: options.key ? String(options.key) : undefined,
+            model: options.model ? String(options.model) : undefined,
+            baseUrl: options['base-url'] ? String(options['base-url']) : undefined,
+          }),
       }
 
       const handler = standardCommands[commandName]

--- a/core/services/embeddings/global.ts
+++ b/core/services/embeddings/global.ts
@@ -1,0 +1,60 @@
+/**
+ * GLOBAL embeddings config — one setting for every project, stored in the
+ * shared `~/.prjct-cli/config/global.json` (flat keys; the secret API key
+ * lives in the Keychain via secure-key, never here).
+ *
+ * This is the BYOT path: the user brings an API key once, globally, and every
+ * project's semantic recall upgrades from the local subword embedder to a real
+ * model. Per-project `config.embeddings` still wins when present.
+ */
+
+import { getConfig, setConfig } from '../global-config'
+
+/** Sensible high-quality default — small, cheap, strong, OpenAI-compatible. */
+export const DEFAULT_EMBEDDINGS_BASE_URL = 'https://api.openai.com/v1'
+export const DEFAULT_EMBEDDINGS_MODEL = 'text-embedding-3-small'
+
+export interface GlobalEmbeddingsSettings {
+  provider: 'openai-compatible'
+  baseUrl: string
+  model: string
+}
+
+const K_PROVIDER = 'embeddings.provider'
+const K_BASE_URL = 'embeddings.baseUrl'
+const K_MODEL = 'embeddings.model'
+
+/** Current global embeddings settings, or null when BYOT isn't configured. */
+export function resolveGlobalEmbeddings(): GlobalEmbeddingsSettings | null {
+  const provider = getConfig(K_PROVIDER)
+  const model = getConfig(K_MODEL)
+  if (provider !== 'openai-compatible' || !model) return null
+  return {
+    provider: 'openai-compatible',
+    baseUrl: String(getConfig(K_BASE_URL) ?? DEFAULT_EMBEDDINGS_BASE_URL),
+    model: String(model),
+  }
+}
+
+/** Persist the global embeddings provider/model/baseUrl (key handled apart). */
+export function setGlobalEmbeddings(opts: {
+  baseUrl?: string
+  model?: string
+}): GlobalEmbeddingsSettings {
+  const settings: GlobalEmbeddingsSettings = {
+    provider: 'openai-compatible',
+    baseUrl: opts.baseUrl?.trim() || DEFAULT_EMBEDDINGS_BASE_URL,
+    model: opts.model?.trim() || DEFAULT_EMBEDDINGS_MODEL,
+  }
+  setConfig(K_PROVIDER, settings.provider)
+  setConfig(K_BASE_URL, settings.baseUrl)
+  setConfig(K_MODEL, settings.model)
+  return settings
+}
+
+/** Forget the global embeddings settings (semantic falls back to local). */
+export function clearGlobalEmbeddings(): void {
+  setConfig(K_PROVIDER, undefined)
+  setConfig(K_BASE_URL, undefined)
+  setConfig(K_MODEL, undefined)
+}

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -22,6 +22,20 @@
 import { type MemoryEntry, projectMemory } from '../../memory/project-memory'
 import prjctDb from '../../storage/database'
 import type { LocalConfig } from '../../types/config'
+import { resolveGlobalEmbeddings } from './global'
+import { getEmbeddingsKey } from './secure-key'
+
+// Global BYOT config surface — re-exported so callers use one import path.
+export {
+  clearGlobalEmbeddings,
+  DEFAULT_EMBEDDINGS_BASE_URL,
+  DEFAULT_EMBEDDINGS_MODEL,
+  resolveGlobalEmbeddings,
+  setGlobalEmbeddings,
+} from './global'
+/** Env var holding the bearer token for the embeddings endpoint (if any).
+ *  Re-exported from secure-key so existing importers keep working. */
+export { EMBEDDINGS_API_KEY_ENV } from './secure-key'
 
 /** Produces one vector per input string, order-preserving. */
 export interface EmbeddingProvider {
@@ -34,9 +48,6 @@ export interface EmbeddingProvider {
   readonly isLocal?: boolean
   embed(texts: string[]): Promise<number[][]>
 }
-
-/** Env var holding the bearer token for the embeddings endpoint (if any). */
-export const EMBEDDINGS_API_KEY_ENV = 'PRJCT_EMBEDDINGS_API_KEY'
 
 /**
  * Resolve a provider from config, or null when embeddings are disabled.
@@ -62,7 +73,7 @@ export class HttpEmbeddingProvider implements EmbeddingProvider {
   async embed(texts: string[]): Promise<number[][]> {
     if (texts.length === 0) return []
     const url = `${this.baseUrl.replace(/\/$/, '')}/embeddings`
-    const key = process.env[EMBEDDINGS_API_KEY_ENV]
+    const key = await getEmbeddingsKey()
     const res = await fetch(url, {
       method: 'POST',
       headers: {
@@ -156,12 +167,20 @@ export class LocalSubwordEmbeddingProvider implements EmbeddingProvider {
 }
 
 /**
- * The provider actually used at runtime: a configured HTTP endpoint when the
- * project opted into one, otherwise the local default. Unlike `resolveProvider`
- * this NEVER returns null — semantic search is on for everyone.
+ * The provider actually used at runtime, in precedence order:
+ *   1. a per-project endpoint (`config.embeddings`) — explicit override;
+ *   2. the GLOBAL BYOT endpoint (`prjct embeddings set`) — one key, all
+ *      projects, the real-model upgrade;
+ *   3. the in-process local subword embedder — the always-available default.
+ * Unlike `resolveProvider` this NEVER returns null — semantic search is on for
+ * everyone.
  */
 export function resolveActiveProvider(config: LocalConfig | null | undefined): EmbeddingProvider {
-  return resolveProvider(config) ?? new LocalSubwordEmbeddingProvider()
+  const explicit = resolveProvider(config)
+  if (explicit) return explicit
+  const global = resolveGlobalEmbeddings()
+  if (global) return new HttpEmbeddingProvider(global.baseUrl, global.model)
+  return new LocalSubwordEmbeddingProvider()
 }
 
 // Vector <-> BLOB packing (Float32 little-endian).

--- a/core/services/embeddings/secure-key.ts
+++ b/core/services/embeddings/secure-key.ts
@@ -1,0 +1,143 @@
+/**
+ * Secure storage for the BYOT embeddings API key.
+ *
+ * The key is a secret, so it never lands in `global.json` (plaintext). Order
+ * of resolution, most-trusted first:
+ *   1. `PRJCT_EMBEDDINGS_API_KEY` env var — CI / ephemeral override.
+ *   2. macOS Keychain (`security` CLI) — the secure store on the user's Mac.
+ *   3. `~/.prjct-cli/config/embeddings.key`, perms 0600 — non-mac fallback.
+ *
+ * Stored GLOBALLY (one key for every project), not per-project. The resolved
+ * value is cached for the process so HttpEmbeddingProvider.embed() doesn't
+ * re-shell to Keychain on every call.
+ */
+
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+/** Env override — also re-exported from the embeddings index for back-compat. */
+export const EMBEDDINGS_API_KEY_ENV = 'PRJCT_EMBEDDINGS_API_KEY'
+
+const KEYCHAIN_SERVICE = 'prjct-embeddings'
+const KEYCHAIN_ACCOUNT = 'prjct'
+const KEY_FILE = path.join(os.homedir(), '.prjct-cli', 'config', 'embeddings.key')
+
+// undefined = not yet resolved; null = resolved-and-absent.
+let cached: string | null | undefined
+
+function isDarwin(): boolean {
+  return process.platform === 'darwin'
+}
+
+async function readKeychain(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('security', [
+      'find-generic-password',
+      '-a',
+      KEYCHAIN_ACCOUNT,
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-w',
+    ])
+    const v = stdout.trim()
+    return v || null
+  } catch {
+    return null
+  }
+}
+
+function readFileKey(): string | null {
+  try {
+    const v = fs.readFileSync(KEY_FILE, 'utf-8').trim()
+    return v || null
+  } catch {
+    return null
+  }
+}
+
+/** Resolve the key (env → Keychain → file), cached for the process. */
+export async function getEmbeddingsKey(): Promise<string | null> {
+  if (cached !== undefined) return cached
+  const env = process.env[EMBEDDINGS_API_KEY_ENV]?.trim()
+  if (env) {
+    cached = env
+    return cached
+  }
+  cached = (isDarwin() ? await readKeychain() : null) ?? readFileKey()
+  return cached
+}
+
+/** Where the key lives, for status output (never prints the value). */
+export type KeyLocation = 'env' | 'keychain' | 'file' | 'none'
+
+export async function getKeyLocation(): Promise<KeyLocation> {
+  if (process.env[EMBEDDINGS_API_KEY_ENV]?.trim()) return 'env'
+  if (isDarwin() && (await readKeychain())) return 'keychain'
+  if (readFileKey()) return 'file'
+  return 'none'
+}
+
+/** Persist the key to the most secure store available. Returns where it went. */
+export async function setEmbeddingsKey(value: string): Promise<'keychain' | 'file'> {
+  const key = value.trim()
+  cached = key
+  if (isDarwin()) {
+    try {
+      // -U updates an existing item instead of erroring on duplicate.
+      await execFileAsync('security', [
+        'add-generic-password',
+        '-U',
+        '-a',
+        KEYCHAIN_ACCOUNT,
+        '-s',
+        KEYCHAIN_SERVICE,
+        '-w',
+        key,
+      ])
+      return 'keychain'
+    } catch {
+      // Keychain unavailable (locked, headless) → fall through to file.
+    }
+  }
+  fs.mkdirSync(path.dirname(KEY_FILE), { recursive: true })
+  fs.writeFileSync(KEY_FILE, key, { mode: 0o600 })
+  try {
+    fs.chmodSync(KEY_FILE, 0o600)
+  } catch {
+    /* best-effort on platforms without POSIX perms */
+  }
+  return 'file'
+}
+
+/** Remove the key from every store. */
+export async function clearEmbeddingsKey(): Promise<void> {
+  cached = null
+  if (isDarwin()) {
+    try {
+      await execFileAsync('security', [
+        'delete-generic-password',
+        '-a',
+        KEYCHAIN_ACCOUNT,
+        '-s',
+        KEYCHAIN_SERVICE,
+      ])
+    } catch {
+      /* not present */
+    }
+  }
+  try {
+    fs.rmSync(KEY_FILE)
+  } catch {
+    /* not present */
+  }
+}
+
+/** Test seam — reset the process cache. */
+export function _resetKeyCache(): void {
+  cached = undefined
+}

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -345,6 +345,7 @@ export type CommandRoutingGroup =
   | 'uninstall'
   | 'update'
   | 'spec'
+  | 'embeddings'
 
 export interface CommandRouting {
   /** Which command-group instance owns the handler. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.32.7",
+  "version": "2.32.8",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Global BYOT embeddings

Bring ONE embedding API key, stored **securely** (macOS Keychain, else a 0600 file) and **globally** — every project's semantic recall upgrades from the local subword embedder to a real model. No per-project setup, no key in plaintext config.

### Pieces
- **`embeddings/secure-key.ts`** — key resolution `env → macOS Keychain (security CLI) → ~/.prjct-cli/config/embeddings.key (0600)`, cached per-process. The key never touches `global.json`.
- **`embeddings/global.ts`** — global provider/baseUrl/model in the existing `~/.prjct-cli/config/global.json` (flat keys). Default: `text-embedding-3-small`, OpenAI-compatible.
- **`resolveActiveProvider`** precedence: per-project `config.embeddings` → **global BYOT** → local subword (never null).
- **`HttpEmbeddingProvider.embed()`** now pulls the key from secure storage (was env-only).
- **`prjct embeddings`** command — `set --key <K> [--model <M>] [--base-url <U>]` · `status` · `test` · `clear`. Wired through the routing group, registry, facade, and the cold-path dispatch with `--flag` forwarding.

### Verified (real Mac)
- `set` stored the key in the **Keychain** + settings in `global.json`; `status` showed `present (keychain)` without leaking it; `test` exercised the HTTP+key path (fake key → expected auth failure); `clear` removed both.
- Each project re-vectorizes with the real model on its next Stop-hook backfill (model string differs → re-embedded).
- `typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1388 tests** ✓ (+ secure-key env-tier tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)