### PR TITLE
release: 2.33.0 — RAG epic consolidation + cleanup + semver fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [Unreleased]
+
+## [2.33.0] - 2026-05-31
+
+A project-memory RAG overhaul — recall that never bloats, never guesses on vocabulary, ingests your documents, and a vault that is synthesis rather than a mirror. Consolidates 2.32.3–2.32.8.
+
+### Added
+
+- Semantic recall **on by default** for every project — a zero-dependency local embedder (feature-hashed character n-grams) vectorizes memory into SQLite, catching morphological / cross-vocabulary matches BM25 misses.
+- Global **BYOT embeddings**: `prjct embeddings set|status|test|clear` — bring one API key, stored in the macOS Keychain (else a 0600 file), used by every project. OpenAI-compatible (OpenAI, Ollama, LM Studio).
+- **Bidirectional vault ingest**: drop text files (`.txt/.json/.csv/.md`, auto-chunked) or binary/rich docs (`.pdf/.docx/.rtf`/images, extracted via `textutil`/`pdftotext`/`tesseract` with zero bundled dependency) into `captured/` — they become vectorized memory.
+- `architecture.md` is now synthesized for **every** project (from decisions + gotchas), not only when an LLM analysis exists.
+
+### Changed
+
+- Capture **dedups** on `(type, content)` — a verbatim re-capture is skipped, so detectors firing each session can't bloat the store.
+- Memory content is authored in **English** by convention, for cleaner embeddings and better LLM comprehension.
+- Vault sprawl cut ~46%: a single `releases/index.md` rollup (was one file per version), and opaque machine tag-pages (hash/session/…) dropped.
+- `prjct ship` infers the semver bump from the change — `feat` → minor, `fix`/`chore` → patch, breaking → major — instead of always bumping patch.
+
+### Fixed
+
+- friction-detector cross-session dedup compared a 64-char hash to a 12-char key, re-recording the same pushback every session. Migration v25 backfills `content_hash` and purges historical duplicates from both memory tables.
+
 ## [2.32.1] - 2026-05-30
 
 ### Bug Fixes
@@ -164,8 +188,6 @@
 - route all remaining os.homedir()/.prjct-cli sites through pathManager (#344)
 - optimistic CAS on StorageManager.update() — close the lost-update data race (#346)
 - gate workflow rules ingested from repo markdown (close clone-to-RCE) (#345)
-
-## [Unreleased]
 
 ## [2.32.8] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,12 @@ check, logs to `~/.prjct-cli/state/auto-update.log`).
 
 Full install + upgrade paths: [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
 
-### Native dependency repair
+### Zero native dependencies
 
-prjct-cli uses SQLite for local project memory. On Node installs, that requires the
-`better-sqlite3` native binding. The package install, `prjct install`, and
-daemon startup all verify the binding and retry `npm rebuild better-sqlite3`
-when needed. If a locked-down sandbox blocks the rebuild, install still
-continues and the daemon retries the repair the next time it starts.
+prjct-cli uses SQLite for local project memory through the runtime's **built-in**
+driver — `bun:sqlite` on Bun, `node:sqlite` on Node (≥22.5). No native addon, no
+`node-gyp`, no postinstall script. It installs cleanly under `--ignore-scripts`
+and locked-down CI, which closes the supply-chain surface a native rebuild opens.
 
 ## What you get
 
@@ -202,6 +201,7 @@ Cursor / Windsurf use the same commands with a `/` prefix: `/capture`, `/task`, 
 | `prjct status <value>` | Inline status change on the active task (`done`, `paused`, `active`, …). |
 | `prjct tag <k:v>` | Tag the active task (`type:bug`, `domain:auth`, …). |
 | `prjct remember <type> "<content>"` | Persist a memory entry (decision, learning, gotcha, …). |
+| `prjct embeddings <set\|status\|test\|clear>` | Configure the global BYOT embeddings provider (one secure key, all projects). |
 | `prjct ship [name]` | Run the project's ship workflow (commit, push, PR, persist). |
 | `prjct sync` | Re-index files, git co-change, imports; refresh project analysis. |
 | `prjct regen` | Full rebuild of the Obsidian vault snapshot from SQLite. |
@@ -302,24 +302,40 @@ prjct capture "check why webhook retries on 502"
 prjct context memory "auth refresh"
 ```
 
-Memory is FTS5-backed (SQLite) and persona-filtered. Every `remember`, `capture`, `ship`, and the SessionStart / Stop hooks regenerate the agent-readable markdown export at `~/Documents/prjct/<slug>/_generated/`.
+Memory is FTS5-backed (SQLite) and persona-filtered. Recall blends three signals — BM25 lexical, semantic vectors, and a usefulness ledger that reinforces what the project keeps building on. Capture **dedups** automatically: a verbatim re-capture of the same `(type, content)` is skipped, so detectors firing each session can't bloat the store. Every `remember`, `capture`, `ship`, and the SessionStart / Stop hooks regenerate the agent-readable markdown export at `~/Documents/prjct/<slug>/_generated/`.
 
 > SQLite is the source of truth. The export is a snapshot — never hand-edit `_generated/`; if data is missing, fix the pipeline.
 
-### Capture from any markdown editor
+### Semantic recall (embeddings)
 
-Drop a markdown file into `~/Documents/prjct/<slug>/captured/` with a YAML frontmatter:
+On by default for **every** project — no setup, no key, no native dependency. A built-in pure-JS embedder (feature-hashed character n-grams) vectorizes memory into SQLite so recall catches morphological / cross-vocabulary matches BM25 misses (`auth`≈`authentication`).
+
+Want higher quality? Bring your own key once, globally:
+
+```bash
+prjct embeddings set --key sk-...      # stored in the macOS Keychain (else a 0600 file), never in config
+prjct embeddings test                  # validate connectivity
+prjct embeddings status                # show provider + key location
+```
+
+One key applies to every project (OpenAI-compatible — OpenAI, Ollama at `http://localhost:11434/v1`, LM Studio, …). Without it, the local embedder is used. Each project re-vectorizes on its next session.
+
+### Drop files into the vault (bidirectional)
+
+Drop a file into `~/Documents/prjct/<slug>/captured/` — it becomes memory, vectorized into the DB. Two shapes:
 
 ```markdown
 ---
 type: learning
-tags:
-  domain: auth
+tags: { domain: auth }
 ---
 JWT refresh rotation needs the prior token's `iat` to detect replay.
 ```
 
-The Stop hook (or `prjct context wiki sync`) ingests it into SQLite, then moves it to `captured/_ingested/<timestamp>/`. Works from Obsidian, vim, iA Writer, or anything that writes a `.md` file. Frontmatter is scanned for secrets before ingest.
+- **Structured** — a markdown file WITH frontmatter → one typed entry.
+- **Raw document** — any text file with no frontmatter (`.txt`, `.json`, `.csv`, `.md`, …) → a `source` entry, auto-chunked when long. Binary/rich docs (`.pdf`, `.docx`, `.rtf`, images) are extracted via tools you already have — `textutil` (macOS), `pdftotext` (poppler), `tesseract` (OCR) — with zero bundled dependency; without the tool the file waits for a re-sync after you install it.
+
+The Stop hook (or `prjct context wiki sync`) ingests, vectorizes, then moves the file to `captured/_ingested/<timestamp>/`. Content is scanned for secrets and prompt-injection before ingest.
 
 ### Why a markdown export?
 
@@ -351,6 +367,7 @@ Bring your own MCP — prjct-cli doesn't duplicate trackers.
 | Variable | Default | Description |
 |---|---|---|
 | `PRJCT_CLI_HOME` | `~/.prjct-cli` | Override global storage |
+| `PRJCT_EMBEDDINGS_API_KEY` | — | Embeddings API key (overrides `prjct embeddings set`; prefer the keychain-backed command) |
 | `PRJCT_DEBUG` | — | Enable debug logging (`1`, `true`, log level) |
 | `PRJCT_NO_DAEMON` | — | Force non-daemon path (debugging) |
 | `DEBUG` | — | Fallback debug flag |

--- a/core/__tests__/commands/shipping.test.ts
+++ b/core/__tests__/commands/shipping.test.ts
@@ -159,7 +159,8 @@ describe('ship() — workflow-first', () => {
     expect(actions).toContain('git:push')
 
     const pkg = JSON.parse(await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8'))
-    expect(pkg.version).toBe('0.5.1')
+    // "first ship" is a described feature (no fix/chore prefix) → MINOR bump.
+    expect(pkg.version).toBe('0.6.0')
   })
 
   test('seed-code-workflow on a non-code project returns a helpful error', async () => {

--- a/core/__tests__/services/version-service.test.ts
+++ b/core/__tests__/services/version-service.test.ts
@@ -2,8 +2,53 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { bumpPatch, VersionService } from '../../services/version-service'
+import {
+  bumpMajor,
+  bumpMinor,
+  bumpPatch,
+  bumpVersion,
+  inferBumpLevel,
+  VersionService,
+} from '../../services/version-service'
 import { execFileAsync } from '../../utils/exec'
+
+describe('bumpMinor / bumpMajor', () => {
+  it('bumpMinor resets patch and drops pre-release', () => {
+    expect(bumpMinor('2.32.8')).toBe('2.33.0')
+    expect(bumpMinor('1.0.5')).toBe('1.1.0')
+    expect(bumpMinor('2.0.0-alpha.3')).toBe('2.1.0')
+  })
+  it('bumpMajor resets minor+patch', () => {
+    expect(bumpMajor('2.32.8')).toBe('3.0.0')
+    expect(bumpMajor('0.9.9')).toBe('1.0.0')
+  })
+  it('bumpVersion dispatches by level', () => {
+    expect(bumpVersion('2.32.8', 'patch')).toBe('2.32.9')
+    expect(bumpVersion('2.32.8', 'minor')).toBe('2.33.0')
+    expect(bumpVersion('2.32.8', 'major')).toBe('3.0.0')
+  })
+})
+
+describe('inferBumpLevel', () => {
+  it('treats a described feature ship as minor', () => {
+    expect(inferBumpLevel('embeddings BYOT support')).toBe('minor')
+    expect(inferBumpLevel('feat: add semantic search')).toBe('minor')
+  })
+  it('defaults to patch with no description (conservative)', () => {
+    expect(inferBumpLevel(undefined)).toBe('patch')
+    expect(inferBumpLevel('')).toBe('patch')
+  })
+  it('treats fix/chore/docs-class prefixes as patch', () => {
+    expect(inferBumpLevel('fix: dedup key bug')).toBe('patch')
+    expect(inferBumpLevel('chore: bump deps')).toBe('patch')
+    expect(inferBumpLevel('docs(readme): update')).toBe('patch')
+    expect(inferBumpLevel('refactor: extract helper')).toBe('patch')
+  })
+  it('treats `!` or BREAKING CHANGE as major', () => {
+    expect(inferBumpLevel('feat!: drop node 18')).toBe('major')
+    expect(inferBumpLevel('feat: x\n\nBREAKING CHANGE: removed API')).toBe('major')
+  })
+})
 
 describe('bumpPatch', () => {
   it('bumps stable patch', () => {

--- a/core/__tests__/workflow/action-prefixes.test.ts
+++ b/core/__tests__/workflow/action-prefixes.test.ts
@@ -136,7 +136,8 @@ describe('action prefix: changelog:add', () => {
 
     expect(result.success).toBe(true)
     const changelog = await fs.readFile(path.join(projectPath, 'CHANGELOG.md'), 'utf-8')
-    expect(changelog).toContain('1.0.1')
+    // A described feature ("flux capacitor", no fix/chore prefix) bumps MINOR.
+    expect(changelog).toContain('1.1.0')
     expect(changelog).toContain('flux capacitor')
   })
 })

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -270,6 +270,16 @@ export const projectMemory = {
     const provenance = args.provenance ?? 'declared'
     const contentHash = memoryFingerprint(args.content)
 
+    // Resolve the project once and reuse it for both the dedup guard and the
+    // sync publish below (each used to read + parse the config independently).
+    let projectId: string | undefined
+    try {
+      const { default: configManager } = await import('../infrastructure/config-manager')
+      projectId = (await configManager.readConfig(projectPath))?.projectId
+    } catch {
+      /* config unreadable — dedup + sync are best-effort; the local write proceeds */
+    }
+
     // Dedup net: a verbatim re-capture of the same (type, content) adds no
     // knowledge — it only dilutes recall and burns slots in the fixed-size
     // injection budget. Skip it. This is the universal guard behind EVERY
@@ -277,20 +287,18 @@ export const projectMemory = {
     // wiki-ingest), so a single detector re-firing each session can't spam the
     // store. Best-effort: any lookup failure falls through to a normal write —
     // a dedup miss is cheaper than a dropped capture.
-    try {
-      const { default: cfgMgr } = await import('../infrastructure/config-manager')
-      const dedupProjectId = (await cfgMgr.readConfig(projectPath))?.projectId
-      if (dedupProjectId) {
+    if (projectId) {
+      try {
         const dup = prjctDb.get<{ id: string }>(
-          dedupProjectId,
+          projectId,
           'SELECT id FROM memories WHERE content_hash = ? AND type = ? AND deleted_at IS NULL LIMIT 1',
           contentHash,
           args.type
         )
         if (dup) return
+      } catch {
+        /* fall through — never block a capture on the dedup check */
       }
-    } catch {
-      /* fall through — never block a capture on the dedup check */
     }
 
     const logResult = await memoryService.log(
@@ -358,11 +366,8 @@ export const projectMemory = {
     // table, but it doesn't enqueue a SyncEvent for push — that's
     // what this call does. Best-effort; a sync queue write must not
     // fail the local memory write.
+    if (!projectId) return
     try {
-      const { default: configManager } = await import('../infrastructure/config-manager')
-      const cfg = await configManager.readConfig(projectPath)
-      const projectId = cfg?.projectId
-      if (!projectId) return
       const { publishCRUD } = await import('../sync/publish-helper')
       const entityId =
         args.tags?.spec_id ??

--- a/core/services/ingest-extractors.ts
+++ b/core/services/ingest-extractors.ts
@@ -98,12 +98,15 @@ export const EXTRACTABLE_EXTENSIONS: Set<string> = new Set(
  *  nothing — so the user knows which tool unlocks the format. */
 export function extractHint(ext: string): string {
   const e = ext.toLowerCase()
-  if (e === '.pdf')
+  // Membership tests against the extractor sets — the single source of truth
+  // for which format each tool owns, so the hint can't drift from reality.
+  if (pdftotextExtractor.exts.has(e)) {
     return 'install poppler (`brew install poppler`) for PDF text, or convert it to .txt'
-  if (['.png', '.jpg', '.jpeg', '.tif', '.tiff', '.bmp', '.webp'].includes(e)) {
+  }
+  if (tesseractExtractor.exts.has(e)) {
     return 'install tesseract (`brew install tesseract`) for image OCR, or add a sidecar .txt note'
   }
-  if (['.docx', '.doc', '.rtf', '.odt', '.pages', '.html', '.htm', '.webarchive'].includes(e)) {
+  if (textutilExtractor.exts.has(e)) {
     return 'rich-doc extraction needs macOS `textutil`; on other platforms convert to .txt/.md'
   }
   return 'convert it to a supported text format (.txt/.md)'

--- a/core/services/version-service.ts
+++ b/core/services/version-service.ts
@@ -64,7 +64,7 @@ export class VersionService {
    * retry" failure mode where a partial ship rerun creates v+2 instead
    * of completing the original v+1.
    */
-  async bump(): Promise<string> {
+  async bump(level: BumpLevel = 'patch'): Promise<string> {
     const info = await this.detect()
 
     // Idempotency check: only consult git when the version source is a
@@ -74,13 +74,16 @@ export class VersionService {
       const headVersion = await this.readVersionFromGitHead(info.file, info.format)
       if (headVersion && this.isAheadOf(info.current, headVersion)) {
         // Working tree was already bumped (likely by a prior failed
-        // ship); reuse it instead of bumping again.
+        // ship, or a manual pre-bump); reuse it instead of bumping again.
         return info.current
       }
     }
 
-    await this.writeVersion(info)
-    return info.next
+    // `detect()` precomputes a patch bump; override with the requested level
+    // (feat ships → minor, etc.) computed from the current version.
+    const next = bumpVersion(info.current, level)
+    await this.writeVersion({ ...info, next })
+    return next
   }
 
   /**
@@ -342,6 +345,46 @@ export function bumpPatch(version: string): string {
   }
 
   return `${major}.${minor}.${Number(patch) + 1}`
+}
+
+export type BumpLevel = 'patch' | 'minor' | 'major'
+
+/** Minor bump: "2.32.8" -> "2.33.0" (resets patch, drops any pre-release). */
+export function bumpMinor(version: string): string {
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return version
+  return `${m[1]}.${Number(m[2]) + 1}.0`
+}
+
+/** Major bump: "2.32.8" -> "3.0.0" (resets minor+patch, drops any pre-release). */
+export function bumpMajor(version: string): string {
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return version
+  return `${Number(m[1]) + 1}.0.0`
+}
+
+/** Bump `version` by the given level. */
+export function bumpVersion(version: string, level: BumpLevel): string {
+  if (level === 'major') return bumpMajor(version)
+  if (level === 'minor') return bumpMinor(version)
+  return bumpPatch(version)
+}
+
+/**
+ * Infer the semver bump level from a conventional-commit-style description.
+ * A ship is a feature by default → MINOR; explicit non-feature prefixes
+ * (fix/chore/docs/refactor/perf/style/test/build/ci/revert) → PATCH; a `!`
+ * marker or "BREAKING CHANGE" → MAJOR. This is what lets `feat:` ships bump
+ * minor instead of every ship defaulting to patch.
+ */
+export function inferBumpLevel(description: string | undefined): BumpLevel {
+  const d = (description ?? '').toLowerCase().trim()
+  if (!d) return 'patch' // no signal → conservative default
+  if (/^[a-z]+(\([^)]*\))?!:/.test(d) || d.includes('breaking change')) return 'major'
+  if (/^(fix|chore|docs|refactor|perf|style|test|build|ci|revert)(\([^)]*\))?:/.test(d)) {
+    return 'patch'
+  }
+  return 'minor'
 }
 
 /**

--- a/core/services/wiki/_shared.ts
+++ b/core/services/wiki/_shared.ts
@@ -84,6 +84,12 @@ export function sha256(body: string): string {
   return crypto.createHash('sha256').update(body).digest('hex').slice(0, 16)
 }
 
+/** Truncate to at most `max` chars, appending an ellipsis when shortened.
+ *  The result (including the ellipsis) never exceeds `max`. */
+export function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
 export function chunkEntries<T>(entries: T[], size = CHUNK_SIZE): T[][] {
   if (entries.length <= size) return [entries]
   const out: T[][] = []

--- a/core/services/wiki/architecture-builder.ts
+++ b/core/services/wiki/architecture-builder.ts
@@ -11,12 +11,12 @@
  */
 
 import { deriveTitle, type MemoryEntry } from '../../memory/project-memory'
+import { truncate } from './_shared'
 
 const MAX_PER_SECTION = 20
 
 function teaser(content: string): string {
-  const flat = content.replace(/\s+/g, ' ').trim()
-  return flat.length > 200 ? `${flat.slice(0, 199)}…` : flat
+  return truncate(content.replace(/\s+/g, ' ').trim(), 200)
 }
 
 function bullet(entry: MemoryEntry): string {

--- a/core/services/wiki/concept-builder.ts
+++ b/core/services/wiki/concept-builder.ts
@@ -18,6 +18,7 @@ import {
   type ConceptRecord,
   conceptKey,
   slugify,
+  truncate,
 } from './_shared'
 
 /**
@@ -185,7 +186,7 @@ function buildHistoryFile(entries: ArchiveEntry[], concepts: Map<string, Concept
 
   const linkFor = (kind: ConceptKind, name: string): string => {
     const rec = concepts.get(conceptKey(kind, name))
-    const display = name.length > 80 ? `${name.slice(0, 77)}…` : name
+    const display = truncate(name, 80)
     if (!rec) return `"${display}"`
     const folder = CONCEPT_FOLDERS[rec.kind]
     return `[${display}](${folder}/${rec.slug}.md)`

--- a/core/services/wiki/release-builder.ts
+++ b/core/services/wiki/release-builder.ts
@@ -10,7 +10,7 @@
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import type { ReleaseEntry } from './_shared'
+import { type ReleaseEntry, truncate } from './_shared'
 
 export function parseChangelog(raw: string): ReleaseEntry[] {
   const out: ReleaseEntry[] = []
@@ -47,10 +47,7 @@ export function parseChangelog(raw: string): ReleaseEntry[] {
 function firstMeaningfulLine(body: string): string {
   for (const raw of body.split('\n')) {
     const t = raw.replace(/^[-*#>\s]+/, '').trim()
-    if (t) {
-      const clean = t.replace(/\|/g, '\\|')
-      return clean.length > 80 ? `${clean.slice(0, 79)}…` : clean
-    }
+    if (t) return truncate(t.replace(/\|/g, '\\|'), 80)
   }
   return '—'
 }

--- a/core/workflow/workflow-engine.ts
+++ b/core/workflow/workflow-engine.ts
@@ -27,7 +27,7 @@ import chalk from 'chalk'
 import { STATUS_CHANGE_ACTION, TAG_EVENT_TYPE } from '../memory/events'
 import { ChangelogService } from '../services/changelog-service'
 import { memoryService } from '../services/memory-service'
-import { VersionService } from '../services/version-service'
+import { inferBumpLevel, VersionService } from '../services/version-service'
 import { getGitBranch } from '../session/git-helpers'
 import prjctDb from '../storage/database'
 import { stateStorage } from '../storage/state-storage'
@@ -186,7 +186,11 @@ async function buildPersonaInstruction(projectPath: string): Promise<string> {
 
 async function runVersionBump(projectPath: string, runCtx: WorkflowRunContext): Promise<void> {
   const service = new VersionService(projectPath)
-  const next = await service.bump()
+  // A ship is a feature by default → minor; a `fix:`/`chore:`-prefixed feature
+  // name → patch; `!`/"BREAKING CHANGE" → major. Previously every ship bumped
+  // patch regardless, so feature releases landed as 2.32.x instead of 2.33.0.
+  const level = inferBumpLevel(typeof runCtx.feature === 'string' ? runCtx.feature : undefined)
+  const next = await service.bump(level)
   runCtx.version = next
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.32.8",
+  "version": "2.33.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## 2.33.0 — consolidation release

Rolls up the project-memory RAG epic (2.32.3–2.32.8) into a minor release, with a code-cleanup pass, refreshed docs, and a fix so feature ships bump minor.

### Code cleanup
- `remember()` resolves the project config once (was 3× per call) and reuses it for the dedup guard + sync publish.
- Shared `truncate(s, max)` helper in `wiki/_shared` replaces three near-identical ellipsis helpers (architecture / release / concept builders).
- `extractHint` derives its format lists from the extractor `exts` sets (single source of truth, can't drift).

### Versioning fix
- `version:bump` now infers the semver level from the ship description: a described feature → **minor**, `fix:`/`chore:`-class → patch, `!`/BREAKING → major. No description → patch (conservative). Previously every ship bumped patch, so feature work landed as 2.32.x instead of 2.33.0.

### Docs
- README: new "Semantic recall (embeddings)" + BYOT, bidirectional vault ingest (text + binary), `prjct embeddings` verb, `PRJCT_EMBEDDINGS_API_KEY`. Removed the stale "native dependency repair" section (zero native deps since 2.32.2).
- CHANGELOG: a consolidated 2.33.0 entry; moved `Unreleased` to the top so future ships insert correctly.

`typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1395 tests** ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)