### PR TITLE
fix: confirmed-bug batch from optimization audit (embeddings flags, phantom recall verb, mem_forget, recall index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## [Unreleased]
 
-## [2.37.2] - 2026-06-01
+## [2.37.3] - 2026-06-01
+
+Confirmed-bug batch from a full optimization audit (4 parallel reviewers, each finding adversarially verified — two "high severity" findings turned out false and were dropped).
+
+### Fixed
+- **`prjct embeddings set --key …` silently lost its flags via the daemon.** `embeddings` had no explicit case in the daemon dispatcher, so it fell through to the option-less registry path — the key never reached the command (the "stale daemon" confusion from 2.34.0). Added an explicit `embeddings` case mirroring the cold path.
+- **Codex skill pointed at a non-existent `prjct recall` verb.** Introduced in 2.36.0; Codex would auto-capture it as an inbox note. Replaced with `prjct context memory <topic>`.
+- **`prjct_mem_forget` was a no-op with a description that claimed it deleted.** Implemented `projectMemory.forget()` — deletes the source `events` row, soft-deletes the `memories` FTS mirror, and drops any stored embedding, so a forgotten entry stops surfacing in recall, search, and semantic search.
+
+### Performance
+- **Recall no longer filesorts on every prompt.** Recall queries (`… WHERE type LIKE 'memory.remember.%' ORDER BY id DESC`) fire on every UserPromptSubmit hook; migration 20's `(type, timestamp DESC)` index couldn't satisfy the `id`-ordered sort, so SQLite ran a separate filesort each time. Added `idx_events_type_id ON events(type, id DESC)` (migration 26) so it's an ordered index scan.
 
 ### Changed
 - **Quality-workflow methodology rewritten as behavior, not procedure** (in the pulled `workflows.md` reference). The `review` / `qa` / `security` / `investigate` / `ship` / `audit` sections were numbered step-by-step lists (40 procedural steps); they now describe the *observable outcome* — "what good looks like" — and let the agent discover the how. Stop-conditions, the per-role model policy, and the parallel-dispatch mechanics are kept verbatim (those are concrete operational rules, not procedure). Rationale (Deep SWE / Theo): over-specified step-by-step prompts flatter weak models and add noise; behavior-framed prompts force end-to-end exploration and let capable models self-verify. Aligns the methodology with prjct's own anti-harness ethos.

--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -492,6 +492,59 @@ describe('projectMemory.searchFts — BM25 relevance over recency', () => {
   })
 })
 
+describe('projectMemory.forget', () => {
+  function writeMemoryRow(args: { id: string; type: string; content: string }): void {
+    const now = new Date().toISOString()
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memories
+         (id, project_id, title, content, tags, type, provenance, user_triggered,
+          created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args.id,
+      projectId,
+      args.content.slice(0, 80),
+      args.content,
+      '{}',
+      args.type,
+      'declared',
+      0,
+      now,
+      now
+    )
+  }
+
+  it('removes a remembered entry from recall', async () => {
+    await writeMemoryEntry({ type: 'decision', content: 'forget me please' })
+    const before = projectMemory.recall(projectId, { types: ['decision'] })
+    const target = before.find((e) => e.content === 'forget me please')
+    expect(target).toBeDefined()
+
+    const ok = projectMemory.forget(projectId, target!.id)
+    expect(ok).toBe(true)
+
+    const after = projectMemory.recall(projectId, { types: ['decision'] })
+    expect(after.some((e) => e.id === target!.id)).toBe(false)
+  })
+
+  it('soft-deletes the FTS mirror so searchFts stops returning it', () => {
+    writeMemoryRow({ id: 'mem_4242', type: 'fact', content: 'forgettable unique token zorptak' })
+    expect(projectMemory.searchFts(projectId, ['zorptak'], 4).length).toBe(1)
+    // No event row backs this mirror-only row, but forget still cleans the
+    // mirror and reports success (it removed the entry from a read surface).
+    expect(projectMemory.forget(projectId, 'mem_4242')).toBe(true)
+    expect(projectMemory.searchFts(projectId, ['zorptak'], 4).length).toBe(0)
+  })
+
+  it('returns false for a non-existent id', () => {
+    expect(projectMemory.forget(projectId, 'mem_999999')).toBe(false)
+  })
+
+  it('returns false for a malformed id', () => {
+    expect(projectMemory.forget(projectId, 'not-an-id')).toBe(false)
+  })
+})
+
 describe('projectMemory.recallForFile — anticipation (pre-edit)', () => {
   it('surfaces a gotcha tagged against the exact repo-relative file', async () => {
     await writeMemoryEntry({

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -125,6 +125,16 @@ export async function executeCommand(
         md,
         limit: opts.limit ? Number(opts.limit) : undefined,
       })
+    case 'embeddings':
+      // Must mirror the cold path (core/index.ts): the default
+      // registry.execute path drops option flags, so `prjct embeddings set
+      // --key …` via the daemon silently lost the key (set became a no-op).
+      return commands.embeddings(param, request.cwd, {
+        md,
+        key: opts.key ? String(opts.key) : undefined,
+        model: opts.model ? String(opts.model) : undefined,
+        baseUrl: opts['base-url'] ? String(opts['base-url']) : undefined,
+      })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/core/mcp/tools/memory.ts
+++ b/core/mcp/tools/memory.ts
@@ -207,16 +207,15 @@ export function registerMemoryTools(server: McpServer) {
       id: z.string().describe('Memory id (e.g. "mem_42" or "ship_7")'),
     },
     safeMcpCall('prjct_mem_forget', async (args: { projectPath: string; id: string }) => {
-      // `projectMemory` doesn't expose a direct forget yet — the
-      // event-sourced store treats deletion as a new entry. When
-      // the API gains `projectMemory.forget(id)`, wire it here.
-      // For now this is a declarative no-op with a hint.
-      void args
+      const projectId = await resolveProjectId(args.projectPath)
+      const removed = projectMemory.forget(projectId, args.id)
       return {
         content: [
           {
             type: 'text',
-            text: 'Forget is not implemented in the projectMemory API yet. Entries persist event-sourced — filter them out client-side, or drop the underlying event manually.',
+            text: removed
+              ? `✓ forgot ${args.id} — removed from recall, search, and embeddings.`
+              : `_No memory entry with id ${args.id} (already gone, or not a remember entry)._`,
           },
         ],
       }

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -614,6 +614,66 @@ export const projectMemory = {
   },
 
   /**
+   * Forget a memory entry by id across EVERY read path, so it stops surfacing:
+   *   - `events` row deleted — recall() + allEntriesForIndex read events directly
+   *     (events has no deleted_at; the dedup migration likewise hard-deletes).
+   *   - `memories` mirror soft-deleted (deleted_at) — searchFts filters on it.
+   *   - any stored embedding dropped — so it can't resurface via semantic search.
+   * Returns true iff a remember-event row existed and was removed. Best-effort
+   * on the mirror/embedding cleanups (their absence must not fail the forget).
+   */
+  forget(projectId: string, id: string): boolean {
+    const m = String(id)
+      .trim()
+      .match(/^(?:mem[_-])?(\d+)$/i)
+    if (!m) return false
+    const rowId = Number(m[1])
+    const memId = `mem_${rowId}`
+    let removed = false
+
+    // Source event (recall + vault index read events directly). A memories
+    // mirror row can outlive its event and vice-versa, so clean each
+    // independently and report success if EITHER surface had the entry.
+    try {
+      const ev = prjctDb.get<{ id: number }>(
+        projectId,
+        'SELECT id FROM events WHERE id = ? AND type LIKE ?',
+        rowId,
+        `${REMEMBER_EVENT_PREFIX}%`
+      )
+      if (ev) {
+        prjctDb.run(projectId, 'DELETE FROM events WHERE id = ?', rowId)
+        removed = true
+      }
+    } catch {}
+
+    // FTS mirror — soft-delete so searchFts (filters deleted_at) stops it.
+    try {
+      const mem = prjctDb.get<{ id: string }>(
+        projectId,
+        'SELECT id FROM memories WHERE id = ? AND deleted_at IS NULL',
+        memId
+      )
+      if (mem) {
+        prjctDb.run(
+          projectId,
+          'UPDATE memories SET deleted_at = ? WHERE id = ?',
+          new Date().toISOString(),
+          memId
+        )
+        removed = true
+      }
+    } catch {}
+
+    // Drop any stored embedding so it can't resurface via semantic search.
+    try {
+      prjctDb.run(projectId, 'DELETE FROM memory_embeddings WHERE memory_id = ?', memId)
+    } catch {}
+
+    return removed
+  },
+
+  /**
    * Follow each seed entry's cross-references ONE hop and return the linked
    * entries (deduped against the seed, capped).
    *

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -853,4 +853,19 @@ export const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 26,
+    name: 'events-type-id-index',
+    up: (db: SqliteDatabase) => {
+      // Recall is `… WHERE type LIKE 'memory.remember.%' ORDER BY id DESC`
+      // (project-memory.ts recall + allEntriesForIndex) and fires on every
+      // UserPromptSubmit hook. Migration 20 added (type, timestamp DESC)
+      // INTENDING to serve that ORDER BY — but the sort column is `id`, not
+      // `timestamp`, so the planner used the index only for the type range and
+      // then ran a separate filesort on `id` every time. This index sorts by
+      // the actual ORDER BY column, collapsing the filesort into an ordered
+      // index scan. Additive; the old index can stay for timestamp-range use.
+      db.run('CREATE INDEX IF NOT EXISTS idx_events_type_id ON events(type, id DESC)')
+    },
+  },
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.37.2",
+  "version": "2.37.3",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -8,7 +8,7 @@ description: Use when the user mentions p., prjct, tasks, specs, shipping, or pr
 Run `prjct <command> --md` and follow its output. Pull context on demand; never dump it all.
 
 - Flow: `task` → work → `done` → `ship`
-- Memory: `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct recall`, `prjct guard <file>` (preventive memory before editing)
+- Memory: `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct context memory <topic>` (recall), `prjct guard <file>` (preventive memory before editing)
 - Capture stray thoughts: `prjct capture "<text>"`
 - Run `prjct --help` for the full command list; prefer the prjct MCP tools (`prjct_*`) when available.
 


### PR DESCRIPTION
## Confirmed-bug batch (from the full optimization audit)

A 4-dimension audit (performance, code-health, data/RAG, MCP-UX) ran as parallel reviewers. **Every finding was adversarially verified against the source before acting** — and two "HIGH severity" findings turned out false:
- *"SKILL.md routes to phantom verbs (`health`/`retro`/`prefs`) → inbox corruption"* — FALSE: those are `bin/prjct.ts` special-cases (`args[0] === 'health'`…) and listed in `_binCommands`.
- *"`prjct context memory <topic>` ignores the topic"* — FALSE: that routes to `runContextTool → runMemoryTool`, which uses the topic via `searchFts` (BM25). The agent confused it with the no-arg `context.ts` path.

This PR ships only the **confirmed** ones.

### Fixed
- **`prjct embeddings set --key …` silently lost its flags via the daemon.** `embeddings` had no explicit case in `core/daemon/dispatch.ts`, so it fell through to the option-less `registry.execute` — the key never reached the command (this is the "stale daemon" confusion from 2.34.0; it was real). Added an explicit case mirroring `core/index.ts`.
- **Codex skill pointed at a non-existent `prjct recall` verb** (I introduced it in 2.36.0). `recall` isn't registered anywhere → Codex auto-captures it as an inbox note. Replaced with `prjct context memory <topic>`. Codex skill stays at 899 B (< 1024 hard limit).
- **`prjct_mem_forget` was a no-op whose description claimed it deleted.** Implemented `projectMemory.forget()`: deletes the source `events` row, soft-deletes the `memories` FTS mirror (`deleted_at`), and drops any stored embedding — so a forgotten entry stops surfacing in recall, search, AND semantic search. The mirror id aligns (`mem_<eventId>`); forget is robust to either surface being already gone. +4 tests.

### Performance
- **Recall no longer filesorts on every prompt.** Recall (`… WHERE type LIKE 'memory.remember.%' ORDER BY id DESC`) fires on every UserPromptSubmit hook. Migration 20 added `(type, timestamp DESC)` *intending* to serve it, but the sort column is `id` — so SQLite did a separate filesort each time. Migration 26 adds `idx_events_type_id ON events(type, id DESC)`. Verified the index lands on the real DB.

### Verification
- typecheck ✓ · biome ✓ · knip ✓ · **full suite 1422 pass / 0 fail** (+4 forget tests)
- Migration 26 confirmed present in the live project DB.

### Remaining audit findings (deferred — separate PRs)
Hot-path perf (merge the 3 prompt-hook recall scans, stop-hook transcript read-once + parallelize, backfill delta query), code-health (execFileAsync dedup, `glob`/`date-fns` removal, routing-dup helper, DB cast guards, `prepare` script), MCP completeness (task write-path tools, drop `prjct_patterns`, intent-led descriptions). Full ranked analysis captured in prjct memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)