### PR TITLE
feat: prjct guard — provider-agnostic anticipation (Codex parity for pillar 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.36.0] - 2026-06-01
+
+### Added
+- feat: prjct guard <file> — provider-agnostic anticipation primitive exposing a file's preventive memory (gotchas/anti-patterns/recurring-bugs) so Codex and any non-Claude agent get pillar 3, plus Codex SKILL.md now instructs guarding before edits
+
 ## [2.35.0] - 2026-05-31
 
 ### Added

--- a/core/__tests__/commands/guard.test.ts
+++ b/core/__tests__/commands/guard.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `prjct guard <file>` — anticipation primitive (pillar 3), provider-agnostic.
+ *
+ * This is the CLI surface that lets Codex (and any agent without Claude
+ * Code's hook system) reach the same preventive memory the pre-edit hook
+ * injects proactively. Contract mirrors the hook: only gotchas /
+ * anti-patterns / recurring-bugs surface; plain decisions never do; a file
+ * with nothing preventive returns success + "clear to edit".
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { GuardCommands } from '../../commands/guard'
+import configManager from '../../infrastructure/config-manager'
+import { projectMemory } from '../../memory/project-memory'
+
+async function freshProject(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-guard-test-'))
+  await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+  const projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(dir, { projectId, dataPath: path.join(dir, '.prjct-data') })
+  return dir
+}
+
+describe('guard verb', () => {
+  let projectPath: string
+  let cmd: GuardCommands
+
+  beforeEach(async () => {
+    projectPath = await freshProject()
+    cmd = new GuardCommands()
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('fails when no file argument is given', async () => {
+    const result = await cmd.guard('', projectPath, { md: true })
+    expect(result.success).toBe(false)
+  })
+
+  test('surfaces a gotcha recorded against the file', async () => {
+    await projectMemory.remember(projectPath, {
+      type: 'gotcha',
+      content: 'stale daemon caches old hook code; stop it before testing',
+      tags: { file: 'core/daemon/daemon.ts' },
+    })
+    const result = await cmd.guard('core/daemon/daemon.ts', projectPath, { md: true })
+    expect(result.success).toBe(true)
+    expect(result.hits).toBe(1)
+  })
+
+  test('returns clear-to-edit (success, 0 hits) when nothing preventive matches', async () => {
+    await projectMemory.remember(projectPath, {
+      type: 'decision',
+      content: 'we use bun runtime',
+      tags: { file: 'core/x.ts' },
+    })
+    const result = await cmd.guard('core/x.ts', projectPath, { md: true })
+    expect(result.success).toBe(true)
+    expect(result.hits).toBe(0)
+  })
+
+  test('matches an absolute path against a repo-relative file tag', async () => {
+    await projectMemory.remember(projectPath, {
+      type: 'gotcha',
+      content: 'params metadata must use [..] not <..>',
+      tags: { file: 'core/commands/embeddings.ts' },
+    })
+    const result = await cmd.guard('/Users/dev/repo/core/commands/embeddings.ts', projectPath, {
+      md: true,
+    })
+    expect(result.success).toBe(true)
+    expect(result.hits).toBe(1)
+  })
+
+  test('respects an explicit limit', async () => {
+    for (let i = 0; i < 4; i++) {
+      await projectMemory.remember(projectPath, {
+        type: 'gotcha',
+        content: `trap ${i} on the hot file number ${i}`,
+        tags: { file: 'core/hot.ts' },
+      })
+    }
+    const result = await cmd.guard('core/hot.ts', projectPath, { md: true, limit: 2 })
+    expect(result.success).toBe(true)
+    expect(result.hits).toBe(2)
+  })
+})

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -483,6 +483,28 @@ export const COMMANDS: CommandMeta[] = [
     ],
   },
   {
+    name: 'guard',
+    group: 'core',
+    routing: { group: 'guard', method: 'guard' },
+    description:
+      'Surface preventive memory (gotchas, anti-patterns, recurring-bugs) recorded against a file BEFORE you edit it — anticipation, provider-agnostic.',
+    usage: {
+      claude: '/p:guard <file>',
+      terminal: 'prjct guard <file>',
+    },
+    params: '<file>',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: true,
+    features: [
+      'Pillar 3 (anticipation): see the trap before you step in it',
+      'Claude Code gets this proactively via the pre-edit hook; Codex/others call it directly',
+      'Strict: only gotchas / anti-patterns / recurring-bugs — never plain decisions, so no noise',
+      'Quiet by design: "clear to edit" when nothing preventive matches',
+      'Matches absolute or repo-relative paths by exact / suffix / basename',
+    ],
+  },
+  {
     name: 'config',
     group: 'core',
     routing: { group: 'config', method: 'config' },

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -22,6 +22,7 @@ import { CaptureCommands } from './capture'
 import { ConfigCommands } from './config'
 import { ContextCommands } from './context'
 import { EmbeddingsCommands } from './embeddings'
+import { GuardCommands } from './guard'
 import { InstallCommands } from './install'
 import { McpCommands } from './mcp'
 import { PlanningCommands } from './planning'
@@ -55,6 +56,7 @@ class PrjctCommands {
   private teamCmds: TeamCommands
   private configCmds: ConfigCommands
   private embeddingsCmds: EmbeddingsCommands
+  private guardCmds: GuardCommands
   private specCmds: SpecCommands
 
   // Shared state
@@ -79,6 +81,7 @@ class PrjctCommands {
     this.teamCmds = new TeamCommands()
     this.configCmds = new ConfigCommands()
     this.embeddingsCmds = new EmbeddingsCommands()
+    this.guardCmds = new GuardCommands()
     this.specCmds = new SpecCommands()
 
     this.agent = null
@@ -258,6 +261,14 @@ class PrjctCommands {
     options: MdOption & { key?: string; model?: string; baseUrl?: string } = {}
   ): Promise<CommandResult> {
     return this.embeddingsCmds.embeddings(input, projectPath, options)
+  }
+
+  async guard(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: MdOption & { limit?: number } = {}
+  ): Promise<CommandResult> {
+    return this.guardCmds.guard(input, projectPath, options)
   }
 
   // ========== Auth Commands ==========

--- a/core/commands/guard.ts
+++ b/core/commands/guard.ts
@@ -1,0 +1,101 @@
+/**
+ * `prjct guard <file>` — ANTICIPATION primitive, provider-agnostic.
+ *
+ * Surfaces the *preventive* memory recorded against a file — gotchas,
+ * anti-patterns, recurring-bugs — so the trap is seen before it's stepped in.
+ * This is pillar 3 (anticipation) of the RAG north star: "anticipar, prevenir
+ * bugs, conocerse para que el dev y el LLM sean uno mismo".
+ *
+ * Two delivery mechanisms share this one intelligence:
+ *   - Claude Code: the `pre-edit` PreToolUse hook fires it proactively (no
+ *     agent effort). See core/hooks/pre-edit.ts.
+ *   - Codex (and any agent without hooks): the SKILL.md instructs calling
+ *     `prjct guard <file>` before editing. Reactive, but it's the only
+ *     injection channel those agents expose.
+ *
+ * Quiet by design: prints "no preventive memory" (exit 0) when nothing
+ * genuinely preventive matches, so it never becomes per-edit noise.
+ */
+
+import { deriveTitle, type MemoryEntry, projectMemory } from '../memory/project-memory'
+import type { MdOption } from '../types/cli'
+import type { CommandResult } from '../types/commands'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
+
+interface GuardOptions extends MdOption {
+  limit?: number
+}
+
+function labelFor(e: MemoryEntry): string {
+  if (e.type === 'gotcha') return 'gotcha'
+  if (e.tags?.pattern === 'recurring-bug') return 'recurring-bug'
+  return e.type
+}
+
+function flatDetail(content: string, max = 220): string {
+  const flat = content.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
+export class GuardCommands extends PrjctCommandsBase {
+  async guard(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: GuardOptions = {}
+  ): Promise<CommandResult> {
+    const file = (input ?? '').trim().split(/\s+/).filter(Boolean)[0]
+    if (!file) {
+      const msg = 'Usage: prjct guard <file> — surfaces preventive memory before you edit it.'
+      if (options.md) console.log(`> ${msg}`)
+      else out.fail(msg)
+      return { success: false, error: 'Missing file argument' }
+    }
+
+    const guard = await requireProject(projectPath, options)
+    if (!guard.ok) return guard.result
+
+    const limit = typeof options.limit === 'number' && options.limit > 0 ? options.limit : 3
+    let hits: MemoryEntry[]
+    try {
+      hits = projectMemory.recallForFile(guard.value, file, limit)
+    } catch {
+      hits = []
+    }
+
+    const base = file.split('/').pop() ?? file
+
+    if (hits.length === 0) {
+      const msg = `No preventive memory recorded against \`${base}\` — clear to edit.`
+      if (options.md) console.log(`> ${msg}`)
+      else out.done(`No preventive memory for ${base} — clear to edit.`)
+      return { success: true, file, hits: 0 }
+    }
+
+    if (options.md) {
+      const lines = [
+        `# prjct: heads up before editing \`${base}\``,
+        '',
+        'Preventive memory recorded against this file — check before you change it:',
+        '',
+      ]
+      for (const e of hits) {
+        lines.push(
+          `- **[${labelFor(e)}] ${deriveTitle(e)}** — ${flatDetail(e.content)}  \`${e.id}\``
+        )
+      }
+      lines.push('', '> Surfaced as prevention. Apply if relevant; ignore if not.')
+      console.log(lines.join('\n'))
+    } else {
+      out.info(
+        `⚠ ${hits.length} preventive memory entr${hits.length === 1 ? 'y' : 'ies'} for ${base}:`
+      )
+      for (const e of hits) {
+        out.info(`  • [${labelFor(e)}] ${deriveTitle(e)} — ${flatDetail(e.content, 120)} (${e.id})`)
+      }
+    }
+
+    return { success: true, file, hits: hits.length }
+  }
+}

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -19,6 +19,7 @@ import { CATEGORIES, COMMANDS } from './command-data'
 import { ConfigCommands } from './config'
 import { ContextCommands } from './context'
 import { EmbeddingsCommands } from './embeddings'
+import { GuardCommands } from './guard'
 import { InstallCommands } from './install'
 import { McpCommands } from './mcp'
 import { PlanningCommands } from './planning'
@@ -53,6 +54,7 @@ const groupInstances: Record<CommandRoutingGroup, object> = {
   update: new UpdateCommands(),
   spec: new SpecCommands(),
   embeddings: new EmbeddingsCommands(),
+  guard: new GuardCommands(),
 }
 
 function registerCategories(): void {

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -120,6 +120,11 @@ export async function executeCommand(
       })
     case 'config':
       return commands.config(param, request.cwd, { md })
+    case 'guard':
+      return commands.guard(param, request.cwd, {
+        md,
+        limit: opts.limit ? Number(opts.limit) : undefined,
+      })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/core/index.ts
+++ b/core/index.ts
@@ -272,6 +272,12 @@ async function main(): Promise<void> {
             model: options.model ? String(options.model) : undefined,
             baseUrl: options['base-url'] ? String(options['base-url']) : undefined,
           }),
+        // Anticipation primitive (provider-agnostic; Codex/others call directly)
+        guard: (p) =>
+          commands.guard(p, process.cwd(), {
+            md,
+            limit: options.limit ? Number(options.limit) : undefined,
+          }),
       }
 
       const handler = standardCommands[commandName]

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -346,6 +346,7 @@ export type CommandRoutingGroup =
   | 'update'
   | 'spec'
   | 'embeddings'
+  | 'guard'
 
 export interface CommandRouting {
   /** Which command-group instance owns the handler. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -7,7 +7,7 @@ description: Use when user mentions p., prjct, task tracking, or workflow comman
 
 Grammar: `p. <command> [args]` or `prjct <command> --md`
 
-Core commands: sync, task, done, ship, pause, resume, next, bug, workflow, tokens
+Core commands: sync, task, done, ship, pause, resume, next, bug, workflow, tokens, guard
 Integrations: linear, jira, enrich
 Other: run `prjct <command> --md` and follow CLI output
 
@@ -20,3 +20,8 @@ Rules:
 - All commits include footer: `Generated with [p/](https://www.prjct.app/)`
 - All storage through `prjct` CLI (SQLite internally)
 - Start code tasks with `p. task` and follow Context Contract from CLI output
+
+Anticipation (prevent known bugs):
+- BEFORE editing any file, run `prjct guard <file> --md` and heed any preventive memory it surfaces (gotchas, anti-patterns, recurring bugs recorded against that file).
+- It is silent when the file is clear, so the cost is near-zero — always check.
+- When you hit a real trap, record it for next time: `prjct remember gotcha "<trap + how to avoid>" --tags file:<path>` so future edits are warned.


### PR DESCRIPTION
## Codex parity for pillar 3 (anticipation)

> *"soportamos codex... principalmente Claude pero también soporte para Codex"*

Pillar 3 shipped in 2.35.0 as a Claude Code `PreToolUse` hook — but **Codex has no hook system**, so it got nothing. Worse, the anticipation intelligence (`recallForFile`) was locked *inside* the hook, not callable by any other agent.

This exposes that intelligence as a **provider-agnostic CLI primitive** and wires Codex to use it.

### One intelligence, two delivery mechanisms
| Provider | How it gets file-anticipation |
|---|---|
| Claude Code | `pre-edit` PreToolUse hook (proactive, no agent effort) — unchanged |
| Codex / any agent | `prjct guard <file>` + SKILL.md instruction to run it before editing |

### `prjct guard <file>`
Prints the file's preventive memory (gotchas / anti-patterns / recurring-bugs) — same strict filter as the hook, so plain decisions/learnings never surface. Quiet by design: "clear to edit" when nothing matches. Supports `--md` and `--limit`. Matches absolute or repo-relative paths.

### Changes
- `core/commands/guard.ts` (new) — the command; reuses `projectMemory.recallForFile`.
- Wired through every dispatch path: `command-data.ts` (metadata), `register.ts` (registry), `commands.ts` (facade), `index.ts` (cold path), `daemon/dispatch.ts` (warm path, with `--md`), `types/commands.ts` (routing group).
- `templates/codex/SKILL.md` — adds an **Anticipation** section: guard before editing, and record new traps with `prjct remember gotcha --tags file:<path>`. Template-hash change auto-refreshes the installed Codex skill on next `prjct setup`.
- Tests: `guard` command (5 cases).

### Verification
- typecheck ✓ · biome ✓ · knip ✓
- 229 pass / 0 fail across commands + daemon + memory + hooks + dispatch-parity
- Built dist smoke-tested: cold path, daemon path, and bundled Codex template all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)