### PR TITLE
perf: slim always-on skill description (2.38.1)

### DIFF
--- a/core/__tests__/services/skill-generator.test.ts
+++ b/core/__tests__/services/skill-generator.test.ts
@@ -368,11 +368,13 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
       expect(ref).toMatch(/Subagent C.*investigate/)
     })
 
-    it('the skill description scopes heavy reviews to when the diff/scope warrants', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      expect(content).toMatch(/heavy reviews \(audit\/review\/security\/investigate\)/i)
-      expect(content).toMatch(/parallel subagents ONLY when the diff\/scope warrants/i)
+    it('scopes heavy-review subagent dispatch to diff size — in the pulled reference, not the always-on description', async () => {
+      // The always-on skill description is a lean trigger; the subagent-
+      // dispatch scoping rule (don't over-dispatch on small diffs) lives in
+      // workflows.md, pulled only when a heavy workflow actually runs.
+      const ref = await readReference()
+      expect(ref).toMatch(/dispatch the read-and-analyze step as a subagent/i)
+      expect(ref).toContain('Skip the subagent only for: diffs under 5 files')
     })
 
     it('teaches the decision-brief format for non-trivial AskUserQuestion calls', async () => {

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -17,8 +17,13 @@
 import { formatProjectHeader, formatRichContext } from './formatters'
 import type { SkillContext } from './types'
 
+// Trigger only — NOT a manual. This string is always in the host model's
+// context (the skill list ships it every turn), so it carries just enough to
+// fire correctly and bias routing; the full triage/verb-map/tiers/language
+// rules live in the body, which loads on invoke. Keeping the methodology out
+// of here is the same pull-not-push rule the rest of the runtime follows.
 export const PRJCT_SKILL_DESCRIPTION =
-  'Project-memory + spec-driven runtime. prjct remembers and shows the path; the agent decides how to execute with its own tools. TRIAGE FIRST, every turn — is this simple or complex? MOST work is SIMPLE (≈1 file, known cause, bug/config/copy/doc, reversible, or the user says fix/hoy/rápido/directo): go DIRECT — `prjct task` → implement → `qa`/`review` → `ship`. NO spec, NO audit-spec, NO reviewer subagents. Spec is the EXCEPTION, ONLY for genuinely complex / high-stakes work (multi-file + new behavior, ambiguous scope, irreversible, or the user frames goals/acceptance/risks): then `spec` → `audit-spec` → `task --spec` → `ship`. Over-routing simple work through spec+reviewers is THE failure mode (burns time/tokens, zero protection on a one-file fix) — when unsure prefer DIRECT and ask one line; never default to spec. Recognize intent in any language (es/en) and run the verb yourself — never make the user type commands. Routine captures (capture/remember/tag) auto-execute, one-line confirm; destructive verbs (ship, status done) suggest-and-confirm; heavy reviews (audit/review/security/investigate) dispatch parallel subagents ONLY when the diff/scope warrants. Lookup-first: vault before re-reading source.'
+  'Project memory + spec-driven runtime: recall and capture decisions/learnings/gotchas, run registered workflows, frame and ship work. Recognize intent in any language (es/en) and run the verb yourself — never make the user type commands. Triage every turn: most work is SIMPLE → go direct (`prjct task` → ship); reserve the spec pipeline for genuinely complex or high-stakes work. Over-routing simple work through spec + reviewers is the main failure mode.'
 
 export const PRJCT_SKILL_ALLOWED_TOOLS = [
   'Bash',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prjct-cli",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prjct-cli",
-      "version": "2.38.0",
+      "version": "2.38.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Why
The skill `description` ships in the host model's context **every turn** (always-on skill list). It had grown to ~250 words of methodology — triage gate, direct pipeline, spec pipeline, routing tiers, language rule — all **duplicated** from the SKILL.md body (loaded on invoke) and `workflows.md` (pulled on demand).

## What
- Cut the description to ~70 words: a trigger + the one always-on behavioral nudge (triage simple→direct, run the verb yourself, don't over-route). **~235 tokens/turn saved.**
- "Qué, not cómo" — no longer prescribes the `→ implement → qa → review` pipeline; that detail stays in the body + pulled reference.
- Updated one test that pinned the old design (heavy-review subagent scoping now asserted against `workflows.md`).

## Verification
typecheck · biome · skill-generator 34/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)