### PR TITLE
feat: LLM-first surface — untruncated agent output, subagent digest, skill-miss loop, indexed recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+LLM-first surface pass: everything an agent reads from prjct — errors, hook context, MCP output, semantic recall — got sharper and cheaper.
+
+### Added
+- **Subagent context digest.** Spawned subagents used to receive the persona block only and re-investigated facts the main session already knew. The `SubagentStart` hook now injects a compact digest: role + the active task for *this worktree* + the top 2 preventive traps, capped at 500 chars. Variable content is safe here because SubagentStart emits via `systemMessage`, outside the cached prompt prefix.
+- **One-line trap cue on prompts.** The per-turn state hook stays PULL-not-PUSH for decisions/learnings/facts, with one exception: when the prompt's keywords BM25-match a `gotcha`/`anti-pattern`, a single `> Trap on this topic:` line rides along with the state block — the same preventive class the pre-edit guard pushes, because a trap only helps *before* it's stepped in.
+- **Skill-miss feedback loop closed.** The Stop-hook detector already recorded "relevant but never referenced" knowledge as improvement-signals; now those signals act. Write side: each miss cancels the automatic `relates:` reference credit and nets the missed entry −0.3 usefulness (a miss is not usage). Read side: the cold-start digest gains a **Keeps being missed** slot for the entry flagged ≥2×, so chronically-missed knowledge gets pushed in front of the agent instead of accumulating silently.
+
+### Changed
+- **No more truncated output for agents.** `out.fail`/`done`/`warn` truncated to 65–80 chars unconditionally; in non-TTY contexts (pipes, agents, CI) messages now pass through untruncated. Human TTY behavior unchanged.
+- **MCP server instructions trimmed ~3×.** The SDD canonical-sequence block duplicated the `prjct_spec_*` tool descriptions verbatim on every MCP turn and contradicted the skill's default-DIRECT routing; the instructions are back to the anti-harness shape (use-when + what's-here + gotchas). `prjct_task_set_status` now surfaces the real "unsupported transition" message instead of a generic no-active-task line.
+
+### Performance
+- **`recallForFile` is indexed.** The `prjct guard` / pre-edit lookup overfetched 500 recall rows and filtered by the `file` tag in JS. Migration 27 adds a virtual generated `file_tag` column (+ partial index) on `events`, so the lookup touches only file-tagged remember rows.
+- **Semantic search is bounded and norm-cached.** Migration 28 stores each vector's L2 norm at write time (backfilled), turning per-row cosine into a dot product; the scan is capped at the 2000 newest vectors per model. Still zero native deps — no sqlite-vec.
+
 ## [2.41.0] - 2026-06-09
 
 Memory recall + apply-loop: prjct now *applies* what it learns at the moment it matters, not just on demand — and the knowledge survives model updates.

--- a/core/__tests__/hooks/prompt.test.ts
+++ b/core/__tests__/hooks/prompt.test.ts
@@ -15,7 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { buildProjectState } from '../../hooks/prompt'
+import { buildProjectState, buildTopicalCue } from '../../hooks/prompt'
 import configManager from '../../infrastructure/config-manager'
 import pathManager from '../../infrastructure/path-manager'
 import prjctDb from '../../storage/database'
@@ -109,5 +109,53 @@ describe('UserPromptSubmit — project state', () => {
     const r = await buildProjectState(projectPath)
     expect(r).not.toBeNull()
     expect(r).toContain('# prjct: project state')
+  })
+})
+
+describe('UserPromptSubmit — topical trap cue', () => {
+  function seedMirror(id: string, type: string, content: string): void {
+    const now = new Date().toISOString()
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memories
+         (id, project_id, title, content, tags, type, provenance, user_triggered,
+          created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      id,
+      projectId,
+      content.slice(0, 80),
+      content,
+      '{}',
+      type,
+      'declared',
+      0,
+      now,
+      now
+    )
+  }
+
+  it('surfaces ONE gotcha when prompt keywords match', async () => {
+    await freshProject()
+    seedMirror('mem_1', 'gotcha', 'the daemon caches stale hook code until restarted')
+    seedMirror('mem_2', 'gotcha', 'embeddings clear also wipes the keychain key')
+    const cue = buildTopicalCue(projectId, 'why is the daemon serving stale responses?')
+    expect(cue).not.toBeNull()
+    expect(cue).toContain('Trap on this topic')
+    expect(cue).toContain('mem_1')
+    expect(cue).not.toContain('mem_2')
+  })
+
+  it('ignores non-preventive types even when they match', async () => {
+    await freshProject()
+    seedMirror('mem_3', 'decision', 'we chose a daemon architecture for warm starts')
+    const cue = buildTopicalCue(projectId, 'tell me about the daemon architecture')
+    expect(cue).toBeNull()
+  })
+
+  it('returns null when nothing matches', async () => {
+    await freshProject()
+    seedMirror('mem_4', 'gotcha', 'biome resolves zero files inside a git worktree')
+    const cue = buildTopicalCue(projectId, 'completely unrelated cooking recipe question')
+    expect(cue).toBeNull()
   })
 })

--- a/core/__tests__/hooks/session-start.test.ts
+++ b/core/__tests__/hooks/session-start.test.ts
@@ -178,6 +178,52 @@ describe('SessionStart hook — knowledge digest (cold-start only)', () => {
     expect(ctx).toBeNull()
   })
 
+  test('digest surfaces an entry skill-missed ≥2× (feedback loop read side)', async () => {
+    await freshProject({ role: 'DEV' })
+    insertMemory('learning', 'embeddings clear deletes the keychain key — use set to keep it')
+    const row = prjctDb.get<{ id: number }>(projectId, 'SELECT MAX(id) AS id FROM events')
+    const memId = `mem_${row?.id}`
+    for (let i = 0; i < 2; i++) {
+      prjctDb.run(
+        projectId,
+        "INSERT INTO events (type, data, timestamp) VALUES (?, ?, datetime('now'))",
+        'memory.remember.improvement-signal',
+        JSON.stringify({
+          content: `[skill-miss] Unused project knowledge (learning, ${memId})`,
+          tags: { kind: 'skill-miss', source: 'skill-miss-detector', relates: memId, key: `k${i}` },
+          provenance: 'extracted',
+        })
+      )
+    }
+    const ctx = await buildSessionContext(projectPath, null, { digest: true })
+    expect(ctx).toContain('Keeps being missed')
+    expect(ctx).toContain(memId)
+    expect(ctx).toContain('2×')
+  })
+
+  test('a single skill-miss does NOT earn a digest slot (threshold is 2)', async () => {
+    await freshProject({ role: 'DEV' })
+    insertMemory('learning', 'embeddings clear deletes the keychain key — use set to keep it')
+    const row = prjctDb.get<{ id: number }>(projectId, 'SELECT MAX(id) AS id FROM events')
+    prjctDb.run(
+      projectId,
+      "INSERT INTO events (type, data, timestamp) VALUES (?, ?, datetime('now'))",
+      'memory.remember.improvement-signal',
+      JSON.stringify({
+        content: '[skill-miss] Unused project knowledge',
+        tags: {
+          kind: 'skill-miss',
+          source: 'skill-miss-detector',
+          relates: `mem_${row?.id}`,
+          key: 'k0',
+        },
+        provenance: 'extracted',
+      })
+    )
+    const ctx = await buildSessionContext(projectPath, null, { digest: true })
+    expect(ctx ?? '').not.toContain('Keeps being missed')
+  })
+
   test('digest references developer.md and id-resolution path', async () => {
     await freshProject({ role: 'DEV' })
     insertMemory('decision', 'ship as minor when the squash title starts with feat:')

--- a/core/__tests__/hooks/subagent-start.test.ts
+++ b/core/__tests__/hooks/subagent-start.test.ts
@@ -1,0 +1,104 @@
+/**
+ * SubagentStart hook — compact digest invariants.
+ *
+ * Subagents receive `buildSubagentDigest`, not the full session context:
+ * role + this worktree's active task + top preventive traps, hard-capped
+ * at 500 chars. Emitted via `systemMessage` (outside the cached prompt
+ * prefix), so variable content is allowed here — unlike SessionStart.
+ *
+ * Locked invariants:
+ *   1. No projectId in config → null (skip injection).
+ *   2. No persona, no task, no traps → null (nothing to say).
+ *   3. Gotchas/anti-patterns surface as traps; other types do not.
+ *   4. Output never exceeds the 500-char cap.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildSubagentDigest } from '../../hooks/session-start'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+
+let projectPath: string
+let projectId: string
+
+async function freshProject(persona?: Record<string, unknown>): Promise<void> {
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-subagent-start-test-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+    ...(persona ? { persona } : {}),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+}
+
+function insertMemory(type: string, content: string): void {
+  prjctDb.run(
+    projectId,
+    "INSERT INTO events (type, data, timestamp) VALUES (?, ?, datetime('now'))",
+    `memory.remember.${type}`,
+    JSON.stringify({ content, tags: {}, provenance: 'declared' })
+  )
+}
+
+afterEach(async () => {
+  if (projectPath) {
+    await fs.rm(projectPath, { recursive: true, force: true })
+    projectPath = ''
+  }
+})
+
+describe('SubagentStart hook — buildSubagentDigest', () => {
+  test('returns null when config has no projectId', async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-subagent-no-id-'))
+    await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+    await fs.writeFile(
+      path.join(projectPath, '.prjct', 'prjct.config.json'),
+      JSON.stringify({ dataPath: '' })
+    )
+    const ctx = await buildSubagentDigest(projectPath)
+    expect(ctx).toBeNull()
+  })
+
+  test('returns null when there is nothing to say', async () => {
+    await freshProject()
+    const ctx = await buildSubagentDigest(projectPath)
+    expect(ctx).toBeNull()
+  })
+
+  test('includes persona role when configured', async () => {
+    await freshProject({ role: 'backend specialist' })
+    const ctx = await buildSubagentDigest(projectPath)
+    expect(ctx).toContain('backend specialist')
+  })
+
+  test('surfaces gotchas as traps', async () => {
+    await freshProject()
+    insertMemory('gotcha', 'The daemon caches stale hook code until restarted')
+    const ctx = await buildSubagentDigest(projectPath)
+    expect(ctx).toContain('Traps to avoid')
+    expect(ctx).toContain('daemon caches stale hook code')
+  })
+
+  test('does not surface non-preventive memory types', async () => {
+    await freshProject()
+    insertMemory('decision', 'We chose SQLite over JSON files')
+    const ctx = await buildSubagentDigest(projectPath)
+    expect(ctx).toBeNull()
+  })
+
+  test('never exceeds the 500-char cap', async () => {
+    await freshProject({ role: 'fullstack' })
+    for (let i = 0; i < 5; i++) {
+      insertMemory('gotcha', `Very long trap description number ${i} — ${'x'.repeat(300)}`)
+    }
+    const ctx = await buildSubagentDigest(projectPath)
+    expect(ctx).not.toBeNull()
+    expect((ctx as string).length).toBeLessThanOrEqual(500)
+  })
+})

--- a/core/__tests__/services/embeddings.test.ts
+++ b/core/__tests__/services/embeddings.test.ts
@@ -191,6 +191,58 @@ describe('LocalSubwordEmbeddingProvider', () => {
   })
 })
 
+describe('embeddings — stored norms (migration 28)', () => {
+  it('store() persists the vector L2 norm', () => {
+    embeddingService.store(projectId, 'mem_n1', [3, 4], 'fake-1', NOW)
+    const row = prjctDb.get<{ norm: number }>(
+      projectId,
+      'SELECT norm FROM memory_embeddings WHERE memory_id = ?',
+      'mem_n1'
+    )
+    expect(row?.norm).toBeCloseTo(5)
+  })
+
+  it('semanticSearch ranks correctly using stored norms', async () => {
+    const provider = new FakeProvider({
+      'auth bug': [1, 0, 0, 0],
+      'auth race condition in login': [0.9, 0.1, 0, 0],
+      'how to cook pasta': [0, 0, 0.9, 0.1],
+    })
+    const near = write('gotcha', 'auth race condition in login')
+    const far = write('gotcha', 'how to cook pasta')
+    await embeddingService.backfill(projectId, enabledConfig, NOW, { provider })
+
+    const hits = await embeddingService.semanticSearch(
+      projectId,
+      'auth bug',
+      enabledConfig,
+      2,
+      provider
+    )
+    expect(hits[0]?.id).toBe(near)
+    expect(hits[1]?.id).toBe(far)
+  })
+
+  it('semanticSearch survives a NULL norm (falls back to recompute)', async () => {
+    const provider = new FakeProvider({
+      'auth bug': [1, 0, 0, 0],
+      'auth race condition in login': [0.9, 0.1, 0, 0],
+    })
+    const id = write('gotcha', 'auth race condition in login')
+    await embeddingService.backfill(projectId, enabledConfig, NOW, { provider })
+    prjctDb.run(projectId, 'UPDATE memory_embeddings SET norm = NULL WHERE memory_id = ?', id)
+
+    const hits = await embeddingService.semanticSearch(
+      projectId,
+      'auth bug',
+      enabledConfig,
+      1,
+      provider
+    )
+    expect(hits[0]?.id).toBe(id)
+  })
+})
+
 describe('cosineSimilarity', () => {
   it('is 1 for identical, 0 for orthogonal', () => {
     expect(cosineSimilarity([1, 0, 0], [1, 0, 0])).toBeCloseTo(1, 5)

--- a/core/__tests__/services/skill-miss-detector.test.ts
+++ b/core/__tests__/services/skill-miss-detector.test.ts
@@ -245,6 +245,30 @@ describe('skill-miss-detector — persistence + containment (DB)', () => {
     expect(r.signalsRecorded).toBe(0)
   })
 
+  it('nets a negative usefulness score on the missed entry (feedback loop)', async () => {
+    await seedDecision('Set sqlite pragma busy_timeout to 5000 on every connection')
+    await writeTranscript('edited the sqlite pragma handling in the storage layer')
+
+    const r = await detectSkillMisses(dir, transcriptPath, 'sess-1')
+    expect(r.signalsRecorded).toBe(1)
+
+    const signals = (await import('../../memory/project-memory')).projectMemory.recall(projectId, {
+      types: ['improvement-signal'],
+      tags: { source: 'skill-miss-detector' },
+      dedupeByKey: false,
+    })
+    const missedId = signals[0]?.tags.relates as string
+    const row = prjctDb.get<{ score: number }>(
+      projectId,
+      'SELECT score FROM memory_usefulness WHERE memory_id = ?',
+      missedId
+    )
+    // remember() auto-credits +1.0 for the relates: tag; the penalty must
+    // cancel it and net the entry slightly negative — a miss is not usage.
+    expect(row).not.toBeNull()
+    expect(row?.score ?? 0).toBeLessThan(0)
+  })
+
   it('writes nothing to disk outside SQLite (persistence rule)', async () => {
     await seedDecision('Set sqlite pragma busy_timeout to 5000 on every connection')
     await writeTranscript('edited the sqlite pragma handling in the storage layer')

--- a/core/__tests__/utils/output.test.ts
+++ b/core/__tests__/utils/output.test.ts
@@ -42,12 +42,35 @@ describe('Output Module', () => {
       expect(output).toContain('task completed')
     })
 
-    it('should truncate long messages', () => {
-      const longMessage = 'a'.repeat(100)
-      out.done(longMessage)
+    it('should truncate long messages in TTY mode', () => {
+      const prevOut = process.stdout.isTTY
+      process.stdout.isTTY = true
+      try {
+        const longMessage = 'a'.repeat(100)
+        out.done(longMessage)
 
-      const output = consoleLogSpy.mock.calls[0][0]
-      expect(output.length).toBeLessThan(80)
+        const output = consoleLogSpy.mock.calls[0][0]
+        expect(output.length).toBeLessThan(80)
+      } finally {
+        process.stdout.isTTY = prevOut
+      }
+    })
+
+    it('should NOT truncate in non-TTY (agent/pipe) mode', () => {
+      const prevOut = process.stdout.isTTY
+      const prevErr = process.stderr.isTTY
+      process.stdout.isTTY = false as never
+      process.stderr.isTTY = false as never
+      try {
+        const longMessage = 'a'.repeat(100)
+        out.done(longMessage)
+
+        const output = consoleLogSpy.mock.calls[0][0]
+        expect(output).toContain(longMessage)
+      } finally {
+        process.stdout.isTTY = prevOut
+        process.stderr.isTTY = prevErr
+      }
     })
 
     it('should return self for chaining', () => {
@@ -66,12 +89,35 @@ describe('Output Module', () => {
       expect(output).toContain('something failed')
     })
 
-    it('should truncate long error messages', () => {
-      const longMessage = 'error '.repeat(50)
-      out.fail(longMessage)
+    it('should truncate long error messages in TTY mode', () => {
+      const prevOut = process.stdout.isTTY
+      process.stdout.isTTY = true
+      try {
+        const longMessage = 'error '.repeat(50)
+        out.fail(longMessage)
 
-      const output = consoleErrorSpy.mock.calls[0][0]
-      expect(output.length).toBeLessThan(80)
+        const output = consoleErrorSpy.mock.calls[0][0]
+        expect(output.length).toBeLessThan(80)
+      } finally {
+        process.stdout.isTTY = prevOut
+      }
+    })
+
+    it('should NOT truncate error messages in non-TTY (agent/pipe) mode', () => {
+      const prevOut = process.stdout.isTTY
+      const prevErr = process.stderr.isTTY
+      process.stdout.isTTY = false as never
+      process.stderr.isTTY = false as never
+      try {
+        const longMessage = 'error '.repeat(50)
+        out.fail(longMessage)
+
+        const output = consoleErrorSpy.mock.calls[0][0]
+        expect(output).toContain(longMessage.trim())
+      } finally {
+        process.stdout.isTTY = prevOut
+        process.stderr.isTTY = prevErr
+      }
     })
 
     it('should return self for chaining', () => {

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -12,22 +12,29 @@
  * stopwords/noise and burn the context window with entries the turn never
  * needed — exactly the bloat we refuse to ship to clients.
  *
+ * ONE exception to PULL: preventive knowledge. When the prompt's keywords
+ * BM25-match a `gotcha`/`anti-pattern`, a single one-line trap cue rides
+ * along — the same class the pre-edit guard pushes, because a trap only
+ * helps BEFORE it's stepped in. Decisions/learnings/facts stay pull-only.
+ *
  * Zero "do X" prescription. The LLM decides. Degrades gracefully: on any
  * error (no project, no git) we emit `{}` and stay out of the way.
  */
 
 import path from 'node:path'
 import configManager from '../infrastructure/config-manager'
-import { projectMemory } from '../memory/project-memory'
+import { deriveTitle, projectMemory } from '../memory/project-memory'
 import { collectActiveTasks } from '../services/task-overview'
 import { shippedStorage } from '../storage/shipped-storage'
 import type { LocalConfig } from '../types/config'
 import { execFileAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
 import { type HookIo, runHook } from './_runner'
-import { safeTruncate } from './_shared'
+import { extractKeywords, safeTruncate } from './_shared'
 
-const STATE_BUDGET = 600
+const STATE_BUDGET = 900
+/** FTS candidates fetched before the preventive-type filter picks ONE. */
+const CUE_CANDIDATES = 8
 
 interface HookInput {
   prompt?: string
@@ -120,6 +127,24 @@ export async function buildProjectState(
   return lines.join('\n')
 }
 
+/**
+ * At most ONE preventive entry (gotcha / anti-pattern) whose content
+ * BM25-matches the prompt's keywords, as a one-line cue. Best-effort —
+ * any failure returns null and the state block ships without it.
+ */
+export function buildTopicalCue(projectId: string, prompt: string): string | null {
+  try {
+    const keywords = extractKeywords(prompt)
+    if (keywords.length === 0) return null
+    const hits = projectMemory.searchFts(projectId, keywords, CUE_CANDIDATES)
+    const trap = hits.find((e) => e.type === 'gotcha' || e.type === 'anti-pattern')
+    if (!trap) return null
+    return `> Trap on this topic: ${deriveTitle(trap)}  \`${trap.id}\``
+  } catch {
+    return null
+  }
+}
+
 interface GitSnapshot {
   branch: string
   modified: number
@@ -201,7 +226,11 @@ export function runPromptHook(projectPath: string = process.cwd(), io?: HookIo):
         // entries the turn never needed.
         const state = await buildProjectState(p, config)
         if (!state) return null
-        return safeTruncate(state, STATE_BUDGET)
+        // The ONE push exception: a single trap cue when the prompt's
+        // keywords hit a gotcha/anti-pattern (see header). State leads;
+        // the cue is appended and shares the same hard budget.
+        const cue = config?.projectId ? buildTopicalCue(config.projectId, prompt) : null
+        return safeTruncate(cue ? `${state}\n\n${cue}` : state, STATE_BUDGET)
       },
     },
     io

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -143,6 +143,51 @@ function buildKnowledgeDigest(projectId: string): string | null {
   return safeTruncate(lines.join('\n'), DIGEST_MAX_CHARS)
 }
 
+const SUBAGENT_DIGEST_MAX_CHARS = 500
+const SUBAGENT_GOTCHA_COUNT = 2
+
+/**
+ * Compact context for a spawned subagent: role, the active task for THIS
+ * worktree, and the top preventive traps. Subagents previously received the
+ * persona block only and re-investigated facts the main session already knew.
+ *
+ * SubagentStart's response schema rejects `additionalContext`, so this is
+ * emitted as `systemMessage` — outside the cached system-prompt prefix —
+ * which is why variable content (the active task) is safe here while the
+ * SessionStart persona block must stay byte-identical.
+ */
+export async function buildSubagentDigest(projectPath: string): Promise<string | null> {
+  const config = await configManager.readConfig(projectPath).catch(() => null)
+  if (!config?.projectId) return null
+
+  const lines: string[] = ['# prjct: subagent context']
+  if (config.persona?.role) lines.push(`Role in this project: ${config.persona.role}`)
+
+  try {
+    const { resolveActiveTask } = await import('../services/task-service')
+    const task = await resolveActiveTask(config.projectId, projectPath)
+    if (task) lines.push(`Active task (this worktree): ${task.description}`)
+  } catch {
+    // best-effort — a digest without the task is still useful
+  }
+
+  try {
+    const gotchas = projectMemory.recall(config.projectId, {
+      types: ['gotcha', 'anti-pattern'],
+      limit: SUBAGENT_GOTCHA_COUNT,
+    })
+    if (gotchas.length > 0) {
+      lines.push('Traps to avoid:')
+      for (const e of gotchas) lines.push(`- ${deriveTitle(e)}  \`${e.id}\``)
+    }
+  } catch {
+    // best-effort
+  }
+
+  if (lines.length <= 1) return null
+  return safeTruncate(lines.join('\n'), SUBAGENT_DIGEST_MAX_CHARS)
+}
+
 function formatPersona(persona: ProjectPersona): string {
   const lines: string[] = []
   lines.push(`## Your role in this project: **${persona.role}**`)

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -122,7 +122,11 @@ function buildKnowledgeDigest(projectId: string): string | null {
   } catch {
     return null
   }
-  if (gotchas.length === 0 && decisions.length === 0) return null
+  const repeatMiss = findRepeatMissedEntry(
+    projectId,
+    new Set([...gotchas, ...decisions].map((e) => e.id))
+  )
+  if (gotchas.length === 0 && decisions.length === 0 && !repeatMiss) return null
 
   const lines: string[] = ['## What this project already knows', '']
   lines.push(
@@ -136,11 +140,61 @@ function buildKnowledgeDigest(projectId: string): string | null {
     lines.push('', '**Decisions in force:**')
     for (const e of decisions) lines.push(`- ${deriveTitle(e)}  \`${e.id}\``)
   }
+  if (repeatMiss) {
+    lines.push(
+      '',
+      '**Keeps being missed:**',
+      `- ${deriveTitle(repeatMiss.entry)}  \`${repeatMiss.entry.id}\` — flagged relevant-but-unused ${repeatMiss.count}×. Apply it or supersede it.`
+    )
+  }
   lines.push(
     '',
     '> Resolve any `mem_id` with `prjct search <id>`. Who the developer is lives in `developer.md` in the vault.'
   )
   return safeTruncate(lines.join('\n'), DIGEST_MAX_CHARS)
+}
+
+/** A memory must be skill-missed at least this often to earn a digest slot. */
+const REPEAT_MISS_THRESHOLD = 2
+
+/**
+ * The skill-miss feedback loop's read side: the entry most often flagged
+ * "relevant but never referenced" across sessions. One slot, ≥2 misses,
+ * skipping anything the digest already shows — knowledge that keeps
+ * failing to land gets pushed in front of the agent instead of silently
+ * accumulating improvement-signal rows. Best-effort: null on any failure.
+ */
+function findRepeatMissedEntry(
+  projectId: string,
+  alreadyShown: Set<string>
+): { entry: MemoryEntry; count: number } | null {
+  try {
+    const signals = projectMemory.recall(projectId, {
+      types: ['improvement-signal'],
+      tags: { kind: 'skill-miss' },
+      limit: 50,
+      dedupeByKey: false,
+    })
+    const counts = new Map<string, number>()
+    for (const s of signals) {
+      const memId = s.tags?.relates
+      if (!memId) continue
+      counts.set(memId, (counts.get(memId) ?? 0) + 1)
+    }
+    let topId: string | null = null
+    let topCount = 0
+    for (const [id, count] of counts) {
+      if (count > topCount) {
+        topId = id
+        topCount = count
+      }
+    }
+    if (!topId || topCount < REPEAT_MISS_THRESHOLD || alreadyShown.has(topId)) return null
+    const entry = projectMemory.getById(projectId, topId)
+    return entry ? { entry, count: topCount } : null
+  } catch {
+    return null
+  }
 }
 
 const SUBAGENT_DIGEST_MAX_CHARS = 500

--- a/core/hooks/subagent-start.ts
+++ b/core/hooks/subagent-start.ts
@@ -1,15 +1,17 @@
 /**
- * SubagentStart hook — inject persona + recent memory into spawned
+ * SubagentStart hook — inject a compact project digest into spawned
  * subagents. Without this, subagents start with zero project context
  * and re-investigate facts the main session already knows.
  *
- * Reuses `buildSessionContext` to keep the per-subagent injection
- * consistent with what the main session sees. Same rules: describe
- * WHAT (role, MCPs, recent memory), never CÓMO.
+ * Uses `buildSubagentDigest` (role + this worktree's active task + top
+ * traps) rather than the full session context: SubagentStart emits via
+ * `systemMessage` (its schema rejects `additionalContext`), which sits
+ * outside the cached prompt prefix, so variable content is safe here.
+ * Same rules: describe WHAT, never CÓMO.
  */
 
 import { type HookIo, runHook } from './_runner'
-import { buildSessionContext } from './session-start'
+import { buildSubagentDigest } from './session-start'
 
 export function runSubagentStartHook(
   projectPath: string = process.cwd(),
@@ -19,7 +21,7 @@ export function runSubagentStartHook(
     {
       event: 'SubagentStart',
       projectPath,
-      build: (_input, p) => buildSessionContext(p),
+      build: (_input, p) => buildSubagentDigest(p),
     },
     io
   )

--- a/core/mcp/server.ts
+++ b/core/mcp/server.ts
@@ -24,22 +24,7 @@ import { registerWorkflowTools } from './tools/workflow'
  */
 const PRJCT_INSTRUCTIONS = `# prjct — Spec-Driven Development + project memory
 
-Use when the user describes work, asks for project memory, or wants to run a registered workflow. **Recognize intent — don't wait for the user to type prjct commands.**
-
-## SDD canonical sequence
-
-When the user describes a feature, fix, or initiative *with goals or stakes attached*, default to the SDD flow:
-
-\`\`\`
-spec → audit-spec → task (linked to spec) → implement → ship (acceptance gate) → remember learning
-\`\`\`
-
-- **\`prjct_spec_create\`** — when the user describes WHAT they want to build / fix and WHY ("we need rate limiting", "the onboarding is broken"). Draft a spec with goal, eli10, stakes, acceptance_criteria, scope, out_of_scope, risks, test_plan.
-- **\`prjct_spec_audit\`** — before any code: dispatch three review subagents in PARALLEL (strategic / architecture / design). Persist verdicts via \`prjct_spec_record_review\`. All three pass → spec auto-promotes draft → reviewed.
-- **\`prjct_spec_link_task\`** — when the user starts implementing, link the task to the spec so ship can gate.
-- **\`prjct_spec_ship\`** — after merge, mark the spec shipped + record the PR number.
-
-Skip the SDD flow only for: routine captures, single-file fixes, doc tweaks, conversational Q&A. If work touches >1 file, ships to users, or takes >30 min — default to spec first.
+Use when the user describes work, asks for project memory, or wants to run a registered workflow. **Recognize intent — don't wait for the user to type prjct commands.** Default DIRECT (task → implement → ship); reserve the spec flow (\`prjct_spec_*\`, detailed in each tool's description) for genuinely complex, high-stakes work.
 
 ## What's here
 

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -123,14 +123,11 @@ export function registerProjectTools(server: McpServer) {
       const projectId = await resolveProjectId(args.projectPath)
       const outcome = await setTaskStatus(projectId, args.projectPath, args.status)
       if (!outcome.ok) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'No active task to update. Start one with prjct_task_start.',
-            },
-          ],
-        }
+        const text =
+          outcome.reason === 'unsupported'
+            ? outcome.message
+            : 'No active task to update. Start one with prjct_task_start.'
+        return { content: [{ type: 'text', text }] }
       }
       return {
         content: [{ type: 'text', text: `✓ status → ${outcome.status} (task ${outcome.taskId})` }],

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -570,19 +570,29 @@ export const projectMemory = {
     const base = filePath.split('/').pop() ?? filePath
     const isPreventive = (e: MemoryEntry) =>
       e.type === 'gotcha' || e.type === 'anti-pattern' || e.tags?.pattern === 'recurring-bug'
-    let pool: MemoryEntry[]
+    // The `file_tag` generated column (migration 27) + partial index narrow
+    // the scan to file-tagged remember rows in SQL — exact / suffix / basename
+    // matching mirrors the original JS filter. Preventive-type filtering and
+    // superseded pruning stay in JS over the (small) matched set.
+    let matches: MemoryEntry[]
     try {
-      pool = this.recall(projectId, { limit: 500 })
+      const rows = prjctDb.query<EventRow>(
+        projectId,
+        `SELECT id, type, data, timestamp FROM events
+          WHERE file_tag IS NOT NULL
+            AND (file_tag = ? OR ? LIKE '%/' || file_tag OR file_tag = ? OR file_tag LIKE '%/' || ?)
+          ORDER BY id DESC`,
+        filePath,
+        filePath,
+        base,
+        base
+      )
+      matches = rows.map(rowToEntry).filter(isPreventive)
     } catch {
       return []
     }
-    const matches = pool.filter((e) => {
-      const f = e.tags?.file
-      if (!f) return false
-      const fileMatch =
-        filePath === f || filePath.endsWith(`/${f}`) || (f.split('/').pop() ?? f) === base
-      return fileMatch && isPreventive(e)
-    })
+    const dead = collectSupersededIds(matches)
+    if (dead.size > 0) matches = matches.filter((e) => !dead.has(e.id))
     return matches.slice(0, limit)
   },
 

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -269,7 +269,28 @@ export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): nu
 interface EmbeddingRow {
   memory_id: string
   vector: Uint8Array
+  norm: number | null
 }
+
+function l2Norm(v: ArrayLike<number>): number {
+  let sum = 0
+  for (let i = 0; i < v.length; i++) sum += v[i] * v[i]
+  return Math.sqrt(sum)
+}
+
+function dot(a: ArrayLike<number>, b: ArrayLike<number>): number {
+  const n = Math.min(a.length, b.length)
+  let d = 0
+  for (let i = 0; i < n; i++) d += a[i] * b[i]
+  return d
+}
+
+/**
+ * Safety bound on how many stored vectors a single semantic query will
+ * deserialize and score (newest-first). A no-op for typical projects
+ * (hundreds of entries); caps BLOB unpacking for pathological ones.
+ */
+const SEMANTIC_SCAN_MAX_ROWS = 2000
 
 export const embeddingService = {
   /**
@@ -291,15 +312,16 @@ export const embeddingService = {
   ): void {
     prjctDb.run(
       projectId,
-      `INSERT INTO memory_embeddings (memory_id, vector, model, dims, created_at)
-       VALUES (?, ?, ?, ?, ?)
+      `INSERT INTO memory_embeddings (memory_id, vector, model, dims, norm, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)
        ON CONFLICT(memory_id) DO UPDATE SET
          vector = excluded.vector, model = excluded.model,
-         dims = excluded.dims, created_at = excluded.created_at`,
+         dims = excluded.dims, norm = excluded.norm, created_at = excluded.created_at`,
       memoryId,
       packVector(vector),
       model,
       vector.length,
+      l2Norm(vector),
       nowIso
     )
   },
@@ -407,15 +429,26 @@ export const embeddingService = {
     try {
       rows = prjctDb.query<EmbeddingRow>(
         projectId,
-        'SELECT memory_id, vector FROM memory_embeddings WHERE model = ?',
-        p.model
+        `SELECT memory_id, vector, norm FROM memory_embeddings
+          WHERE model = ? ORDER BY rowid DESC LIMIT ?`,
+        p.model,
+        SEMANTIC_SCAN_MAX_ROWS
       )
     } catch {
       return []
     }
 
+    // Stored norms (migration 28) turn per-row cosine into a dot product +
+    // one multiply; rows lacking a norm (edge: written mid-migration) fall
+    // back to recomputing it from the unpacked vector.
+    const qNorm = l2Norm(qv)
+    if (qNorm === 0) return []
     const ranked = rows
-      .map((r) => ({ id: r.memory_id, score: cosineSimilarity(qv, unpackVector(r.vector)) }))
+      .map((r) => {
+        const v = unpackVector(r.vector)
+        const denom = qNorm * (r.norm ?? l2Norm(v))
+        return { id: r.memory_id, score: denom === 0 ? 0 : dot(qv, v) / denom }
+      })
       .sort((a, b) => b.score - a.score)
       .slice(0, limit)
 

--- a/core/services/skill-miss-detector.ts
+++ b/core/services/skill-miss-detector.ts
@@ -34,6 +34,7 @@ import fs from 'node:fs/promises'
 import { projectMemory } from '../memory/project-memory'
 import { getModifiedFiles } from '../session/git-helpers'
 import { crewRunStorage } from '../storage/crew-run-storage'
+import { usefulnessService } from './usefulness'
 
 const SOURCE_TAG = 'skill-miss-detector'
 const MAX_SKILL_MISSES_PER_SESSION = 3
@@ -220,6 +221,9 @@ export async function detectSkillMisses(
         },
         provenance: 'extracted',
       })
+      // The remember() above auto-credited the missed entry via its
+      // `relates:` tag — but a miss is not usage. Cancel it + nudge down.
+      usefulnessService.penalizeSkillMiss(projectId, miss.memId)
       recorded++
     } catch {
       skipped++

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -43,6 +43,14 @@ const CORRECTION_WEIGHT = -2.5
  *  fuzzy (the friction may be unrelated) — but it needs NO command, so prjct
  *  learns from mistakes on its own. Bounded by decay + the rerank cap. */
 const FRICTION_WEIGHT = -0.5
+/** AUTOMATIC negative: a skill-miss signal flagged this entry as relevant
+ *  but unused. The signal's `relates:` tag already earned it an automatic
+ *  REF_WEIGHT credit inside `remember()` — but a miss is not load-bearing
+ *  usage, so this cancels that (+1.0) and nets a small −0.3: knowledge that
+ *  keeps failing to land sinks slightly instead of climbing. The session
+ *  digest separately surfaces repeat-missed entries so they get reworded or
+ *  applied rather than just buried. */
+const SKILL_MISS_WEIGHT = -1.3
 const MS_PER_DAY = 86_400_000
 
 /** Tag keys whose values name a related entry (mirrors expandWithLinks). */
@@ -222,6 +230,24 @@ export const usefulnessService = {
       return rows.length
     } catch {
       return 0
+    }
+  },
+
+  /**
+   * AUTOMATIC negative reinforcement for a skill-miss: `memoryId` was
+   * relevant to a session's work but never referenced. Cancels the automatic
+   * ref credit the miss-signal's `relates:` tag just earned it and nets a
+   * small penalty (see SKILL_MISS_WEIGHT). Best-effort.
+   */
+  penalizeSkillMiss(
+    projectId: string,
+    memoryId: string,
+    nowIso: string = new Date().toISOString()
+  ): void {
+    try {
+      addScore(projectId, memoryId, SKILL_MISS_WEIGHT, nowIso)
+    } catch {
+      /* best-effort — never block the Stop hook */
     }
   },
 

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -868,4 +868,28 @@ export const migrations: Migration[] = [
       db.run('CREATE INDEX IF NOT EXISTS idx_events_type_id ON events(type, id DESC)')
     },
   },
+  {
+    version: 27,
+    name: 'events-file-tag-column',
+    up: (db: SqliteDatabase) => {
+      // `recallForFile` (the `prjct guard` / pre-edit anticipation lookup)
+      // used to overfetch 500 recall rows and filter by the `file` tag in JS.
+      // A virtual generated column exposes the tag to SQL so a partial index
+      // covers exactly the file-tagged remember rows — for most projects a
+      // few dozen rows instead of a 500-row JSON.parse sweep per lookup.
+      // VIRTUAL (not STORED) is required for ALTER TABLE; the CASE guard
+      // keeps json_extract off non-remember rows and malformed data.
+      db.run(`
+        ALTER TABLE events ADD COLUMN file_tag TEXT GENERATED ALWAYS AS (
+          CASE
+            WHEN type LIKE 'memory.remember.%' AND json_valid(data)
+            THEN json_extract(data, '$.tags.file')
+          END
+        ) VIRTUAL
+      `)
+      db.run(
+        'CREATE INDEX IF NOT EXISTS idx_events_file_tag ON events(file_tag) WHERE file_tag IS NOT NULL'
+      )
+    },
+  },
 ]

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -892,4 +892,30 @@ export const migrations: Migration[] = [
       )
     },
   },
+  {
+    version: 28,
+    name: 'embedding-norms',
+    up: (db: SqliteDatabase) => {
+      // semanticSearch divides every cosine score by the row vector's L2
+      // norm, which it used to recompute from the unpacked BLOB on every
+      // query. Store the norm once at write time instead; the query loop
+      // becomes a dot product + one multiply. Backfill computes norms for
+      // existing vectors (Float32 little-endian BLOBs) so the column is
+      // immediately authoritative.
+      db.run('ALTER TABLE memory_embeddings ADD COLUMN norm REAL')
+      const rows = db.prepare('SELECT memory_id, vector FROM memory_embeddings').all() as Array<{
+        memory_id: string
+        vector: Uint8Array
+      }>
+      const setNorm = db.prepare('UPDATE memory_embeddings SET norm = ? WHERE memory_id = ?')
+      for (const r of rows) {
+        // Copy for 4-byte alignment — SQLite BLOBs may arrive unaligned.
+        const copy = Uint8Array.from(r.vector)
+        const v = new Float32Array(copy.buffer, 0, Math.floor(copy.byteLength / 4))
+        let sum = 0
+        for (let i = 0; i < v.length; i++) sum += v[i] * v[i]
+        setNorm.run(Math.sqrt(sum), r.memory_id)
+      }
+    },
+  },
 ]

--- a/core/utils/output.ts
+++ b/core/utils/output.ts
@@ -82,6 +82,9 @@ export function setQuietMode(enabled: boolean): void {
  * Truncate string to max chars (uses tier config if no max specified)
  */
 const truncate = (s: string | undefined | null, max?: number): string => {
+  // Agent/pipe context (no TTY on either stream): never truncate — agents act
+  // on full messages, and a 65-char error with an ellipsis is undebuggable.
+  if (!process.stdout.isTTY && !process.stderr.isTTY) return s || ''
   const limit = max ?? (getTierConfig().maxCharsPerLine || OUTPUT_LIMITS.FALLBACK_TRUNCATE)
   return s && s.length > limit ? `${s.slice(0, limit - 1)}…` : s || ''
 }


### PR DESCRIPTION
## What

PR 1 of the improvement epic (LLM surface → performance → dispatch refactor). Everything an agent reads from prjct — errors, hook context, MCP output, semantic recall — gets sharper and cheaper.

### Agent-first outputs
- `out.fail`/`done`/`warn` no longer truncate in non-TTY contexts (pipes/agents/CI). The 65-char `FAIL_MSG` ellipsis class is gone for agents; human TTY behavior unchanged.

### MCP
- Server instructions trimmed ~3× — the SDD canonical-sequence block duplicated per-tool descriptions on every turn and contradicted the skill's default-DIRECT routing.
- `prjct_task_set_status` surfaces the real 'unsupported transition' message.

### Recall that arrives by itself
- **Subagent digest**: role + this worktree's active task + top 2 traps (≤500 chars) via SubagentStart — subagents no longer start blind. Cache-safe (systemMessage is outside the cached prefix).
- **Trap cue on prompts**: ONE gotcha/anti-pattern line when prompt keywords BM25-match — the only PUSH exception; decisions/learnings stay pull-only.
- **Skill-miss feedback loop**: each miss cancels the automatic relates: ref credit (nets −0.3); the cold-start digest gains a 'Keeps being missed' slot for entries flagged ≥2×.

### Search quality
- Migration 27: virtual `file_tag` column + partial index on `events` — `recallForFile` (guard/pre-edit) stops sweeping 500 rows in JS.
- Migration 28: stored L2 norms + bounded scan (2000 newest) for semantic search. Zero native deps preserved.

## Verification
- `bun test`: 1497 pass / 0 fail (full suite)
- `bun run typecheck` + biome clean
- New tests: subagent digest invariants, trap cue, skill-miss penalty, repeat-miss digest slot, norm storage/fallback, non-TTY truncation bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)