### PR TITLE
feat: per-worktree active tasks — multi-agent runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,21 @@ These are enforced by lint/CI, not just convention:
   see `core/__tests__/storage/sqlite-migration.test.ts` for the pattern.
 - **Biome + lefthook** handle format on pre-commit. Run `bun run check:fix`
   to apply all Biome fixes at once.
+
+## Worktree cleanup (any agent)
+
+If you are working inside a git worktree (e.g. under `.worktrees/<slug>`), clean
+it up when you're done so worktrees don't accumulate on the local machine. This
+applies to **any** agent/LLM, not just Claude.
+
+- **Trigger: after the PR for the worktree's branch is *merged*** — not at
+  session end. An open or unmerged PR keeps its worktree (the work isn't landed
+  yet). Check with e.g. `gh pr view <branch> --json state`.
+- **Remove from the main worktree**, never from inside the worktree being removed
+  (git refuses to delete the worktree you're standing in): `cd` to the main repo,
+  then `git worktree remove <path>` followed by `git worktree prune`.
+- **Never remove a worktree with uncommitted or unpushed work.** Verify
+  `git status` is clean and `git rev-list @{u}..HEAD` is empty first. If in
+  doubt, leave it and clean up on a later pass once the PR is merged.
+- Do not `--force` a removal to override a dirty tree — that silently discards
+  work. A dirty/unpushed worktree means cleanup is not yet safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Multi-agent: per-worktree active tasks.** prjct's single-`currentTask` runtime now supports several AI agents working concurrently, each in its own git worktree, without clobbering a shared task. A deterministic `workspaceId` (derived from the git worktree root) keys each task into the existing `activeTasks[]` layer; the main worktree keeps the singular `currentTask` path, so single-agent use is unchanged. The single-task gate is now evaluated **per workspace** (a task in worktree A no longer blocks worktree B; a second task in the *same* worktree still gates), atomic inside the SQLite compare-and-set updater. Wiring lives at one choke point — `task-service` (`startTask`/`setTaskStatus`/`resolveActiveTask`/`completeActiveTask`) — inherited by the CLI, the MCP `prjct_task_*` tools, and `prjct ship`. Every read path (`prjct task`/`status` no-arg, `prjct remember` attribution, the session hooks, `prjct_task_status`, `prjct_workflow_status`) now resolves the **current worktree's** task and renders a workspace label (`shortId · branch`) plus a multi-workspace list, so it's always clear which worktree a task belongs to. Pause/resume **per worktree** is a planned follow-up (a child-worktree `prjct status paused` returns an explicit "unsupported" rather than a silent no-op); `done`/`ship` isolate correctly today.
+
 The long-lived daemon no longer serves stale code, and embeddings reach any provider.
 
 ### Fixed

--- a/core/__tests__/services/task-overview.test.ts
+++ b/core/__tests__/services/task-overview.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Multi-workspace task overview — the observable read side. Asserts that the
+ * main currentTask and child-worktree activeTasks[] are merged into one
+ * labelled, current-marked list (the output contract), driven off a real DB.
+ *
+ * `current` is resolved from the caller's projectPath. In tests the path is a
+ * plain temp dir (not a git worktree) so it derives to the `main` sentinel —
+ * which is exactly the single-agent / main-worktree case.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import type { WorkspaceTask } from '../../schemas/state'
+import { collectActiveTasks, formatActiveTaskList } from '../../services/task-overview'
+import { prjctDb } from '../../storage/database'
+import { stateStorage } from '../../storage/state-storage'
+
+let tmpRoot: string | null = null
+let projectId: string
+let projectPath: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-overview-'))
+  projectId = `test-ov-${Date.now()}`
+  projectPath = path.join(tmpRoot, 'work') // plain dir → main sentinel
+  await fs.mkdir(projectPath, { recursive: true })
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot!, id)
+  pathManager.getStoragePath = (id: string, f: string) => path.join(tmpRoot!, id, 'storage', f)
+  pathManager.getFilePath = (id: string, layer: string, f: string) =>
+    path.join(tmpRoot!, id, layer, f)
+  await fs.mkdir(pathManager.getStoragePath(projectId, ''), { recursive: true })
+  await fs.mkdir(path.join(tmpRoot!, projectId, 'sync'), { recursive: true })
+})
+
+afterEach(async () => {
+  prjctDb.close()
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  if (tmpRoot) {
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+    tmpRoot = null
+  }
+})
+
+describe('collectActiveTasks', () => {
+  it('empty → no current, empty list', async () => {
+    const ov = await collectActiveTasks(projectId, projectPath)
+    expect(ov.current).toBeNull()
+    expect(ov.all).toHaveLength(0)
+    expect(formatActiveTaskList(ov)).toBe('No active task.')
+  })
+
+  it('main currentTask is the current workspace; child tasks are listed as others', async () => {
+    await stateStorage.startTask(projectId, {
+      id: 'main-1',
+      description: 'main work',
+      sessionId: 's-main',
+    } as Parameters<typeof stateStorage.startTask>[1])
+    await stateStorage.startTaskInWorkspace(
+      projectId,
+      {
+        id: 'child-1',
+        description: 'child work',
+        sessionId: 's-child',
+        workspaceId: 'ws-child',
+        branch: 'feat/x',
+      } as Omit<WorkspaceTask, 'startedAt'>,
+      'ws-child'
+    )
+
+    const ov = await collectActiveTasks(projectId, projectPath)
+    expect(ov.current?.id).toBe('main-1')
+    expect(ov.current?.isCurrent).toBe(true)
+    expect(ov.all).toHaveLength(2)
+
+    const child = ov.all.find((v) => v.id === 'child-1')!
+    expect(child.isCurrent).toBe(false)
+    expect(child.shortId).toBe('ws-chi')
+    expect(child.label).toBe('ws-chi · feat/x')
+
+    // Current-first ordering + multi-workspace list rendering.
+    expect(ov.all[0]!.isCurrent).toBe(true)
+    const rendered = formatActiveTaskList(ov)
+    expect(rendered).toContain('Active tasks (2)')
+    expect(rendered).toContain('(this worktree)')
+  })
+})

--- a/core/__tests__/services/task-service-workspace.test.ts
+++ b/core/__tests__/services/task-service-workspace.test.ts
@@ -1,0 +1,148 @@
+/**
+ * End-to-end workspace routing for the read/complete helpers used by
+ * `prjct ship` and `prjct status`. Combines a REAL git worktree (so
+ * deriveWorkspace resolves a child workspaceId from the path) with a mocked
+ * storage path (so state persists under a temp projectId). Proves that
+ * resolveActiveTask / completeActiveTask target the worktree's own task.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { exec } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import pathManager from '../../infrastructure/path-manager'
+import type { WorkspaceTask } from '../../schemas/state'
+import { completeActiveTask, resolveActiveTask, setTaskStatus } from '../../services/task-service'
+import { deriveWorkspace } from '../../services/workspace-id'
+import { prjctDb } from '../../storage/database'
+import { stateStorage } from '../../storage/state-storage'
+
+const execAsync = promisify(exec)
+
+let tmpRoot: string
+let mainRepo: string
+let wt: string
+let projectId: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+beforeEach(async () => {
+  tmpRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-tsw-')))
+  projectId = `test-tsw-${Date.now()}`
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+  pathManager.getStoragePath = (id: string, f: string) => path.join(tmpRoot, id, 'storage', f)
+  pathManager.getFilePath = (id: string, layer: string, f: string) =>
+    path.join(tmpRoot, id, layer, f)
+  await fs.mkdir(pathManager.getStoragePath(projectId, ''), { recursive: true })
+  await fs.mkdir(path.join(tmpRoot, projectId, 'sync'), { recursive: true })
+
+  mainRepo = path.join(tmpRoot, 'repo')
+  await fs.mkdir(mainRepo, { recursive: true })
+  const git = (c: string, cwd: string) => execAsync(`git ${c}`, { cwd })
+  await git('init -q', mainRepo)
+  await git('config user.email t@t.io', mainRepo)
+  await git('config user.name t', mainRepo)
+  await fs.writeFile(path.join(mainRepo, 'f.txt'), 'x')
+  await git('add -A', mainRepo)
+  await git('commit -q -m init', mainRepo)
+  wt = path.join(tmpRoot, 'wt')
+  await git(`worktree add -q "${wt}" -b feat-wt`, mainRepo)
+})
+
+afterEach(async () => {
+  prjctDb.close()
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('resolve/completeActiveTask routing', () => {
+  it('resolves the child worktree task, isolated from the main task', async () => {
+    const ws = await deriveWorkspace(wt)
+    expect(ws.isMain).toBe(false)
+
+    // main task + this worktree's task
+    await stateStorage.startTask(projectId, {
+      id: 'main-1',
+      description: 'main',
+      sessionId: 's1',
+    } as Parameters<typeof stateStorage.startTask>[1])
+    await stateStorage.startTaskInWorkspace(
+      projectId,
+      {
+        id: 'wt-1',
+        description: 'wt work',
+        sessionId: 's2',
+        workspaceId: ws.workspaceId,
+        linkedSpecId: 'spec-xyz',
+      } as Omit<WorkspaceTask, 'startedAt'>,
+      ws.workspaceId
+    )
+
+    // From the worktree path → the worktree's task (with its spec linkage).
+    const fromWt = await resolveActiveTask(projectId, wt)
+    expect(fromWt?.id).toBe('wt-1')
+    expect(fromWt?.linkedSpecId).toBe('spec-xyz')
+
+    // From the main repo path → the main task.
+    const fromMain = await resolveActiveTask(projectId, mainRepo)
+    expect(fromMain?.id).toBe('main-1')
+  })
+
+  it('completing from the worktree removes only the worktree task', async () => {
+    const ws = await deriveWorkspace(wt)
+    await stateStorage.startTask(projectId, {
+      id: 'main-1',
+      description: 'main',
+      sessionId: 's1',
+    } as Parameters<typeof stateStorage.startTask>[1])
+    await stateStorage.startTaskInWorkspace(
+      projectId,
+      {
+        id: 'wt-1',
+        description: 'wt work',
+        sessionId: 's2',
+        workspaceId: ws.workspaceId,
+      } as Omit<WorkspaceTask, 'startedAt'>,
+      ws.workspaceId
+    )
+
+    const done = await completeActiveTask(projectId, wt)
+    expect(done?.id).toBe('wt-1')
+    expect(await resolveActiveTask(projectId, wt)).toBeNull()
+    // Main task untouched.
+    expect((await resolveActiveTask(projectId, mainRepo))?.id).toBe('main-1')
+  })
+
+  it('setTaskStatus: done completes the worktree task; paused is unsupported (no false success)', async () => {
+    const ws = await deriveWorkspace(wt)
+    await stateStorage.startTaskInWorkspace(
+      projectId,
+      {
+        id: 'wt-1',
+        description: 'wt work',
+        sessionId: 's2',
+        workspaceId: ws.workspaceId,
+      } as Omit<WorkspaceTask, 'startedAt'>,
+      ws.workspaceId
+    )
+
+    // paused/active not yet supported per-worktree → explicit unsupported,
+    // NOT a false ok that would leave the task wedged.
+    const paused = await setTaskStatus(projectId, wt, 'paused')
+    expect(paused.ok).toBe(false)
+    if (!paused.ok) expect(paused.reason).toBe('unsupported')
+    // Task is still active (not mutated by the failed pause).
+    expect((await resolveActiveTask(projectId, wt))?.id).toBe('wt-1')
+
+    // done works and clears it.
+    const done = await setTaskStatus(projectId, wt, 'done')
+    expect(done.ok).toBe(true)
+    expect(await resolveActiveTask(projectId, wt)).toBeNull()
+  })
+})

--- a/core/__tests__/services/workspace-id.test.ts
+++ b/core/__tests__/services/workspace-id.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Workspace identity derivation. Builds a REAL git repo + worktree in a temp
+ * dir so the git-common-dir detection runs for real (not mocked), then asserts
+ * the identity rules the multi-agent layer relies on: deterministic per
+ * worktree, distinct across worktrees, stable from a subdirectory, and the
+ * main-worktree sentinel.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { exec } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { deriveWorkspace, MAIN_WORKSPACE_ID } from '../../services/workspace-id'
+
+const execAsync = promisify(exec)
+
+let root: string
+let mainRepo: string
+let wtA: string
+let wtB: string
+
+beforeAll(async () => {
+  root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-ws-')))
+  mainRepo = path.join(root, 'repo')
+  await fs.mkdir(mainRepo, { recursive: true })
+
+  const git = (cmd: string, cwd: string) => execAsync(`git ${cmd}`, { cwd })
+  await git('init -q', mainRepo)
+  await git('config user.email t@t.io', mainRepo)
+  await git('config user.name test', mainRepo)
+  await fs.writeFile(path.join(mainRepo, 'f.txt'), 'hi')
+  await git('add -A', mainRepo)
+  await git('commit -q -m init', mainRepo)
+
+  wtA = path.join(root, 'wt-a')
+  wtB = path.join(root, 'wt-b')
+  await git(`worktree add -q "${wtA}" -b feat-a`, mainRepo)
+  await git(`worktree add -q "${wtB}" -b feat-b`, mainRepo)
+})
+
+afterAll(async () => {
+  await fs.rm(root, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('deriveWorkspace', () => {
+  test('main worktree → sentinel id, isMain', async () => {
+    const ws = await deriveWorkspace(mainRepo)
+    expect(ws.workspaceId).toBe(MAIN_WORKSPACE_ID)
+    expect(ws.isMain).toBe(true)
+    expect(ws.shortId).toBe(MAIN_WORKSPACE_ID)
+  })
+
+  test('child worktree → hashed id, not main', async () => {
+    const ws = await deriveWorkspace(wtA)
+    expect(ws.workspaceId).not.toBe(MAIN_WORKSPACE_ID)
+    expect(ws.isMain).toBe(false)
+    expect(ws.workspaceId).toHaveLength(16)
+    expect(ws.branch).toBe('feat-a')
+    expect(ws.label).toContain('feat-a')
+  })
+
+  test('deterministic — same worktree, same id', async () => {
+    const a1 = await deriveWorkspace(wtA)
+    const a2 = await deriveWorkspace(wtA)
+    expect(a1.workspaceId).toBe(a2.workspaceId)
+  })
+
+  test('distinct worktrees → distinct ids', async () => {
+    const a = await deriveWorkspace(wtA)
+    const b = await deriveWorkspace(wtB)
+    expect(a.workspaceId).not.toBe(b.workspaceId)
+  })
+
+  test('subdirectory of a worktree → same id as its root', async () => {
+    const sub = path.join(wtA, 'src', 'deep')
+    await fs.mkdir(sub, { recursive: true })
+    const rootWs = await deriveWorkspace(wtA)
+    const subWs = await deriveWorkspace(sub)
+    expect(subWs.workspaceId).toBe(rootWs.workspaceId)
+    expect(subWs.isMain).toBe(false)
+  })
+
+  test('non-git path → main sentinel (degrade, never throw)', async () => {
+    const plain = path.join(root, 'not-a-repo')
+    await fs.mkdir(plain, { recursive: true })
+    const ws = await deriveWorkspace(plain)
+    expect(ws.workspaceId).toBe(MAIN_WORKSPACE_ID)
+    expect(ws.isMain).toBe(true)
+  })
+})

--- a/core/__tests__/storage/state-storage-workspace-gate.test.ts
+++ b/core/__tests__/storage/state-storage-workspace-gate.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Per-workspace task isolation + gating (multi-agent parallel mode).
+ *
+ * Exercises the storage layer that the CLI/MCP write path now routes through
+ * for child worktrees: each workspaceId owns its slot in activeTasks[], the
+ * single-task gate is evaluated per workspace, and a main-worktree currentTask
+ * never leaks into a child workspace's lifecycle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import type { WorkspaceTask } from '../../schemas/state'
+import { prjctDb } from '../../storage/database'
+import { stateStorage } from '../../storage/state-storage'
+
+let tmpRoot: string | null = null
+let projectId: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-ws-gate-'))
+  projectId = `test-ws-${Date.now()}`
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot!, id)
+  pathManager.getStoragePath = (id: string, f: string) => path.join(tmpRoot!, id, 'storage', f)
+  pathManager.getFilePath = (id: string, layer: string, f: string) =>
+    path.join(tmpRoot!, id, layer, f)
+  await fs.mkdir(pathManager.getStoragePath(projectId, ''), { recursive: true })
+  await fs.mkdir(path.join(tmpRoot!, projectId, 'sync'), { recursive: true })
+})
+
+afterEach(async () => {
+  prjctDb.close()
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  if (tmpRoot) {
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+    tmpRoot = null
+  }
+})
+
+const task = (id: string, wsId: string): Omit<WorkspaceTask, 'startedAt'> =>
+  ({
+    id,
+    description: `task ${id}`,
+    sessionId: `sess-${id}`,
+    workspaceId: wsId,
+  }) as Omit<WorkspaceTask, 'startedAt'>
+
+describe('per-workspace gate + isolation', () => {
+  it('two workspaces can each hold an active task concurrently', async () => {
+    await stateStorage.startTaskInWorkspace(projectId, task('a', 'ws-a'), 'ws-a')
+    await stateStorage.startTaskInWorkspace(projectId, task('b', 'ws-b'), 'ws-b')
+
+    const active = await stateStorage.getActiveTasks(projectId)
+    expect(active.map((t) => t.workspaceId).sort()).toEqual(['ws-a', 'ws-b'])
+  })
+
+  it('a second task in the SAME workspace is gated', async () => {
+    await stateStorage.startTaskInWorkspace(projectId, task('a', 'ws-a'), 'ws-a')
+    await expect(
+      stateStorage.startTaskInWorkspace(projectId, task('a2', 'ws-a'), 'ws-a')
+    ).rejects.toThrow()
+  })
+
+  it('a main-worktree currentTask does NOT block a child workspace', async () => {
+    await stateStorage.startTask(projectId, {
+      id: 'main',
+      description: 'main task',
+      sessionId: 'sess-main',
+    } as Parameters<typeof stateStorage.startTask>[1])
+
+    // Should not throw — the child workspace is independent of currentTask.
+    await stateStorage.startTaskInWorkspace(projectId, task('a', 'ws-a'), 'ws-a')
+    const wsTask = await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-a')
+    expect(wsTask?.id).toBe('a')
+  })
+
+  it('addTokens accumulates against the named workspace only', async () => {
+    await stateStorage.startTaskInWorkspace(projectId, task('a', 'ws-a'), 'ws-a')
+    await stateStorage.startTaskInWorkspace(projectId, task('b', 'ws-b'), 'ws-b')
+
+    await stateStorage.addTokens(projectId, 10, 5, 'ws-a')
+    const r = await stateStorage.addTokens(projectId, 3, 2, 'ws-a')
+    expect(r).toEqual({ tokensIn: 13, tokensOut: 7 })
+
+    const a = await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-a')
+    const b = await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-b')
+    expect(a?.tokensIn).toBe(13)
+    expect(b?.tokensIn ?? 0).toBe(0) // ws-b untouched
+  })
+
+  it('updateWorkspaceTask merges by workspaceId', async () => {
+    await stateStorage.startTaskInWorkspace(projectId, task('a', 'ws-a'), 'ws-a')
+    const updated = await stateStorage.updateWorkspaceTask(projectId, 'ws-a', {
+      type: 'bug',
+    })
+    expect(updated?.type).toBe('bug')
+    expect((await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-a'))?.type).toBe('bug')
+  })
+
+  it('completing one workspace leaves the others untouched', async () => {
+    await stateStorage.startTaskInWorkspace(projectId, task('a', 'ws-a'), 'ws-a')
+    await stateStorage.startTaskInWorkspace(projectId, task('b', 'ws-b'), 'ws-b')
+
+    await stateStorage.completeTaskInWorkspace(projectId, 'ws-a')
+
+    expect(await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-a')).toBeNull()
+    expect((await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-b'))?.id).toBe('b')
+    // After completing its task, the workspace is idle → can start again.
+    await stateStorage.startTaskInWorkspace(projectId, task('a3', 'ws-a'), 'ws-a')
+    expect((await stateStorage.getCurrentTaskForWorkspace(projectId, 'ws-a'))?.id).toBe('a3')
+  })
+})

--- a/core/commands/guards.ts
+++ b/core/commands/guards.ts
@@ -10,8 +10,8 @@
 import configManager from '../infrastructure/config-manager'
 import type { CurrentTask } from '../schemas/state'
 import { projectService } from '../services/project-service'
+import { resolveActiveTask } from '../services/task-service'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
-import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { failWith } from '../utils/md-aware'
@@ -63,9 +63,13 @@ export async function requireProject(
  */
 export async function requireActiveTask(
   projectId: string,
-  options: MdOption = {}
+  options: MdOption = {},
+  projectPath: string = process.cwd()
 ): Promise<Guard<CurrentTask>> {
-  const active = await stateStorage.getCurrentTask(projectId)
+  // Workspace-aware: resolves the CURRENT worktree's task (main → currentTask,
+  // child worktree → its activeTasks[] slot) so the shared guard works for
+  // parallel agents, not just the main worktree.
+  const active = await resolveActiveTask(projectId, projectPath)
   if (!active) {
     return {
       ok: false,

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -12,7 +12,7 @@
 import { MEMORY_TYPES, type MemoryType, projectMemory } from '../memory/project-memory'
 import type { TaskType } from '../schemas/state'
 import { memoryService } from '../services/memory-service'
-import { readLastStatus, setTaskStatus } from '../services/task-service'
+import { readLastStatus, resolveActiveTask, setTaskStatus } from '../services/task-service'
 import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
@@ -48,8 +48,13 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       if (value) {
         const outcome = await setTaskStatus(pid.value, projectPath, value)
         if (!outcome.ok) {
+          if (outcome.reason === 'unsupported') {
+            if (options.md) console.log(`> ${outcome.message}`)
+            else out.fail(outcome.message)
+            return { success: false, error: outcome.message }
+          }
           // No active task and no paused task to resume — emit the uniform guard.
-          const task = await requireActiveTask(pid.value, options)
+          const task = await requireActiveTask(pid.value, options, projectPath)
           if (!task.ok) return task.result
           return { success: false, error: 'No active task' }
         }
@@ -62,7 +67,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       // No-arg `status` → informative display. When the task is paused there's
       // no `currentTask`; show the paused task rather than a bogus "no active
       // task" — the task exists, it just isn't the focus.
-      const current = await stateStorage.getCurrentTask(pid.value)
+      const current = await resolveActiveTask(pid.value, projectPath)
       if (!current) {
         const paused = await stateStorage.getPausedTasks(pid.value)
         if (paused.length > 0) {
@@ -74,7 +79,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
         }
       }
 
-      const task = await requireActiveTask(pid.value, options)
+      const task = await requireActiveTask(pid.value, options, projectPath)
       if (!task.ok) return task.result
 
       const active = task.value
@@ -106,7 +111,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result
 
-      const task = await requireActiveTask(pid.value, options)
+      const task = await requireActiveTask(pid.value, options, projectPath)
       if (!task.ok) return task.result
 
       if (!args) {
@@ -195,7 +200,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       // `remember` works even without an active task — you might be
       // capturing a fact before kicking off work. Just record without
       // source in that case.
-      const active = await stateStorage.getCurrentTask(pid.value)
+      const active = await resolveActiveTask(pid.value, projectPath)
 
       await projectMemory.remember(projectPath, {
         type,

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -14,9 +14,9 @@
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { syncService } from '../services/sync-service'
+import { completeActiveTask, resolveActiveTask } from '../services/task-service'
 import { prjctDb } from '../storage/database'
 import { shippedStorage } from '../storage/shipped-storage'
-import { stateStorage } from '../storage/state-storage'
 import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { CommandClarification, CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
@@ -86,11 +86,14 @@ export class ShippingCommands extends PrjctCommandsBase {
 
       let featureName = feature
 
-      const currentTask = await stateStorage.getCurrentTask(projectId)
+      // Resolve + complete the task for THIS worktree (main → currentTask,
+      // child worktree → its activeTasks[] slot) so parallel agents ship their
+      // own work without disturbing sibling worktrees.
+      const currentTask = await resolveActiveTask(projectId, projectPath)
       const linkedSpecId = currentTask?.linkedSpecId
       if (currentTask) {
         if (!featureName) featureName = currentTask.description || 'current work'
-        await stateStorage.completeTask(projectId)
+        await completeActiveTask(projectId, projectPath)
       }
       if (!featureName) featureName = 'current work'
 
@@ -402,7 +405,7 @@ async function buildClarification(
   }
 
   // Case 2 — steps are defined AND there's an active task → proceed.
-  const activeTask = await stateStorage.getCurrentTask(projectId)
+  const activeTask = await resolveActiveTask(projectId, projectPath)
   if (activeTask) return null
 
   // Case 3 — no active task but steps exist. Dangerous when there's a

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -15,9 +15,9 @@
  *   - md-helpers.ts    — buildFlowDiagram for `--md` output
  */
 
+import { collectActiveTasks } from '../services/task-overview'
 import { startTask } from '../services/task-service'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
-import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
@@ -73,7 +73,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const projectId = proj.value
 
       // No task arg → show the active one (or none).
-      if (!task) return this._showActiveTask(projectId, options)
+      if (!task) return this._showActiveTask(projectId, projectPath, options)
 
       // Side-effecting core lives in task-service so the MCP write-path
       // fires identical gates/state/memory without printing to stdout.
@@ -140,11 +140,23 @@ export class WorkflowCommands extends PrjctCommandsBase {
    */
   private async _showActiveTask(
     projectId: string,
+    projectPath: string,
     options: { md?: boolean }
   ): Promise<CommandResult> {
-    const active = await stateStorage.getCurrentTask(projectId)
+    const overview = await collectActiveTasks(projectId, projectPath)
+    const active = overview.current
+    const others = overview.all.filter((v) => !v.isCurrent)
+
     if (!active) {
-      const msg = 'no active task. `prjct task "<description>"` to start one.'
+      // Nothing in THIS worktree — but sibling worktrees may be busy.
+      const base = 'no active task. `prjct task "<description>"` to start one.'
+      const hint =
+        others.length > 0
+          ? `\n${others.length} active in other workspace(s):\n${others
+              .map((v) => `  ${v.label}    ${v.description}`)
+              .join('\n')}`
+          : ''
+      const msg = base + hint
       if (options.md) console.log(`> ${msg}`)
       else out.info(msg)
       return { success: true, message: 'no active task' }
@@ -158,16 +170,26 @@ export class WorkflowCommands extends PrjctCommandsBase {
             mdList(
               [
                 `Task: \`${active.id}\``,
+                `Workspace: \`${active.label}\``,
                 active.branch ? `Branch: \`${active.branch}\`` : null,
                 active.linearId ? `Linear: \`${active.linearId}\`` : null,
                 `Started: ${active.startedAt}`,
+                others.length > 0 ? `Other active workspaces: ${others.length}` : null,
               ].filter((s): s is string => s !== null)
             )
-          )
+          ),
+          others.length > 0
+            ? mdSection(
+                'Other Active Workspaces',
+                mdList(others.map((v) => `${v.label} — ${v.description}`))
+              )
+            : null
         )
       )
     } else {
       out.info(`Active: ${active.description}`)
+      out.info(`Workspace: ${active.label}`)
+      for (const v of others) out.info(`  other: ${v.label} — ${v.description}`)
     }
     return { success: true, currentTask: active }
   }

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -19,8 +19,8 @@
 import path from 'node:path'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
+import { collectActiveTasks } from '../services/task-overview'
 import { shippedStorage } from '../storage/shipped-storage'
-import { stateStorage } from '../storage/state-storage'
 import type { LocalConfig } from '../types/config'
 import { execFileAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
@@ -51,12 +51,21 @@ export async function buildProjectState(
   const lines: string[] = ['# prjct: project state']
   let hasContent = false
 
-  // Active task — most useful single fact.
+  // Active task — most useful single fact. Resolved PER worktree so a parallel
+  // agent sees its own task, not a sibling's. Falls back to singular outside a
+  // worktree.
   try {
-    const activeTask = await stateStorage.getCurrentTask(config.projectId)
-    if (activeTask) {
-      const startedAgo = formatRelative(activeTask.startedAt)
-      lines.push(`- Active task: "${activeTask.description}" (${startedAgo})`)
+    const overview = await collectActiveTasks(config.projectId, projectPath)
+    if (overview.current) {
+      const startedAgo = formatRelative(overview.current.startedAt)
+      lines.push(
+        `- Active task: "${overview.current.description}" (${startedAgo}) [${overview.current.label}]`
+      )
+      hasContent = true
+    }
+    const others = overview.all.filter((v) => !v.isCurrent)
+    if (others.length > 0) {
+      lines.push(`- ${others.length} task(s) active in other workspace(s)`)
       hasContent = true
     }
   } catch {

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -27,7 +27,6 @@ import { ingestTranscript } from '../services/transcript-learner'
 import { usefulnessService } from '../services/usefulness'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
-import { stateStorage } from '../storage/state-storage'
 import { type HookIo, runHook } from './_runner'
 
 interface HookInput {
@@ -108,8 +107,12 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
             // own — the explicit `corrects:` tag is now an optional override,
             // not a requirement.
             if (friction.signalsRecorded > 0) {
-              const task = await stateStorage.getCurrentTask(config.projectId)
-              if (task?.id) usefulnessService.penalizeSurfaced(config.projectId, task.id)
+              // Per-worktree: penalize memories surfaced for THIS workspace's
+              // task, not a sibling worktree's. Falls back to singular.
+              const { collectActiveTasks } = await import('../services/task-overview')
+              const overview = await collectActiveTasks(config.projectId, p)
+              const taskId = overview.current?.id
+              if (taskId) usefulnessService.penalizeSurfaced(config.projectId, taskId)
             }
           } catch {
             /* same contract as transcript-learner — silent best-effort */

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -11,10 +11,10 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
+import { collectActiveTasks } from '../../services/task-overview'
 import { setTaskStatus, startTask } from '../../services/task-service'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
 import { queueStorage } from '../../storage/queue-storage'
-import { stateStorage } from '../../storage/state-storage'
 import { resolveProjectId } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
@@ -33,16 +33,24 @@ export function registerProjectTools(server: McpServer) {
     },
     safeMcpCall('prjct_task_status', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
-      const current = await stateStorage.getCurrentTask(projectId)
+      const overview = await collectActiveTasks(projectId, args.projectPath)
       const queue = await queueStorage.getActiveTasks(projectId)
 
       const parts: string[] = []
-      if (current) {
-        parts.push(`## Active Task\n**${current.description}**`)
-        if (current.branch) parts.push(`Branch: ${current.branch}`)
-        parts.push(`Started: ${current.startedAt}`)
-      } else {
+      if (overview.all.length === 0) {
         parts.push('No active task.')
+      } else if (overview.all.length === 1 && overview.current) {
+        const v = overview.current
+        parts.push(`## Active Task\n**${v.description}**`)
+        parts.push(`Workspace: ${v.label}`)
+        if (v.branch) parts.push(`Branch: ${v.branch}`)
+        parts.push(`Started: ${v.startedAt}`)
+      } else {
+        parts.push(`## Active Tasks (${overview.all.length})`)
+        for (const v of overview.all) {
+          const here = v.isCurrent ? ' [this worktree]' : ''
+          parts.push(`-${here} ${v.label}: ${v.description} — started ${v.startedAt}`)
+        }
       }
 
       if (queue.length > 0) {

--- a/core/mcp/tools/workflow.ts
+++ b/core/mcp/tools/workflow.ts
@@ -7,7 +7,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { customWorkflowStorage } from '../../storage/custom-workflow-storage'
-import { stateStorage } from '../../storage/state-storage'
 import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
 import { resolveProjectId } from '../resolve'
 import { safeMcpCall } from './error-handler'
@@ -92,7 +91,10 @@ export function registerWorkflowTools(server: McpServer) {
     },
     safeMcpCall('prjct_workflow_status', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
-      const currentTask = await stateStorage.getCurrentTask(projectId)
+      // Workspace-aware: surface THIS worktree's task (main → currentTask,
+      // child worktree → its activeTasks[] slot), not just the main slot.
+      const { resolveActiveTask } = await import('../../services/task-service')
+      const currentTask = await resolveActiveTask(projectId, args.projectPath)
       const allRules = workflowRuleStorage.getAllRules(projectId)
 
       const parts: string[] = ['## Workflow Status']

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -182,6 +182,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '- Secret-like content is refused by `remember` and `capture` unless `--force`.',
     '- Bare `prjct "<text>"` routes to `capture` (inbox), not `task`. Use `prjct task` explicitly for work that needs a branch/worktree.',
     '- Hooks in `~/.claude/settings.json` already inject persona + topical memory on SessionStart / UserPromptSubmit — you rarely need to call prjct by hand at session start.',
+    "- **Worktree hygiene.** If you are working inside a git worktree, clean it up so they don't pile up on the local machine: AFTER the branch's PR is *merged* (not at session end — an open PR keeps its worktree), `git worktree remove <path>` + `git worktree prune`, run from the MAIN worktree (git won't remove the worktree you're standing in). NEVER remove a worktree with uncommitted or unpushed work, and never `--force` over a dirty tree (it silently discards work).",
     '',
   ].join('\n')
 }

--- a/core/services/task-overview.ts
+++ b/core/services/task-overview.ts
@@ -1,0 +1,112 @@
+/**
+ * Multi-workspace task overview — the read-side counterpart to task-service.
+ *
+ * One place that answers "what is active, and in which workspace?" so every
+ * surface (CLI `prjct task` no-arg + `prjct status`, the MCP prjct_task_status
+ * tool, and the session hooks) renders the SAME workspace-labelled view and
+ * agrees on which task belongs to the caller's worktree. This is what makes
+ * the per-workspace state observable instead of silently singular.
+ */
+
+import { stateStorage } from '../storage/state-storage'
+import { deriveWorkspace, MAIN_WORKSPACE_ID } from './workspace-id'
+
+export interface ActiveTaskView {
+  id: string
+  description: string
+  workspaceId: string
+  /** Short display id: `main` or the first 6 chars of the hash. */
+  shortId: string
+  /** `shortId · branch` — the workspace label rendered to users. */
+  label: string
+  branch?: string
+  /** Linear issue id when the task is linked (preserved for `--md` output). */
+  linearId?: string
+  startedAt: string
+  /** True when this task belongs to the caller's current worktree. */
+  isCurrent: boolean
+}
+
+export interface TaskOverview {
+  /** The caller's own workspace task, if any. */
+  current: ActiveTaskView | null
+  /** Every active task across the project, current-first. */
+  all: ActiveTaskView[]
+}
+
+function labelFor(workspaceId: string, branch?: string): { shortId: string; label: string } {
+  const shortId = workspaceId === MAIN_WORKSPACE_ID ? MAIN_WORKSPACE_ID : workspaceId.slice(0, 6)
+  return { shortId, label: `${shortId} · ${branch ?? '(detached)'}` }
+}
+
+/**
+ * Collect the active task for the caller's worktree plus every other active
+ * task in the project. `current` is resolved by deriving the caller's
+ * workspaceId from `projectPath`; the main worktree maps onto the singular
+ * currentTask, child worktrees onto their activeTasks[] slot.
+ */
+export async function collectActiveTasks(
+  projectId: string,
+  projectPath: string
+): Promise<TaskOverview> {
+  const ws = await deriveWorkspace(projectPath)
+  const views: ActiveTaskView[] = []
+
+  // Main worktree task (singular currentTask), surfaced as the `main` workspace.
+  const mainTask = await stateStorage.getCurrentTask(projectId)
+  if (mainTask) {
+    const { shortId, label } = labelFor(MAIN_WORKSPACE_ID, mainTask.branch)
+    views.push({
+      id: mainTask.id,
+      description: mainTask.description,
+      workspaceId: MAIN_WORKSPACE_ID,
+      shortId,
+      label,
+      branch: mainTask.branch,
+      linearId: mainTask.linearId,
+      startedAt: mainTask.startedAt,
+      isCurrent: ws.workspaceId === MAIN_WORKSPACE_ID,
+    })
+  }
+
+  // Child-worktree tasks (activeTasks[]). Defensive: skip any stray entry
+  // tagged as the main workspace so it can never double-count with currentTask.
+  for (const t of await stateStorage.getActiveTasks(projectId)) {
+    if (t.workspaceId === MAIN_WORKSPACE_ID) continue
+    const { shortId, label } = labelFor(t.workspaceId, t.branch)
+    views.push({
+      id: t.id,
+      description: t.description,
+      workspaceId: t.workspaceId,
+      shortId,
+      label,
+      branch: t.branch,
+      linearId: t.linearId,
+      startedAt: t.startedAt,
+      isCurrent: ws.workspaceId === t.workspaceId,
+    })
+  }
+
+  views.sort((a, b) => Number(b.isCurrent) - Number(a.isCurrent))
+  const current = views.find((v) => v.isCurrent) ?? null
+  return { current, all: views }
+}
+
+/** One-line plain-text rendering of a task with its workspace marker. */
+export function formatActiveTaskLine(v: ActiveTaskView): string {
+  const marker = v.isCurrent ? '→' : ' '
+  const here = v.isCurrent ? '  (this worktree)' : ''
+  return `${marker} ${v.label}    ${v.description}${here}`
+}
+
+/** Multi-workspace list view shared by `prjct status` and prjct_task_status. */
+export function formatActiveTaskList(overview: TaskOverview): string {
+  if (overview.all.length === 0) return 'No active task.'
+  if (overview.all.length === 1 && overview.current) {
+    const v = overview.current
+    return `Active: ${v.description}\n  Workspace: ${v.label}`
+  }
+  const lines = [`Active tasks (${overview.all.length})`]
+  for (const v of overview.all) lines.push(formatActiveTaskLine(v))
+  return lines.join('\n')
+}

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -18,12 +18,14 @@
 
 import { STATUS_CHANGE_ACTION } from '../memory/events'
 import { generateUUID } from '../schemas/schemas'
+import type { CurrentTask, TaskFeedback } from '../schemas/state'
 import { getGitBranch } from '../session/git-helpers'
 import { stateStorage } from '../storage/state-storage'
 import * as dateHelper from '../utils/date-helper'
 import { executeWorkflowRules } from '../workflow/workflow-engine'
 import { memoryService } from './memory-service'
 import projectService from './project-service'
+import { deriveWorkspace } from './workspace-id'
 
 /** Status values that mean "make this task the active one again". */
 const RESUME_VALUES = ['active', 'resume', 'in_progress', 'working']
@@ -70,13 +72,36 @@ export async function startTask(
 
   const taskId = generateUUID()
   const linkedSpecId = options.spec
-  await stateStorage.startTask(projectId, {
+
+  // Multi-agent: a task in a child worktree lands in activeTasks[] keyed by
+  // its workspaceId, so parallel agents don't clobber a shared currentTask.
+  // The main worktree keeps the singular currentTask path (transparent for
+  // single-agent use, and the backward-compatible mirror for read paths).
+  const ws = await deriveWorkspace(projectPath)
+  const taskFields = {
     id: taskId,
     description,
     sessionId: generateUUID(),
     linearId,
     linkedSpecId,
-  } as Parameters<typeof stateStorage.startTask>[1])
+  }
+  if (ws.isMain) {
+    await stateStorage.startTask(
+      projectId,
+      taskFields as Parameters<typeof stateStorage.startTask>[1]
+    )
+  } else {
+    await stateStorage.startTaskInWorkspace(
+      projectId,
+      {
+        ...taskFields,
+        branch: ws.branch,
+        workspaceId: ws.workspaceId,
+        worktreePath: ws.worktreePath,
+      } as Parameters<typeof stateStorage.startTaskInWorkspace>[1],
+      ws.workspaceId
+    )
+  }
 
   // Mirror the linkage on the spec side so `prjct spec show <id>` lists the
   // linked task. Best-effort — a missing spec just no-ops.
@@ -119,6 +144,8 @@ export type SetStatusOutcome =
   | { ok: true; taskId: string; status: string }
   /** No active task and no paused task to resume — caller emits the guard. */
   | { ok: false; reason: 'no-active-task' }
+  /** The transition isn't supported in this context — caller prints `message`. */
+  | { ok: false; reason: 'unsupported'; message: string }
 
 /**
  * Change the active task's status. Drives the real workflow state machine so
@@ -134,6 +161,39 @@ export async function setTaskStatus(
 ): Promise<SetStatusOutcome> {
   const normalized = value.toLowerCase()
   const resumeIntent = RESUME_VALUES.includes(normalized)
+
+  // Multi-agent: in a child worktree the status applies to THAT workspace's
+  // task in activeTasks[], isolated from other worktrees. The main worktree
+  // keeps the singular currentTask path below.
+  const ws = await deriveWorkspace(projectPath)
+  if (!ws.isMain) {
+    const wsTask = await stateStorage.getCurrentTaskForWorkspace(projectId, ws.workspaceId)
+    if (!wsTask) return { ok: false, reason: 'no-active-task' }
+
+    // `done` removes the task from this workspace (-> idle for this worktree),
+    // leaving every other workspace's task untouched.
+    if (normalized === 'done' || normalized === 'completed') {
+      const lastStatus = await readLastStatus(projectId, wsTask.id)
+      await memoryService.log(projectPath, STATUS_CHANGE_ACTION, {
+        taskId: wsTask.id,
+        from: lastStatus ?? null,
+        to: value,
+        workspaceId: ws.workspaceId,
+      })
+      await stateStorage.completeTaskInWorkspace(projectId, ws.workspaceId)
+      return { ok: true, taskId: wsTask.id, status: value }
+    }
+
+    // Pause/resume PER worktree needs a per-workspace paused store (planned
+    // follow-up). Returning an explicit `unsupported` — rather than a false
+    // success that mutates nothing — avoids leaving the worktree task wedged
+    // in `working` (which would then block the next `prjct task` here).
+    return {
+      ok: false,
+      reason: 'unsupported',
+      message: `'${value}' isn't supported for a worktree task yet — only 'done'. (pause/resume per-worktree is a planned follow-up)`,
+    }
+  }
 
   // Resume-intent bypasses the active-task guard: when the current task is
   // paused, there's no `currentTask` — promote a paused one first.
@@ -183,6 +243,36 @@ export async function setTaskStatus(
   }
 
   return { ok: true, taskId: active.id, status: value }
+}
+
+/**
+ * Resolve the active task for the CALLER's worktree — the main worktree's
+ * singular currentTask, or the child worktree's slot in activeTasks[]. Returns
+ * the full task (incl. linkedSpecId) so callers like `prjct ship` can read its
+ * spec linkage and description. Null when this workspace has no active task.
+ */
+export async function resolveActiveTask(
+  projectId: string,
+  projectPath: string
+): Promise<CurrentTask | null> {
+  const ws = await deriveWorkspace(projectPath)
+  if (ws.isMain) return stateStorage.getCurrentTask(projectId)
+  return stateStorage.getCurrentTaskForWorkspace(projectId, ws.workspaceId)
+}
+
+/**
+ * Complete the active task for the CALLER's worktree, routing to the singular
+ * (main) or per-workspace (child) completion so ship/done isolate correctly.
+ * Returns the completed task, or null when nothing was active.
+ */
+export async function completeActiveTask(
+  projectId: string,
+  projectPath: string,
+  feedback?: TaskFeedback
+): Promise<CurrentTask | null> {
+  const ws = await deriveWorkspace(projectPath)
+  if (ws.isMain) return stateStorage.completeTask(projectId, feedback)
+  return stateStorage.completeTaskInWorkspace(projectId, ws.workspaceId, feedback)
 }
 
 /**

--- a/core/services/workspace-id.ts
+++ b/core/services/workspace-id.ts
@@ -1,0 +1,152 @@
+/**
+ * Workspace identity — derive a stable, per-worktree `workspaceId` from a path.
+ *
+ * The multi-agent runtime keys each active task to a *workspace* so parallel
+ * agents (each in its own git worktree) don't clobber a single shared task.
+ * This is the ONE place that decides what a workspace is; the CLI, the MCP
+ * tools, and the hooks all derive identity here so there is zero drift.
+ *
+ * Identity rule (decision: key by git worktree):
+ *   - main worktree (or a non-git path) → the sentinel `MAIN_WORKSPACE_ID`.
+ *     Single-agent / single-worktree usage stays on this id, so it maps 1:1
+ *     onto the legacy singular `currentTask` and behaves exactly as before.
+ *   - a child worktree → `sha256Short(realpath(worktreeRoot))`. Realpath
+ *     normalizes symlinks and macOS `/var`↔`/private/var`, and using the
+ *     worktree ROOT (not the passed cwd) means any subdirectory of the
+ *     worktree resolves to the same id.
+ *
+ * The returned `label` is the human/agent-facing tag (short id · branch) that
+ * the output contract renders so it is always clear WHICH workspace a task
+ * belongs to.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { execFileAsync } from '../utils/exec'
+import { sha256Short } from '../utils/hash'
+
+/** Sentinel id for the main worktree (and any non-worktree path). */
+export const MAIN_WORKSPACE_ID = 'main'
+
+export interface WorkspaceContext {
+  /** Stable key: `MAIN_WORKSPACE_ID` or sha256Short(realpath(worktreeRoot)). */
+  workspaceId: string
+  /** Realpath'd worktree root, or the passed path when not a git worktree. */
+  worktreePath: string
+  /** Short display id: `'main'` or the first 6 chars of the hash. */
+  shortId: string
+  /** Current branch, or undefined when detached / unknown. */
+  branch?: string
+  /** True for the main worktree or a non-git path. */
+  isMain: boolean
+  /** Output-contract label, e.g. `fdf22d · feat/foo` or `main · trunk`. */
+  label: string
+}
+
+/** Realpath a path, falling back to the input when it can't be resolved. */
+async function safeRealpath(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p)
+  } catch {
+    return p
+  }
+}
+
+function buildLabel(shortId: string, branch?: string): string {
+  return `${shortId} · ${branch ?? '(detached)'}`
+}
+
+/**
+ * Per-path memo with a short TTL. `deriveWorkspace` runs on hot paths (the
+ * prompt hook fires every turn; the no-arg CLI/MCP status reads call it too),
+ * so we avoid a git fork per call. The workspaceId is path-derived and never
+ * changes, but the `branch`/`label` CAN change in a long-running MCP server
+ * when the user checks out a different branch — the TTL bounds that staleness
+ * to a few seconds while still collapsing bursts within a single turn.
+ */
+interface CacheEntry {
+  ctx: WorkspaceContext
+  at: number
+}
+const cache = new Map<string, CacheEntry>()
+const CACHE_TTL_MS = 5000
+
+/**
+ * Derive the workspace context for a given path (cwd or an MCP `projectPath`).
+ * Never throws — degrades to the main sentinel on any git/fs failure so the
+ * caller can always fall back to singular behavior.
+ *
+ * Uses a SINGLE `git rev-parse` invocation (multiple flags → multiple output
+ * lines) instead of several sequential forks, to stay cheap on the hot path.
+ */
+export async function deriveWorkspace(cwd: string): Promise<WorkspaceContext> {
+  const now = Date.now()
+  const cached = cache.get(cwd)
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.ctx
+
+  const ctx = await computeWorkspace(cwd)
+  cache.set(cwd, { ctx, at: now })
+  return ctx
+}
+
+async function computeWorkspace(cwd: string): Promise<WorkspaceContext> {
+  let toplevel = ''
+  let gitDir = ''
+  let commonDir = ''
+  let branch: string | undefined
+  try {
+    // One fork: rev-parse prints one line per flag, in order.
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--show-toplevel', '--git-dir', '--git-common-dir', '--abbrev-ref', 'HEAD'],
+      { cwd }
+    )
+    const [tl = '', gd = '', cd = '', br = ''] = stdout.trim().split('\n')
+    toplevel = tl.trim()
+    gitDir = gd.trim()
+    commonDir = cd.trim()
+    branch = br.trim() && br.trim() !== 'HEAD' ? br.trim() : undefined
+  } catch {
+    // Not a git repo / git missing → main sentinel on the raw path.
+    const worktreePath = await safeRealpath(cwd)
+    return {
+      workspaceId: MAIN_WORKSPACE_ID,
+      worktreePath,
+      shortId: MAIN_WORKSPACE_ID,
+      isMain: true,
+      label: buildLabel(MAIN_WORKSPACE_ID),
+    }
+  }
+
+  // A child worktree has a per-worktree git-dir distinct from the shared
+  // common-dir; in the main worktree they resolve to the same directory.
+  const isMain = path.resolve(cwd, gitDir) === path.resolve(cwd, commonDir)
+  const worktreePath = await safeRealpath(toplevel || cwd)
+
+  if (isMain) {
+    return {
+      workspaceId: MAIN_WORKSPACE_ID,
+      worktreePath,
+      shortId: MAIN_WORKSPACE_ID,
+      branch,
+      isMain: true,
+      label: buildLabel(MAIN_WORKSPACE_ID, branch),
+    }
+  }
+
+  const workspaceId = sha256Short(worktreePath)
+  const shortId = workspaceId.slice(0, 6)
+  return {
+    workspaceId,
+    worktreePath,
+    shortId,
+    branch,
+    isMain: false,
+    label: buildLabel(shortId, branch),
+  }
+}
+
+/** Convenience: just the id (most call sites only need the key). */
+export async function deriveWorkspaceId(cwd: string): Promise<string> {
+  return (await deriveWorkspace(cwd)).workspaceId
+}

--- a/core/storage/state-storage.ts
+++ b/core/storage/state-storage.ts
@@ -57,9 +57,18 @@ class StateStorage extends StorageManager<StateJson> {
   /**
    * Validate a state transition through the state machine.
    * Throws if the transition is invalid.
+   *
+   * When `workspaceId` is provided the lifecycle is evaluated PER workspace
+   * (multi-agent parallel mode): a task active in one worktree does not block
+   * starting one in another, but a second task in the SAME workspace still
+   * gates. Omitting it preserves the legacy singular (currentTask) gate.
    */
-  private validateTransition(state: StateJson, command: WorkflowCommand): void {
-    const currentState = workflowStateMachine.getCurrentState(state)
+  private validateTransition(
+    state: StateJson,
+    command: WorkflowCommand,
+    workspaceId?: string
+  ): void {
+    const currentState = workflowStateMachine.getCurrentState(state, workspaceId)
     const result = workflowStateMachine.canTransition(currentState, command)
     if (!result.valid) {
       throw new Error(`${result.error}. ${result.suggestion || ''}`.trim())
@@ -351,6 +360,10 @@ class StateStorage extends StorageManager<StateJson> {
     task: Omit<WorkspaceTask, 'startedAt'>,
     workspaceId: string
   ): Promise<WorkspaceTask> {
+    // Per-workspace gate: a task already active in THIS workspace blocks a new
+    // one (same as the singular path), but other workspaces are unaffected.
+    const state = await this.read(projectId)
+    this.validateTransition(state, 'task', workspaceId)
     return workspace.startTaskInWorkspace(this.workspaceBackend(), projectId, task, workspaceId)
   }
 
@@ -393,9 +406,10 @@ class StateStorage extends StorageManager<StateJson> {
   async addTokens(
     projectId: string,
     tokensIn: number,
-    tokensOut: number
+    tokensOut: number,
+    workspaceId?: string
   ): Promise<{ tokensIn: number; tokensOut: number } | null> {
-    return workspace.addTokens(this.workspaceBackend(), projectId, tokensIn, tokensOut)
+    return workspace.addTokens(this.workspaceBackend(), projectId, tokensIn, tokensOut, workspaceId)
   }
 
   // =========== Subtask Methods (delegated to ./state-storage/subtasks) ===========

--- a/core/storage/state-storage/workspace.ts
+++ b/core/storage/state-storage/workspace.ts
@@ -35,11 +35,20 @@ export async function startTaskInWorkspace(
     startedAt: getTimestamp(),
   }
 
-  await backend.update(projectId, (state) => ({
-    ...state,
-    activeTasks: [...(state.activeTasks || []), workspaceTask],
-    lastUpdated: getTimestamp(),
-  }))
+  await backend.update(projectId, (state) => {
+    // Atomic per-workspace gate: re-checked against the FRESH state inside the
+    // CAS updater, so two concurrent starts in the same workspace can't both
+    // win (the outer validateTransition gives the friendly message; this is
+    // the race-proof backstop that keeps activeTasks one-per-workspace).
+    if ((state.activeTasks || []).some((t) => t.workspaceId === workspaceId)) {
+      throw new Error('A task is already active in this workspace')
+    }
+    return {
+      ...state,
+      activeTasks: [...(state.activeTasks || []), workspaceTask],
+      lastUpdated: getTimestamp(),
+    }
+  })
 
   await backend.publish(projectId, 'task.started', {
     taskId: workspaceTask.id,
@@ -68,21 +77,28 @@ export async function completeTaskInWorkspace(
   feedback?: TaskFeedback
 ): Promise<WorkspaceTask | null> {
   const state = await backend.read(projectId)
-  const activeTasks = state.activeTasks || []
-  const task = activeTasks.find((t) => t.workspaceId === workspaceId)
+  const task = (state.activeTasks || []).find((t) => t.workspaceId === workspaceId)
   if (!task) return null
 
   const completedAt = getTimestamp()
-  const historyEntry = backend.createTaskHistoryEntry(task, completedAt, feedback)
-  const existingHistory = backend.getTaskHistoryFromState(state)
-  const taskHistory = [historyEntry, ...existingHistory].slice(0, backend.maxTaskHistory)
 
-  await backend.update(projectId, (s) => ({
-    ...s,
-    activeTasks: (s.activeTasks || []).filter((t) => t.workspaceId !== workspaceId),
-    taskHistory,
-    lastUpdated: completedAt,
-  }))
+  // Build the history entry + trimmed history INSIDE the CAS updater so a
+  // concurrent completion's retry re-applies against the freshest history
+  // (closing over an outer-read history would clobber the other completer).
+  await backend.update(projectId, (s) => {
+    const fresh = (s.activeTasks || []).find((t) => t.workspaceId === workspaceId) ?? task
+    const historyEntry = backend.createTaskHistoryEntry(fresh, completedAt, feedback)
+    const taskHistory = [historyEntry, ...backend.getTaskHistoryFromState(s)].slice(
+      0,
+      backend.maxTaskHistory
+    )
+    return {
+      ...s,
+      activeTasks: (s.activeTasks || []).filter((t) => t.workspaceId !== workspaceId),
+      taskHistory,
+      lastUpdated: completedAt,
+    }
+  })
 
   await backend.publish(projectId, 'task.completed', {
     taskId: task.id,
@@ -118,42 +134,70 @@ export async function updateWorkspaceTask(
   fields: Partial<WorkspaceTask>
 ): Promise<WorkspaceTask | null> {
   const state = await backend.read(projectId)
-  const activeTasks = state.activeTasks || []
-  const index = activeTasks.findIndex((t) => t.workspaceId === workspaceId)
-  if (index === -1) return null
+  const existing = (state.activeTasks || []).find((t) => t.workspaceId === workspaceId)
+  if (!existing) return null
 
-  const updated: WorkspaceTask = { ...activeTasks[index], ...fields, workspaceId }
+  // Merge by workspaceId INSIDE the updater (not by a stale positional index),
+  // so a concurrent insert/remove can't make the index point at the wrong row.
+  await backend.update(projectId, (s) => ({
+    ...s,
+    activeTasks: (s.activeTasks || []).map((t) =>
+      t.workspaceId === workspaceId ? { ...t, ...fields, workspaceId } : t
+    ),
+    lastUpdated: getTimestamp(),
+  }))
 
-  await backend.update(projectId, (s) => {
-    const tasks = [...(s.activeTasks || [])]
-    tasks[index] = updated
-    return { ...s, activeTasks: tasks, lastUpdated: getTimestamp() }
-  })
-
-  return updated
+  return { ...existing, ...fields, workspaceId }
 }
 
 export async function addTokens(
   backend: WorkspaceBackend,
   projectId: string,
   tokensIn: number,
-  tokensOut: number
+  tokensOut: number,
+  workspaceId?: string
 ): Promise<{ tokensIn: number; tokensOut: number } | null> {
   const state = await backend.read(projectId)
+
+  // Deltas are summed INSIDE the updater against the freshest token totals, so
+  // concurrent flushes accumulate instead of clobbering (closing over an
+  // outer-read sum would lose the other writer's tokens on CAS retry). The
+  // committed total is captured from the winning updater run.
+
+  // Multi-agent: accumulate against the named workspace's task in activeTasks[].
+  // Without a workspaceId (or for the main worktree) accumulate on currentTask.
+  // This avoids the silent no-op where a child-worktree task has no currentTask.
+  if (workspaceId) {
+    if (!(state.activeTasks || []).some((t) => t.workspaceId === workspaceId)) return null
+    let result: { tokensIn: number; tokensOut: number } | null = null
+    await backend.update(projectId, (s) => ({
+      ...s,
+      activeTasks: (s.activeTasks || []).map((t) => {
+        if (t.workspaceId !== workspaceId) return t
+        const newIn = (t.tokensIn || 0) + tokensIn
+        const newOut = (t.tokensOut || 0) + tokensOut
+        result = { tokensIn: newIn, tokensOut: newOut }
+        return { ...t, tokensIn: newIn, tokensOut: newOut }
+      }),
+      lastUpdated: getTimestamp(),
+    }))
+    return result
+  }
+
   if (!state.currentTask) return null
 
-  const newIn = (state.currentTask.tokensIn || 0) + tokensIn
-  const newOut = (state.currentTask.tokensOut || 0) + tokensOut
+  let result: { tokensIn: number; tokensOut: number } | null = null
+  await backend.update(projectId, (s) => {
+    if (!s.currentTask) return s
+    const newIn = (s.currentTask.tokensIn || 0) + tokensIn
+    const newOut = (s.currentTask.tokensOut || 0) + tokensOut
+    result = { tokensIn: newIn, tokensOut: newOut }
+    return {
+      ...s,
+      currentTask: { ...s.currentTask, tokensIn: newIn, tokensOut: newOut },
+      lastUpdated: getTimestamp(),
+    }
+  })
 
-  await backend.update(projectId, (s) => ({
-    ...s,
-    currentTask: {
-      ...s.currentTask!,
-      tokensIn: newIn,
-      tokensOut: newOut,
-    },
-    lastUpdated: getTimestamp(),
-  }))
-
-  return { tokensIn: newIn, tokensOut: newOut }
+  return result
 }

--- a/core/workflow/state-machine.ts
+++ b/core/workflow/state-machine.ts
@@ -71,16 +71,19 @@ export class WorkflowStateMachine {
     },
     workspaceId?: string
   ): WorkflowState {
-    // Multi-agent mode: look up task by workspaceId in activeTasks
-    let task: Record<string, unknown> | null | undefined = null
-    if (workspaceId && storageState?.activeTasks?.length) {
-      task = storageState.activeTasks.find((t) => t.workspaceId === workspaceId)
+    // Multi-agent mode: a workspace's lifecycle is resolved PURELY from its own
+    // task in activeTasks[]. We deliberately do NOT fall back to the singular
+    // currentTask here — that belongs to the main worktree, and letting it leak
+    // in would make a main-worktree task block sibling worktrees. No task for
+    // this workspace ⇒ idle ⇒ `prjct task` is allowed.
+    if (workspaceId) {
+      const wsTask = (storageState?.activeTasks ?? []).find((t) => t.workspaceId === workspaceId)
+      if (!wsTask) return 'idle'
+      return this.statusToState(wsTask)
     }
 
-    // Fallback to single-task mode
-    if (!task) {
-      task = storageState?.currentTask
-    }
+    // Single-task (legacy / main worktree) mode.
+    const task: Record<string, unknown> | null | undefined = storageState?.currentTask
 
     if (!task) {
       // Check if there are paused tasks (array or legacy previousTask)
@@ -90,6 +93,12 @@ export class WorkflowStateMachine {
       return hasPaused ? 'paused' : 'idle'
     }
 
+    return this.statusToState(task)
+  }
+
+  /** Map a task's `status` field to a workflow state (a present task with no
+   * explicit status is treated as `working`). */
+  private statusToState(task: Record<string, unknown>): WorkflowState {
     const status = (typeof task.status === 'string' ? task.status : '').toLowerCase()
 
     switch (status) {
@@ -104,7 +113,7 @@ export class WorkflowStateMachine {
       case 'shipped':
         return 'shipped'
       default:
-        return task ? 'working' : 'idle'
+        return 'working'
     }
   }
 

--- a/templates/antigravity/SKILL.md
+++ b/templates/antigravity/SKILL.md
@@ -18,3 +18,4 @@ Rules:
 - All commits include footer: `Generated with [p/](https://www.prjct.app/)`
 - All storage through `prjct` CLI (SQLite internally)
 - Start code tasks with `p. task` and follow Context Contract from CLI output
+- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -10,6 +10,7 @@ Run `prjct <command> --md` and follow its output. Pull context on demand; never 
 - Flow: `task` → work → `done` → `ship`
 - Memory: `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct context memory <topic>` (recall), `prjct guard <file>` (preventive memory before editing)
 - Capture stray thoughts: `prjct capture "<text>"`
+- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`.
 - Run `prjct --help` for the full command list; prefer the prjct MCP tools (`prjct_*`) when available.
 
 Commit footer: `Generated with [p/](https://www.prjct.app/)`

--- a/templates/global/ANTIGRAVITY.md
+++ b/templates/global/ANTIGRAVITY.md
@@ -13,6 +13,7 @@ Data:
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)
+- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`
 
 Crew (opt-in via `prjct crew install`): Leader (blue) · Implementer (purple) · Reviewer (pink). Subagent dispatch is Claude-Code-only; in Antigravity, identify the role you are playing explicitly.
 

--- a/templates/global/CURSOR.mdc
+++ b/templates/global/CURSOR.mdc
@@ -18,6 +18,7 @@ Data:
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)
+- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`
 
 Crew (opt-in via `prjct crew install`): Leader (blue) · Implementer (purple) · Reviewer (pink). Subagent dispatch is Claude-Code-only; in Cursor, identify the role you are playing explicitly.
 

--- a/templates/global/GEMINI.md
+++ b/templates/global/GEMINI.md
@@ -13,6 +13,7 @@ Data:
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)
+- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`
 
 Crew (opt-in via `prjct crew install`): Leader (blue) · Implementer (purple) · Reviewer (pink). Subagent dispatch is Claude-Code-only; in Gemini, identify the role you are playing explicitly.
 

--- a/templates/global/WINDSURF.md
+++ b/templates/global/WINDSURF.md
@@ -18,6 +18,7 @@ Data:
 - Commit footer: `Generated with [p/](https://www.prjct.app/)`
 - Path resolution: `.prjct/prjct.config.json` → `~/.prjct-cli/projects/{projectId}`
 - Storage: `prjct` CLI (SQLite internally)
+- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`
 
 Crew (opt-in via `prjct crew install`): Leader (blue) · Implementer (purple) · Reviewer (pink). Subagent dispatch is Claude-Code-only; in Windsurf, identify the role you are playing explicitly.
 


### PR DESCRIPTION
## What & why

prjct was designed around **one active task at a time**. Reality shifted: multiple AI agents now work concurrently, each in its own git worktree, all sharing one project — and they clobber the single `currentTask`. This activates the already-built-but-dormant `activeTasks[]`/`WorkspaceTask` layer so each worktree gets its own active task, with shared memory/vault. **Not a rewrite — wiring.**

Spec: `d5b3d3d6` (drafted → audit-spec'd by 3 reviewers → reviewed).

## How

- **`workspace-id`** (new): deterministic `workspaceId` from the git worktree root — one `git rev-parse`, 5s-TTL cache. Main worktree → `main` sentinel (single-agent path unchanged).
- **`task-service`** is the single choke point (`startTask`/`setTaskStatus`/`resolveActiveTask`/`completeActiveTask`), inherited by the CLI, the MCP `prjct_task_*` tools, and `prjct ship`.
- **Per-workspace single-task gate**, made **atomic inside the SQLite CAS updater** (no TOCTOU).
- **All read paths workspace-aware**: `prjct task`/`status` (no-arg), `prjct remember` attribution, `requireActiveTask`, the session hooks, `prjct_task_status`, `prjct_workflow_status` — each resolves the *current worktree's* task and renders a workspace label (`shortId · branch`) + a multi-workspace list (the output contract).
- **`workspace.ts` mutations made CAS-pure** (compute inside the updater) — found by adversarial review; prevents lost updates on retry.

## Verification

- **20 new tests** (workspace-id derivation, per-workspace gate/isolation, CAS-pure addTokens/updateWorkspaceTask, ship/status routing, `setTaskStatus` unsupported). 767 pass / 0 fail across the relevant suite; **typecheck + `biome check core` clean.**
- Concurrency relies on the **existing** `StorageManager.update` 8-attempt CAS over WAL/busy_timeout (no new lock — confirmed by audit).

## Deferred (follow-up)

- **Pause/resume per worktree** — needs a per-workspace paused store. Today a child-worktree `prjct status paused` returns an explicit `unsupported` (never a silent no-op that would wedge the task). `done`/`ship` isolate correctly.
- Version bump / release intentionally **not** done on this feature branch — happens at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)