### PR TITLE
perf: hot paths — Stop hook config/transcript once, CAS→txn, backfill anti-join + ghost-DB fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,17 @@
 
 ## [Unreleased]
 
-LLM-first surface pass: everything an agent reads from prjct — errors, hook context, MCP output, semantic recall — got sharper and cheaper.
+Hot-path performance pass over the hooks that fire on every Claude turn.
 
-### Added
-- **Subagent context digest.** Spawned subagents used to receive the persona block only and re-investigated facts the main session already knew. The `SubagentStart` hook now injects a compact digest: role + the active task for *this worktree* + the top 2 preventive traps, capped at 500 chars. Variable content is safe here because SubagentStart emits via `systemMessage`, outside the cached prompt prefix.
-- **One-line trap cue on prompts.** The per-turn state hook stays PULL-not-PUSH for decisions/learnings/facts, with one exception: when the prompt's keywords BM25-match a `gotcha`/`anti-pattern`, a single `> Trap on this topic:` line rides along with the state block — the same preventive class the pre-edit guard pushes, because a trap only helps *before* it's stepped in.
-- **Skill-miss feedback loop closed.** The Stop-hook detector already recorded "relevant but never referenced" knowledge as improvement-signals; now those signals act. Write side: each miss cancels the automatic `relates:` reference credit and nets the missed entry −0.3 usefulness (a miss is not usage). Read side: the cold-start digest gains a **Keeps being missed** slot for the entry flagged ≥2×, so chronically-missed knowledge gets pushed in front of the agent instead of accumulating silently.
+### Fixed
+- **Session-end embedding backfill was a silent no-op.** The Stop hook passed the project *path* where `backfill` expects the project *id*, so every session end wrote vectors to a phantom database under `~/.prjct-cli/projects/Users/…` instead of the real project DB. Vectors now land where semantic search reads them.
 
-### Changed
-- **No more truncated output for agents.** `out.fail`/`done`/`warn` truncated to 65–80 chars unconditionally; in non-TTY contexts (pipes, agents, CI) messages now pass through untruncated. Human TTY behavior unchanged.
-- **MCP server instructions trimmed ~3×.** The SDD canonical-sequence block duplicated the `prjct_spec_*` tool descriptions verbatim on every MCP turn and contradicted the skill's default-DIRECT routing; the instructions are back to the anti-harness shape (use-when + what's-here + gotchas). `prjct_task_set_status` now surfaces the real "unsupported transition" message instead of a generic no-active-task line.
-
-### Performance
-- **`recallForFile` is indexed.** The `prjct guard` / pre-edit lookup overfetched 500 recall rows and filtered by the `file` tag in JS. Migration 27 adds a virtual generated `file_tag` column (+ partial index) on `events`, so the lookup touches only file-tagged remember rows.
-- **Semantic search is bounded and norm-cached.** Migration 28 stores each vector's L2 norm at write time (backfilled), turning per-row cosine into a dot product; the scan is capped at the 2000 newest vectors per model. Still zero native deps — no sqlite-vec.
+### Performance (per-turn hooks)
+- **Stop hook reads the config once and the transcript once.** It read `prjct.config.json` 4–5× per turn (once per sub-service, plus once per `remember()` call) and read+parsed the session transcript JSONL 3× (transcript-learner, friction-detector, skill-miss-detector). The hook now reads each once and threads them through; the three detectors share one JSONL tokenizer (`transcript-jsonl.ts`), deduplicating three identical parsers.
+- **`StorageManager.update` is one transaction.** The optimistic-CAS retry loop (up to 8 × [2 SELECTs + UPDATE]) is now a single `BEGIN IMMEDIATE` read-modify-write — strictly stronger for multi-agent state (concurrent writers wait on the lock instead of looping), with 1 SELECT + 1 write per update.
+- **Embedding backfill fetches only new entries.** A SQL anti-join replaces deserializing the whole memory corpus per Stop hook; noise-vector pruning (which needs the full corpus) is throttled to every 10th run.
+- **Global config is stat-cached.** `resolveGlobalEmbeddings` did 7 `readFileSync`+parse of `global.json` per Stop hook; reads now revalidate against mtime+size, so a CLI write is still picked up by a long-lived daemon.
+- **CLI cold-path reorder.** The hook fast path runs before the verb-registry import and the update/self-heal blocks (hooks need none of them); self-heal moved after the daemon fast path (SessionStart's own self-heal keeps coverage).
 
 ## [2.42.0] - 2026-06-10
 

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -98,125 +98,6 @@ const _binCommands = new Set([
   'context-restore',
 ])
 
-// v2 verbs registered in the command registry — imported from the single
-// source of truth so adding a verb only requires updating one list.
-const { REGISTERED_VERBS_SET } = await import('../core/commands/verb-names')
-
-// Update notice — print at process exit so the banner appears AFTER the
-// command's own output. Uses a sync read of the cached latest version;
-// the cache is refreshed in a detached background process so the
-// network call never delays the user-visible command. Skipped for
-// machine-consumed paths (`hook`, `--md`/`--json`, `--quiet`) and for
-// the updater itself. Awaited at top-level so the exit handler is
-// installed BEFORE the daemon fast path's `process.exit` runs.
-const _updateSkipCommands = new Set([
-  'update',
-  'upgrade',
-  'daemon',
-  'hook',
-  'version',
-  '-v',
-  '--version',
-])
-if (
-  _fastCommand &&
-  !_updateSkipCommands.has(_fastCommand) &&
-  process.stderr.isTTY &&
-  !_fastArgs.includes('--md') &&
-  !_fastArgs.includes('--json') &&
-  !_fastArgs.includes('--quiet') &&
-  !_fastArgs.includes('-q') &&
-  process.env.PRJCT_NO_UPDATE_NOTICE !== '1'
-) {
-  const { triggerBackgroundRefreshIfStale, getUpdateNotificationSync } = await import(
-    '../core/infrastructure/update-checker'
-  )
-  // Resolve the running version once, synchronously, so the exit
-  // handler (which can't await) has it ready.
-  const _fs = await import('node:fs')
-  const _path = await import('node:path')
-  let _currentVersion = ''
-  try {
-    const pkgPath = _path.resolve(
-      _path.dirname(new URL(import.meta.url).pathname),
-      '..',
-      'package.json'
-    )
-    _currentVersion = JSON.parse(_fs.readFileSync(pkgPath, 'utf-8')).version ?? ''
-  } catch {
-    /* no version, no banner */
-  }
-  try {
-    triggerBackgroundRefreshIfStale()
-  } catch {
-    /* best-effort */
-  }
-  if (_currentVersion) {
-    process.on('exit', () => {
-      try {
-        const banner = getUpdateNotificationSync(_currentVersion)
-        if (banner) process.stderr.write(banner)
-      } catch {
-        /* never block exit on a notification */
-      }
-    })
-  }
-}
-
-// === SELF-HEAL ===
-// Re-install hooks + global CLAUDE.md when the binary version has moved
-// past the last successful sync. Replaces postinstall (which is disabled
-// by --ignore-scripts and corporate security policies on many client
-// machines). Hot path is a single fs read of the stamp file; the slow
-// path (a few writes to settings.json + CLAUDE.md) only fires once per
-// version bump per machine.
-//
-// Skipped for:
-//   - `daemon`/`update`/`version` (would deadlock the upgrade flow)
-//   - `hook` (session-start fires its own self-heal; other hook events
-//     fire too often to pay even the fs-read cost)
-//   - PRJCT_NO_SELF_SYNC=1 (escape hatch)
-const _selfHealSkip = new Set(['daemon', 'update', 'upgrade', 'version', '-v', '--version', 'hook'])
-if (_fastCommand && !_selfHealSkip.has(_fastCommand) && process.env.PRJCT_NO_SELF_SYNC !== '1') {
-  try {
-    const { VERSION } = await import('../core/utils/version')
-    if (VERSION) {
-      const { isSyncCurrent, runSelfHeal } = await import('../core/infrastructure/self-heal')
-      if (!isSyncCurrent(VERSION)) {
-        await runSelfHeal(VERSION)
-      }
-    }
-  } catch {
-    // best-effort — never block the user's command on self-heal
-  }
-}
-
-// v2 auto-route: if the first positional isn't a known verb, treat the
-// whole argv as GTD-style inbox capture → `prjct capture "<argv>"`.
-// Explicit verbs still win. Capture is zero-ceremony; if the user
-// wanted a task (branch/worktree), they type `prjct task "..."`
-// explicitly.
-if (_fastCommand && !_binCommands.has(_fastCommand) && !REGISTERED_VERBS_SET.has(_fastCommand)) {
-  const positionals = _fastArgs.filter((a) => !a.startsWith('-'))
-  const description = positionals.join(' ')
-  const flags = _fastArgs.filter((a) => a.startsWith('-'))
-  // A single command-shaped token (e.g. `prjct upgrade`) is almost never a
-  // GTD note — it's a MISROUTED command: a typo, or a stale parallel
-  // install / long-lived daemon that predates the verb. Silently turning it
-  // into an inbox capture buries it with zero feedback (same silent-no-op
-  // class as the WS1 exit-0 bug). Still capture (don't break free-text GTD)
-  // but make it LOUD + actionable so it's never a silent surprise.
-  if (positionals.length === 1 && /^[a-z][a-z0-9:-]+$/.test(positionals[0])) {
-    process.stderr.write(
-      `prjct: '${positionals[0]}' is not a known command in this install — ` +
-        'saving it to the inbox instead. If you meant the command, this prjct ' +
-        'may be stale: run `prjct update`.\n'
-    )
-  }
-  _fastCommand = 'capture'
-  _fastArgs = ['capture', description, ...flags]
-}
-
 // === HOOK FAST PATH (daemon-served) ===
 // Hooks fire on session-start + every prompt + every stop. A cold spawn
 // costs ~300ms (bun) to ~950ms (node) in process + module load alone; the
@@ -226,6 +107,8 @@ if (_fastCommand && !_binCommands.has(_fastCommand) && !REGISTERED_VERBS_SET.has
 // already read (so it's never read twice), preserving the fail-soft contract.
 // `hook` stays in `_binCommands` so the GTD auto-route + generic daemon block
 // skip it; PRJCT_NO_DAEMON=1 also skips this and falls through to main().
+// Runs BEFORE the verb-registry import and the update/self-heal blocks —
+// hooks are the hottest path and need none of them.
 if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
   const fs = await import('node:fs')
   const { DAEMON_PATHS } = await import('../core/daemon/protocol')
@@ -287,6 +170,99 @@ if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
       process.stdout.write('{}\n')
       process.exit(0)
     }
+  }
+}
+
+// v2 verbs registered in the command registry — imported from the single
+// source of truth so adding a verb only requires updating one list.
+// Imported AFTER the hook fast path: hooks never need it.
+const { REGISTERED_VERBS_SET } = await import('../core/commands/verb-names')
+
+// v2 auto-route: if the first positional isn't a known verb, treat the
+// whole argv as GTD-style inbox capture → `prjct capture "<argv>"`.
+// Explicit verbs still win. Capture is zero-ceremony; if the user
+// wanted a task (branch/worktree), they type `prjct task "..."`
+// explicitly. Must run BEFORE the daemon fast path so the rewritten
+// `capture` routes there.
+if (_fastCommand && !_binCommands.has(_fastCommand) && !REGISTERED_VERBS_SET.has(_fastCommand)) {
+  const positionals = _fastArgs.filter((a) => !a.startsWith('-'))
+  const description = positionals.join(' ')
+  const flags = _fastArgs.filter((a) => a.startsWith('-'))
+  // A single command-shaped token (e.g. `prjct upgrade`) is almost never a
+  // GTD note — it's a MISROUTED command: a typo, or a stale parallel
+  // install / long-lived daemon that predates the verb. Silently turning it
+  // into an inbox capture buries it with zero feedback (same silent-no-op
+  // class as the WS1 exit-0 bug). Still capture (don't break free-text GTD)
+  // but make it LOUD + actionable so it's never a silent surprise.
+  if (positionals.length === 1 && /^[a-z][a-z0-9:-]+$/.test(positionals[0])) {
+    process.stderr.write(
+      `prjct: '${positionals[0]}' is not a known command in this install — ` +
+        'saving it to the inbox instead. If you meant the command, this prjct ' +
+        'may be stale: run `prjct update`.\n'
+    )
+  }
+  _fastCommand = 'capture'
+  _fastArgs = ['capture', description, ...flags]
+}
+
+// Update notice — print at process exit so the banner appears AFTER the
+// command's own output. Uses a sync read of the cached latest version;
+// the cache is refreshed in a detached background process so the
+// network call never delays the user-visible command. Skipped for
+// machine-consumed paths (`hook`, `--md`/`--json`, `--quiet`) and for
+// the updater itself. Awaited at top-level so the exit handler is
+// installed BEFORE the daemon fast path's `process.exit` runs.
+const _updateSkipCommands = new Set([
+  'update',
+  'upgrade',
+  'daemon',
+  'hook',
+  'version',
+  '-v',
+  '--version',
+])
+if (
+  _fastCommand &&
+  !_updateSkipCommands.has(_fastCommand) &&
+  process.stderr.isTTY &&
+  !_fastArgs.includes('--md') &&
+  !_fastArgs.includes('--json') &&
+  !_fastArgs.includes('--quiet') &&
+  !_fastArgs.includes('-q') &&
+  process.env.PRJCT_NO_UPDATE_NOTICE !== '1'
+) {
+  const { triggerBackgroundRefreshIfStale, getUpdateNotificationSync } = await import(
+    '../core/infrastructure/update-checker'
+  )
+  // Resolve the running version once, synchronously, so the exit
+  // handler (which can't await) has it ready.
+  const _fs = await import('node:fs')
+  const _path = await import('node:path')
+  let _currentVersion = ''
+  try {
+    const pkgPath = _path.resolve(
+      _path.dirname(new URL(import.meta.url).pathname),
+      '..',
+      'package.json'
+    )
+    _currentVersion = JSON.parse(_fs.readFileSync(pkgPath, 'utf-8')).version ?? ''
+  } catch {
+    /* no version, no banner */
+  }
+  try {
+    triggerBackgroundRefreshIfStale()
+  } catch {
+    /* best-effort */
+  }
+  if (_currentVersion) {
+    process.on('exit', () => {
+      try {
+        const banner = getUpdateNotificationSync(_currentVersion)
+        if (banner) process.stderr.write(banner)
+      } catch {
+        /* never block exit on a notification */
+      }
+    })
   }
 }
 
@@ -373,6 +349,39 @@ if (_fastCommand && !_binCommands.has(_fastCommand) && process.env.PRJCT_NO_DAEM
       }
       // Stale socket / no listener — fall through to direct execution.
     }
+  }
+}
+
+// === SELF-HEAL ===
+// Re-install hooks + global CLAUDE.md when the binary version has moved
+// past the last successful sync. Replaces postinstall (which is disabled
+// by --ignore-scripts and corporate security policies on many client
+// machines). Hot path is a single fs read of the stamp file; the slow
+// path (a few writes to settings.json + CLAUDE.md) only fires once per
+// version bump per machine.
+//
+// Runs AFTER the daemon fast path: daemon-served commands exit above and
+// skip it, which is fine — the SessionStart hook fires its own self-heal
+// every session, so healing coverage is unchanged while the daemon path
+// stops paying the version/stamp reads.
+//
+// Skipped for:
+//   - `daemon`/`update`/`version` (would deadlock the upgrade flow)
+//   - `hook` (session-start fires its own self-heal; other hook events
+//     fire too often to pay even the fs-read cost)
+//   - PRJCT_NO_SELF_SYNC=1 (escape hatch)
+const _selfHealSkip = new Set(['daemon', 'update', 'upgrade', 'version', '-v', '--version', 'hook'])
+if (_fastCommand && !_selfHealSkip.has(_fastCommand) && process.env.PRJCT_NO_SELF_SYNC !== '1') {
+  try {
+    const { VERSION } = await import('../core/utils/version')
+    if (VERSION) {
+      const { isSyncCurrent, runSelfHeal } = await import('../core/infrastructure/self-heal')
+      if (!isSyncCurrent(VERSION)) {
+        await runSelfHeal(VERSION)
+      }
+    }
+  } catch {
+    // best-effort — never block the user's command on self-heal
   }
 }
 

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -17,12 +17,14 @@
  * delegated capture to Claude instead of doing it ourselves).
  */
 
+import fs from 'node:fs/promises'
 import configManager from '../infrastructure/config-manager'
 import { embeddingService } from '../services/embeddings'
 import { detectFriction } from '../services/friction-detector'
 import { detectAndPersistPatterns } from '../services/pattern-detector'
 import { recordCleanupReport, runSessionCleanup } from '../services/session-cleanup'
 import { detectSkillMisses } from '../services/skill-miss-detector'
+import { parseTranscriptJsonl, type TranscriptJsonlLine } from '../services/transcript-jsonl'
 import { ingestTranscript } from '../services/transcript-learner'
 import { usefulnessService } from '../services/usefulness'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
@@ -43,6 +45,15 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         const config = await configManager.readConfig(p).catch(() => null)
         if (!config?.projectId) return
 
+        // Read + parse the transcript ONCE. Three consumers below
+        // (transcript-learner, friction-detector, skill-miss-detector) each
+        // used to re-read and re-tokenize the same multi-hundred-KB JSONL.
+        let transcriptLines: TranscriptJsonlLine[] | undefined
+        if (input.transcript_path) {
+          const raw = await fs.readFile(input.transcript_path, 'utf-8').catch(() => null)
+          if (raw !== null) transcriptLines = parseTranscriptJsonl(raw)
+        }
+
         // Captured notes → memory entries (existing behavior).
         try {
           await ingestCapturedNotes(p)
@@ -52,7 +63,7 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
 
         // M1b INPUT: workflow overrides → workflow_rules table.
         try {
-          await ingestWorkflowEdits(p)
+          await ingestWorkflowEdits(p, config)
         } catch {
           // Same contract — failed parses leave the file in place for the user.
         }
@@ -61,7 +72,10 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // transcript. Conservative heuristics, hashed-dedup, never blocks.
         if (input.transcript_path) {
           try {
-            await ingestTranscript(p, input.transcript_path, input.session_id ?? null)
+            await ingestTranscript(p, input.transcript_path, input.session_id ?? null, {
+              preloadedConfig: config,
+              preloadedLines: transcriptLines,
+            })
           } catch {
             // Failed parse / unexpected format → swallow. The user can
             // always run `prjct remember` explicitly.
@@ -72,7 +86,7 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // as learning memory entries. Lookup-first protocol means Claude
         // finds them on next session start without inflating context.
         try {
-          await detectAndPersistPatterns(p)
+          await detectAndPersistPatterns(p, config)
         } catch {
           // Git failure / non-repo → swallow; nothing to do here.
         }
@@ -99,7 +113,10 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
             const friction = await detectFriction(
               p,
               input.transcript_path,
-              input.session_id ?? null
+              input.session_id ?? null,
+              {
+                preloadedLines: transcriptLines,
+              }
             )
             // AUTOMATIC negative reinforcement (no command): if the user
             // pushed back this session, demote the memories that were in
@@ -127,7 +144,9 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // best-effort contract as the friction detector above.
         if (input.transcript_path) {
           try {
-            await detectSkillMisses(p, input.transcript_path, input.session_id ?? null)
+            await detectSkillMisses(p, input.transcript_path, input.session_id ?? null, {
+              preloadedLines: transcriptLines,
+            })
           } catch {
             /* silent best-effort — must never block session end */
           }
@@ -140,7 +159,11 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // Best-effort, idempotent (only un-embedded entries are touched), and
         // must never block session end.
         try {
-          await embeddingService.backfill(p, config, new Date().toISOString())
+          // First arg is the projectId, NOT the path: passing `p` here keyed
+          // every query to path.join(projectsDir, <abs path>) — a phantom DB
+          // under ~/.prjct-cli/projects/Users/... that made the session-end
+          // backfill a silent no-op (ghost dirs confirmed on disk).
+          await embeddingService.backfill(config.projectId, config, new Date().toISOString())
         } catch {
           /* never block session end on index maintenance */
         }

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -785,6 +785,45 @@ export const projectMemory = {
    * every cross-reference resolvable (the mem_3233 dangling class, at
    * graph scale). Read-only, best-effort.
    */
+  /**
+   * Entries that still LACK a vector for `model` — the embedding-backfill
+   * work list, via SQL anti-join instead of deserializing the whole corpus
+   * and set-diffing in JS. The improvement-signal / hot-file exclusions
+   * mirror `isModelMemory` as SQL pre-filters; callers still apply
+   * `isModelMemory` over the (small) result for authority.
+   */
+  unembeddedEntriesForIndex(projectId: string, model: string): MemoryEntry[] {
+    try {
+      const rows = prjctDb.query<EventRow>(
+        projectId,
+        `SELECT e.id, e.type, e.data, e.timestamp FROM events e
+          WHERE e.type LIKE ?
+            AND e.type != ?
+            AND NOT EXISTS (
+              SELECT 1 FROM memory_embeddings me
+               WHERE me.memory_id = 'mem_' || e.id AND me.model = ?
+            )
+          ORDER BY e.id DESC`,
+        `${REMEMBER_EVENT_PREFIX}%`,
+        `${REMEMBER_EVENT_PREFIX}improvement-signal`,
+        model
+      )
+      const shipped = prjctDb.query<ShippedRow>(
+        projectId,
+        `SELECT s.id, s.name, s.type, s.shipped_at, s.data FROM shipped_features s
+          WHERE NOT EXISTS (
+            SELECT 1 FROM memory_embeddings me
+             WHERE me.memory_id = 'ship_' || s.id AND me.model = ?
+          )
+          ORDER BY s.shipped_at DESC`,
+        model
+      )
+      return [...rows.map(rowToEntry), ...shipped.map(shippedRowToEntry)]
+    } catch {
+      return []
+    }
+  },
+
   allEntriesForIndex(projectId: string): MemoryEntry[] {
     try {
       const rows = prjctDb.query<EventRow>(

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -283,6 +283,10 @@ export const projectMemory = {
       source?: string
       /** Defaults to `declared` — user/LLM asserted this directly. */
       provenance?: MemoryProvenance
+      /** Skips the config read when the caller already resolved it — the
+       *  Stop-hook detectors fire several remembers per turn and each used
+       *  to re-read + re-parse prjct.config.json. */
+      projectId?: string
     }
   ): Promise<void> {
     const tags = args.tags ?? {}
@@ -291,12 +295,14 @@ export const projectMemory = {
 
     // Resolve the project once and reuse it for both the dedup guard and the
     // sync publish below (each used to read + parse the config independently).
-    let projectId: string | undefined
-    try {
-      const { default: configManager } = await import('../infrastructure/config-manager')
-      projectId = (await configManager.readConfig(projectPath))?.projectId
-    } catch {
-      /* config unreadable — dedup + sync are best-effort; the local write proceeds */
+    let projectId: string | undefined = args.projectId
+    if (!projectId) {
+      try {
+        const { default: configManager } = await import('../infrastructure/config-manager')
+        projectId = (await configManager.readConfig(projectPath))?.projectId
+      } catch {
+        /* config unreadable — dedup + sync are best-effort; the local write proceeds */
+      }
     }
 
     // Dedup net: a verbatim re-capture of the same (type, content) adds no

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -292,6 +292,9 @@ function dot(a: ArrayLike<number>, b: ArrayLike<number>): number {
  */
 const SEMANTIC_SCAN_MAX_ROWS = 2000
 
+/** Noise-vector pruning runs on every Nth backfill (see shouldPruneThisRun). */
+const PRUNE_EVERY = 10
+
 export const embeddingService = {
   /**
    * Always true now: the local default provider makes semantic search
@@ -353,20 +356,29 @@ export const embeddingService = {
   ): Promise<{ embedded: number; skipped: number; total: number }> {
     const provider = opts.provider ?? resolveActiveProvider(config)
     const batchSize = opts.batchSize ?? 64
-    const all = projectMemory.allEntriesForIndex(projectId)
+
+    // Work list via SQL anti-join: only entries that still lack a vector are
+    // fetched + deserialized. The old path loaded the WHOLE corpus on every
+    // Stop hook just to set-diff against embeddedIds in JS.
+    const todo = projectMemory
+      .unembeddedEntriesForIndex(projectId, provider.model)
+      .filter((e) => isModelMemory(e) && e.content.trim().length > 0)
 
     // Selectivity (RAG north star): embed only entries that MODEL the
-    // project/developer, never bulk-vectorize telemetry noise. Prune any noise
-    // vectors a prior (indiscriminate) backfill stored, so semantic recall
-    // stops surfacing hot-file churn / raw friction.
-    const model = all.filter((e) => isModelMemory(e))
-    this.pruneNonModelVectors(
-      projectId,
-      all.filter((e) => !isModelMemory(e)).map((e) => e.id)
-    )
+    // project/developer, never bulk-vectorize telemetry noise. Pruning noise
+    // vectors needs the full corpus, so it's throttled to every Nth backfill
+    // (first run always prunes) — a stale noise vector is harmless meanwhile.
+    if (this.shouldPruneThisRun(projectId)) {
+      const all = projectMemory.allEntriesForIndex(projectId)
+      this.pruneNonModelVectors(
+        projectId,
+        all.filter((e) => !isModelMemory(e)).map((e) => e.id)
+      )
+    }
 
-    const have = this.embeddedIds(projectId, provider.model)
-    const todo = model.filter((e) => !have.has(e.id) && e.content.trim().length > 0)
+    // "skipped" = entries already vectorized by prior runs (counted before
+    // this run's stores land, mirroring the old set-diff semantics).
+    const alreadyEmbedded = this.countByModel(projectId, provider.model)
 
     let embedded = 0
     for (let i = 0; i < todo.length; i += batchSize) {
@@ -384,7 +396,35 @@ export const embeddingService = {
         // Skip this batch; the next backfill retries it.
       }
     }
-    return { embedded, skipped: model.length - todo.length, total: model.length }
+    return { embedded, skipped: alreadyEmbedded, total: alreadyEmbedded + todo.length }
+  },
+
+  /** Vectors already stored for `model` — the previous runs' work. */
+  countByModel(projectId: string, model: string): number {
+    try {
+      const row = prjctDb.get<{ n: number }>(
+        projectId,
+        'SELECT COUNT(*) AS n FROM memory_embeddings WHERE model = ?',
+        model
+      )
+      return row?.n ?? 0
+    } catch {
+      return 0
+    }
+  },
+
+  /** Prune throttle: every PRUNE_EVERY-th backfill, starting with the first.
+   *  Counter lives in kv_store so it survives across processes. Best-effort —
+   *  any storage error defaults to pruning (the safe, if slower, choice). */
+  shouldPruneThisRun(projectId: string): boolean {
+    try {
+      const KEY = 'embeddings:prune-tick'
+      const tick = prjctDb.getDoc<number>(projectId, KEY) ?? 0
+      prjctDb.setDoc(projectId, KEY, (tick + 1) % PRUNE_EVERY)
+      return tick === 0
+    } catch {
+      return true
+    }
   },
 
   /** Delete stored vectors for entries that are no longer model-worthy

--- a/core/services/friction-detector.ts
+++ b/core/services/friction-detector.ts
@@ -25,6 +25,7 @@
 import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import { projectMemory } from '../memory/project-memory'
+import { parseTranscriptJsonl, type TranscriptJsonlLine } from './transcript-jsonl'
 
 const SOURCE_TAG = 'friction-detector'
 const MAX_SIGNALS_PER_SESSION = 5
@@ -88,16 +89,21 @@ export interface FrictionResult {
 export async function detectFriction(
   projectPath: string,
   transcriptPath: string,
-  sessionId: string | null
+  sessionId: string | null,
+  opts: { preloadedLines?: TranscriptJsonlLine[] } = {}
 ): Promise<FrictionResult> {
-  let raw = ''
-  try {
-    raw = await fs.readFile(transcriptPath, 'utf-8')
-  } catch {
-    return { signalsRecorded: 0, signalsSkipped: 0 }
+  let lines: TranscriptLine[]
+  if (opts.preloadedLines) {
+    lines = opts.preloadedLines as TranscriptLine[]
+  } else {
+    let raw = ''
+    try {
+      raw = await fs.readFile(transcriptPath, 'utf-8')
+    } catch {
+      return { signalsRecorded: 0, signalsSkipped: 0 }
+    }
+    lines = parseJsonl(raw)
   }
-
-  const lines = parseJsonl(raw)
   const signals = extractSignals(lines)
   if (signals.length === 0) {
     return { signalsRecorded: 0, signalsSkipped: 0 }
@@ -105,6 +111,7 @@ export async function detectFriction(
 
   // Dedup against signals already in memory (hashing on excerpt).
   const existing = projectMemoryHashes(projectPath)
+  const projectId = projectIdFromPath(projectPath) ?? undefined
   let recorded = 0
   let skipped = 0
   for (const signal of signals.slice(0, MAX_SIGNALS_PER_SESSION)) {
@@ -128,6 +135,7 @@ export async function detectFriction(
           key: dedupKey, // dedup key for the (type, key) latest-winner rule
         },
         provenance: 'extracted',
+        projectId,
       })
       recorded++
     } catch {
@@ -140,16 +148,7 @@ export async function detectFriction(
 // Helpers — exported for tests via _internal.
 
 function parseJsonl(raw: string): TranscriptLine[] {
-  const out: TranscriptLine[] = []
-  for (const line of raw.split('\n')) {
-    if (!line.trim()) continue
-    try {
-      out.push(JSON.parse(line) as TranscriptLine)
-    } catch {
-      /* skip malformed line */
-    }
-  }
-  return out
+  return parseTranscriptJsonl(raw) as TranscriptLine[]
 }
 
 /**

--- a/core/services/global-config.ts
+++ b/core/services/global-config.ts
@@ -42,21 +42,45 @@ interface GlobalConfig {
   [key: string]: GlobalConfigValue | undefined
 }
 
-function readRaw(): GlobalConfig {
+// Parsed-config cache validated by file identity (path + mtime + size).
+// `resolveGlobalEmbeddings` calls getConfig 7× per invocation, on every
+// Stop hook — each was a readFileSync + JSON.parse. A stat is ~10× cheaper
+// and stays correct across processes (a CLI `prjct embeddings set` bumps
+// the mtime, so a long-lived daemon picks the change up on its next read).
+let _cache: GlobalConfig | null = null
+let _cacheStamp = ''
+
+function fileStamp(file: string): string {
   try {
-    const raw = fs.readFileSync(configFilePath(), 'utf-8')
+    const st = fs.statSync(file)
+    return `${file}|${st.mtimeMs}|${st.size}`
+  } catch {
+    return `${file}|absent`
+  }
+}
+
+function readRaw(): GlobalConfig {
+  const file = configFilePath()
+  const stamp = fileStamp(file)
+  if (_cache !== null && stamp === _cacheStamp) return _cache
+  let cfg: GlobalConfig = {}
+  try {
+    const raw = fs.readFileSync(file, 'utf-8')
     const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-      return parsed as GlobalConfig
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) cfg = parsed as GlobalConfig
   } catch {
     // missing or malformed → start fresh
   }
-  return {}
+  _cache = cfg
+  _cacheStamp = stamp
+  return cfg
 }
 
 function writeRaw(cfg: GlobalConfig): void {
   fs.mkdirSync(configDir(), { recursive: true })
   fs.writeFileSync(configFilePath(), `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8')
+  _cache = cfg
+  _cacheStamp = fileStamp(configFilePath())
 }
 
 export function getConfig<K extends keyof GlobalConfig>(key: K): GlobalConfig[K] {

--- a/core/services/pattern-detector.ts
+++ b/core/services/pattern-detector.ts
@@ -29,6 +29,7 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
+import type { LocalConfig } from '../types/config'
 
 const execFileP = promisify(execFile)
 
@@ -86,7 +87,10 @@ interface DetectResult {
  * hook awaits this best-effort. Each detector is wrapped so a single
  * failure (e.g. git missing) never breaks the others.
  */
-export async function detectAndPersistPatterns(projectPath: string): Promise<DetectResult> {
+export async function detectAndPersistPatterns(
+  projectPath: string,
+  preloadedConfig?: LocalConfig | null
+): Promise<DetectResult> {
   const result: DetectResult = {
     scanned: 0,
     hotFiles: [],
@@ -95,7 +99,10 @@ export async function detectAndPersistPatterns(projectPath: string): Promise<Det
     errors: [],
   }
 
-  const config = await configManager.readConfig(projectPath).catch(() => null)
+  const config =
+    preloadedConfig !== undefined
+      ? preloadedConfig
+      : await configManager.readConfig(projectPath).catch(() => null)
   if (!config?.projectId) {
     result.errors.push('no project config')
     return result

--- a/core/services/skill-miss-detector.ts
+++ b/core/services/skill-miss-detector.ts
@@ -34,6 +34,7 @@ import fs from 'node:fs/promises'
 import { projectMemory } from '../memory/project-memory'
 import { getModifiedFiles } from '../session/git-helpers'
 import { crewRunStorage } from '../storage/crew-run-storage'
+import { parseTranscriptJsonl, type TranscriptJsonlLine } from './transcript-jsonl'
 import { usefulnessService } from './usefulness'
 
 const SOURCE_TAG = 'skill-miss-detector'
@@ -148,19 +149,26 @@ export interface SkillMissResult {
 export async function detectSkillMisses(
   projectPath: string,
   transcriptPath: string,
-  sessionId: string | null
+  sessionId: string | null,
+  opts: { preloadedLines?: TranscriptJsonlLine[] } = {}
 ): Promise<SkillMissResult> {
-  let raw = ''
-  try {
-    raw = await fs.readFile(transcriptPath, 'utf-8')
-  } catch {
-    return { signalsRecorded: 0, signalsSkipped: 0 }
+  let lines: TranscriptLine[]
+  if (opts.preloadedLines) {
+    lines = opts.preloadedLines as TranscriptLine[]
+  } else {
+    let raw = ''
+    try {
+      raw = await fs.readFile(transcriptPath, 'utf-8')
+    } catch {
+      return { signalsRecorded: 0, signalsSkipped: 0 }
+    }
+    lines = parseJsonl(raw)
   }
 
   const projectId = projectIdFromPath(projectPath)
   if (!projectId) return { signalsRecorded: 0, signalsSkipped: 0 }
 
-  const transcriptText = transcriptTextOf(parseJsonl(raw))
+  const transcriptText = transcriptTextOf(lines)
   if (!transcriptText) return { signalsRecorded: 0, signalsSkipped: 0 }
 
   let candidates: CandidateMemory[]
@@ -220,6 +228,7 @@ export async function detectSkillMisses(
           ...(sessionId ? { session: sessionId } : {}),
         },
         provenance: 'extracted',
+        projectId,
       })
       // The remember() above auto-credited the missed entry via its
       // `relates:` tag — but a miss is not usage. Cancel it + nudge down.
@@ -309,16 +318,7 @@ function analyze(
 }
 
 function parseJsonl(raw: string): TranscriptLine[] {
-  const out: TranscriptLine[] = []
-  for (const line of raw.split('\n')) {
-    if (!line.trim()) continue
-    try {
-      out.push(JSON.parse(line) as TranscriptLine)
-    } catch {
-      /* skip malformed line */
-    }
-  }
-  return out
+  return parseTranscriptJsonl(raw) as TranscriptLine[]
 }
 
 /** Flatten all user + assistant turn text into one lowercased blob. */

--- a/core/services/transcript-jsonl.ts
+++ b/core/services/transcript-jsonl.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared JSONL tokenization for Claude Code session transcripts.
+ *
+ * Three Stop-hook services (transcript-learner, friction-detector,
+ * skill-miss-detector) consume the same transcript file. Each used to
+ * read and JSON.parse it independently — 3 reads + 3 parse passes of a
+ * potentially multi-hundred-KB file per session end. The Stop hook now
+ * reads + parses ONCE via this module and hands the raw line objects to
+ * each service; every service keeps its own typed projection (role
+ * inference, text extraction) over the shared lines.
+ */
+
+export type TranscriptJsonlLine = Record<string, unknown>
+
+/** Parse transcript JSONL into raw line objects, skipping malformed lines. */
+export function parseTranscriptJsonl(raw: string): TranscriptJsonlLine[] {
+  const out: TranscriptJsonlLine[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      if (parsed && typeof parsed === 'object') out.push(parsed as TranscriptJsonlLine)
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return out
+}

--- a/core/services/transcript-learner.ts
+++ b/core/services/transcript-learner.ts
@@ -25,6 +25,8 @@ import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import configManager from '../infrastructure/config-manager'
 import { type MemoryType, projectMemory } from '../memory/project-memory'
+import type { LocalConfig } from '../types/config'
+import { parseTranscriptJsonl, type TranscriptJsonlLine } from './transcript-jsonl'
 
 const SOURCE_TAG = 'transcript-auto'
 const MIN_PARAGRAPH_CHARS = 80
@@ -84,25 +86,35 @@ const PHRASE_TYPE_MAP: Array<{ phrase: string; type: MemoryType }> = [
 export async function ingestTranscript(
   projectPath: string,
   transcriptPath: string,
-  sessionId: string | null
+  sessionId: string | null,
+  opts: { preloadedConfig?: LocalConfig | null; preloadedLines?: TranscriptJsonlLine[] } = {}
 ): Promise<IngestResult> {
   const result: IngestResult = { scanned: 0, ingested: 0, skipped: [], errors: [] }
 
-  const config = await configManager.readConfig(projectPath).catch(() => null)
+  const config =
+    opts.preloadedConfig !== undefined
+      ? opts.preloadedConfig
+      : await configManager.readConfig(projectPath).catch(() => null)
   if (!config?.projectId) {
     result.errors.push('no project config')
     return result
   }
 
-  let raw: string
-  try {
-    raw = await fs.readFile(transcriptPath, 'utf-8')
-  } catch (err) {
-    result.errors.push(`transcript read failed: ${(err as Error).message}`)
-    return result
+  let lines: TranscriptJsonlLine[]
+  if (opts.preloadedLines) {
+    lines = opts.preloadedLines
+  } else {
+    let raw: string
+    try {
+      raw = await fs.readFile(transcriptPath, 'utf-8')
+    } catch (err) {
+      result.errors.push(`transcript read failed: ${(err as Error).message}`)
+      return result
+    }
+    lines = parseTranscriptJsonl(raw)
   }
 
-  const messages = parseTranscript(raw)
+  const messages = projectMessages(lines)
   result.scanned = messages.length
   if (messages.length === 0) return result
 
@@ -132,6 +144,7 @@ export async function ingestTranscript(
           phrase: cand.matchedPhrase,
         },
         provenance: 'inferred',
+        projectId: config.projectId,
       })
       result.ingested += 1
     } catch (err) {
@@ -158,16 +171,13 @@ interface TranscriptMessage {
  * calls, tool results, and user turns are skipped.
  */
 function parseTranscript(raw: string): TranscriptMessage[] {
+  return projectMessages(parseTranscriptJsonl(raw))
+}
+
+/** Typed projection over shared raw lines: assistant turns with real text. */
+function projectMessages(lines: TranscriptJsonlLine[]): TranscriptMessage[] {
   const out: TranscriptMessage[] = []
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    let parsed: Record<string, unknown>
-    try {
-      parsed = JSON.parse(trimmed) as Record<string, unknown>
-    } catch {
-      continue
-    }
+  for (const parsed of lines) {
     const role = inferRole(parsed)
     if (role !== 'assistant') continue
     const text = extractText(parsed)

--- a/core/services/wiki-ingest.ts
+++ b/core/services/wiki-ingest.ts
@@ -32,6 +32,7 @@ import path from 'node:path'
 import configManager from '../infrastructure/config-manager'
 import { MEMORY_TYPES, type MemoryType, projectMemory } from '../memory/project-memory'
 import { workflowRuleStorage } from '../storage/workflow-rule-storage'
+import type { LocalConfig } from '../types/config'
 import type { WorkflowRule } from '../types/storage/extended'
 import { scanForPromptInjection } from '../utils/prompt-injection'
 import { scanForSecrets } from '../utils/secret-scanner'
@@ -490,9 +491,15 @@ interface WorkflowIngestResult {
  * snapshot under _generated/workflows/ on the next run, so the user
  * sees their edits reflected immediately.
  */
-export async function ingestWorkflowEdits(projectPath: string): Promise<WorkflowIngestResult> {
+export async function ingestWorkflowEdits(
+  projectPath: string,
+  preloadedConfig?: LocalConfig | null
+): Promise<WorkflowIngestResult> {
   const result: WorkflowIngestResult = { ingested: [], skipped: [], errors: [] }
-  const config = await configManager.readConfig(projectPath).catch(() => null)
+  const config =
+    preloadedConfig !== undefined
+      ? preloadedConfig
+      : await configManager.readConfig(projectPath).catch(() => null)
   if (!config?.projectId) return result
   const projectId = config.projectId
 

--- a/core/storage/database.ts
+++ b/core/storage/database.ts
@@ -241,6 +241,36 @@ class PrjctDatabase {
     )
   }
 
+  /**
+   * Atomic read-modify-write for a kv_store doc inside one BEGIN IMMEDIATE
+   * transaction. Replaces the optimistic CAS retry loop in
+   * StorageManager.update: IMMEDIATE takes the write lock up front, so a
+   * concurrent writer (daemon vs CLI, sibling worktree agents) WAITS — up
+   * to busy_timeout (5000ms) — instead of looping read→conflict→re-read.
+   * One SELECT + one write per update instead of up to 8×(2 SELECTs +
+   * UPDATE). The monotonic-stamp rule from nextKvStamp is preserved using
+   * the row already read — no second SELECT.
+   */
+  updateDoc<T>(projectId: string, key: string, updater: (current: T) => T, getDefault: () => T): T {
+    const db = this.getDb(projectId)
+    return runImmediate(db, () => {
+      const row = this.prepareCached(db, 'SELECT data, updated_at FROM kv_store WHERE key = ?').get(
+        key
+      ) as { data: string; updated_at: string } | null
+      const base = row ? (JSON.parse(row.data) as T) : getDefault()
+      const updated = updater(base)
+      const nowIso = new Date().toISOString()
+      const prev = row?.updated_at
+      const stamp =
+        !prev || nowIso > prev ? nowIso : new Date(new Date(prev).getTime() + 1).toISOString()
+      this.prepareCached(
+        db,
+        'INSERT OR REPLACE INTO kv_store (key, data, updated_at) VALUES (?, ?, ?)'
+      ).run(key, JSON.stringify(updated), stamp)
+      return updated
+    })
+  }
+
   deleteDoc(projectId: string, key: string): void {
     const db = this.getDb(projectId)
     this.prepareCached(db, 'DELETE FROM kv_store WHERE key = ?').run(key)

--- a/core/storage/storage-manager.ts
+++ b/core/storage/storage-manager.ts
@@ -159,29 +159,19 @@ export abstract class StorageManager<T> {
    * Update data with a transform function
    */
   async update(projectId: string, updater: (current: T) => T): Promise<T> {
-    // Optimistic CAS retry. The old read→transform→write was a lost-update
+    // Atomic read-modify-write inside one BEGIN IMMEDIATE transaction
+    // (prjctDb.updateDoc). The old read→transform→write was a lost-update
     // race: the daemon and a concurrent CLI both read `state`, both wrote,
     // the second blind-overwrote the first (a paused/completed task lost).
-    // WAL+busy_timeout does NOT prevent this — it's an application-level
-    // read-modify-write. We re-read the freshest COMMITTED doc (bypassing
-    // the 5s TTL cache, which can be cross-process stale) and only commit
-    // when the row is unchanged since our read; otherwise re-read & retry.
+    // The write lock is taken up front, so a concurrent writer WAITS (up to
+    // busy_timeout=5000ms) and then re-reads committed state — strictly
+    // stronger than the previous 8-attempt optimistic CAS loop, with one
+    // SELECT + one write per update instead of up to 24 round-trips. True
+    // sustained contention surfaces as SQLITE_BUSY from the driver.
     const key = this.getStoreKey()
-    const MAX_ATTEMPTS = 8
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      const snap = prjctDb.getDocWithStamp<T>(projectId, key)
-      const base = snap ? snap.data : this.getDefault()
-      const updated = updater(base)
-      if (prjctDb.casSetDoc(projectId, key, updated, snap?.updatedAt ?? null)) {
-        this.cache.set(projectId, updated) // keep cache coherent with the win
-        return updated
-      }
-      // Another writer committed between our read and write — loop re-reads
-      // the now-current state and re-applies the (pure) transform.
-    }
-    throw new Error(
-      `StorageManager.update: unresolved write contention after ${MAX_ATTEMPTS} attempts (key=${key})`
-    )
+    const updated = prjctDb.updateDoc<T>(projectId, key, updater, () => this.getDefault())
+    this.cache.set(projectId, updated) // keep cache coherent with the committed write
+    return updated
   }
 
   /**


### PR DESCRIPTION
## What

PR 2 of the improvement epic (rebased onto main after #415 / v2.42.0 merged).

### Bug found & fixed
- **Session-end embedding backfill was a silent no-op**: `stop.ts` passed the project *path* where `backfill` expects the project *id* — every session end wrote vectors to a phantom DB under `~/.prjct-cli/projects/Users/…` (ghost dirs confirmed on disk).

### Per-turn hot paths
- Stop hook reads `prjct.config.json` **once** (was 4–5×: per sub-service + per `remember()`) and the transcript JSONL **once** (was 3×). New shared `transcript-jsonl.ts` also deduplicates three identical parsers.
- `StorageManager.update`: 8-attempt optimistic CAS loop (up to 24 SQLite round-trips) → one `BEGIN IMMEDIATE` read-modify-write. Strictly stronger for multi-agent state.
- Embedding backfill: SQL anti-join fetches only un-vectorized entries instead of deserializing the whole corpus per Stop; noise pruning throttled to every 10th run.
- `global-config`: stat-validated cache kills 7 sync read+parse per `resolveActiveProvider` call; cross-process safe via mtime.
- `bin/prjct.ts` cold-path reorder: hook fast path first (no verb-registry/update/self-heal cost), self-heal after the daemon fast path (SessionStart self-heal keeps coverage).

### Plan deviations (with rationale)
- **Dropped** the fingerprint TTL memo: a 5s memo can serve a pre-write fingerprint when another process (MCP server) writes within the TTL — same staleness class this project fixed twice already; ~0.5ms not worth it.
- **Deferred** daemon lazy command-group loading to PR 3: it requires refactoring `commands.ts` + `register.ts` dispatch machinery that PR 3's command manifest restructures anyway.

## Verification
- `bun test`: 1497 pass / 0 fail (full suite), typecheck + biome clean
- Cold-path smoke: `version`, `help`, `hook prompt` via `PRJCT_NO_DAEMON=1 bun bin/prjct.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)