### PR TITLE
fix: review follow-ups — cold-only routing, true SIGHUP reload, subagent repeat-miss, in-process prune counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+Follow-ups from the v2.42.x range review (the reported-not-fixed list).
+
+### Fixed
+- **SIGHUP now actually reloads.** The handler refreshed only the explicit-dispatch instance; schema-covered commands kept pre-reload group instances forever (the registry's lazy memos were never reset). Both lazy layers now register resetters and SIGHUP clears them.
+
+### Changed
+- **`routingMode: 'cold-only'`** — spec/audit-spec's "shim must serve these cold" condition moves from a side list in scripts/build.js into the manifest; the generated shim skip set is byte-identical, but the truth now lives where a manifest cleanup can't accidentally delete it.
+- **Subagents get the repeat-miss slot** — the "Keeps being missed" entry the session digest gained now reaches subagent digests too (they do most of the editing and were blind to it).
+- **Prune throttle is in-process** — the kv-store counter paid a read+write per session Stop just to decide "skip pruning" 9/10 times; per-process counting is the safe direction (cold runs prune more often, never less).
+
 Fixes from a full code review of the v2.42.0–v2.42.4 range (7 review angles, 42 candidates, verified).
 
 ### Fixed

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -593,6 +593,7 @@ export const COMMANDS: CommandMeta[] = [
     name: 'spec',
     group: 'core',
     routing: { group: 'spec', method: 'draft' },
+    routingMode: 'cold-only',
     description:
       'Draft a spec — Goal/Acceptance/Scope/Risks. The SDD entry point: spec → audit → task → ship.',
     usage: {
@@ -614,6 +615,7 @@ export const COMMANDS: CommandMeta[] = [
     name: 'audit-spec',
     group: 'core',
     routing: { group: 'spec', method: 'audit' },
+    routingMode: 'cold-only',
     description:
       'Emit subagent dispatch for parallel strategic/architecture/design review of a spec',
     usage: { claude: '/p:audit-spec <id>', terminal: 'prjct audit-spec <id>' },
@@ -683,6 +685,15 @@ export const COMMAND_ALIASES: Record<string, string> = {
  * skip-set in scripts/build.js and `_binCommands` in bin/prjct.ts both
  * consume this, so routing is declared in exactly one place.
  */
+/**
+ * Commands the SHIM must serve cold even though the daemon can handle them
+ * when reached via bin/prjct.ts (multi-positional parsing). Consumed by
+ * scripts/build.js alongside BIN_ONLY_COMMANDS.
+ */
+export const COLD_ONLY_COMMANDS: ReadonlySet<string> = new Set(
+  COMMANDS.filter((c) => c.routingMode === 'cold-only').map((c) => c.name)
+)
+
 export const BIN_ONLY_COMMANDS: ReadonlySet<string> = new Set([
   ...COMMANDS.filter((c) => c.routingMode === 'bin-only').map((c) => c.name),
   ...Object.entries(COMMAND_ALIASES)

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -22,8 +22,19 @@ import { commandRegistry } from './registry'
 // costs nothing beyond the manifest. Heavy groups (analysis drags in
 // sync-service -> BM25 indexer, import-graph, skill generator) stay
 // unparsed until a request actually needs them.
+const loaderResetters: Array<() => void> = []
+
+/** SIGHUP support: drop every memoized group instance so the next dispatch
+ *  constructs fresh ones. Paired with commandRegistry.resetLazyResolutions(). */
+export function resetGroupLoaders(): void {
+  for (const reset of loaderResetters) reset()
+}
+
 function lazy(factory: () => Promise<object>): () => Promise<object> {
   let memo: Promise<object> | undefined
+  loaderResetters.push(() => {
+    memo = undefined
+  })
   return () =>
     (memo ??= factory().catch((err) => {
       // A failed load must NOT be memoized: a transient import/constructor

--- a/core/commands/registry.ts
+++ b/core/commands/registry.ts
@@ -43,6 +43,8 @@ class CommandRegistry {
       options: Record<string, unknown>
     ) => Promise<CommandResult>
   > = new Map()
+  /** SIGHUP support: per-command resolved {instance, method} memo resets. */
+  private lazyResetters: Array<() => void> = []
   private metadata: Map<string, CommandMeta> = new Map()
   private categories: Map<string, CategoryInfo> = new Map()
   private noProjectCommands: Set<string> = new Set(['init', 'setup', 'start', 'migrateAll'])
@@ -120,6 +122,9 @@ class CommandRegistry {
     // Memoized on success only: a failed load/lookup leaves `resolved`
     // unset so the next dispatch retries instead of replaying the error.
     let resolved: { instance: object; method: LegacyMethod } | undefined
+    this.lazyResetters.push(() => {
+      resolved = undefined
+    })
     const resolve = async (): Promise<{ instance: object; method: LegacyMethod }> => {
       if (resolved) return resolved
       const instance = await loadInstance()
@@ -145,6 +150,16 @@ class CommandRegistry {
       return method.call(instance, param, projectPath, options)
     })
     this.setMeta(name, meta)
+  }
+
+  /**
+   * Drop every memoized resolved handler so the next dispatch re-resolves
+   * through the (also reset) group loaders. SIGHUP's reload path — without
+   * this, schema-covered commands kept pre-reload instances forever while
+   * the explicit dispatch cases got fresh ones.
+   */
+  resetLazyResolutions(): void {
+    for (const reset of this.lazyResetters) reset()
   }
 
   /**

--- a/core/commands/verb-names.ts
+++ b/core/commands/verb-names.ts
@@ -11,7 +11,7 @@
  * pure data + types, so the import chain stays light.
  */
 
-import { BIN_ONLY_COMMANDS, COMMANDS } from './command-data'
+import { BIN_ONLY_COMMANDS, COLD_ONLY_COMMANDS, COMMANDS } from './command-data'
 
 export const REGISTERED_VERBS_SET: ReadonlySet<string> = new Set(
   COMMANDS.filter((c) => c.routing).map((c) => c.name)
@@ -23,3 +23,10 @@ export const REGISTERED_VERBS_SET: ReadonlySet<string> = new Set(
  * path imports one tiny module.
  */
 export const BIN_COMMANDS_SET: ReadonlySet<string> = BIN_ONLY_COMMANDS
+
+/** Shim skip set = bin-handled + cold-only (manifest-derived; build.js
+ *  evaluates this module to emit the generated shim's literal). */
+export const SHIM_SKIP_SET: ReadonlySet<string> = new Set([
+  ...BIN_ONLY_COMMANDS,
+  ...COLD_ONLY_COMMANDS,
+])

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -15,8 +15,8 @@ import fs from 'node:fs'
 import type { Server, Socket } from 'node:net'
 import { createServer as createNetServer } from 'node:net'
 import { PrjctCommands } from '../commands/commands'
+import { resetGroupLoaders } from '../commands/register'
 import { commandRegistry } from '../commands/registry'
-import '../commands/register'
 import type { HookIo } from '../hooks/_runner'
 import { getHookRunner } from '../hooks/registry'
 import prjctDb from '../storage/database'
@@ -147,7 +147,12 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
   process.on('SIGTERM', () => shutdown(0))
   process.on('SIGINT', () => shutdown(0))
   process.on('SIGHUP', () => {
+    // Refresh BOTH dispatch paths: the explicit-case instance below AND the
+    // registry's lazy group memos (schema-covered commands kept pre-reload
+    // instances otherwise — the review's stale-SIGHUP finding).
     commands = new PrjctCommands()
+    resetGroupLoaders()
+    commandRegistry.resetLazyResolutions()
     console.log('Daemon reloaded (SIGHUP)')
   })
 

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -236,6 +236,13 @@ export async function buildSubagentDigest(projectPath: string): Promise<string |
       lines.push('Traps to avoid:')
       for (const e of gotchas) lines.push(`- ${deriveTitle(e)}  \`${e.id}\``)
     }
+    // Same repeat-miss slot the session digest has: knowledge flagged
+    // relevant-but-unused 2+ times reaches subagents too — they do the
+    // bulk of the editing and were blind to it (review follow-up).
+    const repeatMiss = findRepeatMissedEntry(config.projectId, new Set(gotchas.map((e) => e.id)))
+    if (repeatMiss) {
+      lines.push(`Keeps being missed: ${deriveTitle(repeatMiss.entry)}  \`${repeatMiss.entry.id}\``)
+    }
   } catch {
     // best-effort
   }

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -288,6 +288,8 @@ const SEMANTIC_SCAN_MAX_ROWS = 2000
 
 /** Noise-vector pruning runs on every Nth backfill (see shouldPruneThisRun). */
 const PRUNE_EVERY = 10
+/** Per-process backfill tick per project — see shouldPruneThisRun. */
+const pruneTicks = new Map<string, number>()
 
 export const embeddingService = {
   /**
@@ -408,17 +410,15 @@ export const embeddingService = {
   },
 
   /** Prune throttle: every PRUNE_EVERY-th backfill, starting with the first.
-   *  Counter lives in kv_store so it survives across processes. Best-effort —
-   *  any storage error defaults to pruning (the safe, if slower, choice). */
+   *  In-process counter (review follow-up: the kv version paid a read+write
+   *  per Stop just to decide "skip" 9/10 times). Per-process semantics are
+   *  the SAFE direction: a long-lived daemon throttles correctly, and
+   *  short-lived cold runs prune on their first backfill — pruning more
+   *  often is harmless, skipping it forever would not be. */
   shouldPruneThisRun(projectId: string): boolean {
-    try {
-      const KEY = 'embeddings:prune-tick'
-      const tick = prjctDb.getDoc<number>(projectId, KEY) ?? 0
-      prjctDb.setDoc(projectId, KEY, (tick + 1) % PRUNE_EVERY)
-      return tick === 0
-    } catch {
-      return true
-    }
+    const tick = pruneTicks.get(projectId) ?? 0
+    pruneTicks.set(projectId, (tick + 1) % PRUNE_EVERY)
+    return tick === 0
   },
 
   /** Delete stored vectors for entries that are no longer model-worthy

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -366,8 +366,11 @@ export interface CommandRouting {
  *  - 'daemon': forwarded to the daemon when its socket exists; falls
  *    through to cold in-process execution otherwise. The default for any
  *    entry with `routing` set.
+ *  - 'cold-only': the SHIM must not forward it (multi-positional parsing
+ *    the wire protocol can't reconstruct — spec/audit-spec), but the full
+ *    bin/prjct.ts can. Used to live as a side list in scripts/build.js.
  */
-export type CommandRoutingMode = 'bin-only' | 'daemon'
+export type CommandRoutingMode = 'bin-only' | 'daemon' | 'cold-only'
 
 /**
  * Declarative option surface for a daemon-routed command. dispatch.ts and

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -159,11 +159,11 @@ var __dirname = __pathDirname(__filename);`,
 }
 
 /**
- * Legacy/extra shim-only skips. `dev`/`web`/`serve` are inert orphans that
- * pre-date the manifest; `spec`/`audit-spec` are deliberately served cold
- * (multi-positional parsing). Everything else derives from the manifest.
+ * Legacy shim-only skips: inert orphans that pre-date the manifest and have
+ * no handler anywhere. Everything real derives from the manifest
+ * (routingMode 'bin-only' + 'cold-only' via SHIM_SKIP_SET).
  */
-const SHIM_EXTRA_SKIP = ['dev', 'web', 'serve', 'spec', 'audit-spec']
+const SHIM_EXTRA_SKIP = ['dev', 'web', 'serve']
 
 /**
  * Evaluate the command manifest (command-data.ts via verb-names.ts) at
@@ -187,7 +187,7 @@ function deriveShimSkipSet() {
     mod.exports,
     require
   )
-  const derived = [...mod.exports.BIN_COMMANDS_SET]
+  const derived = [...mod.exports.SHIM_SKIP_SET]
   return [...new Set([...derived, ...SHIM_EXTRA_SKIP])]
 }
 


### PR DESCRIPTION
## What

The four reported-not-fixed findings from the v2.42.x range review (#421's follow-up list, tracked in the prjct inbox):

1. **`routingMode: 'cold-only'`** — spec/audit-spec's "shim must serve these cold" condition moves from `SHIM_EXTRA_SKIP` (a side list in scripts/build.js a manifest cleanup could delete) into the manifest. `SHIM_SKIP_SET` = bin-only + cold-only; generated shim verified **byte-identical** (36 entries); legacy extras shrink to the true orphans (dev/web/serve).
2. **SIGHUP now actually reloads** — it refreshed only the explicit-dispatch `PrjctCommands` instance; schema-covered commands kept pre-reload group instances forever. Both lazy layers (register.ts loader memos + the registry's resolved-handler memos) register resetters that SIGHUP clears.
3. **Subagents get the repeat-miss slot** — the "Keeps being missed" entry now reaches subagent digests (they do most of the editing and were blind to chronically-unapplied knowledge).
4. **Prune throttle in-process** — the kv counter paid a read+write per session Stop to decide "skip" 9/10 times; a per-process Map errs toward pruning more often, never less.

## Verification
- `bun test`: 1495 pass / 0 fail (full suite), typecheck + biome clean
- Real build: generated shim skip set inspected — spec/audit-spec/dev present, count unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)