### PR TITLE
fix(daemon): never serve stale code + feat(embeddings): any provider, incl. non-Bearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The long-lived daemon no longer serves stale code, and embeddings reach any prov
 - **Embeddings test isolation:** `global-config` resolves its directory lazily from `PRJCT_CLI_HOME`, so config/embeddings tests no longer read the developer's real `~/.prjct-cli`.
 
 ### Added
+- **Zero-config embeddings setup — paste just the key.** `prjct embeddings set --key <k>` now infers the base URL from the key's prefix (`sk-or-…` → OpenRouter, `sk-…` → OpenAI, `pa-…` → Voyage; `sk-ant-`/Groq/unknown → keep default), so `--base-url` is optional for known providers. An explicit `--base-url` still wins, and detection re-fires when you switch keys. `set` is now partial-update friendly too: `set --key …` keeps your existing model/base URL instead of resetting them.
 - **Embeddings support ANY OpenAI-compatible provider, including non-Bearer ones.** Already worked with OpenAI, OpenRouter, Ollama, Together, Mistral, Voyage, Jina, LM Studio, … via `--base-url` + `--model` + `--key`; now providers that deviate from `Authorization: Bearer` are covered too — e.g. **Azure OpenAI** (`api-key` header + `api-version` query) and custom gateways. New `prjct embeddings set` flags: `--auth-header <h>`, `--auth-scheme <s|none>` (`none` = raw key), `--headers "k=v,…"`, `--query <qs>`. Default stays `Bearer`/`authorization`, so existing providers are unchanged. Vector dimensionality is detected from the response (no hardcoded size).
 
 ## [2.38.1] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+The long-lived daemon no longer serves stale code, and embeddings reach any provider.
+
+### Fixed
+- **Daemon could serve output from an outdated build (the recurring "stale daemon" trap).** Two compounding defects: staleness was detected *after* the daemon decided to serve, so the request that first observed a new build/install was still answered by the old code; and on refusal the client printed `Daemon restarting — retry the command` and exited 1, so the command never ran (1st call stale → 2nd fails → 3rd fresh). Now staleness is detected *before* serving, the daemon refuses cleanly with a `retry` signal (the request never executes → zero side effects), and **both `bin/prjct.ts` and the daemon shim** (`scripts/build.js` → `dist/bin/prjct.mjs`, what users actually run) transparently fall through to direct in-process execution on the fresh code — no error, no manual re-run. Hooks degrade to the fail-soft `{}` no-op. The global-install version-drift check is now time-throttled (1s) instead of every-10-commands (which could leak up to 9 stale responses). Closes the "stale daemon caches old hook code" gotcha.
+- **`prjct embeddings test` no longer truncates its failure** to 65 chars (`embeddings endpoi…`). It now prints the full endpoint response plus an actionable hint (401 → base-url/key mismatch, 404 → wrong route, network → unreachable) — the one command meant to diagnose connectivity stopped hiding the diagnosis.
+- **Embeddings test isolation:** `global-config` resolves its directory lazily from `PRJCT_CLI_HOME`, so config/embeddings tests no longer read the developer's real `~/.prjct-cli`.
+
+### Added
+- **Embeddings support ANY OpenAI-compatible provider, including non-Bearer ones.** Already worked with OpenAI, OpenRouter, Ollama, Together, Mistral, Voyage, Jina, LM Studio, … via `--base-url` + `--model` + `--key`; now providers that deviate from `Authorization: Bearer` are covered too — e.g. **Azure OpenAI** (`api-key` header + `api-version` query) and custom gateways. New `prjct embeddings set` flags: `--auth-header <h>`, `--auth-scheme <s|none>` (`none` = raw key), `--headers "k=v,…"`, `--query <qs>`. Default stays `Bearer`/`authorization`, so existing providers are unchanged. Vector dimensionality is detected from the response (no hardcoded size).
+
 ## [2.38.1] - 2026-06-02
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Cursor / Windsurf use the same commands with a `/` prefix: `/capture`, `/task`, 
 | `prjct status <value>` | Inline status change on the active task (`done`, `paused`, `active`, …). |
 | `prjct tag <k:v>` | Tag the active task (`type:bug`, `domain:auth`, …). |
 | `prjct remember <type> "<content>"` | Persist a memory entry (decision, learning, gotcha, …). |
-| `prjct embeddings <set\|status\|test\|clear>` | Configure the global BYOT embeddings provider (one secure key, all projects). |
+| `prjct embeddings <set\|status\|test\|clear>` | Configure the global BYOT embeddings provider — any OpenAI-compatible API (OpenAI, OpenRouter, Ollama, Azure, …), one secure key, all projects. |
 | `prjct ship [name]` | Run the project's ship workflow (commit, push, PR, persist). |
 | `prjct sync` | Re-index files, git co-change, imports; refresh project analysis. |
 | `prjct regen` | Full rebuild of the Obsidian vault snapshot from SQLite. |
@@ -282,7 +282,7 @@ prjct hooks <install|uninstall|status>  Git hooks for auto-sync
 prjct context <memory|learnings|wiki>  Recall memory / sync the vault
 prjct review-risk        Advisory change-size + delivery-geometry hint (read-only)
 prjct workflow ["config"]  Configure hooks via natural language
-prjct stop / restart     Background daemon control
+prjct stop / restart     Background daemon control (self-reloads on stale code; manual restart rarely needed)
 prjct login / logout / auth   Cloud sync authentication
 prjct update             Update CLI system-wide (alias: prjct upgrade)
 prjct --version / --help
@@ -314,11 +314,41 @@ Want higher quality? Bring your own key once, globally:
 
 ```bash
 prjct embeddings set --key sk-...      # stored in the macOS Keychain (else a 0600 file), never in config
-prjct embeddings test                  # validate connectivity
-prjct embeddings status                # show provider + key location
+prjct embeddings test                  # validate connectivity (full error + hint on failure)
+prjct embeddings status                # show provider, model, base URL + key location
+prjct embeddings clear                 # forget the key AND settings (falls back to local)
 ```
 
-One key applies to every project (OpenAI-compatible — OpenAI, Ollama at `http://localhost:11434/v1`, LM Studio, …). Without it, the local embedder is used. Each project re-vectorizes on its next session.
+One key applies to every project. **Any OpenAI-compatible `/embeddings` provider works** — just point `--base-url` at its root:
+
+```bash
+# OpenAI (default)
+prjct embeddings set --key sk-...      --base-url https://api.openai.com/v1
+# OpenRouter
+prjct embeddings set --key sk-or-v1-... --base-url https://openrouter.ai/api/v1
+# Ollama (local, no key) / LM Studio / Together / Mistral / Voyage / Jina / DeepInfra …
+prjct embeddings set --model nomic-embed-text --base-url http://localhost:11434/v1
+```
+
+Providers that don't use `Authorization: Bearer` are supported too via auth flags — e.g. **Azure OpenAI** (`api-key` header + `api-version` query):
+
+```bash
+prjct embeddings set --key "$AZURE_KEY" \
+  --base-url https://RESOURCE.openai.azure.com/openai/deployments/DEPLOYMENT \
+  --auth-header api-key --auth-scheme none --query "api-version=2023-05-15"
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--key <k>` | API key — stored in the Keychain (else a 0600 file), never in config |
+| `--base-url <u>` | Provider's OpenAI-compatible root (default `https://api.openai.com/v1`) |
+| `--model <m>` | Model id (default `text-embedding-3-small`) |
+| `--auth-header <h>` | Header carrying the key (default `authorization`; `api-key` for Azure) |
+| `--auth-scheme <s\|none>` | Prefix before the key (default `Bearer`; `none` = raw key) |
+| `--headers "k=v,k2=v2"` | Extra static headers (gateways, attribution) |
+| `--query <qs>` | Raw query string appended to the URL (e.g. `api-version=2023-05-15`) |
+
+Without a key the built-in local embedder is used. Vector dimensionality is detected from the provider's response (no hardcoded size). Each project re-vectorizes on its next session.
 
 ### Drop files into the vault (bidirectional)
 

--- a/README.md
+++ b/README.md
@@ -310,25 +310,24 @@ Memory is FTS5-backed (SQLite) and persona-filtered. Recall blends three signals
 
 On by default for **every** project — no setup, no key, no native dependency. A built-in pure-JS embedder (feature-hashed character n-grams) vectorizes memory into SQLite so recall catches morphological / cross-vocabulary matches BM25 misses (`auth`≈`authentication`).
 
-Want higher quality? Bring your own key once, globally:
+Want higher quality? Bring your own key once, globally — **just paste the key, the provider is auto-detected from its prefix:**
 
 ```bash
-prjct embeddings set --key sk-...      # stored in the macOS Keychain (else a 0600 file), never in config
-prjct embeddings test                  # validate connectivity (full error + hint on failure)
-prjct embeddings status                # show provider, model, base URL + key location
-prjct embeddings clear                 # forget the key AND settings (falls back to local)
+prjct embeddings set --key sk-or-v1-...   # → OpenRouter (auto-detected)
+prjct embeddings set --key sk-...         # → OpenAI (auto-detected)
+prjct embeddings test                     # validate connectivity (full error + hint on failure)
+prjct embeddings status                   # show provider, model, base URL + key location
+prjct embeddings clear                    # forget the key AND settings (falls back to local)
 ```
 
-One key applies to every project. **Any OpenAI-compatible `/embeddings` provider works** — just point `--base-url` at its root:
+One key applies to every project. **Any OpenAI-compatible `/embeddings` provider works.** For providers without a recognizable key prefix (or a custom/self-hosted endpoint), point `--base-url` at its root:
 
 ```bash
-# OpenAI (default)
-prjct embeddings set --key sk-...      --base-url https://api.openai.com/v1
-# OpenRouter
-prjct embeddings set --key sk-or-v1-... --base-url https://openrouter.ai/api/v1
 # Ollama (local, no key) / LM Studio / Together / Mistral / Voyage / Jina / DeepInfra …
 prjct embeddings set --model nomic-embed-text --base-url http://localhost:11434/v1
 ```
+
+`set` is partial-update friendly — `set --key …` keeps your existing model and base URL; `set --model …` keeps your key. An explicit `--base-url` always overrides auto-detection.
 
 Providers that don't use `Authorization: Bearer` are supported too via auth flags — e.g. **Azure OpenAI** (`api-key` header + `api-version` query):
 

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -243,42 +243,49 @@ if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
         cwd: process.cwd(),
         stdin: stdinPayload,
       })
-      if (response.stdout) process.stdout.write(response.stdout)
-      process.exit(response.exitCode ?? 0)
+      // `retry` = daemon code is stale; the hook did NOT run there. Fall
+      // through to in-process execution below so the hook always runs on the
+      // fresh code (this was the original "stale daemon caches old hook code"
+      // trap). Otherwise write the daemon's output and exit.
+      if (!response.retry) {
+        if (response.stdout) process.stdout.write(response.stdout)
+        process.exit(response.exitCode ?? 0)
+      }
     } catch {
-      // Daemon unreachable mid-request. stdin is already consumed, so we
-      // can't fall through to main()'s stdin-reading handler — run the hook
-      // in-process right here with the payload we captured. Mirrors the cold
-      // path: emit, then await afterEmit before exit.
-      try {
-        const { getHookRunner } = await import('../core/hooks/registry')
-        const runner = getHookRunner(subcommand)
-        if (!runner) {
-          process.stdout.write('{}\n')
-          process.exit(0)
-        }
-        let input: unknown = {}
-        try {
-          input = stdinPayload ? JSON.parse(stdinPayload) : {}
-        } catch {
-          input = {}
-        }
-        const pending: Array<() => Promise<void>> = []
-        await runner(process.cwd(), {
-          input,
-          sink: (chunk: string) => {
-            process.stdout.write(chunk)
-          },
-          detachAfterEmit: (fn: () => Promise<void>) => {
-            pending.push(fn)
-          },
-        })
-        for (const fn of pending) await fn().catch(() => undefined)
-        process.exit(0)
-      } catch {
+      // Fall through to in-process execution below (handles both daemon-
+      // unreachable and the stale-retry case).
+    }
+    // stdin is already consumed, so we can't defer to main()'s stdin-reading
+    // handler — run the hook in-process right here with the payload we
+    // captured. Mirrors the cold path: emit, then await afterEmit before exit.
+    try {
+      const { getHookRunner } = await import('../core/hooks/registry')
+      const runner = getHookRunner(subcommand)
+      if (!runner) {
         process.stdout.write('{}\n')
         process.exit(0)
       }
+      let input: unknown = {}
+      try {
+        input = stdinPayload ? JSON.parse(stdinPayload) : {}
+      } catch {
+        input = {}
+      }
+      const pending: Array<() => Promise<void>> = []
+      await runner(process.cwd(), {
+        input,
+        sink: (chunk: string) => {
+          process.stdout.write(chunk)
+        },
+        detachAfterEmit: (fn: () => Promise<void>) => {
+          pending.push(fn)
+        },
+      })
+      for (const fn of pending) await fn().catch(() => undefined)
+      process.exit(0)
+    } catch {
+      process.stdout.write('{}\n')
+      process.exit(0)
     }
   }
 }
@@ -324,9 +331,15 @@ if (_fastCommand && !_binCommands.has(_fastCommand) && process.env.PRJCT_NO_DAEM
         perfStartNs: ((globalThis as Record<string, unknown>).__perfStartNs as bigint)?.toString(),
       })
 
-      if (response.stdout) console.log(response.stdout)
-      if (response.stderr) console.error(response.stderr)
-      process.exit(response.exitCode)
+      // Daemon refused because its code is stale (newer build/install on
+      // disk). The command did NOT run there — fall through to direct
+      // in-process execution on the fresh code. Transparent: no error, no
+      // manual re-run. The daemon restarts itself in the background.
+      if (!response.retry) {
+        if (response.stdout) console.log(response.stdout)
+        if (response.stderr) console.error(response.stderr)
+        process.exit(response.exitCode)
+      }
     } catch (err) {
       // The socket file existed when we entered this block, so the
       // daemon was running (or had been running, with a stale socket

--- a/core/__tests__/daemon/staleness-decision.test.ts
+++ b/core/__tests__/daemon/staleness-decision.test.ts
@@ -1,0 +1,134 @@
+/**
+ * decideRestart contract — the daemon's "should I restart BEFORE serving?"
+ * decision. This is the fix for the recurring stale-daemon trap: the daemon
+ * used to detect a new build AFTER serving, so the triggering request was
+ * answered by the outdated code. These tests pin the ordering and the
+ * time-throttled drift probe so that regression can't creep back.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { decideRestart } from '../../daemon/staleness'
+
+const NEVER = () => false
+const ALWAYS = () => true
+
+describe('decideRestart', () => {
+  test('a rebuilt entry file (codeStale) restarts immediately, no drift probe', () => {
+    let probed = false
+    const d = decideRestart({
+      codeStale: true,
+      command: 'status',
+      ownVersion: '1.0.0',
+      now: 10_000,
+      lastDriftCheckMs: 0,
+      driftMinIntervalMs: 1000,
+      checkDrift: () => {
+        probed = true
+        return false
+      },
+    })
+    expect(d.restart).toBe(true)
+    expect(probed).toBe(false) // mtime wins; never pays for the drift probe
+  })
+
+  test('global-install drift restarts and advances the throttle timestamp', () => {
+    const d = decideRestart({
+      codeStale: false,
+      command: 'status',
+      ownVersion: '1.0.0',
+      now: 5000,
+      lastDriftCheckMs: 0,
+      driftMinIntervalMs: 1000,
+      checkDrift: ALWAYS,
+    })
+    expect(d.restart).toBe(true)
+    expect(d.lastDriftCheckMs).toBe(5000)
+  })
+
+  test('no staleness → no restart, throttle timestamp still advances after a probe', () => {
+    const d = decideRestart({
+      codeStale: false,
+      command: 'status',
+      ownVersion: '1.0.0',
+      now: 5000,
+      lastDriftCheckMs: 0,
+      driftMinIntervalMs: 1000,
+      checkDrift: NEVER,
+    })
+    expect(d.restart).toBe(false)
+    expect(d.lastDriftCheckMs).toBe(5000) // a probe ran, so the clock advances
+  })
+
+  test('drift probe is throttled — skipped when within the min interval', () => {
+    let probes = 0
+    const d = decideRestart({
+      codeStale: false,
+      command: 'status',
+      ownVersion: '1.0.0',
+      now: 1500, // only 500ms since last check
+      lastDriftCheckMs: 1000,
+      driftMinIntervalMs: 1000,
+      checkDrift: () => {
+        probes++
+        return true
+      },
+    })
+    expect(probes).toBe(0) // throttled — no probe, no restart
+    expect(d.restart).toBe(false)
+    expect(d.lastDriftCheckMs).toBe(1000) // unchanged
+  })
+
+  test('drift probe fires once the min interval has elapsed', () => {
+    let probes = 0
+    const d = decideRestart({
+      codeStale: false,
+      command: 'status',
+      ownVersion: '1.0.0',
+      now: 2000, // exactly 1000ms since last check
+      lastDriftCheckMs: 1000,
+      driftMinIntervalMs: 1000,
+      checkDrift: () => {
+        probes++
+        return false
+      },
+    })
+    expect(probes).toBe(1)
+    expect(d.lastDriftCheckMs).toBe(2000)
+  })
+
+  test('health pings (__ping) never trigger the drift probe', () => {
+    let probed = false
+    const d = decideRestart({
+      codeStale: false,
+      command: '__ping',
+      ownVersion: '1.0.0',
+      now: 999_999,
+      lastDriftCheckMs: 0,
+      driftMinIntervalMs: 1000,
+      checkDrift: () => {
+        probed = true
+        return true
+      },
+    })
+    expect(probed).toBe(false)
+    expect(d.restart).toBe(false)
+  })
+
+  test('no ownVersion → drift probe is skipped (nothing to compare)', () => {
+    let probed = false
+    const d = decideRestart({
+      codeStale: false,
+      command: 'status',
+      ownVersion: null,
+      now: 999_999,
+      lastDriftCheckMs: 0,
+      driftMinIntervalMs: 1000,
+      checkDrift: () => {
+        probed = true
+        return true
+      },
+    })
+    expect(probed).toBe(false)
+    expect(d.restart).toBe(false)
+  })
+})

--- a/core/__tests__/services/embeddings-auth.test.ts
+++ b/core/__tests__/services/embeddings-auth.test.ts
@@ -1,0 +1,87 @@
+/**
+ * buildEmbeddingsRequest — auth/header/query wiring for the OpenAI-compatible
+ * embeddings path. Pins that we reach ANY provider, not just Bearer/OpenAI:
+ * the default shape (OpenAI/OpenRouter/Ollama), Azure OpenAI (api-key header +
+ * api-version query), and arbitrary custom headers.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { buildEmbeddingsRequest } from '../../services/embeddings'
+
+function headers(init: RequestInit): Record<string, string> {
+  return init.headers as Record<string, string>
+}
+
+describe('buildEmbeddingsRequest', () => {
+  test('default: OpenAI/OpenRouter shape — Bearer on authorization', () => {
+    const { url, init } = buildEmbeddingsRequest(
+      'https://openrouter.ai/api/v1',
+      'text-embedding-3-small',
+      ['hi'],
+      'sk-or-v1-abc'
+    )
+    expect(url).toBe('https://openrouter.ai/api/v1/embeddings')
+    expect(headers(init).authorization).toBe('Bearer sk-or-v1-abc')
+    expect(headers(init)['content-type']).toBe('application/json')
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: 'text-embedding-3-small',
+      input: ['hi'],
+    })
+  })
+
+  test('trailing slashes on baseUrl are normalized', () => {
+    const { url } = buildEmbeddingsRequest('https://api.openai.com/v1///', 'm', ['x'], 'k')
+    expect(url).toBe('https://api.openai.com/v1/embeddings')
+  })
+
+  test('Azure OpenAI: api-key header (no scheme) + api-version query', () => {
+    const { url, init } = buildEmbeddingsRequest(
+      'https://res.openai.azure.com/openai/deployments/embed',
+      'text-embedding-3-small',
+      ['hi'],
+      'AZURE_KEY',
+      { authHeader: 'api-key', authScheme: '', query: 'api-version=2023-05-15' }
+    )
+    expect(url).toBe(
+      'https://res.openai.azure.com/openai/deployments/embed/embeddings?api-version=2023-05-15'
+    )
+    expect(headers(init)['api-key']).toBe('AZURE_KEY')
+    // No Bearer / authorization header when a custom scheme-less header is used.
+    expect(headers(init).authorization).toBeUndefined()
+  })
+
+  test('leading ? on query is tolerated', () => {
+    const { url } = buildEmbeddingsRequest('https://x/v1', 'm', ['x'], 'k', {
+      query: '?api-version=2024-02-01',
+    })
+    expect(url).toBe('https://x/v1/embeddings?api-version=2024-02-01')
+  })
+
+  test('custom header name with a scheme', () => {
+    const { init } = buildEmbeddingsRequest('https://x/v1', 'm', ['x'], 'k', {
+      authHeader: 'x-api-key',
+      authScheme: 'Token',
+    })
+    expect(headers(init)['x-api-key']).toBe('Token k')
+  })
+
+  test('extra static headers are merged', () => {
+    const { init } = buildEmbeddingsRequest('https://x/v1', 'm', ['x'], 'k', {
+      extraHeaders: { 'HTTP-Referer': 'https://prjct.app', 'X-Title': 'prjct' },
+    })
+    expect(headers(init)['HTTP-Referer']).toBe('https://prjct.app')
+    expect(headers(init)['X-Title']).toBe('prjct')
+    expect(headers(init).authorization).toBe('Bearer k') // default auth still applied
+  })
+
+  test('no key → no auth header (e.g. local Ollama)', () => {
+    const { init } = buildEmbeddingsRequest(
+      'http://localhost:11434/v1',
+      'nomic-embed-text',
+      ['x'],
+      null
+    )
+    expect(headers(init).authorization).toBeUndefined()
+    expect(headers(init)['content-type']).toBe('application/json')
+  })
+})

--- a/core/__tests__/services/embeddings-detect.test.ts
+++ b/core/__tests__/services/embeddings-detect.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Zero-config provider detection + partial-update preservation for global
+ * embeddings. Pasting just `--key sk-or-…` should infer the OpenRouter base
+ * URL; a later `set --model …` must not silently reset the provider.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  detectBaseUrlFromKey,
+  resolveGlobalEmbeddings,
+  setGlobalEmbeddings,
+} from '../../services/embeddings'
+
+describe('detectBaseUrlFromKey', () => {
+  test('OpenRouter key → openrouter.ai', () => {
+    expect(detectBaseUrlFromKey('sk-or-v1-abcdef')).toEqual({
+      baseUrl: 'https://openrouter.ai/api/v1',
+      provider: 'OpenRouter',
+    })
+  })
+
+  test('OpenAI key → api.openai.com (and is not mistaken for OpenRouter)', () => {
+    expect(detectBaseUrlFromKey('sk-proj-abcdef')?.baseUrl).toBe('https://api.openai.com/v1')
+    expect(detectBaseUrlFromKey('sk-abcdef')?.provider).toBe('OpenAI')
+  })
+
+  test('Anthropic key → undefined (no embeddings endpoint, not routed to OpenAI)', () => {
+    expect(detectBaseUrlFromKey('sk-ant-api03-xyz')).toBeUndefined()
+  })
+
+  test('Voyage key → voyageai', () => {
+    expect(detectBaseUrlFromKey('pa-xyz')?.provider).toBe('Voyage')
+  })
+
+  test('unknown prefix → undefined (caller keeps default/existing)', () => {
+    expect(detectBaseUrlFromKey('xoxb-not-a-key')).toBeUndefined()
+    expect(detectBaseUrlFromKey('gsk_groq')).toBeUndefined()
+  })
+})
+
+describe('setGlobalEmbeddings partial-update preservation', () => {
+  let tmp: string
+  let orig: string | undefined
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-embset-'))
+    orig = process.env.PRJCT_CLI_HOME
+    process.env.PRJCT_CLI_HOME = tmp
+  })
+  afterEach(async () => {
+    if (orig === undefined) delete process.env.PRJCT_CLI_HOME
+    else process.env.PRJCT_CLI_HOME = orig
+    await fs.rm(tmp, { recursive: true, force: true }).catch(() => undefined)
+  })
+
+  test('first config seeds defaults; later partial set preserves them', () => {
+    setGlobalEmbeddings({
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'text-embedding-3-small',
+    })
+    // A later set that only changes the model must keep the base URL.
+    setGlobalEmbeddings({ model: 'text-embedding-3-large' })
+    const g = resolveGlobalEmbeddings()
+    expect(g?.baseUrl).toBe('https://openrouter.ai/api/v1')
+    expect(g?.model).toBe('text-embedding-3-large')
+  })
+
+  test('a set with neither base URL nor model on first config uses defaults', () => {
+    setGlobalEmbeddings({})
+    const g = resolveGlobalEmbeddings()
+    expect(g?.baseUrl).toBe('https://api.openai.com/v1')
+    expect(g?.model).toBe('text-embedding-3-small')
+  })
+})

--- a/core/__tests__/services/embeddings.test.ts
+++ b/core/__tests__/services/embeddings.test.ts
@@ -28,6 +28,7 @@ import type { LocalConfig } from '../../types/config'
 
 let tmpRoot: string
 let projectId: string
+let origCliHome: string | undefined
 
 const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
 const origStorage = pathManager.getStoragePath.bind(pathManager)
@@ -63,6 +64,11 @@ function write(type: string, content: string, tags: Record<string, string> = {})
 beforeEach(async () => {
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-embed-'))
   projectId = `test-embed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  // Isolate the GLOBAL embeddings config: without this, resolveActiveProvider
+  // reads the developer's real ~/.prjct-cli/config/global.json, so the
+  // "falls back to the local default" cases fail on any BYOT-configured machine.
+  origCliHome = process.env.PRJCT_CLI_HOME
+  process.env.PRJCT_CLI_HOME = tmpRoot
   pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
   pathManager.getStoragePath = (id: string, filename: string) =>
     path.join(tmpRoot, id, 'storage', filename)
@@ -71,6 +77,8 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  if (origCliHome === undefined) delete process.env.PRJCT_CLI_HOME
+  else process.env.PRJCT_CLI_HOME = origCliHome
   pathManager.getGlobalProjectPath = origGlobal
   pathManager.getStoragePath = origStorage
   pathManager.getFilePath = origFile

--- a/core/__tests__/services/global-config.test.ts
+++ b/core/__tests__/services/global-config.test.ts
@@ -1,18 +1,22 @@
 /**
  * global-config tests — read/write to ~/.prjct-cli/config/global.json.
  *
- * Tests redirect to a temp HOME so the user's real config never gets
- * touched. We re-import the module fresh per test to pick up the new
- * HOME env var (config dir is computed at module load).
+ * Tests redirect to a temp dir via `PRJCT_CLI_HOME` so the user's real config
+ * is never touched. This MUST use the env override, not a patched `process.env
+ * .HOME`: Bun's `os.homedir()` ignores a mutated HOME, so the old HOME-patch
+ * strategy silently read/wrote the real `~/.prjct-cli/config/global.json` — the
+ * "malformed JSON" case below would otherwise corrupt it to `{invalid json`.
+ * The path is resolved per call in the module, so a static import is fine.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import * as m from '../../services/global-config'
 
 let tempHome = ''
-let originalHome = ''
+let originalCliHome: string | undefined
 
 beforeEach(async () => {
   tempHome = path.join(
@@ -20,12 +24,13 @@ beforeEach(async () => {
     `prjct-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
   )
   await fs.mkdir(tempHome, { recursive: true })
-  originalHome = process.env.HOME ?? ''
-  process.env.HOME = tempHome
+  originalCliHome = process.env.PRJCT_CLI_HOME
+  process.env.PRJCT_CLI_HOME = tempHome
 })
 
 afterEach(async () => {
-  process.env.HOME = originalHome
+  if (originalCliHome === undefined) delete process.env.PRJCT_CLI_HOME
+  else process.env.PRJCT_CLI_HOME = originalCliHome
   if (tempHome) {
     await fs.rm(tempHome, { recursive: true, force: true }).catch(() => undefined)
     tempHome = ''
@@ -33,11 +38,9 @@ afterEach(async () => {
 })
 
 async function freshImport(): Promise<typeof import('../../services/global-config')> {
-  // Bun caches modules — flush so module-level `path.join(os.homedir(), …)`
-  // re-evaluates with the patched HOME. Cache flush is per-test-runner
-  // best-effort; if it doesn't take, the assertions still hold because
-  // we always read/write through the public API.
-  return import(`../../services/global-config?t=${Date.now()}`)
+  // The module resolves its path lazily from PRJCT_CLI_HOME on every call, so
+  // no cache-busting is needed — return the statically imported module.
+  return m
 }
 
 describe('global-config', () => {

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -476,6 +476,7 @@ export const COMMANDS: CommandMeta[] = [
     requiresProject: false,
     features: [
       'BYOT: bring your own embedding API key — ANY OpenAI-compatible provider',
+      'Zero-config: paste just --key, the base URL is auto-detected from its prefix',
       'OpenAI, OpenRouter, Ollama, Together, Mistral, Voyage, Jina, LM Studio…',
       'Non-Bearer providers too: --auth-header api-key --auth-scheme none --query "api-version=..." (Azure OpenAI)',
       'Key stored in the macOS Keychain (else a 0600 file), never in config',

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -468,14 +468,16 @@ export const COMMANDS: CommandMeta[] = [
     usage: {
       claude: '/p:embeddings status',
       terminal:
-        'prjct embeddings <set|status|test|clear> [--key <K>] [--model <M>] [--base-url <U>]',
+        'prjct embeddings <set|status|test|clear> [--key <K>] [--model <M>] [--base-url <U>] [--auth-header <H>] [--auth-scheme <S|none>] [--headers "k=v,..."] [--query <qs>]',
     },
     params: '[set|status|test|clear]',
     implemented: true,
     hasTemplate: false,
     requiresProject: false,
     features: [
-      'BYOT: bring your own embedding API key (OpenAI-compatible)',
+      'BYOT: bring your own embedding API key — ANY OpenAI-compatible provider',
+      'OpenAI, OpenRouter, Ollama, Together, Mistral, Voyage, Jina, LM Studio…',
+      'Non-Bearer providers too: --auth-header api-key --auth-scheme none --query "api-version=..." (Azure OpenAI)',
       'Key stored in the macOS Keychain (else a 0600 file), never in config',
       'Global — applies to all projects; per-project config still overrides',
       'Without a key, recall uses the always-on local subword embedder',

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -258,7 +258,15 @@ class PrjctCommands {
   async embeddings(
     input: string | null = null,
     projectPath: string = process.cwd(),
-    options: MdOption & { key?: string; model?: string; baseUrl?: string } = {}
+    options: MdOption & {
+      key?: string
+      model?: string
+      baseUrl?: string
+      authHeader?: string
+      authScheme?: string
+      headers?: string
+      query?: string
+    } = {}
   ): Promise<CommandResult> {
     return this.embeddingsCmds.embeddings(input, projectPath, options)
   }

--- a/core/commands/embeddings.ts
+++ b/core/commands/embeddings.ts
@@ -24,9 +24,27 @@ import {
 } from '../services/embeddings/secure-key'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
-import { failHard } from '../utils/md-aware'
+import { failHard, notifyFail, notifyInfo } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
+
+/**
+ * Best-effort, actionable hint derived from a failed-embedding error string.
+ * The common failures are config mismatches the user can fix; map them to a
+ * concrete next step instead of leaving the raw HTTP body to speak for itself.
+ */
+function embeddingsFailureHint(detail: string): string | undefined {
+  if (/\b401\b|invalid_api_key|incorrect api key|unauthor/i.test(detail)) {
+    return "The endpoint rejected the key (401). The base URL must match the key's provider — e.g. an OpenRouter key (sk-or-…) needs `--base-url https://openrouter.ai/api/v1`, not OpenAI's. Re-set with: prjct embeddings set --key <api-key> --base-url <url>"
+  }
+  if (/\b404\b|not found/i.test(detail)) {
+    return "No /embeddings route at that base URL (404). Check the base URL is the provider's OpenAI-compatible root (e.g. https://openrouter.ai/api/v1, https://api.openai.com/v1)."
+  }
+  if (/ENOTFOUND|ECONNREFUSED|fetch failed|getaddrinfo|ETIMEDOUT/i.test(detail)) {
+    return 'Could not reach the endpoint. Check the base URL and your network: prjct embeddings status'
+  }
+  return undefined
+}
 
 interface EmbeddingsOptions {
   md?: boolean
@@ -34,6 +52,13 @@ interface EmbeddingsOptions {
   key?: string
   model?: string
   baseUrl?: string
+  /** Auth knobs for non-Bearer providers (Azure OpenAI, custom gateways). */
+  authHeader?: string
+  authScheme?: string
+  /** Extra static headers as "k=v,k2=v2". */
+  headers?: string
+  /** Raw query string appended to the URL, e.g. "api-version=2023-05-15". */
+  query?: string
 }
 
 function flag(parts: string[], name: string): string | undefined {
@@ -41,6 +66,20 @@ function flag(parts: string[], name: string): string | undefined {
   if (i >= 0 && parts[i + 1]) return parts[i + 1]
   const eq = parts.find((p) => p.startsWith(`--${name}=`))
   return eq ? eq.slice(name.length + 3) : undefined
+}
+
+/** Parse a "k=v,k2=v2" header string into an object (skips malformed pairs). */
+function parseHeaderPairs(raw: string | undefined): Record<string, string> | undefined {
+  if (!raw?.trim()) return undefined
+  const out: Record<string, string> = {}
+  for (const pair of raw.split(',')) {
+    const eq = pair.indexOf('=')
+    if (eq <= 0) continue
+    const k = pair.slice(0, eq).trim()
+    const v = pair.slice(eq + 1).trim()
+    if (k) out[k] = v
+  }
+  return Object.keys(out).length ? out : undefined
 }
 
 export class EmbeddingsCommands extends PrjctCommandsBase {
@@ -73,9 +112,24 @@ export class EmbeddingsCommands extends PrjctCommandsBase {
     const key = options.key ?? flag(parts, 'key')
     const model = options.model ?? flag(parts, 'model')
     const baseUrl = options.baseUrl ?? flag(parts, 'base-url') ?? flag(parts, 'baseUrl')
-    if (!key && !model && !baseUrl) {
+    const authHeader = options.authHeader ?? flag(parts, 'auth-header')
+    // `none` (case-insensitive) → raw key, no scheme prefix (Azure's api-key).
+    const authSchemeRaw = options.authScheme ?? flag(parts, 'auth-scheme')
+    const authScheme =
+      authSchemeRaw === undefined ? undefined : /^none$/i.test(authSchemeRaw) ? '' : authSchemeRaw
+    const extraHeaders = parseHeaderPairs(options.headers ?? flag(parts, 'headers'))
+    const query = options.query ?? flag(parts, 'query')
+    if (
+      !key &&
+      !model &&
+      !baseUrl &&
+      authHeader === undefined &&
+      authScheme === undefined &&
+      !extraHeaders &&
+      query === undefined
+    ) {
       return failHard(
-        'Nothing to set. Usage: prjct embeddings set --key <api-key> [--model <id>] [--base-url <url>]'
+        'Nothing to set. Usage: prjct embeddings set --key <api-key> [--model <id>] [--base-url <url>] [--auth-header <h>] [--auth-scheme <s|none>] [--headers "k=v,..."] [--query <qs>]'
       )
     }
 
@@ -87,12 +141,25 @@ export class EmbeddingsCommands extends PrjctCommandsBase {
         return failHard(`Could not store the key securely: ${getErrorMessage(error)}`)
       }
     }
-    const settings = setGlobalEmbeddings({ model, baseUrl })
+    const settings = setGlobalEmbeddings({
+      model,
+      baseUrl,
+      authHeader,
+      authScheme,
+      extraHeaders,
+      query,
+    })
 
     out.done('Global embeddings configured (applies to all projects)')
     out.info(`provider: ${settings.provider}`)
     out.info(`model:    ${settings.model}`)
     out.info(`base URL: ${settings.baseUrl}`)
+    if (settings.authHeader) out.info(`auth hdr: ${settings.authHeader}`)
+    if (settings.authScheme !== undefined)
+      out.info(`auth:     ${settings.authScheme ? settings.authScheme : '(raw key, no scheme)'}`)
+    if (settings.query) out.info(`query:    ${settings.query}`)
+    if (settings.extraHeaders)
+      out.info(`headers:  ${Object.keys(settings.extraHeaders).join(', ')}`)
     if (location)
       out.info(
         `api key:  stored in ${location === 'keychain' ? 'macOS Keychain' : '~/.prjct-cli/config/embeddings.key (0600)'}`
@@ -116,18 +183,23 @@ export class EmbeddingsCommands extends PrjctCommandsBase {
     out.info(`provider: ${g.provider}`)
     out.info(`model:    ${g.model}`)
     out.info(`base URL: ${g.baseUrl}`)
+    if (g.authHeader) out.info(`auth hdr: ${g.authHeader}`)
+    if (g.authScheme !== undefined)
+      out.info(`auth:     ${g.authScheme ? g.authScheme : '(raw key, no scheme)'}`)
+    if (g.query) out.info(`query:    ${g.query}`)
+    if (g.extraHeaders) out.info(`headers:  ${Object.keys(g.extraHeaders).join(', ')}`)
     out.info(
       `api key:  ${loc === 'none' ? 'MISSING — set with `prjct embeddings set --key <api-key>`' : `present (${loc})`}`
     )
     return { success: true, configured: true }
   }
 
-  private async test(_options: EmbeddingsOptions): Promise<CommandResult> {
+  private async test(options: EmbeddingsOptions): Promise<CommandResult> {
     const provider = resolveActiveProvider(null)
     try {
       const [vector] = await provider.embed(['prjct embeddings connectivity probe'])
       if (!vector || vector.length === 0) {
-        return failHard(`Provider '${provider.model}' returned an empty vector.`)
+        return failHard(`Provider '${provider.model}' returned an empty vector.`, options)
       }
       out.done(`OK — '${provider.model}' returned a ${vector.length}-dim vector.`)
       if (provider.isLocal) {
@@ -137,9 +209,15 @@ export class EmbeddingsCommands extends PrjctCommandsBase {
       }
       return { success: true, model: provider.model, dims: vector.length }
     } catch (error) {
-      return failHard(
-        `Embedding failed for '${provider.model}': ${getErrorMessage(error)}. Check the key and base URL.`
-      )
+      // Headline only — out.fail truncates to ~65 chars. The full endpoint
+      // response and a targeted hint go through notifyInfo (no truncation), so
+      // the one command meant to diagnose connectivity doesn't hide the reason.
+      const detail = getErrorMessage(error)
+      notifyFail(`Embedding test failed for '${provider.model}'.`, options)
+      notifyInfo(detail, options)
+      const hint = embeddingsFailureHint(detail)
+      if (hint) notifyInfo(hint, options)
+      return { success: false, error: detail }
     }
   }
 

--- a/core/commands/embeddings.ts
+++ b/core/commands/embeddings.ts
@@ -13,6 +13,7 @@
 import {
   clearGlobalEmbeddings,
   DEFAULT_EMBEDDINGS_MODEL,
+  detectBaseUrlFromKey,
   resolveActiveProvider,
   resolveGlobalEmbeddings,
   setGlobalEmbeddings,
@@ -111,7 +112,18 @@ export class EmbeddingsCommands extends PrjctCommandsBase {
     // direct programmatic call (or a test) works the same way.
     const key = options.key ?? flag(parts, 'key')
     const model = options.model ?? flag(parts, 'model')
-    const baseUrl = options.baseUrl ?? flag(parts, 'base-url') ?? flag(parts, 'baseUrl')
+    let baseUrl = options.baseUrl ?? flag(parts, 'base-url') ?? flag(parts, 'baseUrl')
+    // Zero-config: infer the base URL from the key prefix (sk-or-… → OpenRouter,
+    // sk-… → OpenAI, …) so pasting just `--key` is enough. An explicit
+    // `--base-url` always wins; detection also fires when switching providers.
+    let detectedProvider: string | undefined
+    if (!baseUrl && key) {
+      const detected = detectBaseUrlFromKey(key)
+      if (detected) {
+        baseUrl = detected.baseUrl
+        detectedProvider = detected.provider
+      }
+    }
     const authHeader = options.authHeader ?? flag(parts, 'auth-header')
     // `none` (case-insensitive) → raw key, no scheme prefix (Azure's api-key).
     const authSchemeRaw = options.authScheme ?? flag(parts, 'auth-scheme')
@@ -151,6 +163,7 @@ export class EmbeddingsCommands extends PrjctCommandsBase {
     })
 
     out.done('Global embeddings configured (applies to all projects)')
+    if (detectedProvider) out.info(`detected: ${detectedProvider} (from key prefix)`)
     out.info(`provider: ${settings.provider}`)
     out.info(`model:    ${settings.model}`)
     out.info(`base URL: ${settings.baseUrl}`)

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -24,6 +24,7 @@ import type { DaemonRequest, DaemonResponse, DaemonState } from '../types/daemon
 import { executeCommand } from './dispatch'
 import { DAEMON_PATHS, encodeMessage, IDLE_TIMEOUT_MS, MAX_BUFFER_SIZE } from './protocol'
 import {
+  decideRestart,
   isCodeStale as detectStaleCode,
   isGlobalVersionDrifted,
   isProcessRunning,
@@ -35,13 +36,20 @@ import {
 /** Run WAL checkpoint every N requests to reclaim disk space */
 const WAL_CHECKPOINT_INTERVAL = 50
 
-/** Re-check global install version every N requests (cheap readlink+readFile) */
-const VERSION_DRIFT_CHECK_INTERVAL = 10
+/**
+ * Min interval between global-install version-drift checks. The mtime check is
+ * a single stat and runs on every request; drift does a few readlink+readFile,
+ * so we throttle it by TIME (not request count) — at most once per second. A
+ * time bound caps the staleness window to ~1s regardless of request rate,
+ * unlike a per-N-request counter which could serve N-1 stale commands.
+ */
+const VERSION_DRIFT_CHECK_MIN_MS = 1000
 
 let ipcServer: Server | null = null
 let commands: PrjctCommands | null = null
 let state: DaemonState | null = null
 let ownVersion: string | null = null
+let lastDriftCheckMs = 0
 
 // Serializes command execution. handleRequestInner patches the GLOBAL
 // console.log/error to capture a command's output; with concurrent socket
@@ -201,6 +209,40 @@ function handleConnection(socket: Socket): void {
   })
 }
 
+/**
+ * Decide — BEFORE serving — whether the loaded code is stale (a newer build or
+ * global install is on disk). Sets `restartPending`. Running this ahead of
+ * execution is the whole point: it guarantees a request is never answered by an
+ * outdated build (the previous design checked AFTER serving, so the request
+ * that first observed the new code was still served stale).
+ */
+function markStaleIfNeeded(command: string): void {
+  if (!state || state.restartPending) return
+
+  // Cheap (one stat): catches local rebuilds. The drift probe (readlink +
+  // readFile) is throttled inside decideRestart and skipped for health pings.
+  const codeStale = detectStaleCode(state.entryPath, state.entryMtime)
+  const decision = decideRestart({
+    codeStale,
+    command,
+    ownVersion,
+    now: Date.now(),
+    lastDriftCheckMs,
+    driftMinIntervalMs: VERSION_DRIFT_CHECK_MIN_MS,
+    checkDrift: isGlobalVersionDrifted,
+  })
+  lastDriftCheckMs = decision.lastDriftCheckMs
+
+  if (decision.restart) {
+    state.restartPending = true
+    console.log(
+      codeStale
+        ? 'Build change detected — daemon will restart; request runs on fresh code.'
+        : `Version drift detected — daemon v${ownVersion} is stale; request runs on fresh code.`
+    )
+  }
+}
+
 async function handleRequest(request: DaemonRequest): Promise<DaemonResponse> {
   if (!state || !commands) {
     return {
@@ -211,15 +253,26 @@ async function handleRequest(request: DaemonRequest): Promise<DaemonResponse> {
     }
   }
 
-  // If we already decided to restart, refuse new work so the client
-  // takes the direct path on its first try (instead of getting a
-  // dropped socket mid-request and falling through silently).
-  if (state.restartPending) {
+  // Detect staleness BEFORE serving so no request is ever answered by an
+  // outdated build.
+  markStaleIfNeeded(request.command)
+
+  // When stale, refuse real work and tell the client to run it directly on the
+  // fresh code (the `retry` flag). The request did NOT execute → zero side
+  // effects → the client falls through safely, no error shown to the user.
+  // Control commands (`daemon`, health `__ping`) still pass so `daemon
+  // stop`/`status` and liveness checks keep working while we drain.
+  if (state.restartPending && request.command !== 'daemon' && request.command !== '__ping') {
+    if (state.activeRequests === 0) {
+      console.log('Daemon shutting down for code reload...')
+      setImmediate(() => shutdown(0))
+    }
     return {
       id: request.id,
       success: false,
       exitCode: 1,
-      stderr: 'Daemon restarting — retry the command',
+      retry: true,
+      stderr: 'daemon code is stale — running directly',
     }
   }
 
@@ -264,27 +317,9 @@ async function handleRequestInner(request: DaemonRequest): Promise<DaemonRespons
     prjctDb.checkpointAll()
   }
 
-  // Stale-code detection: check if the entry file was rebuilt. Mark
-  // restart as pending and let the request finish.
-  if (!state.restartPending && detectStaleCode(state.entryPath, state.entryMtime)) {
-    console.log('Build changed detected — daemon will restart after this request')
-    state.restartPending = true
-  }
-
-  // Global-install drift detection: catches pnpm content-store upgrades
-  // where the old daemon's files are untouched but the user-facing `prjct`
-  // binary now points at a different version.
-  if (
-    !state.restartPending &&
-    ownVersion &&
-    state.commandsServed % VERSION_DRIFT_CHECK_INTERVAL === 0 &&
-    isGlobalVersionDrifted(ownVersion)
-  ) {
-    console.log(
-      `Version drift detected — daemon v${ownVersion} is stale; shutting down so the next request spawns fresh.`
-    )
-    state.restartPending = true
-  }
+  // NOTE: stale-code / version-drift detection happens in markStaleIfNeeded()
+  // BEFORE serving (see handleRequest) — never here, or the triggering request
+  // would be answered by the outdated build.
 
   if (request.command === 'daemon') return handleDaemonCommand(request)
 

--- a/core/daemon/staleness.ts
+++ b/core/daemon/staleness.ts
@@ -48,6 +48,35 @@ export function resolveEntryPath(): string | null {
   return null
 }
 
+/**
+ * Pure restart decision, separated from the fs-touching detectors so the
+ * ordering/throttle contract is unit-testable:
+ *   - a rebuilt entry file (cheap mtime check) always wins immediately;
+ *   - global-install drift is checked at most once per `driftMinIntervalMs`
+ *     (time-throttled, not request-counted) and skipped for health pings.
+ * The drift probe is injected (`checkDrift`) so tests don't touch the fs.
+ * Returns whether to restart plus the (possibly advanced) throttle timestamp.
+ */
+export function decideRestart(opts: {
+  codeStale: boolean
+  command: string
+  ownVersion: string | null
+  now: number
+  lastDriftCheckMs: number
+  driftMinIntervalMs: number
+  checkDrift: (ownVersion: string) => boolean
+}): { restart: boolean; lastDriftCheckMs: number } {
+  if (opts.codeStale) return { restart: true, lastDriftCheckMs: opts.lastDriftCheckMs }
+
+  if (opts.ownVersion && opts.command !== '__ping') {
+    if (opts.now - opts.lastDriftCheckMs >= opts.driftMinIntervalMs) {
+      return { restart: opts.checkDrift(opts.ownVersion), lastDriftCheckMs: opts.now }
+    }
+  }
+
+  return { restart: false, lastDriftCheckMs: opts.lastDriftCheckMs }
+}
+
 export function isCodeStale(entryPath: string | null, originalMtime: number | null): boolean {
   if (!entryPath || originalMtime === null) return false
 

--- a/core/index.ts
+++ b/core/index.ts
@@ -271,6 +271,10 @@ async function main(): Promise<void> {
             key: options.key ? String(options.key) : undefined,
             model: options.model ? String(options.model) : undefined,
             baseUrl: options['base-url'] ? String(options['base-url']) : undefined,
+            authHeader: options['auth-header'] ? String(options['auth-header']) : undefined,
+            authScheme: options['auth-scheme'] != null ? String(options['auth-scheme']) : undefined,
+            headers: options.headers ? String(options.headers) : undefined,
+            query: options.query ? String(options.query) : undefined,
           }),
         // Anticipation primitive (provider-agnostic; Codex/others call directly)
         guard: (p) =>

--- a/core/services/embeddings/global.ts
+++ b/core/services/embeddings/global.ts
@@ -14,6 +14,26 @@ import { getConfig, setConfig } from '../global-config'
 export const DEFAULT_EMBEDDINGS_BASE_URL = 'https://api.openai.com/v1'
 export const DEFAULT_EMBEDDINGS_MODEL = 'text-embedding-3-small'
 
+/**
+ * Infer the provider's base URL from an API-key prefix, so users can paste just
+ * `--key` and skip `--base-url`. API keys are provider-stamped at the prefix:
+ * `sk-or-…` is OpenRouter, `sk-ant-…` is Anthropic, etc. Returns undefined when
+ * the prefix isn't recognized (the caller keeps the existing/default base URL).
+ * Order matters — the OpenRouter/Anthropic prefixes are checked before the
+ * generic `sk-` (OpenAI) so they don't get misrouted.
+ */
+export function detectBaseUrlFromKey(
+  key: string
+): { baseUrl: string; provider: string } | undefined {
+  const k = key.trim()
+  if (/^sk-or-/i.test(k)) return { baseUrl: 'https://openrouter.ai/api/v1', provider: 'OpenRouter' }
+  if (/^sk-ant-/i.test(k)) return undefined // Anthropic has no /embeddings endpoint
+  if (/^(gsk_|gpg_)/i.test(k)) return undefined // Groq / others without embeddings
+  if (/^sk-/i.test(k)) return { baseUrl: 'https://api.openai.com/v1', provider: 'OpenAI' }
+  if (/^pa-/i.test(k)) return { baseUrl: 'https://api.voyageai.com/v1', provider: 'Voyage' }
+  return undefined
+}
+
 export interface GlobalEmbeddingsSettings {
   provider: 'openai-compatible'
   baseUrl: string
@@ -73,8 +93,9 @@ export function resolveGlobalEmbeddings(): GlobalEmbeddingsSettings | null {
 }
 
 /** Persist the global embeddings provider/model/baseUrl + auth (key handled
- *  apart). A field passed as `undefined` is left untouched; pass an empty
- *  string to clear an optional auth field. */
+ *  apart). Partial-update friendly: a field not provided is LEFT AS-IS (so
+ *  `set --key …` keeps your model/base URL); defaults apply only on first
+ *  config. Pass an empty string to clear an optional auth field. */
 export function setGlobalEmbeddings(opts: {
   baseUrl?: string
   model?: string
@@ -83,9 +104,15 @@ export function setGlobalEmbeddings(opts: {
   extraHeaders?: Record<string, string>
   query?: string
 }): GlobalEmbeddingsSettings {
+  const existing = resolveGlobalEmbeddings()
   setConfig(K_PROVIDER, 'openai-compatible')
-  setConfig(K_BASE_URL, opts.baseUrl?.trim() || DEFAULT_EMBEDDINGS_BASE_URL)
-  setConfig(K_MODEL, opts.model?.trim() || DEFAULT_EMBEDDINGS_MODEL)
+  // Only overwrite baseUrl/model when explicitly given; otherwise preserve the
+  // current value (or seed the default on first config). This stops a partial
+  // `set` from silently resetting an already-configured provider.
+  if (opts.baseUrl?.trim()) setConfig(K_BASE_URL, opts.baseUrl.trim())
+  else if (!existing) setConfig(K_BASE_URL, DEFAULT_EMBEDDINGS_BASE_URL)
+  if (opts.model?.trim()) setConfig(K_MODEL, opts.model.trim())
+  else if (!existing) setConfig(K_MODEL, DEFAULT_EMBEDDINGS_MODEL)
 
   // Optional auth knobs: only written when explicitly provided. Empty string
   // clears (deletes) the key; for authScheme, '' is meaningful (raw key) so we

--- a/core/services/embeddings/global.ts
+++ b/core/services/embeddings/global.ts
@@ -18,38 +18,89 @@ export interface GlobalEmbeddingsSettings {
   provider: 'openai-compatible'
   baseUrl: string
   model: string
+  /** Header carrying the key. Default `authorization`. `api-key` for Azure. */
+  authHeader?: string
+  /** Scheme/prefix before the key. Default `Bearer`. `''` = raw key. */
+  authScheme?: string
+  /** Extra static headers sent on every request. */
+  extraHeaders?: Record<string, string>
+  /** Raw query string appended to the URL, e.g. `api-version=2023-05-15`. */
+  query?: string
 }
 
 const K_PROVIDER = 'embeddings.provider'
 const K_BASE_URL = 'embeddings.baseUrl'
 const K_MODEL = 'embeddings.model'
+const K_AUTH_HEADER = 'embeddings.authHeader'
+const K_AUTH_SCHEME = 'embeddings.authScheme'
+const K_HEADERS = 'embeddings.headers' // JSON string of Record<string,string>
+const K_QUERY = 'embeddings.query'
+
+/** Parse the stored extra-headers JSON; never throw on malformed input. */
+function parseHeaders(raw: unknown): Record<string, string> | undefined {
+  if (typeof raw !== 'string' || !raw.trim()) return undefined
+  try {
+    const obj = JSON.parse(raw)
+    if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+      const out: Record<string, string> = {}
+      for (const [k, v] of Object.entries(obj)) out[k] = String(v)
+      return Object.keys(out).length ? out : undefined
+    }
+  } catch {
+    /* malformed — ignore, fall back to no extra headers */
+  }
+  return undefined
+}
 
 /** Current global embeddings settings, or null when BYOT isn't configured. */
 export function resolveGlobalEmbeddings(): GlobalEmbeddingsSettings | null {
   const provider = getConfig(K_PROVIDER)
   const model = getConfig(K_MODEL)
   if (provider !== 'openai-compatible' || !model) return null
+  // `?? 'Bearer'` (not `||`) so an explicit empty scheme (raw key) is preserved.
+  const authScheme = getConfig(K_AUTH_SCHEME)
+  const authHeader = getConfig(K_AUTH_HEADER)
+  const query = getConfig(K_QUERY)
   return {
     provider: 'openai-compatible',
     baseUrl: String(getConfig(K_BASE_URL) ?? DEFAULT_EMBEDDINGS_BASE_URL),
     model: String(model),
+    authHeader: authHeader != null ? String(authHeader) : undefined,
+    authScheme: authScheme != null ? String(authScheme) : undefined,
+    extraHeaders: parseHeaders(getConfig(K_HEADERS)),
+    query: query != null ? String(query) : undefined,
   }
 }
 
-/** Persist the global embeddings provider/model/baseUrl (key handled apart). */
+/** Persist the global embeddings provider/model/baseUrl + auth (key handled
+ *  apart). A field passed as `undefined` is left untouched; pass an empty
+ *  string to clear an optional auth field. */
 export function setGlobalEmbeddings(opts: {
   baseUrl?: string
   model?: string
+  authHeader?: string
+  authScheme?: string
+  extraHeaders?: Record<string, string>
+  query?: string
 }): GlobalEmbeddingsSettings {
-  const settings: GlobalEmbeddingsSettings = {
-    provider: 'openai-compatible',
-    baseUrl: opts.baseUrl?.trim() || DEFAULT_EMBEDDINGS_BASE_URL,
-    model: opts.model?.trim() || DEFAULT_EMBEDDINGS_MODEL,
+  setConfig(K_PROVIDER, 'openai-compatible')
+  setConfig(K_BASE_URL, opts.baseUrl?.trim() || DEFAULT_EMBEDDINGS_BASE_URL)
+  setConfig(K_MODEL, opts.model?.trim() || DEFAULT_EMBEDDINGS_MODEL)
+
+  // Optional auth knobs: only written when explicitly provided. Empty string
+  // clears (deletes) the key; for authScheme, '' is meaningful (raw key) so we
+  // store it literally rather than deleting.
+  if (opts.authHeader !== undefined) setConfig(K_AUTH_HEADER, opts.authHeader.trim() || undefined)
+  if (opts.authScheme !== undefined) setConfig(K_AUTH_SCHEME, opts.authScheme)
+  if (opts.query !== undefined) setConfig(K_QUERY, opts.query.trim() || undefined)
+  if (opts.extraHeaders !== undefined) {
+    const has = Object.keys(opts.extraHeaders).length > 0
+    setConfig(K_HEADERS, has ? JSON.stringify(opts.extraHeaders) : undefined)
   }
-  setConfig(K_PROVIDER, settings.provider)
-  setConfig(K_BASE_URL, settings.baseUrl)
-  setConfig(K_MODEL, settings.model)
-  return settings
+
+  const settings = resolveGlobalEmbeddings()
+  // resolveGlobalEmbeddings can't be null here — we just set provider+model.
+  return settings as GlobalEmbeddingsSettings
 }
 
 /** Forget the global embeddings settings (semantic falls back to local). */
@@ -57,4 +108,8 @@ export function clearGlobalEmbeddings(): void {
   setConfig(K_PROVIDER, undefined)
   setConfig(K_BASE_URL, undefined)
   setConfig(K_MODEL, undefined)
+  setConfig(K_AUTH_HEADER, undefined)
+  setConfig(K_AUTH_SCHEME, undefined)
+  setConfig(K_HEADERS, undefined)
+  setConfig(K_QUERY, undefined)
 }

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -58,30 +58,79 @@ export function resolveProvider(config: LocalConfig | null | undefined): Embeddi
   const e = config?.embeddings
   if (!e || !e.provider || !e.model) return null
   if (e.provider === 'openai-compatible') {
-    return new HttpEmbeddingProvider(e.baseUrl ?? 'https://api.openai.com/v1', e.model)
+    return new HttpEmbeddingProvider(e.baseUrl ?? 'https://api.openai.com/v1', e.model, {
+      authHeader: e.authHeader,
+      authScheme: e.authScheme,
+      extraHeaders: e.headers,
+      query: e.query,
+    })
   }
   return null
+}
+
+/**
+ * Auth/transport knobs so the OpenAI-compatible path reaches providers that
+ * deviate from the `Authorization: Bearer` default — Azure OpenAI (`api-key`
+ * header + `api-version` query), gateways needing extra static headers, etc.
+ * All optional; the defaults are exactly the OpenAI/OpenRouter/Ollama shape.
+ */
+export interface HttpAuthOptions {
+  /** Header that carries the API key. Default `authorization`. */
+  authHeader?: string
+  /** Scheme/prefix before the key, e.g. `Bearer`. Empty string = raw key
+   *  (Azure's `api-key: <key>`). Default `Bearer`. */
+  authScheme?: string
+  /** Extra static headers sent on every request. */
+  extraHeaders?: Record<string, string>
+  /** Raw query string appended to the URL, e.g. `api-version=2023-05-15`. */
+  query?: string
+}
+
+/**
+ * Build the `/embeddings` request (URL + fetch init) for an OpenAI-compatible
+ * endpoint. Pure and exported so the auth/header/query wiring is unit-testable
+ * without a network round-trip.
+ */
+export function buildEmbeddingsRequest(
+  baseUrl: string,
+  model: string,
+  texts: string[],
+  key: string | null,
+  auth: HttpAuthOptions = {}
+): { url: string; init: RequestInit } {
+  const root = baseUrl.replace(/\/+$/, '')
+  const q = auth.query?.trim().replace(/^\?/, '')
+  const url = `${root}/embeddings${q ? `?${q}` : ''}`
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    ...(auth.extraHeaders ?? {}),
+  }
+  if (key) {
+    const headerName = auth.authHeader?.trim() || 'authorization'
+    const scheme = auth.authScheme ?? 'Bearer'
+    headers[headerName] = scheme ? `${scheme} ${key}` : key
+  }
+
+  return {
+    url,
+    init: { method: 'POST', headers, body: JSON.stringify({ model, input: texts }) },
+  }
 }
 
 /** OpenAI-compatible `/embeddings` provider over `fetch` (no SDK). */
 export class HttpEmbeddingProvider implements EmbeddingProvider {
   constructor(
     private readonly baseUrl: string,
-    public readonly model: string
+    public readonly model: string,
+    private readonly auth: HttpAuthOptions = {}
   ) {}
 
   async embed(texts: string[]): Promise<number[][]> {
     if (texts.length === 0) return []
-    const url = `${this.baseUrl.replace(/\/$/, '')}/embeddings`
     const key = await getEmbeddingsKey()
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        ...(key ? { authorization: `Bearer ${key}` } : {}),
-      },
-      body: JSON.stringify({ model: this.model, input: texts }),
-    })
+    const { url, init } = buildEmbeddingsRequest(this.baseUrl, this.model, texts, key, this.auth)
+    const res = await fetch(url, init)
     if (!res.ok) {
       throw new Error(`embeddings endpoint ${res.status}: ${await res.text().catch(() => '')}`)
     }
@@ -179,7 +228,13 @@ export function resolveActiveProvider(config: LocalConfig | null | undefined): E
   const explicit = resolveProvider(config)
   if (explicit) return explicit
   const global = resolveGlobalEmbeddings()
-  if (global) return new HttpEmbeddingProvider(global.baseUrl, global.model)
+  if (global)
+    return new HttpEmbeddingProvider(global.baseUrl, global.model, {
+      authHeader: global.authHeader,
+      authScheme: global.authScheme,
+      extraHeaders: global.extraHeaders,
+      query: global.query,
+    })
   return new LocalSubwordEmbeddingProvider()
 }
 

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -30,6 +30,7 @@ export {
   clearGlobalEmbeddings,
   DEFAULT_EMBEDDINGS_BASE_URL,
   DEFAULT_EMBEDDINGS_MODEL,
+  detectBaseUrlFromKey,
   resolveGlobalEmbeddings,
   setGlobalEmbeddings,
 } from './global'

--- a/core/services/global-config.ts
+++ b/core/services/global-config.ts
@@ -12,8 +12,22 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-const CONFIG_DIR = path.join(os.homedir(), '.prjct-cli', 'config')
-const CONFIG_PATH = path.join(CONFIG_DIR, 'global.json')
+/**
+ * Resolve the config dir at call time. Honors `PRJCT_CLI_HOME` (the same
+ * override `system-database.ts` uses) so tests and alt-home installs redirect
+ * cleanly. Resolving lazily — not once at module load — matters because tests
+ * can't rely on `os.homedir()`: Bun ignores a mutated `process.env.HOME`, so a
+ * test that only patched HOME would silently read/write the user's REAL config.
+ */
+function configDir(): string {
+  const override = process.env.PRJCT_CLI_HOME?.trim()
+  const base = override ? path.resolve(override) : path.join(os.homedir(), '.prjct-cli')
+  return path.join(base, 'config')
+}
+
+function configFilePath(): string {
+  return path.join(configDir(), 'global.json')
+}
 
 type GlobalConfigValue = string | number | boolean
 
@@ -30,7 +44,7 @@ interface GlobalConfig {
 
 function readRaw(): GlobalConfig {
   try {
-    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8')
+    const raw = fs.readFileSync(configFilePath(), 'utf-8')
     const parsed = JSON.parse(raw)
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
       return parsed as GlobalConfig
@@ -41,8 +55,8 @@ function readRaw(): GlobalConfig {
 }
 
 function writeRaw(cfg: GlobalConfig): void {
-  fs.mkdirSync(CONFIG_DIR, { recursive: true })
-  fs.writeFileSync(CONFIG_PATH, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+  fs.mkdirSync(configDir(), { recursive: true })
+  fs.writeFileSync(configFilePath(), `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
 }
 
 export function getConfig<K extends keyof GlobalConfig>(key: K): GlobalConfig[K] {
@@ -65,5 +79,5 @@ export function unsetConfig(key: keyof GlobalConfig): void {
 }
 
 export function configPath(): string {
-  return CONFIG_PATH
+  return configFilePath()
 }

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -94,6 +94,15 @@ export interface LocalConfig {
     model?: string
     /** Expected vector dimensionality (used to invalidate stale vectors). */
     dims?: number
+    /** Header carrying the API key. Default `authorization` (Bearer). Set to
+     *  `api-key` for Azure OpenAI, or any custom header a gateway expects. */
+    authHeader?: string
+    /** Scheme/prefix before the key, e.g. `Bearer`. Empty string = raw key. */
+    authScheme?: string
+    /** Extra static headers sent on every request. */
+    headers?: Record<string, string>
+    /** Raw query string appended to the URL, e.g. `api-version=2023-05-15`. */
+    query?: string
   }
 }
 

--- a/core/types/daemon.ts
+++ b/core/types/daemon.ts
@@ -38,6 +38,13 @@ export interface DaemonResponse {
   stderr?: string
   /** Structured result (for --json mode) */
   result?: unknown
+  /**
+   * Set when the daemon refused the request because its code is stale (a
+   * newer build/install is on disk). The request was NOT executed, so there
+   * are zero side effects — the client must transparently fall through to
+   * direct in-process execution on the fresh code, NOT print this as an error.
+   */
+  retry?: boolean
 }
 
 /** Daemon status info returned by `daemon status` */

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -176,6 +176,13 @@ function generateDaemonShim() {
   //     misc network errors) MAY mean the daemon already started executing
   //     the request, so re-running can double-bump version / double-push.
   //   - On socket close before response: NEVER fall through — exit 1.
+  //   - On a `retry` response (daemon refused because its CODE IS STALE — the
+  //     request did NOT execute, so there are zero side effects): the generic
+  //     path re-runs DIRECTLY in-process (set PRJCT_NO_DAEMON=1 so the imported
+  //     core skips the dying daemon) on the fresh code; the hook path degrades
+  //     to the fail-soft `{}` no-op (it can't re-read consumed stdin, and a
+  //     hook is best-effort). This is the definitive fix for the recurring
+  //     stale-daemon trap — output is never served from an outdated build.
   //
   // This blocked the bin/prjct.ts hardening from commit d08727b8 from
   // reaching production for ~10 days (the shim is what end users actually
@@ -201,7 +208,7 @@ function sendHook(sub,data){
   const soft=()=>{if(!done){done=true;clearTimeout(t);sock.destroy();process.stdout.write("{}\\n");process.exit(0)}};
   const t=setTimeout(soft,5000);
   sock.on("connect",()=>sock.write(msg));
-  sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));done=true;clearTimeout(t);sock.end();if(r.stdout)process.stdout.write(r.stdout);process.exit(r.exitCode!=null?r.exitCode:0)}});
+  sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));if(r.retry){soft();return}done=true;clearTimeout(t);sock.end();if(r.stdout)process.stdout.write(r.stdout);process.exit(r.exitCode!=null?r.exitCode:0)}});
   sock.on("error",soft);
   sock.on("close",soft);
 }
@@ -215,7 +222,7 @@ if(cmd==="hook"&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
   const sock=connect(sockPath);let buf="",done=false;
   const t=setTimeout(()=>{if(!done){done=true;sock.destroy();refuse("timed out")}},30000);
   sock.on("connect",()=>sock.write(msg));
-  sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));done=true;clearTimeout(t);sock.end();if(r.stdout)console.log(r.stdout);if(r.stderr)console.error(r.stderr);process.exit(r.exitCode)}});
+  sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));done=true;clearTimeout(t);sock.end();if(r.retry){process.env.PRJCT_NO_DAEMON="1";fallback();return}if(r.stdout)console.log(r.stdout);if(r.stderr)console.error(r.stderr);process.exit(r.exitCode)}});
   sock.on("error",e=>{if(!done){done=true;clearTimeout(t);if(isSafeRetry(e))fallback();else refuse(e&&e.message||String(e))}});
   sock.on("close",()=>{if(!done){done=true;clearTimeout(t);refuse("Connection closed before response")}});
 }else{fallback()}


### PR DESCRIPTION
## Why

Two recurring user-facing problems, fixed at the root.

### 1. Daemon served stale code (the recurring trap)
After any rebuild/update the long-lived daemon kept answering with the **old code**:
- staleness was detected *after* deciding to serve → the triggering request was served stale;
- on refusal the client printed `Daemon restarting — retry the command` and exited 1 → the command never ran.

So every fix/update went: 1st cmd stale → 2nd fails → 3rd finally fresh.

**Fix:** detect staleness *before* serving (`markStaleIfNeeded`), refuse cleanly with a new `DaemonResponse.retry` signal, and have **both** `bin/prjct.ts` and the `scripts/build.js` daemon shim (what users actually run) fall through transparently to direct execution on fresh code. Hooks degrade to the fail-soft `{}` no-op. Drift check is now time-throttled (1s) instead of every-10-commands. Pure `decideRestart()` with unit tests. Closes gotcha mem_884.

### 2. Embeddings — support ANY provider
Already worked with any OpenAI-compatible endpoint (OpenAI, OpenRouter, Ollama, Together, Mistral, Voyage, Jina, LM Studio…). Now also covers **non-Bearer** providers — Azure OpenAI (`api-key` header + `api-version` query) and custom gateways — via `HttpAuthOptions` + pure `buildEmbeddingsRequest()` and new `set` flags (`--auth-header`, `--auth-scheme <s|none>`, `--headers`, `--query`). Default stays `Bearer`/`authorization`, so existing providers are unchanged.

Also: `embeddings test` no longer truncates the failure to 65 chars (`embeddings endpoi…`) — it prints the full response + an actionable hint.

## Tests
Full suite **1442 pass / 0 fail** (+15 new). Typecheck + biome clean. Daemon stale→retry→fresh verified end-to-end against an isolated daemon; embeddings verified live against OpenRouter (1536-dim) incl. custom-header round-trip; Azure auth shape covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)