### PR TITLE
feat: pillar 3 — anticipation (pre-edit gotcha warnings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.35.0] - 2026-05-31
+
+### Added
+- feat: pillar 3 anticipation — PreToolUse(Edit|Write) hook surfaces a file's gotchas/anti-patterns/recurring-bugs before you edit it, so traps are prevented not repeated
+
 ## [2.34.0] - 2026-05-31
 
 ### Added

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -814,6 +814,11 @@ async function main(): Promise<void> {
           await runPreCommitHook(projectPath)
           break
         }
+        case 'pre-edit': {
+          const { runPreEditHook } = await import('../core/hooks/pre-edit')
+          await runPreEditHook(projectPath)
+          break
+        }
         case 'post-edit': {
           const { runPostEditHook } = await import('../core/hooks/post-edit')
           await runPostEditHook(projectPath)

--- a/core/__tests__/hooks/hook-schema.test.ts
+++ b/core/__tests__/hooks/hook-schema.test.ts
@@ -2,10 +2,11 @@
  * Claude Code hook response schema guard.
  *
  * Every hook emits JSON that Claude Code validates. The schema is strict:
- * `hookSpecificOutput.additionalContext` is only valid for SessionStart,
- * UserPromptSubmit, and PostToolUse. Emitting it on Stop / PreToolUse /
+ * `hookSpecificOutput.additionalContext` is valid for SessionStart,
+ * UserPromptSubmit, PreToolUse, and PostToolUse. Emitting it on Stop /
  * SubagentStart / CwdChanged triggers a visible "The hook's output was …
- * Expected schema: …" error to the user every turn.
+ * Expected schema: …" error to the user every turn, so those fall back
+ * to the universal top-level `systemMessage` channel.
  *
  * `buildHookOutput` is the single routing point, so this test pins its
  * behavior per event. If someone adds a new event or forgets to widen
@@ -49,10 +50,10 @@ describe('buildHookOutput routes per Claude Code schema', () => {
     expect(out.hookSpecificOutput).toBeUndefined()
   })
 
-  test('PreToolUse falls back to systemMessage — additionalContext not in its schema', () => {
-    const out = buildHookOutput('PreToolUse', 'nudge')
-    expect(out.systemMessage).toBe('nudge')
-    expect(out.hookSpecificOutput).toBeUndefined()
+  test('PreToolUse uses hookSpecificOutput.additionalContext', () => {
+    const out = buildHookOutput('PreToolUse', 'ctx')
+    expect(out.hookSpecificOutput?.additionalContext).toBe('ctx')
+    expect(out.systemMessage).toBeUndefined()
   })
 
   test('SubagentStart falls back to systemMessage', () => {

--- a/core/__tests__/hooks/pre-edit.test.ts
+++ b/core/__tests__/hooks/pre-edit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * PreToolUse(Edit|Write) hook — ANTICIPATION (RAG north star, pillar 3).
+ *
+ * Contract: right before a file is edited, surface ONLY the preventive
+ * memory recorded against that file (gotchas / anti-patterns /
+ * recurring-bugs) so the trap is seen before it's stepped in. It must be
+ * quiet by design — no projectId, no file, or no preventive match → null,
+ * so it never becomes per-edit noise.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildPreEditContext } from '../../hooks/pre-edit'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+
+let projectPath: string
+let projectId: string
+
+async function freshProject(): Promise<void> {
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-pre-edit-test-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+}
+
+function insertMemory(type: string, content: string, tags: Record<string, string>): void {
+  prjctDb.run(
+    projectId,
+    "INSERT INTO events (type, data, timestamp) VALUES (?, ?, datetime('now'))",
+    `memory.remember.${type}`,
+    JSON.stringify({ content, tags, provenance: 'declared' })
+  )
+}
+
+afterEach(async () => {
+  if (projectPath) {
+    await fs.rm(projectPath, { recursive: true, force: true })
+    projectPath = ''
+  }
+})
+
+describe('PreToolUse pre-edit hook — buildPreEditContext', () => {
+  test('returns null when the tool input has no file_path', async () => {
+    await freshProject()
+    insertMemory('gotcha', 'a trap', { file: 'core/x.ts' })
+    expect(await buildPreEditContext({ tool_input: {} }, projectPath)).toBeNull()
+  })
+
+  test('returns null when config has no projectId', async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-pre-edit-no-id-'))
+    await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+    await fs.writeFile(
+      path.join(projectPath, '.prjct', 'prjct.config.json'),
+      JSON.stringify({ dataPath: '' })
+    )
+    const ctx = await buildPreEditContext({ tool_input: { file_path: 'core/x.ts' } }, projectPath)
+    expect(ctx).toBeNull()
+  })
+
+  test('returns null (quiet) when no preventive memory matches the file', async () => {
+    await freshProject()
+    insertMemory('decision', 'use bun runtime', { file: 'core/x.ts' })
+    const ctx = await buildPreEditContext({ tool_input: { file_path: 'core/x.ts' } }, projectPath)
+    expect(ctx).toBeNull()
+  })
+
+  test('injects a heads-up block when a gotcha targets the edited file', async () => {
+    await freshProject()
+    insertMemory('gotcha', 'stale daemon caches old hook code; stop it before testing', {
+      file: 'core/daemon/daemon.ts',
+    })
+    const ctx = await buildPreEditContext(
+      { tool_input: { file_path: 'core/daemon/daemon.ts' } },
+      projectPath
+    )
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('heads up before editing `daemon.ts`')
+    expect(ctx).toContain('[gotcha]')
+    expect(ctx).toContain('stale daemon')
+  })
+
+  test('matches an absolute editor path against a repo-relative file tag', async () => {
+    await freshProject()
+    insertMemory('gotcha', 'params metadata must use [..] not <..>', {
+      file: 'core/commands/embeddings.ts',
+    })
+    const ctx = await buildPreEditContext(
+      { tool_input: { file_path: `${projectPath}/core/commands/embeddings.ts` } },
+      projectPath
+    )
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('embeddings.ts')
+  })
+
+  test('describes state — never prescribes a forced action', async () => {
+    await freshProject()
+    insertMemory('gotcha', 'a real trap on this file', { file: 'core/x.ts' })
+    const ctx = await buildPreEditContext({ tool_input: { file_path: 'core/x.ts' } }, projectPath)
+    expect(ctx).not.toBeNull()
+    expect((ctx ?? '').toLowerCase()).not.toContain('you must')
+  })
+})

--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -491,3 +491,69 @@ describe('projectMemory.searchFts — BM25 relevance over recency', () => {
     expect(hits.some((e) => e.id === 'mem_stripe')).toBe(true)
   })
 })
+
+describe('projectMemory.recallForFile — anticipation (pre-edit)', () => {
+  it('surfaces a gotcha tagged against the exact repo-relative file', async () => {
+    await writeMemoryEntry({
+      type: 'gotcha',
+      content: 'stale daemon caches old hook code; stop it before testing',
+      tags: { file: 'core/daemon/daemon.ts' },
+    })
+    const hits = projectMemory.recallForFile(projectId, 'core/daemon/daemon.ts')
+    expect(hits.length).toBe(1)
+    expect(hits[0]?.type).toBe('gotcha')
+  })
+
+  it('matches an absolute editor path by basename/suffix against the stored file tag', async () => {
+    await writeMemoryEntry({
+      type: 'gotcha',
+      content: 'params metadata must use [..] not <..> or registry treats it as required',
+      tags: { file: 'core/commands/embeddings.ts' },
+    })
+    const hits = projectMemory.recallForFile(
+      projectId,
+      '/Users/JJ/Apps/prjct-cli/core/commands/embeddings.ts'
+    )
+    expect(hits.length).toBe(1)
+  })
+
+  it('includes recurring-bug pattern entries, not just gotchas', async () => {
+    await writeMemoryEntry({
+      type: 'learning',
+      content: 'friction-detector compared 64-char hash vs 12-char key — never matched',
+      tags: { file: 'core/services/friction-detector.ts', pattern: 'recurring-bug' },
+    })
+    const hits = projectMemory.recallForFile(projectId, 'core/services/friction-detector.ts')
+    expect(hits.length).toBe(1)
+    expect(hits[0]?.tags?.pattern).toBe('recurring-bug')
+  })
+
+  it('excludes plain decisions/learnings about the file (strict, no noise)', async () => {
+    await writeMemoryEntry({
+      type: 'decision',
+      content: 'we keep the dispatcher registry as the single source of truth',
+      tags: { file: 'core/hooks/registry.ts' },
+    })
+    const hits = projectMemory.recallForFile(projectId, 'core/hooks/registry.ts')
+    expect(hits).toEqual([])
+  })
+
+  it('returns an empty array when no memory targets the file', () => {
+    expect(projectMemory.recallForFile(projectId, 'core/some/untouched-file.ts')).toEqual([])
+  })
+
+  it('returns an empty array for an empty file path', () => {
+    expect(projectMemory.recallForFile(projectId, '')).toEqual([])
+  })
+
+  it('caps results at the requested limit', async () => {
+    for (let i = 0; i < 5; i++) {
+      await writeMemoryEntry({
+        type: 'gotcha',
+        content: `trap number ${i} on the hot file`,
+        tags: { file: 'core/hot.ts' },
+      })
+    }
+    expect(projectMemory.recallForFile(projectId, 'core/hot.ts', 2).length).toBe(2)
+  })
+})

--- a/core/hooks/_shared.ts
+++ b/core/hooks/_shared.ts
@@ -15,14 +15,14 @@
 
 interface HookOutput {
   /** Top-level informational message. Accepted by every Claude Code hook
-   *  event — the only safe channel for Stop, SubagentStart, CwdChanged,
-   *  and PreToolUse since their response schemas reject
+   *  event — the only safe channel for Stop, SubagentStart, and
+   *  CwdChanged since their response schemas reject
    *  `hookSpecificOutput.additionalContext`. */
   systemMessage?: string
-  /** Only valid for SessionStart, UserPromptSubmit, and PostToolUse.
-   *  Injects context into the model's turn (stronger than a user-facing
-   *  system message). Emitting this on any other event triggers a
-   *  schema validation error in Claude Code. */
+  /** Valid for SessionStart, UserPromptSubmit, PreToolUse, and
+   *  PostToolUse. Injects context into the model's turn (stronger than a
+   *  user-facing system message). Emitting this on any other event
+   *  triggers a schema validation error in Claude Code. */
   hookSpecificOutput?: {
     hookEventName: string
     additionalContext?: string
@@ -30,7 +30,12 @@ interface HookOutput {
 }
 
 /** Events whose response schema accepts `hookSpecificOutput.additionalContext`. */
-const ADDITIONAL_CONTEXT_EVENTS = new Set(['SessionStart', 'UserPromptSubmit', 'PostToolUse'])
+const ADDITIONAL_CONTEXT_EVENTS = new Set([
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+])
 
 export async function readStdinSafe<T = Record<string, unknown>>(): Promise<T> {
   if (process.stdin.isTTY) return {} as T

--- a/core/hooks/pre-edit.ts
+++ b/core/hooks/pre-edit.ts
@@ -1,0 +1,85 @@
+/**
+ * PreToolUse hook (matcher: Edit|Write) — ANTICIPATION (RAG north star,
+ * pillar 3).
+ *
+ * Right before a file is edited, surface the preventive memory recorded
+ * against THAT file — gotchas, anti-patterns, recurring bugs — so the trap is
+ * seen before it's stepped in. This is the "prevent bugs / know the project"
+ * half made proactive: not a search the agent has to remember to run, but a
+ * heads-up at the exact moment it matters.
+ *
+ * Strict + quiet by design: it injects nothing unless a genuinely preventive
+ * memory matches the file (see projectMemory.recallForFile), so it never
+ * becomes per-edit noise.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { deriveTitle, type MemoryEntry, projectMemory } from '../memory/project-memory'
+import { type HookIo, runHook } from './_runner'
+import { safeTruncate } from './_shared'
+
+const MAX_CHARS = 700
+
+interface EditOrWriteToolInput {
+  file_path?: string
+}
+
+interface HookInput {
+  tool_name?: string
+  tool_input?: EditOrWriteToolInput
+}
+
+function render(filePath: string, hits: MemoryEntry[]): string {
+  const base = filePath.split('/').pop() ?? filePath
+  const lines = [`# prjct: heads up before editing \`${base}\``, '']
+  lines.push('Preventive memory recorded against this file — check before you change it:')
+  lines.push('')
+  for (const e of hits) {
+    const label =
+      e.type === 'gotcha'
+        ? 'gotcha'
+        : e.tags?.pattern === 'recurring-bug'
+          ? 'recurring-bug'
+          : e.type
+    const flat = e.content.replace(/\s+/g, ' ').trim()
+    const detail = flat.length > 220 ? `${flat.slice(0, 219)}…` : flat
+    lines.push(`- **[${label}] ${deriveTitle(e)}** — ${detail}  \`${e.id}\``)
+  }
+  lines.push('', '> Surfaced as prevention. Apply if relevant; ignore if not.')
+  return safeTruncate(lines.join('\n'), MAX_CHARS)
+}
+
+/**
+ * Build the pre-edit context block for `input` under `projectPath`, or
+ * null when nothing preventive matches the edited file. Exported so the
+ * anticipation contract (quiet unless a real trap matches) is testable
+ * without driving stdin through the runner.
+ */
+export async function buildPreEditContext(
+  input: HookInput,
+  projectPath: string
+): Promise<string | null> {
+  const file = input.tool_input?.file_path
+  if (!file) return null
+  const config = await configManager.readConfig(projectPath)
+  if (!config?.projectId) return null
+  let hits: MemoryEntry[]
+  try {
+    hits = projectMemory.recallForFile(config.projectId, file, 3)
+  } catch {
+    return null
+  }
+  if (hits.length === 0) return null
+  return render(file, hits)
+}
+
+export function runPreEditHook(projectPath: string = process.cwd(), io?: HookIo): Promise<void> {
+  return runHook<HookInput>(
+    {
+      event: 'PreToolUse',
+      projectPath,
+      build: (input, p) => buildPreEditContext(input, p),
+    },
+    io
+  )
+}

--- a/core/hooks/registry.ts
+++ b/core/hooks/registry.ts
@@ -16,6 +16,7 @@ import type { HookIo } from './_runner'
 import { runCwdChangedHook } from './cwd-changed'
 import { runPostEditHook } from './post-edit'
 import { runPreCommitHook } from './pre-commit'
+import { runPreEditHook } from './pre-edit'
 import { runPromptHook } from './prompt'
 import { runSessionStartHook } from './session-start'
 import { runStopHook } from './stop'
@@ -29,6 +30,7 @@ export const HOOK_RUNNERS: Record<string, HookRunner> = {
   'session-start': runSessionStartHook,
   prompt: runPromptHook,
   'pre-commit': runPreCommitHook,
+  'pre-edit': runPreEditHook,
   'post-edit': runPostEditHook,
   stop: runStopHook,
   'subagent-start': runSubagentStartHook,

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -553,6 +553,40 @@ export const projectMemory = {
   },
 
   /**
+   * Anticipation lookup (RAG north star, pillar 3): the PREVENTIVE memories
+   * recorded against a specific file — gotchas, anti-patterns, recurring-bug
+   * patterns. Surfaced right before the file is edited so the trap is seen
+   * before it's stepped in, not after.
+   *
+   * Deliberately strict: only the "you'll break something" types, so the
+   * pre-edit warning fires rarely and never becomes noise. Plain decisions /
+   * learnings about the file are NOT included here.
+   *
+   * Matches the stored `file` tag (repo-relative) against the edited path by
+   * exact / suffix / basename so an absolute path from the editor still hits.
+   */
+  recallForFile(projectId: string, filePath: string, limit = 3): MemoryEntry[] {
+    if (!filePath) return []
+    const base = filePath.split('/').pop() ?? filePath
+    const isPreventive = (e: MemoryEntry) =>
+      e.type === 'gotcha' || e.type === 'anti-pattern' || e.tags?.pattern === 'recurring-bug'
+    let pool: MemoryEntry[]
+    try {
+      pool = this.recall(projectId, { limit: 500 })
+    } catch {
+      return []
+    }
+    const matches = pool.filter((e) => {
+      const f = e.tags?.file
+      if (!f) return false
+      const fileMatch =
+        filePath === f || filePath.endsWith(`/${f}`) || (f.split('/').pop() ?? f) === base
+      return fileMatch && isPreventive(e)
+    })
+    return matches.slice(0, limit)
+  },
+
+  /**
    * Resolve a single memory entry by its `mem_<rowid>` id (or a bare
    * numeric id). This is the legibility fix: every `mem_NNNN` reference
    * the topical-memory injection / a memory body cites (`relates=mem_X`,

--- a/core/services/settings-installer.ts
+++ b/core/services/settings-installer.ts
@@ -39,6 +39,7 @@ export const PRJCT_HOOKS = [
     subcommand: 'pre-commit',
     ifClause: 'Bash(git commit *)',
   },
+  { event: 'PreToolUse', matcher: 'Edit|Write', subcommand: 'pre-edit' },
   { event: 'PostToolUse', matcher: 'Edit|Write', subcommand: 'post-edit' },
   { event: 'Stop', matcher: '', subcommand: 'stop' },
   { event: 'SubagentStart', matcher: '', subcommand: 'subagent-start' },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Pillar 3 — Anticipation (RAG north star)

> *"el objetivo es anticipar prevenir bugs conocerse para que el dev y el llm sean uno mismo mimetizados"*

Completes the third pillar of the RAG reorientation: **the project memory now warns about a file's traps at the exact moment they matter** — right before an edit — instead of waiting for the agent to remember to search.

### What it does
A new `PreToolUse(Edit|Write)` hook (`pre-edit`) calls `projectMemory.recallForFile()` and, **only when a genuinely preventive memory targets the file** (gotcha / anti-pattern / `recurring-bug`), injects a short heads-up via `hookSpecificOutput.additionalContext`. Plain decisions/learnings about the file are excluded, so it never becomes per-edit noise. No match → emits `{}` (silent).

### Changes
- `core/memory/project-memory.ts` — `recallForFile(projectId, filePath, limit=3)`; strict preventive-only filter; exact / suffix / basename path matching so an absolute editor path hits a repo-relative `file` tag.
- `core/hooks/pre-edit.ts` (new) — hook + exported `buildPreEditContext` for testability.
- `core/hooks/registry.ts`, `bin/prjct.ts` — wire `pre-edit` into both warm (daemon) and cold (CLI) dispatch paths.
- `core/services/settings-installer.ts` — install the `PreToolUse: Edit|Write` hook.
- `core/hooks/_shared.ts` + `hook-schema.test.ts` — PreToolUse now uses `additionalContext` (confirmed in current Claude Code schema; older comment said it was rejected).
- Tests: `recallForFile` (7 cases) + `pre-edit` hook (6 cases).

### Verification
- typecheck ✓, biome ✓, knip ✓
- 120 pass / 0 fail across hooks + memory + installer + dispatcher-parity
- End-to-end against the real DB: a file-tagged gotcha surfaces; unrelated files emit `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)