### PR TITLE
fix: confirmed findings from the v2.42.x range code review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+Fixes from a full code review of the v2.42.0–v2.42.4 range (7 review angles, 42 candidates, verified).
+
+### Fixed
+- **Lazy command loaders no longer memoize rejected promises.** A transient import/constructor error during the first dispatch of a command group used to be cached forever — every later command in that group replayed the same error for the daemon's lifetime (the old eager loading failed loud at startup instead). Both layers fixed (registry group loaders + the 17 `PrjctCommands` getters); the next dispatch now retries.
+- **`mapOptions` numbers**: non-numeric input for a numeric flag maps to `undefined` (flag ignored) instead of `NaN`.
+
+### Changed
+- New CI guard: `manifest-completeness` instantiates every command group and verifies each manifest `routing.method` actually exists — restoring the registration-time validation the lazy refactor deferred to first dispatch.
+- `registerLazyMethod` memoizes the resolved instance+method pair (was re-resolving per dispatch); dead `registerMethod` deleted (single registration mechanism).
+- `runBinCommand` imports moved into the branches that use them — every bin command was paying the `version` branch's chalk/ai-provider/file-helper imports.
+- `compareSemver` deduped to the `schemas/model.ts` implementation; the monotonic-stamp rule shared between `nextKvStamp` and `updateDoc`; `cosineSimilarity` single-sourced over `dot`/`l2Norm`.
+
+
 Optimization backlog pass (the items deferred since v2.37.x, consolidated in mem_1814).
 
 ### Fixed

--- a/core/__tests__/commands/manifest-completeness.test.ts
+++ b/core/__tests__/commands/manifest-completeness.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, test } from 'bun:test'
 import { BIN_ONLY_COMMANDS, COMMAND_ALIASES, COMMANDS } from '../../commands/command-data'
 import { mapOptions } from '../../commands/option-mapper'
+import { groupLoaders } from '../../commands/register'
 import { BIN_COMMANDS_SET, REGISTERED_VERBS_SET } from '../../commands/verb-names'
 
 describe('command manifest — completeness', () => {
@@ -70,6 +71,25 @@ describe('command manifest — completeness', () => {
     const missing = COMMANDS.filter(
       (c) => c.routing && !complex.has(c.name) && !c.optionSchema
     ).map((c) => c.name)
+    expect(missing).toEqual([])
+  })
+})
+
+describe('command manifest — handler validation', () => {
+  test('every routing.method exists on its group class', async () => {
+    // registerLazyMethod defers "method is not a function" from registration
+    // to first dispatch — a typo'd routing.method in the manifest would only
+    // surface when a user runs the verb. This test restores the old
+    // registration-time guarantee at CI time: instantiate every group once
+    // and probe each method.
+    const missing: string[] = []
+    for (const meta of COMMANDS) {
+      if (!meta.routing) continue
+      const instance = (await groupLoaders[meta.routing.group]()) as Record<string, unknown>
+      if (typeof instance[meta.routing.method] !== 'function') {
+        missing.push(`${meta.name} -> ${meta.routing.group}.${meta.routing.method}`)
+      }
+    }
     expect(missing).toEqual([])
   })
 })

--- a/core/cli/bin-commands.ts
+++ b/core/cli/bin-commands.ts
@@ -24,22 +24,6 @@ export interface BinCommandContext {
  * path (setup check + core/index.ts dispatch).
  */
 export async function runBinCommand(args: string[], ctx: BinCommandContext): Promise<boolean> {
-  const os = await import('node:os')
-  const path = await import('node:path')
-  const chalk = (await import('chalk')).default
-  const { detectAllProviders } = await import('../infrastructure/ai-provider')
-  const configManager = (await import('../infrastructure/config-manager')).default
-  const { fileExists } = await import('../utils/file-helper')
-  const { VERSION } = await import('../utils/version')
-  // Keep TS quiet about branch-conditional usage of the shared imports.
-  void os
-  void path
-  void chalk
-  void detectAllProviders
-  void configManager
-  void fileExists
-  void VERSION
-
   if (args[0] === 'daemon') {
     const subcommand = args[1] || 'status'
 
@@ -85,6 +69,7 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
       const status = await getDaemonStatus()
 
       if (status.running) {
+        const chalk = (await import('chalk')).default
         const uptime = status.uptime ? Math.round(status.uptime / 1000) : 0
         const stale = (status as unknown as Record<string, unknown>).stale
         console.log(`Daemon running (PID ${status.pid})${stale ? ' ⚠ STALE' : ''}`)
@@ -221,6 +206,7 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
     await runStart()
   } else if (args[0] === 'context') {
     const projectPath = process.cwd()
+    const configManager = (await import('../infrastructure/config-manager')).default
     const projectId = await configManager.getProjectId(projectPath)
 
     if (!projectId) {
@@ -498,6 +484,7 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
     process.exitCode = result.success ? 0 : 1
   } else if (args[0] === 'watch') {
     const projectPath = process.cwd()
+    const configManager = (await import('../infrastructure/config-manager')).default
     const projectId = await configManager.getProjectId(projectPath)
 
     if (!projectId) {
@@ -529,6 +516,12 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
     console.log(getHelp(topic))
     process.exitCode = 0
   } else if (args[0] === 'version' || args[0] === '-v' || args[0] === '--version') {
+    const os = await import('node:os')
+    const path = await import('node:path')
+    const chalk = (await import('chalk')).default
+    const { detectAllProviders } = await import('../infrastructure/ai-provider')
+    const { fileExists } = await import('../utils/file-helper')
+    const { VERSION } = await import('../utils/version')
     const detection = await detectAllProviders(ctx.isRefresh)
     const home = os.homedir()
     const cwd = process.cwd()

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -48,71 +48,173 @@ class PrjctCommands {
   // keep the signatures without the load.
   private _workflow?: Promise<WorkflowCommands>
   private workflowG(): Promise<WorkflowCommands> {
-    return (this._workflow ??= import('./workflow').then((m) => new m.WorkflowCommands()))
+    return (this._workflow ??= import('./workflow')
+      .then((m) => new m.WorkflowCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._workflow = undefined
+        throw err
+      }))
   }
   private _planning?: Promise<PlanningCommands>
   private planningG(): Promise<PlanningCommands> {
-    return (this._planning ??= import('./planning').then((m) => new m.PlanningCommands()))
+    return (this._planning ??= import('./planning')
+      .then((m) => new m.PlanningCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._planning = undefined
+        throw err
+      }))
   }
   private _shipping?: Promise<ShippingCommands>
   private shippingG(): Promise<ShippingCommands> {
-    return (this._shipping ??= import('./shipping').then((m) => new m.ShippingCommands()))
+    return (this._shipping ??= import('./shipping')
+      .then((m) => new m.ShippingCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._shipping = undefined
+        throw err
+      }))
   }
   private _analysis?: Promise<AnalysisCommands>
   private analysisG(): Promise<AnalysisCommands> {
-    return (this._analysis ??= import('./analysis').then((m) => new m.AnalysisCommands()))
+    return (this._analysis ??= import('./analysis')
+      .then((m) => new m.AnalysisCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._analysis = undefined
+        throw err
+      }))
   }
   private _setupCmds?: Promise<SetupCommands>
   private setupCmdsG(): Promise<SetupCommands> {
-    return (this._setupCmds ??= import('./setup').then((m) => new m.SetupCommands()))
+    return (this._setupCmds ??= import('./setup')
+      .then((m) => new m.SetupCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._setupCmds = undefined
+        throw err
+      }))
   }
   private _updateCmds?: Promise<UpdateCommands>
   private updateCmdsG(): Promise<UpdateCommands> {
-    return (this._updateCmds ??= import('./update').then((m) => new m.UpdateCommands()))
+    return (this._updateCmds ??= import('./update')
+      .then((m) => new m.UpdateCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._updateCmds = undefined
+        throw err
+      }))
   }
   private _contextCmds?: Promise<ContextCommands>
   private contextCmdsG(): Promise<ContextCommands> {
-    return (this._contextCmds ??= import('./context').then((m) => new m.ContextCommands()))
+    return (this._contextCmds ??= import('./context')
+      .then((m) => new m.ContextCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._contextCmds = undefined
+        throw err
+      }))
   }
   private _primitivesCmds?: Promise<PrimitiveCommands>
   private primitivesCmdsG(): Promise<PrimitiveCommands> {
-    return (this._primitivesCmds ??= import('./primitives').then((m) => new m.PrimitiveCommands()))
+    return (this._primitivesCmds ??= import('./primitives')
+      .then((m) => new m.PrimitiveCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._primitivesCmds = undefined
+        throw err
+      }))
   }
   private _seedCmds?: Promise<SeedCommands>
   private seedCmdsG(): Promise<SeedCommands> {
-    return (this._seedCmds ??= import('./seed').then((m) => new m.SeedCommands()))
+    return (this._seedCmds ??= import('./seed')
+      .then((m) => new m.SeedCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._seedCmds = undefined
+        throw err
+      }))
   }
   private _installCmds?: Promise<InstallCommands>
   private installCmdsG(): Promise<InstallCommands> {
-    return (this._installCmds ??= import('./install').then((m) => new m.InstallCommands()))
+    return (this._installCmds ??= import('./install')
+      .then((m) => new m.InstallCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._installCmds = undefined
+        throw err
+      }))
   }
   private _captureCmds?: Promise<CaptureCommands>
   private captureCmdsG(): Promise<CaptureCommands> {
-    return (this._captureCmds ??= import('./capture').then((m) => new m.CaptureCommands()))
+    return (this._captureCmds ??= import('./capture')
+      .then((m) => new m.CaptureCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._captureCmds = undefined
+        throw err
+      }))
   }
   private _mcpCmds?: Promise<McpCommands>
   private mcpCmdsG(): Promise<McpCommands> {
-    return (this._mcpCmds ??= import('./mcp').then((m) => new m.McpCommands()))
+    return (this._mcpCmds ??= import('./mcp')
+      .then((m) => new m.McpCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._mcpCmds = undefined
+        throw err
+      }))
   }
   private _teamCmds?: Promise<TeamCommands>
   private teamCmdsG(): Promise<TeamCommands> {
-    return (this._teamCmds ??= import('./team').then((m) => new m.TeamCommands()))
+    return (this._teamCmds ??= import('./team')
+      .then((m) => new m.TeamCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._teamCmds = undefined
+        throw err
+      }))
   }
   private _configCmds?: Promise<ConfigCommands>
   private configCmdsG(): Promise<ConfigCommands> {
-    return (this._configCmds ??= import('./config').then((m) => new m.ConfigCommands()))
+    return (this._configCmds ??= import('./config')
+      .then((m) => new m.ConfigCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._configCmds = undefined
+        throw err
+      }))
   }
   private _embeddingsCmds?: Promise<EmbeddingsCommands>
   private embeddingsCmdsG(): Promise<EmbeddingsCommands> {
-    return (this._embeddingsCmds ??= import('./embeddings').then((m) => new m.EmbeddingsCommands()))
+    return (this._embeddingsCmds ??= import('./embeddings')
+      .then((m) => new m.EmbeddingsCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._embeddingsCmds = undefined
+        throw err
+      }))
   }
   private _guardCmds?: Promise<GuardCommands>
   private guardCmdsG(): Promise<GuardCommands> {
-    return (this._guardCmds ??= import('./guard').then((m) => new m.GuardCommands()))
+    return (this._guardCmds ??= import('./guard')
+      .then((m) => new m.GuardCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._guardCmds = undefined
+        throw err
+      }))
   }
   private _specCmds?: Promise<SpecCommands>
   private specCmdsG(): Promise<SpecCommands> {
-    return (this._specCmds ??= import('./spec').then((m) => new m.SpecCommands()))
+    return (this._specCmds ??= import('./spec')
+      .then((m) => new m.SpecCommands())
+      .catch((err) => {
+        // Don't memoize a failed load — clear so the next call retries.
+        this._specCmds = undefined
+        throw err
+      }))
   }
 
   // Shared state

--- a/core/commands/option-mapper.ts
+++ b/core/commands/option-mapper.ts
@@ -20,6 +20,9 @@ export function mapOptions(
   opts: Record<string, unknown>,
   schema: CommandOptionSchema
 ): Record<string, unknown> {
+  // Precedence: an explicit camelCase key wins over its kebab twin when a
+  // caller (test / programmatic DaemonRequest) supplies both. The CLI parser
+  // only ever produces kebab keys, so the wire path is unambiguous.
   const pick = (key: string): unknown => (opts[key] !== undefined ? opts[key] : opts[kebab(key)])
   const result: Record<string, unknown> = { md: opts.md === true }
   for (const key of schema.booleans ?? []) {
@@ -31,7 +34,10 @@ export function mapOptions(
   }
   for (const key of schema.numbers ?? []) {
     const v = pick(key)
-    result[key] = v != null && v !== false && v !== '' ? Number(v) : undefined
+    const n = v != null && v !== false && v !== '' ? Number(v) : Number.NaN
+    // Non-numeric input maps to undefined (flag ignored), never NaN —
+    // handlers must not have to NaN-guard every numeric option.
+    result[key] = Number.isNaN(n) ? undefined : n
   }
   return result
 }

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -24,10 +24,20 @@ import { commandRegistry } from './registry'
 // unparsed until a request actually needs them.
 function lazy(factory: () => Promise<object>): () => Promise<object> {
   let memo: Promise<object> | undefined
-  return () => (memo ??= factory())
+  return () =>
+    (memo ??= factory().catch((err) => {
+      // A failed load must NOT be memoized: a transient import/constructor
+      // error would otherwise poison every command in the group for the
+      // daemon's lifetime. Clear the memo so the next dispatch retries.
+      memo = undefined
+      throw err
+    }))
 }
 
-const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = {
+/** Exported for manifest-completeness.test.ts, which instantiates every
+ *  group and verifies each routing.method exists — the registration-time
+ *  validation registerLazyMethod deferred to first dispatch. */
+export const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = {
   workflow: lazy(async () => new (await import('./workflow')).WorkflowCommands()),
   planning: lazy(async () => new (await import('./planning')).PlanningCommands()),
   shipping: lazy(async () => new (await import('./shipping')).ShippingCommands()),

--- a/core/commands/registry.ts
+++ b/core/commands/registry.ts
@@ -33,7 +33,7 @@ class CommandRegistry {
   private handlers: Map<string, CommandHandler<unknown>> = new Map()
   private handlerFns: Map<string, HandlerFn<unknown>> = new Map()
   /** Option-aware bridges: (param, projectPath, options) → result. Set by
-   *  registerMethod; consumed by executeWithOptions for schema-covered
+   *  registerLazyMethod; consumed by executeWithOptions for schema-covered
    *  commands. */
   private optionFns: Map<
     string,
@@ -99,47 +99,16 @@ class CommandRegistry {
   }
 
   /**
-   * Register a bound method from an existing command group
-   * Bridges command classes to the registry pattern
-   */
-  registerMethod<T extends object>(
-    name: string,
-    instance: T,
-    methodName: keyof T,
-    meta?: Partial<CommandMeta>
-  ): void {
-    const method = instance[methodName]
-    if (typeof method !== 'function') {
-      throw new Error(`${String(methodName)} is not a function`)
-    }
-
-    // Create a wrapper that adapts method signature to HandlerFn
-    const wrapper: HandlerFn<unknown> = async (params, context) => {
-      // Commands expect (param?, projectPath) signature
-      type LegacyMethod = (...args: unknown[]) => Promise<CommandResult>
-      if (params !== undefined && params !== null) {
-        return (method as LegacyMethod).call(instance, params, context.projectPath)
-      }
-      return (method as LegacyMethod).call(instance, context.projectPath)
-    }
-
-    this.handlerFns.set(name, wrapper)
-    // Option-aware bridge with the uniform group-method shape
-    // (param, projectPath, options). executeWithOptions uses it so flags
-    // survive dispatch without a hand-written case per command.
-    this.optionFns.set(name, (param, projectPath, options) => {
-      type LegacyMethod = (...args: unknown[]) => Promise<CommandResult>
-      return (method as LegacyMethod).call(instance, param, projectPath, options)
-    })
-    this.setMeta(name, meta)
-  }
-
-  /**
-   * Like registerMethod, but the owning instance loads lazily on first
+   * Register a command whose owning instance loads lazily on first
    * dispatch — register.ts hands a memoized async factory instead of a
    * constructed instance, so registering every command at import time
    * costs nothing (the daemon cold-start win). The "method exists"
-   * validation moves from registration to first call.
+   * validation moves from registration to first call (CI-guarded by
+   * manifest-completeness.test.ts, which instantiates every group).
+   *
+   * This is the ONLY registration path for group methods — the old
+   * eager `registerMethod` was deleted when register.ts migrated, so
+   * the two mechanisms can't drift.
    */
   registerLazyMethod(
     name: string,
@@ -148,13 +117,18 @@ class CommandRegistry {
     meta?: Partial<CommandMeta>
   ): void {
     type LegacyMethod = (...args: unknown[]) => Promise<CommandResult>
+    // Memoized on success only: a failed load/lookup leaves `resolved`
+    // unset so the next dispatch retries instead of replaying the error.
+    let resolved: { instance: object; method: LegacyMethod } | undefined
     const resolve = async (): Promise<{ instance: object; method: LegacyMethod }> => {
+      if (resolved) return resolved
       const instance = await loadInstance()
       const method = (instance as Record<string, unknown>)[methodName]
       if (typeof method !== 'function') {
         throw new Error(`${methodName} is not a function`)
       }
-      return { instance, method: method as LegacyMethod }
+      resolved = { instance, method: method as LegacyMethod }
+      return resolved
     }
 
     const wrapper: HandlerFn<unknown> = async (params, context) => {
@@ -436,7 +410,7 @@ class CommandRegistry {
   }
 
   /**
-   * Execute a registerMethod-bound command WITH its options object —
+   * Execute a registerLazyMethod-bound command WITH its options object —
    * (param, projectPath, options), the uniform group-method shape. The
    * caller maps wire flags through the command's `optionSchema` first
    * (see option-mapper.ts). Same context rules as execute().

--- a/core/services/auto-updater.ts
+++ b/core/services/auto-updater.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { resolveCliHome } from '../infrastructure/cli-home'
+import { compareSemver } from '../schemas/model'
 import { getConfig, setConfig } from './global-config'
 
 const execFileP = promisify(execFile)
@@ -145,16 +146,6 @@ async function applyUpgrade(source: InstallSource, _targetVersion: string): Prom
     })
     return
   }
-}
-
-function compareSemver(a: string, b: string): number {
-  const pa = a.split('.').map((n) => Number.parseInt(n, 10) || 0)
-  const pb = b.split('.').map((n) => Number.parseInt(n, 10) || 0)
-  for (let i = 0; i < 3; i++) {
-    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return 1
-    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return -1
-  }
-  return 0
 }
 
 function log(line: string): void {

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -254,17 +254,10 @@ function unpackVector(blob: Uint8Array): Float32Array {
 }
 
 export function cosineSimilarity(a: ArrayLike<number>, b: ArrayLike<number>): number {
-  const n = Math.min(a.length, b.length)
-  let dot = 0
-  let na = 0
-  let nb = 0
-  for (let i = 0; i < n; i++) {
-    dot += a[i] * b[i]
-    na += a[i] * a[i]
-    nb += b[i] * b[i]
-  }
-  const denom = Math.sqrt(na) * Math.sqrt(nb)
-  return denom === 0 ? 0 : dot / denom
+  // Single-sourced over dot/l2Norm so a numeric fix (e.g. clamping) can
+  // never diverge between this and the norm-cached semanticSearch path.
+  const denom = l2Norm(a) * l2Norm(b)
+  return denom === 0 ? 0 : dot(a, b) / denom
 }
 
 interface EmbeddingRow {

--- a/core/storage/database.ts
+++ b/core/storage/database.ts
@@ -32,6 +32,18 @@ function runImmediate<T>(db: SqliteDatabase, fn: (db: SqliteDatabase) => T): T {
   return typeof txn.immediate === 'function' ? txn.immediate(db) : txn(db)
 }
 
+/**
+ * Strictly-monotonic ISO stamp relative to `prev` — two writes inside the
+ * same millisecond must not produce an equal token (a stale CAS read could
+ * silently win). Shared by nextKvStamp and updateDoc so the bump rule can
+ * never drift between the two write paths.
+ */
+function monotonicStamp(prev: string | null | undefined): string {
+  const now = new Date().toISOString()
+  if (!prev || now > prev) return now
+  return new Date(new Date(prev).getTime() + 1).toISOString()
+}
+
 /** Max concurrent DB connections before evicting least-recently-used */
 const MAX_DB_CONNECTIONS = 3
 
@@ -205,10 +217,7 @@ class PrjctDatabase {
     ) as {
       updated_at: string
     } | null
-    const now = new Date().toISOString()
-    const prev = row?.updated_at
-    if (!prev || now > prev) return now
-    return new Date(new Date(prev).getTime() + 1).toISOString()
+    return monotonicStamp(row?.updated_at)
   }
 
   /**
@@ -259,10 +268,7 @@ class PrjctDatabase {
       ) as { data: string; updated_at: string } | null
       const base = row ? (JSON.parse(row.data) as T) : getDefault()
       const updated = updater(base)
-      const nowIso = new Date().toISOString()
-      const prev = row?.updated_at
-      const stamp =
-        !prev || nowIso > prev ? nowIso : new Date(new Date(prev).getTime() + 1).toISOString()
+      const stamp = monotonicStamp(row?.updated_at)
       this.prepareCached(
         db,
         'INSERT OR REPLACE INTO kv_store (key, data, updated_at) VALUES (?, ?, ?)'

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -323,7 +323,7 @@ export interface BlockingRules {
  */
 /**
  * Single source of truth for verb → handler dispatch.
- * `register.ts` walks this to call `commandRegistry.registerMethod`,
+ * `register.ts` walks this to call `commandRegistry.registerLazyMethod`,
  * and `verb-names.ts` derives the fast-path verb set from it. Both
  * used to maintain hand-written copies — adding a new command meant
  * three coordinated edits across files (the "triple-touch" smell).


### PR DESCRIPTION
## What

Ran a 7-angle code review (3 correctness + reuse/simplification/efficiency/altitude) over everything shipped today (dddf243..aa32bfb, ~9k lines). 42 candidates → verified → 9 confirmed fixes; the scariest candidates were refuted with evidence.

### Correctness
- **Lazy loaders memoized rejected promises** (both register.ts `lazy()` and the 17 `PrjctCommands` getters): a transient import error on first dispatch poisoned the whole command group for the daemon's lifetime — the old eager path failed loud at startup. Now a failed load clears the memo and the next dispatch retries.
- **Manifest method validation restored at CI time**: new test instantiates every command group and probes each `routing.method` — the lazy refactor had deferred 'method is not a function' from registration to first user dispatch with no net.
- `mapOptions`: non-numeric numeric flags → `undefined`, never `NaN`; camel/kebab precedence documented.

### Cleanup (reuse/simplification/altitude angles)
- Dead `registerMethod` deleted (zero callers; dual registration mechanisms invited drift — e.g. calling it after registerLazyMethod silently defeated lazy memoization).
- `runBinCommand`: 7 hoisted awaits moved into their branches (every bin command paid the version branch's imports; the `void x` suppression hack is gone).
- `registerLazyMethod` memoizes the resolved pair (was per-dispatch lookup).
- `compareSemver` deduped to schemas/model.ts (3rd divergent copy); `monotonicStamp()` shared by both kv write paths; `cosineSimilarity` single-sourced over `dot`/`l2Norm`.

### Refuted (no action, evidence in review)
- 'Migration 29 leaves FTS permanently dropped on crash' — the runner wraps each `up()` + version INSERT in `BEGIN IMMEDIATE`: crash = rollback + retry.
- repeat-miss undercount via dedupeByKey — the call already passes `dedupeByKey: false`.
- SQLITE_BUSY message matchers — no caller matched the old contention string.

### Reported, not fixed (follow-up candidates)
SIGHUP doesn't refresh group instances (pre-existing asymmetry), `spec`/`audit-spec` cold-only routing lives in build.js's side list instead of the manifest (`routingMode: 'cold-only'`?), subagent digest lacks the repeat-miss slot, minor hook micro-efficiencies.

## Verification
- `bun test`: 1495 pass / 0 fail (incl. the new manifest validation test), typecheck + biome clean
- Cold smoke: `version`, `daemon status`, `status --md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)