### PR TITLE
fix: forward command flags through the daemon — close the flag-strip class + parity guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## [Unreleased]
 
-## [2.37.4] - 2026-06-01
+## [2.37.5] - 2026-06-01
+
+Robustness sweep: close an entire class of "works in the terminal, broken via the daemon" bugs — and add a test so it can't come back.
+
+### Fixed
+- **Commands silently dropped their flags when run through the daemon.** A command whose cold handler (`core/index.ts`) reads option flags but has no explicit `case` in the daemon dispatcher fell through to the option-less registry path, dropping every flag. Beyond `embeddings` (fixed in 2.37.3), this hit:
+  - `prjct capture "…" --tags … --force` — tags and the secret-override were dropped (an explicit `capture` is registered, so it skipped the unknown-verb auto-route and fell through).
+  - `prjct init --pack … --persona … --yes` — onboarding pack/persona selection was ignored.
+  - `prjct regen --md` — agents got non-md output.
+  - `prjct login --url …`, `prjct logout`, `prjct auth` — flags/args dropped.
+  Each now has an explicit dispatch case mirroring the cold path (and `init` correctly uses the request's cwd, not the daemon's).
+
+### Internal
+- New `dispatch-option-parity.test.ts`: every option-bearing cold command must be either cold-handled (`_binCommands`) or explicitly cased in the daemon dispatcher. CI now fails if a future option-taking command reintroduces this drift.
 
 Hot-path performance (batch 2 from the optimization audit) — the UserPromptSubmit hook fires on every prompt and blocks context injection, so its DB work is the most worth trimming.
 

--- a/core/__tests__/daemon/dispatch-option-parity.test.ts
+++ b/core/__tests__/daemon/dispatch-option-parity.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Cold-path ↔ daemon-path option-forwarding parity.
+ *
+ * Root-cause guard for a recurring class of bug ("works in the terminal,
+ * broken via the daemon"): a command's COLD handler in `core/index.ts`
+ * (`standardCommands`) reads option flags (`options.key`, `options['no-spec-
+ * gate']`, …) and forwards them, but the DAEMON path (`core/daemon/dispatch.ts`)
+ * has no explicit `case` for it — so it falls through to the option-less
+ * `commandRegistry.execute`, silently dropping every flag.
+ *
+ * This bit `embeddings` (`set --key` became a no-op via the daemon, 2.34.0)
+ * and `init`/`login`/`auth`/`regen` (flags dropped). Every command whose cold
+ * handler consumes an `options.X` flag MUST be either:
+ *   - cold-handled (listed in `_binCommands` in bin/prjct.ts → never forwarded), or
+ *   - explicitly cased in dispatch.ts (so the daemon forwards its flags).
+ *
+ * If this test fails, add a `case` in dispatch.ts mirroring the index.ts handler
+ * (and pass `request.cwd`, not the daemon's cwd).
+ */
+
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = path.resolve(__dirname, '../../..')
+
+/** Keys in `standardCommands` whose handler body reads an `options.X` flag. */
+function optionBearingColdCommands(): string[] {
+  const src = fs.readFileSync(path.join(ROOT, 'core/index.ts'), 'utf-8')
+  const start = src.indexOf('const standardCommands')
+  // The object is consumed right after via `standardCommands[commandName]`.
+  const end = src.indexOf('const handler = standardCommands', start)
+  if (start < 0 || end < 0) throw new Error('Could not bound standardCommands in core/index.ts')
+  const block = src.slice(start, end)
+
+  // Handler entries look like `  task: (p) =>` / `  'audit-spec': (p) =>` /
+  // `  logout: () =>`. Capture each key and the slice up to the next entry.
+  const keyRe = /\n {8}('?[\w-]+'?):\s*\(/g
+  const entries: { key: string; index: number }[] = []
+  for (const m of block.matchAll(keyRe)) {
+    entries.push({ key: m[1].replace(/'/g, ''), index: m.index ?? 0 })
+  }
+
+  const optionBearing: string[] = []
+  for (let i = 0; i < entries.length; i++) {
+    const body = block.slice(entries[i].index, entries[i + 1]?.index ?? block.length)
+    // A real option flag is `options.<name>` or `options['<name>']`. The
+    // local `md` var and the positional `p` are not option flags.
+    if (/\boptions[.[]/.test(body)) optionBearing.push(entries[i].key)
+  }
+  return optionBearing
+}
+
+function binCommandsSkipSet(): Set<string> {
+  const src = fs.readFileSync(path.join(ROOT, 'bin/prjct.ts'), 'utf-8')
+  const m = src.match(/_binCommands = new Set\(\[([\s\S]+?)\]\)/)
+  if (!m) throw new Error('Could not find _binCommands in bin/prjct.ts')
+  const out = new Set<string>()
+  for (const s of m[1].matchAll(/['"]([^'"]+)['"]/g)) out.add(s[1])
+  return out
+}
+
+function dispatchCaseLabels(): Set<string> {
+  const src = fs.readFileSync(path.join(ROOT, 'core/daemon/dispatch.ts'), 'utf-8')
+  const out = new Set<string>()
+  for (const m of src.matchAll(/case\s+'([\w-]+)'\s*:/g)) out.add(m[1])
+  return out
+}
+
+describe('cold ↔ daemon option-forwarding parity', () => {
+  test('every option-bearing cold command is cold-handled or explicitly cased in dispatch', () => {
+    const optionBearing = optionBearingColdCommands()
+    // Sanity: the extractor actually found the known flag-bearing commands.
+    expect(optionBearing).toContain('embeddings')
+    expect(optionBearing).toContain('init')
+    expect(optionBearing).toContain('ship')
+
+    const cold = binCommandsSkipSet()
+    const cased = dispatchCaseLabels()
+
+    const dropped = optionBearing.filter((c) => !cold.has(c) && !cased.has(c))
+    expect(dropped).toEqual([])
+  })
+
+  test('the previously-broken commands now have dispatch cases', () => {
+    const cased = dispatchCaseLabels()
+    for (const c of ['embeddings', 'init', 'regen', 'login', 'logout', 'auth', 'capture']) {
+      expect(cased.has(c)).toBe(true)
+    }
+  })
+})

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -77,6 +77,15 @@ export async function executeCommand(
         noSpecGate: opts['no-spec-gate'] === true,
       })
     }
+    case 'capture':
+      // Explicit `prjct capture "…" --tags …`: `capture` IS registered, so it
+      // skips the unknown-verb auto-route above and lands here. Without this
+      // case it fell to the option-less registry path, dropping --tags/--force.
+      return commands.capture(param, request.cwd, {
+        md,
+        tags: opts.tags ? String(opts.tags) : undefined,
+        force: opts.force === true,
+      })
     case 'spec':
       return routeSpec(commands, request.args, opts, request.cwd)
     case 'audit-spec':
@@ -135,6 +144,29 @@ export async function executeCommand(
         model: opts.model ? String(opts.model) : undefined,
         baseUrl: opts['base-url'] ? String(opts['base-url']) : undefined,
       })
+    // The cases below close the same flag-stripping gap as embeddings: each
+    // is registered + daemon-routed but used to fall through to the
+    // option-less registry path. `dispatch-option-parity.test.ts` guards
+    // against this class of drift recurring.
+    case 'init':
+      // request.cwd (NOT the daemon's process.cwd) is the project dir.
+      return commands.init(
+        {
+          idea: param,
+          yes: opts.yes === true,
+          pack: opts.pack ? String(opts.pack) : undefined,
+          persona: opts.persona ? String(opts.persona) : undefined,
+        },
+        request.cwd
+      )
+    case 'regen':
+      return commands.regenVault(request.cwd, { md })
+    case 'login':
+      return commands.login({ md, url: opts.url ? String(opts.url) : undefined })
+    case 'logout':
+      return commands.logout()
+    case 'auth':
+      return commands.auth(param, { md })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.37.4",
+  "version": "2.37.5",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## "Works in the terminal, broken via the daemon"

During an end-to-end *"make sure everything works perfectly"* verification pass (embeddings/skill/hooks/migration all confirmed live), a systematic cold↔daemon audit found a whole class of latent bug — and the new parity test caught one I'd have missed.

**Root cause:** a command whose cold handler (`core/index.ts` `standardCommands`) reads option flags but has **no explicit `case`** in `core/daemon/dispatch.ts` falls through to the option-less `commandRegistry.execute` — silently dropping **every flag** when run via the daemon. Two existing learnings flagged this exact drift as a top risk; `embeddings` (2.37.3) was one instance.

### The six found
| Command | Dropped via daemon |
|---|---|
| `prjct capture "…" --tags … --force` | tags + secret-override (explicit `capture` is registered → skips the unknown-verb auto-route → fell through) |
| `prjct init --pack … --persona … --yes` | onboarding pack/persona/non-interactive |
| `prjct regen --md` | agents got non-md output |
| `prjct login --url …` / `logout` / `auth` | flags/args |

`capture` was the sharp one — the daemon's auto-route only handles *unknown* verbs, so an explicit `prjct capture` skipped it and fell through with its flags stripped. The empirical check was a false-negative (ran cold); the code path and the parity test confirm it.

Each now has an explicit dispatch case mirroring the cold handler. `init` also correctly uses `request.cwd` (not the daemon's cwd — the cwd-drift hazard a prior learning called out).

### Drift-killer
`core/__tests__/daemon/dispatch-option-parity.test.ts`: every option-bearing cold command must be either cold-handled (`_binCommands`) or explicitly cased in the dispatcher. **CI now fails if a future option-taking command reintroduces this gap** — same pattern as the existing hook-dispatcher-parity and daemon-shim-sync guards.

### Verification
- typecheck ✓ · biome ✓ · knip ✓ · **full suite 1428 pass / 0 fail** (+ parity test)
- Session changes re-verified live before this: `embeddings set --model` forwards through the daemon ✓, Codex skill 899 B ✓, Claude skill lean+workflows.md ✓, pre-edit hook no-ops ✓, migration 26 index present ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)