### PR TITLE
feat: RAG reorientation — selective memory + developer profile (2.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.34.0] - 2026-05-31
+
+### Added
+- RAG reorientation pillars 1+2: selective memory (embed only model-building knowledge, prune noise) + developer profile (developer.md from feedback+friction so the LLM acts as the dev)
+
 ## [2.33.0] - 2026-05-31
 
 A project-memory RAG overhaul — recall that never bloats, never guesses on vocabulary, ingests your documents, and a vault that is synthesis rather than a mirror. Consolidates 2.32.3–2.32.8.

--- a/core/__tests__/services/developer-profile-builder.test.ts
+++ b/core/__tests__/services/developer-profile-builder.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Developer profile synthesis — the "know the developer" half of the model.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { MemoryEntry } from '../../memory/project-memory'
+import { buildDeveloperProfile } from '../../services/wiki/developer-profile-builder'
+
+function entry(
+  id: string,
+  type: string,
+  content: string,
+  tags: Record<string, string> = {}
+): MemoryEntry {
+  return {
+    id,
+    type,
+    content,
+    tags,
+    rememberedAt: '2026-05-31T00:00:00Z',
+    provenance: 'declared',
+  } as MemoryEntry
+}
+
+describe('buildDeveloperProfile', () => {
+  it('returns null with no feedback and no friction', () => {
+    expect(buildDeveloperProfile([entry('mem_1', 'decision', 'use sqlite')])).toBeNull()
+  })
+
+  it('synthesizes preferences from feedback and friction from pushback signals', () => {
+    const out = buildDeveloperProfile([
+      entry('mem_1', 'feedback', 'Author memory in English regardless of conversation language.'),
+      entry('mem_2', 'improvement-signal', '[negation] User pushback: "no native deps"', {
+        source: 'friction-detector',
+      }),
+      entry('mem_3', 'decision', 'unrelated decision'),
+    ])
+    expect(out).not.toBeNull()
+    expect(out).toContain('# Developer profile')
+    expect(out).toContain('## Preferences & guidance')
+    expect(out).toContain('English')
+    expect(out).toContain('## Friction history')
+    expect(out).toContain('no native deps')
+    expect(out).toContain('`mem_1`')
+    expect(out).not.toContain('unrelated decision')
+  })
+
+  it('omits the friction section when there is no friction signal', () => {
+    const out = buildDeveloperProfile([entry('mem_1', 'feedback', 'ship as minor')])
+    expect(out).toContain('## Preferences & guidance')
+    expect(out).not.toContain('## Friction history')
+  })
+
+  it('ignores improvement-signals that are not from the friction detector', () => {
+    const out = buildDeveloperProfile([
+      entry('mem_1', 'feedback', 'a rule'),
+      entry('mem_2', 'improvement-signal', 'skill-miss noise', { source: 'skill-miss-detector' }),
+    ])
+    expect(out).not.toContain('## Friction history')
+  })
+})

--- a/core/__tests__/services/embeddings.test.ts
+++ b/core/__tests__/services/embeddings.test.ts
@@ -13,7 +13,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import pathManager from '../../infrastructure/path-manager'
-import { projectMemory } from '../../memory/project-memory'
+import { isModelMemory, projectMemory } from '../../memory/project-memory'
 import {
   cosineSimilarity,
   type EmbeddingProvider,
@@ -104,6 +104,41 @@ describe('embeddings — provider resolution', () => {
       dataPath: '',
     } as LocalConfig)
     expect(out).toHaveLength(0)
+  })
+})
+
+describe('isModelMemory — selectivity predicate', () => {
+  it('excludes raw friction signals and hot-file churn, keeps real knowledge', () => {
+    expect(isModelMemory({ type: 'decision', tags: {} })).toBe(true)
+    expect(isModelMemory({ type: 'gotcha', tags: {} })).toBe(true)
+    expect(isModelMemory({ type: 'feedback', tags: {} })).toBe(true)
+    expect(isModelMemory({ type: 'improvement-signal', tags: {} })).toBe(false)
+    expect(isModelMemory({ type: 'learning', tags: { pattern: 'hot-file' } })).toBe(false)
+    // a recurring-bug pattern learning is signal, not noise
+    expect(isModelMemory({ type: 'learning', tags: { pattern: 'recurring-bug' } })).toBe(true)
+  })
+})
+
+describe('embeddings — backfill is selective (model memory only)', () => {
+  it('embeds only model memories and prunes noise vectors', async () => {
+    const decision = write('decision', 'we chose sqlite for local-first storage')
+    write('improvement-signal', '[negation] pushback', { source: 'friction-detector' })
+    write('learning', 'bin/prjct.ts — 5 touches in 7 days', { pattern: 'hot-file' })
+
+    const r = await embeddingService.backfill(
+      projectId,
+      { projectId, dataPath: '' } as LocalConfig,
+      NOW
+    )
+    // total/embedded count only the model-worthy entry (the decision).
+    expect(r.total).toBe(1)
+    expect(r.embedded).toBe(1)
+
+    const rows = prjctDb.query<{ memory_id: string }>(
+      projectId,
+      'SELECT memory_id FROM memory_embeddings'
+    )
+    expect(rows.map((row) => row.memory_id)).toEqual([decision])
   })
 })
 

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -84,6 +84,25 @@ export interface MemoryEntry {
   provenance: MemoryProvenance
 }
 
+/**
+ * Is this entry knowledge that MODELS the project/developer — worth embedding
+ * for semantic recall — or auto-generated telemetry that is noise?
+ *
+ * Per the RAG north star, the point is a model that anticipates, not bulk
+ * vectorization. Two classes of high-volume / low-signal noise are excluded:
+ *   - `improvement-signal` — raw friction / skill-miss captures. They feed the
+ *     DEVELOPER PROFILE (synthesized separately), not semantic recall, where
+ *     near-duplicate pushbacks would only dilute results.
+ *   - `pattern: hot-file` — "file changed N times this week" churn counters.
+ * Everything else (decisions, gotchas, learnings, facts, feedback, recurring
+ * bug patterns, ingested sources, specs) builds the model and is embedded.
+ */
+export function isModelMemory(entry: Pick<MemoryEntry, 'type' | 'tags'>): boolean {
+  if (entry.type === 'improvement-signal') return false
+  if (entry.tags?.pattern === 'hot-file') return false
+  return true
+}
+
 interface RecallOpts {
   /** Fuzzy-match against content + tag values */
   topic?: string

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -19,7 +19,7 @@
  * The provider is injectable so tests run fully offline against a fake.
  */
 
-import { type MemoryEntry, projectMemory } from '../../memory/project-memory'
+import { isModelMemory, type MemoryEntry, projectMemory } from '../../memory/project-memory'
 import prjctDb from '../../storage/database'
 import type { LocalConfig } from '../../types/config'
 import { resolveGlobalEmbeddings } from './global'
@@ -276,8 +276,19 @@ export const embeddingService = {
     const provider = opts.provider ?? resolveActiveProvider(config)
     const batchSize = opts.batchSize ?? 64
     const all = projectMemory.allEntriesForIndex(projectId)
+
+    // Selectivity (RAG north star): embed only entries that MODEL the
+    // project/developer, never bulk-vectorize telemetry noise. Prune any noise
+    // vectors a prior (indiscriminate) backfill stored, so semantic recall
+    // stops surfacing hot-file churn / raw friction.
+    const model = all.filter((e) => isModelMemory(e))
+    this.pruneNonModelVectors(
+      projectId,
+      all.filter((e) => !isModelMemory(e)).map((e) => e.id)
+    )
+
     const have = this.embeddedIds(projectId, provider.model)
-    const todo = all.filter((e) => !have.has(e.id) && e.content.trim().length > 0)
+    const todo = model.filter((e) => !have.has(e.id) && e.content.trim().length > 0)
 
     let embedded = 0
     for (let i = 0; i < todo.length; i += batchSize) {
@@ -295,7 +306,23 @@ export const embeddingService = {
         // Skip this batch; the next backfill retries it.
       }
     }
-    return { embedded, skipped: all.length - todo.length, total: all.length }
+    return { embedded, skipped: model.length - todo.length, total: model.length }
+  },
+
+  /** Delete stored vectors for entries that are no longer model-worthy
+   *  (e.g. noise embedded by an older indiscriminate backfill). Best-effort. */
+  pruneNonModelVectors(projectId: string, noiseIds: string[]): void {
+    if (noiseIds.length === 0) return
+    try {
+      const placeholders = noiseIds.map(() => '?').join(',')
+      prjctDb.run(
+        projectId,
+        `DELETE FROM memory_embeddings WHERE memory_id IN (${placeholders})`,
+        ...noiseIds
+      )
+    } catch {
+      /* best-effort — a stale noise vector is harmless until the next run */
+    }
   },
 
   /**

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -43,6 +43,7 @@ import type { Manifest } from './wiki/_shared'
 import { sha256, slugify } from './wiki/_shared'
 import { buildArchitectureBaseline } from './wiki/architecture-builder'
 import { buildAnalysisArchiveFiles, collectConcepts } from './wiki/concept-builder'
+import { buildDeveloperProfile } from './wiki/developer-profile-builder'
 import { computeRegenFingerprint, FINGERPRINT_FILE } from './wiki/fingerprint'
 import { buildIndexFile } from './wiki/index-builder'
 import {
@@ -212,6 +213,11 @@ export async function generateWiki(
   const archBody =
     (llmAnalysis ? buildArchitectureFile(llmAnalysis) : null) ?? buildArchitectureBaseline(declared)
   if (archBody) files.set('architecture.md', archBody)
+
+  // developer.md: the "know the developer" half of the model — preferences +
+  // friction synthesized so an agent acts as the developer would (RAG north star).
+  const devBody = buildDeveloperProfile(declared)
+  if (devBody) files.set('developer.md', devBody)
 
   // tech-debt / insights remain LLM-only — a deterministic baseline would be
   // too thin to be worth a page.

--- a/core/services/wiki/developer-profile-builder.ts
+++ b/core/services/wiki/developer-profile-builder.ts
@@ -1,0 +1,62 @@
+/**
+ * Developer profile synthesis — the "know the developer" half of the RAG north
+ * star (the project half is architecture.md).
+ *
+ * prjct already captures who the developer is, scattered across two memory
+ * streams: explicit `feedback` (the rules they stated — "memory in English",
+ * "no native deps", "ship as minor") and `improvement-signal` friction (the
+ * moments they pushed back). This builder synthesizes them into one
+ * `developer.md` so an agent can act as the developer would WITHOUT being told
+ * each time — the dev and the LLM moving as one.
+ *
+ * Deterministic; no LLM. Returns null when there's nothing to say yet.
+ */
+
+import { deriveTitle, type MemoryEntry } from '../../memory/project-memory'
+import { truncate } from './_shared'
+
+const MAX_PREFERENCES = 25
+const MAX_FRICTION = 15
+
+function teaser(content: string): string {
+  return truncate(content.replace(/\s+/g, ' ').trim(), 200)
+}
+
+/** First line of a friction signal is `[category] User pushback: "<quote>"`. */
+function frictionLine(content: string): string {
+  const first = content.split('\n')[0] ?? content
+  return truncate(first.replace(/\s+/g, ' ').trim(), 200)
+}
+
+export function buildDeveloperProfile(declared: MemoryEntry[]): string | null {
+  // `declared` is newest-first; recent guidance reflects current preference.
+  const preferences = declared.filter((e) => e.type === 'feedback').slice(0, MAX_PREFERENCES)
+  const friction = declared
+    .filter((e) => e.type === 'improvement-signal' && e.tags?.source === 'friction-detector')
+    .slice(0, MAX_FRICTION)
+
+  if (preferences.length === 0 && friction.length === 0) return null
+
+  const lines: string[] = ['# Developer profile', '']
+  lines.push(
+    '> Synthesized from the developer’s stated feedback and their pushback.',
+    '> Read this to act as they would — match these preferences without being asked.',
+    ''
+  )
+
+  if (preferences.length > 0) {
+    lines.push('## Preferences & guidance — the rules to follow', '')
+    for (const p of preferences)
+      lines.push(`- **${deriveTitle(p)}** — ${teaser(p.content)}  \`${p.id}\``)
+    lines.push('')
+  }
+
+  if (friction.length > 0) {
+    lines.push('## Friction history — what frustrated them, do not repeat', '')
+    for (const f of friction) lines.push(`- ${frictionLine(f.content)}  \`${f.id}\``)
+    lines.push('')
+  }
+
+  lines.push('---', '', 'See also: [architecture](architecture.md) · [project wiki](index.md)', '')
+  return `${lines.join('\n')}\n`
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## RAG reorientation, pillars 1+2

Re-points the RAG substrate at the north star: **a model that anticipates, not bulk vectorization.** "Vectorize everything" was the anti-pattern; this makes it selective and dev-aware.

### Pillar 1 — selective memory
- New `isModelMemory(entry)` predicate (`project-memory.ts`): excludes `improvement-signal` (raw friction/skill-miss — feeds the dev profile, not semantic recall) and `pattern: hot-file` churn counters; keeps decisions/gotchas/learnings/facts/feedback/recurring-bug/source/spec.
- `embeddingService.backfill` now embeds only model memories **and prunes** vectors an older indiscriminate backfill stored (`pruneNonModelVectors`).
- Verified on the real DB: stored embeddings **87 → 50** (noise gone), so semantic recall stops surfacing hot-file churn / dup friction.

### Pillar 2 — developer profile
- New `wiki/developer-profile-builder.ts`: synthesizes `developer.md` from the developer's `feedback` (their stated rules) + friction-detector pushback (what frustrated them), wired into the generator next to `architecture.md`.
- Verified: `developer.md` generated with the real rules (English-memory, no-stoplight colors, no-emojis) + friction history — so an agent can act as the developer would without being told.

Together with `architecture.md` (the project half), the vault now models **both the project and the developer**.

`typecheck` ✓ · `biome` ✓ · `knip` ✓ · **1401 tests** ✓ (isModelMemory, backfill-selectivity, developer-profile-builder).

Next: pillar 3 — anticipation (proactive warnings at task-start / before edits, tied to files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)