### PR TITLE
feat: vault v2 — signal-first RAG (telemetry quarantine, link-only tags, dashboard index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## [Unreleased]
 
-Follow-ups from the v2.42.x range review (the reported-not-fixed list).
+Vault v2 — signal-first RAG. The generated vault now renders knowledge, not telemetry: on this repo it dropped from 326 files to ~113 with zero information loss (everything stays in SQLite).
+
+### Changed
+- **Machine signals quarantined to one `signals.md` dashboard.** Detector output (hot-file churn, skill-miss, friction, recurring bugs — 45% of all entries on a busy project) no longer spawns per-entry notes or tag pages. One page, grouped by section, hot files deduped per path, every row block-anchored so `[[signals#^mem-N|title]]` refs still resolve. The graph shows one hub instead of a dust cloud of `hot-file-NNN` nodes.
+- **Tag pages are link-only.** The old `tags/<key>/<value>.md` model copied every entry's full content into every tag page it appeared on (54% of vault files, all duplicated content). Now: one `tags/<key>.md` index per dimension with values as sections and entries as wikilinks, plus a `tags.md` master index. Dimensions used by fewer than 2 entries get no page (orphan-node guard).
+- **Native Obsidian frontmatter tags.** `tags: { topic: "x" }` (a YAML flow map Obsidian ignores) → `tags: [topic/x]` — graph coloring/filtering and the tag pane now work. Machine bookkeeping keys (source/session/touches/hash/…) are excluded from note bodies and frontmatter; they stay queryable in SQLite.
+- **index.md is a dashboard.** Recent decisions and known traps surface as wikilinks on the landing page; signals get their own section.
+- **Readable filenames.** Slugs cut at word boundaries (no more `…-porque-la-key-guardada-es-de.md`); `retro` entries get per-entry notes.
 
 ### Fixed
 - **CI/Release no longer resolve bun `latest` per run.** `setup-bun` queried the bun tags API on every workflow run (the 500-prone call that aborted the v2.42.6 release) and silently drifted from local dev. All non-canary jobs now pin via a single `.bun-version` file; the install-compat matrix keeps `latest` deliberately as the canary.

--- a/core/__tests__/services/memory-builder.test.ts
+++ b/core/__tests__/services/memory-builder.test.ts
@@ -123,18 +123,107 @@ describe('buildTagFiles — Defect C: relation tags are NOT tag pages', () => {
       content: 'changelog root cause fixed',
       tags: { topic: 'release', resolves: 'mem_3135', relates: 'mem_2895', closes: 'mem_2604' },
     }),
+    mk({
+      id: 'mem_3206',
+      content: 'second release note so the topic dimension is browsable',
+      tags: { topic: 'release', once: 'single-use' },
+    }),
   ]
   const files = buildTagFiles(entries, entries)
   const keys = [...files.keys()]
 
-  it('does not emit tags/relates|resolves|closes/* orphan stubs', () => {
-    expect(keys.some((k) => k.startsWith('tags/relates/'))).toBe(false)
-    expect(keys.some((k) => k.startsWith('tags/resolves/'))).toBe(false)
-    expect(keys.some((k) => k.startsWith('tags/closes/'))).toBe(false)
+  it('does not emit relation-key tag pages (relates/resolves/closes)', () => {
+    expect(keys.some((k) => k.includes('relates'))).toBe(false)
+    expect(keys.some((k) => k.includes('resolves'))).toBe(false)
+    expect(keys.some((k) => k.includes('closes'))).toBe(false)
   })
 
-  it('still emits real category tag pages (topic)', () => {
-    expect(keys.some((k) => k.startsWith('tags/topic/'))).toBe(true)
+  it('emits a LINK-ONLY index page per category key — no content duplication', () => {
+    expect(files.has('tags/topic.md')).toBe(true)
+    const page = files.get('tags/topic.md') ?? ''
+    // Wikilinks to the entry notes, never the entry content copied in
+    // (the old model embedded full formatMemoryMd rows with provenance
+    // markers and block anchors).
+    expect(page).toMatch(/- \[\[[a-z0-9-]+\|[^\]]+\]\]/)
+    expect(page).not.toContain('`DECL`')
+    expect(page).not.toContain('^mem-')
+    // No per-value pages at all (the old tags/<key>/<value>.md model).
+    expect(keys.some((k) => /^tags\/[^/]+\//.test(k))).toBe(false)
+  })
+
+  it('emits a tags.md master index linking each key page', () => {
+    const index = files.get('tags.md') ?? ''
+    expect(index).toContain('[[tags/topic|topic]]')
+  })
+
+  it('a dimension used once gets no page (orphan-node guard)', () => {
+    expect(files.has('tags/once.md')).toBe(false)
+  })
+})
+
+describe('machine-signal quarantine — telemetry never becomes notes or tags', () => {
+  const signal = mk({
+    id: 'mem_900',
+    type: 'learning',
+    content: 'Hot file: `core/x.ts` — 3 touches in the last 7 days. Worth a refactor pass.',
+    tags: { source: 'pattern-detector-auto', pattern: 'hot-file', file: 'core/x.ts', touches: '3' },
+    provenance: 'inferred',
+  })
+  const improvement = mk({
+    id: 'mem_901',
+    type: 'improvement-signal',
+    content: 'skill-miss: unused project knowledge mem_902',
+    tags: { source: 'skill-miss-detector' },
+    provenance: 'inferred',
+  })
+  const knowledge = mk({
+    id: 'mem_902',
+    type: 'gotcha',
+    content: 'Real trap worth its own note. See mem_900 for the churn signal.',
+    tags: { topic: 'storage' },
+  })
+  const all = [signal, improvement, knowledge]
+
+  it('signal entries get no per-entry note and no MOC row', () => {
+    const files = buildMemoryFiles(all, all)
+    expect([...files.keys()].some((k) => k.startsWith('memory/learning/'))).toBe(false)
+    expect(files.has('memory/improvement-signal.md')).toBe(false)
+    const gotchaMoc = files.get('memory/gotcha.md') ?? ''
+    expect(gotchaMoc).toContain('Real trap')
+  })
+
+  it('signal entries get no tag pages either', () => {
+    const files = buildTagFiles(all, all)
+    const bodies = [...files.values()].join('\n')
+    expect(bodies).not.toContain('Hot file')
+  })
+
+  it('refs to a signal id resolve into signals.md, not a dangling node', () => {
+    const files = buildMemoryFiles(all, all)
+    const note = [...files.entries()].find(([k]) => k.startsWith('memory/gotcha/'))?.[1] ?? ''
+    expect(note).toContain('[[signals#^mem-900|')
+  })
+})
+
+describe('frontmatter — native Obsidian tag list', () => {
+  it('emits tags: [key/value] and hides machine/relation keys', () => {
+    const entries = [
+      mk({
+        id: 'mem_10',
+        content: 'A decision with mixed tags worth keeping around',
+        tags: {
+          topic: 'Daemon Lazy Loading',
+          source: 'analysis',
+          session: 'abc-123',
+          resolves: 'mem_9',
+        },
+      }),
+    ]
+    const files = buildMemoryFiles(entries, entries)
+    const note = [...files.entries()].find(([k]) => k.startsWith('memory/decision/'))?.[1] ?? ''
+    expect(note).toContain('tags: [topic/daemon-lazy-loading]')
+    expect(note).not.toContain('session')
+    expect(note).not.toMatch(/tags:.*resolves/)
   })
 })
 

--- a/core/__tests__/services/signals-builder.test.ts
+++ b/core/__tests__/services/signals-builder.test.ts
@@ -1,0 +1,96 @@
+/**
+ * signals.md — the single dashboard for machine telemetry.
+ *
+ * Locks the vault-v2 contract: detector output (hot-file churn,
+ * skill-miss, friction) renders as ONE page with block anchors, so the
+ * graph shows one hub node instead of dozens of telemetry stubs.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { MemoryEntry } from '../../memory/entries'
+import { buildVaultOpts } from '../../services/wiki/memory-builder'
+import { buildSignalsFile, isSignalEntry } from '../../services/wiki/signals-builder'
+
+const mk = (over: Partial<MemoryEntry> & { id: string }): MemoryEntry => ({
+  type: 'improvement-signal',
+  content: '',
+  tags: {},
+  rememberedAt: '2026-06-10T00:00:00.000Z',
+  provenance: 'inferred',
+  ...over,
+})
+
+describe('isSignalEntry', () => {
+  it('classifies improvement-signal and detector-sourced entries as signals', () => {
+    expect(isSignalEntry(mk({ id: 'mem_1' }))).toBe(true)
+    expect(
+      isSignalEntry(
+        mk({ id: 'mem_2', type: 'learning', tags: { source: 'pattern-detector-auto' } })
+      )
+    ).toBe(true)
+    expect(
+      isSignalEntry(mk({ id: 'mem_3', type: 'learning', tags: { source: 'friction-detector' } }))
+    ).toBe(true)
+  })
+
+  it('keeps declared/extracted knowledge out (transcript-auto, analysis, user)', () => {
+    expect(
+      isSignalEntry(mk({ id: 'mem_4', type: 'learning', tags: { source: 'transcript-auto' } }))
+    ).toBe(false)
+    expect(isSignalEntry(mk({ id: 'mem_5', type: 'decision', tags: { source: 'analysis' } }))).toBe(
+      false
+    )
+    expect(isSignalEntry(mk({ id: 'mem_6', type: 'gotcha' }))).toBe(false)
+  })
+})
+
+describe('buildSignalsFile', () => {
+  const signals = [
+    mk({
+      id: 'mem_100',
+      type: 'learning',
+      content: 'Hot file: `core/a.ts` — 4 touches in the last 7 days.',
+      tags: { source: 'pattern-detector-auto', file: 'core/a.ts', touches: '4', window_days: '7' },
+      rememberedAt: '2026-06-09T00:00:00.000Z',
+    }),
+    mk({
+      id: 'mem_101',
+      type: 'learning',
+      content: 'Hot file: `core/a.ts` — 3 touches in the last 7 days.',
+      tags: { source: 'pattern-detector-auto', file: 'core/a.ts', touches: '3', window_days: '7' },
+      rememberedAt: '2026-06-02T00:00:00.000Z',
+    }),
+    mk({
+      id: 'mem_102',
+      content: 'skill-miss: unused project knowledge — agent re-read source instead of vault',
+      tags: { source: 'skill-miss-detector' },
+    }),
+    mk({
+      id: 'mem_103',
+      content: '[workflow] User pushback: "no corras el ship manual"',
+      tags: { source: 'friction-detector' },
+    }),
+  ]
+  const body = buildSignalsFile(signals, buildVaultOpts(signals)) ?? ''
+
+  it('returns null when there are no signals (no empty stub page)', () => {
+    expect(buildSignalsFile([], buildVaultOpts([]))).toBeNull()
+  })
+
+  it('groups hot files by file with the newest entry leading', () => {
+    expect(body).toContain('## Hot files')
+    expect(body).toContain('`core/a.ts` — 4 touches in 7d')
+    expect(body.indexOf('^mem-100')).toBeLessThan(body.indexOf('^mem-101'))
+  })
+
+  it('every signal keeps a block anchor so [[signals#^mem-N]] resolves', () => {
+    for (const id of ['100', '101', '102', '103']) {
+      expect(body).toContain(`^mem-${id}`)
+    }
+  })
+
+  it('sections skill-misses and friction separately', () => {
+    expect(body).toContain('## Knowledge being missed')
+    expect(body).toContain('## Friction')
+  })
+})

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -57,7 +57,37 @@ export interface FormatMemoryMdOptions {
    * the relations actually appear in the graph (the v2.23.3 regression).
    */
   idSlugIndex?: Map<string, string>
+  /**
+   * Ids of machine-signal entries (detector output). They have no note
+   * of their own — refs resolve into the single `signals.md` dashboard
+   * (`[[signals#^mem-N|title]]`) instead of spawning telemetry nodes.
+   */
+  signalIds?: ReadonlySet<string>
 }
+
+/**
+ * Tag keys that are machine bookkeeping (detector provenance, counters,
+ * hashes, session ids). Hidden from vault note bodies and never turned
+ * into Obsidian tags — they stay queryable in SQLite, which is where
+ * machines look.
+ */
+export const MACHINE_TAG_KEYS: ReadonlySet<string> = new Set([
+  'source',
+  'session',
+  'window_days',
+  'window-days',
+  'touches',
+  'occurrences',
+  'phrase',
+  'slug',
+  'hash',
+  'content-hash',
+  'content_hash',
+  'key',
+  'kind',
+  'spec-id',
+  'spec_id',
+])
 
 const TITLE_MAX = 72
 
@@ -124,6 +154,11 @@ export function linkifyMemRefs(text: string, opts?: FormatMemoryMdOptions): stri
       const title = opts?.idTitleIndex?.get(canonical)
       const slug = opts?.idSlugIndex?.get(canonical)
       const display = title ? linkLabel(title) : canonical
+      // Machine signals live on the single signals.md dashboard — link
+      // its block anchor, never a per-entry node.
+      if (opts?.signalIds?.has(canonical)) {
+        return `[[signals#^mem-${n}|${display}]]`
+      }
       // Per-entry note → link the REAL basename so the graph draws the
       // edge (alias-only links are invisible to Obsidian's graph).
       if (slug && type && opts?.perEntryTypes?.has(type)) {
@@ -179,7 +214,11 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
     if (items.length === 0) return
     lines.push(`### ${type.toUpperCase()}`)
     for (const e of items) {
+      // Vault output hides machine-bookkeeping tags (source=, touches=,
+      // session=, …) — they read as noise in every entry row. CLI/LLM
+      // surfaces keep the full set (byte-identical legacy output).
       const tags = Object.entries(e.tags)
+        .filter(([k]) => !opts?.vault || !MACHINE_TAG_KEYS.has(k))
         .map(([k, v]) => `${k}=${llmBoundary ? escapeMarkdownInline(v) : v}`)
         .join(' ')
       const prov = PROV_PREFIX[e.provenance]

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -66,6 +66,7 @@ import {
   formatShipBody,
 } from './wiki/memory-builder'
 import { buildReleasesFiles } from './wiki/release-builder'
+import { buildSignalsFile, isSignalEntry } from './wiki/signals-builder'
 import { buildSpecFiles } from './wiki/spec-builder'
 import { buildWorkflowFiles } from './wiki/workflow-builder'
 import { ensureCapturedReadme, ensureWorkflowsReadme } from './wiki-ingest'
@@ -169,6 +170,10 @@ export async function generateWiki(
     }
   })()
   const declared = entries.filter((e) => e.type !== 'shipped')
+  // Knowledge vs telemetry: detector output (hot-file churn, skill-miss,
+  // friction) renders on ONE signals.md dashboard, never as notes/tags.
+  const signals = declared.filter(isSignalEntry)
+  const knowledge = declared.filter((e) => !isSignalEntry(e))
 
   // --- Build all file bodies in memory ---
   const files = new Map<string, string>()
@@ -179,6 +184,8 @@ export async function generateWiki(
   for (const [rel, body] of buildMemoryFiles(declared, entries)) files.set(rel, body)
   for (const [rel, body] of buildTagFiles(declared, entries)) files.set(rel, body)
   const vaultLinkOpts = buildVaultOpts(entries)
+  const signalsBody = buildSignalsFile(signals, vaultLinkOpts)
+  if (signalsBody) files.set('signals.md', signalsBody)
   for (const [rel, body] of buildSpecFiles(specs, queueTasks, vaultLinkOpts)) files.set(rel, body)
 
   // crew-runs/<slug>-<ts>.md — one file per recorded crew session.
@@ -254,14 +261,26 @@ export async function generateWiki(
   // releases" not "182 files".
   const releaseCount = releasesMap.size > 0 ? releasesMap.size - 1 : 0
 
+  // Counts reflect what the vault actually renders: knowledge only —
+  // telemetry is summarized by signalsCount, and tag keys are limited
+  // to the keys buildTagFiles emitted a page for.
   const memoryTypeCounts = new Map<string, number>()
-  for (const e of declared) memoryTypeCounts.set(e.type, (memoryTypeCounts.get(e.type) ?? 0) + 1)
+  for (const e of knowledge) memoryTypeCounts.set(e.type, (memoryTypeCounts.get(e.type) ?? 0) + 1)
   const tagKeyCounts = new Map<string, number>()
-  for (const e of declared) {
+  for (const rel of files.keys()) {
+    const m = rel.match(/^tags\/(.+)\.md$/)
+    if (m) tagKeyCounts.set(m[1], 0)
+  }
+  for (const e of knowledge) {
     for (const k of Object.keys(e.tags)) {
-      tagKeyCounts.set(k, (tagKeyCounts.get(k) ?? 0) + 1)
+      const slug = slugify(k)
+      if (tagKeyCounts.has(slug)) tagKeyCounts.set(slug, (tagKeyCounts.get(slug) ?? 0) + 1)
     }
   }
+  const noteRef = (e: { id: string }) => ({
+    slug: vaultLinkOpts.idSlugIndex?.get(e.id) ?? '',
+    title: vaultLinkOpts.idTitleIndex?.get(e.id) ?? e.id,
+  })
   files.set(
     'index.md',
     buildIndexFile({
@@ -277,6 +296,17 @@ export async function generateWiki(
       archiveCount: collectConcepts(archiveEntries).size,
       releaseCount,
       workflowCount,
+      signalsCount: signals.length,
+      recentDecisions: knowledge
+        .filter((e) => e.type === 'decision')
+        .slice(0, 5)
+        .map(noteRef)
+        .filter((r) => r.slug),
+      topGotchas: knowledge
+        .filter((e) => e.type === 'gotcha')
+        .slice(0, 5)
+        .map(noteRef)
+        .filter((r) => r.slug),
     })
   )
 

--- a/core/services/wiki/_shared.ts
+++ b/core/services/wiki/_shared.ts
@@ -70,14 +70,18 @@ export function deburr(value: string): string {
   return value.normalize('NFD').replace(/[̀-ͯ]/g, '')
 }
 
-export function slugify(value: string): string {
-  return (
-    deburr(value)
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '')
-      .slice(0, 60) || 'unnamed'
-  )
+export function slugify(value: string, max = 60): string {
+  let slug = deburr(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  if (slug.length > max) {
+    // Cut at a word boundary — `...porque-la-key-guardada-es-de.md` style
+    // mid-word truncation made filenames unreadable in the file view.
+    const cut = slug.lastIndexOf('-', max)
+    slug = slug.slice(0, cut > max / 2 ? cut : max).replace(/-+$/, '')
+  }
+  return slug || 'unnamed'
 }
 
 export function sha256(body: string): string {

--- a/core/services/wiki/index-builder.ts
+++ b/core/services/wiki/index-builder.ts
@@ -8,6 +8,10 @@ import type { LLMAnalysis } from '../../types/llm-analysis'
 import type { ShippedFeature } from '../../types/storage'
 import { slugify } from './_shared'
 
+type NoteRef = { slug: string; title: string }
+
+const wikilink = ({ slug, title }: NoteRef) => `[[${slug}|${title.replace(/[[\]|]/g, '')}]]`
+
 export function buildIndexFile(args: {
   ships: ShippedFeature[]
   memoryTypeCounts: Map<string, number>
@@ -18,6 +22,9 @@ export function buildIndexFile(args: {
   archiveCount: number
   releaseCount: number
   workflowCount: number
+  signalsCount?: number
+  recentDecisions?: NoteRef[]
+  topGotchas?: NoteRef[]
 }): string {
   const { ships, memoryTypeCounts, tagKeyCounts, patternsCount, antiPatternsCount, llmAnalysis } =
     args
@@ -34,6 +41,20 @@ export function buildIndexFile(args: {
     '> with `type:` frontmatter — the Stop hook ingests it.',
     '',
   ]
+
+  // Dashboard: the freshest, highest-stakes knowledge surfaces on the
+  // landing page itself — an agent (or human) sees what matters without
+  // opening a single MOC.
+  if (args.recentDecisions?.length) {
+    lines.push('## Recent decisions')
+    for (const d of args.recentDecisions) lines.push(`- ${wikilink(d)}`)
+    lines.push('')
+  }
+  if (args.topGotchas?.length) {
+    lines.push('## Known traps')
+    for (const g of args.topGotchas) lines.push(`- ${wikilink(g)}`)
+    lines.push('')
+  }
 
   if (ships.length > 0) {
     lines.push('## Ships')
@@ -68,9 +89,18 @@ export function buildIndexFile(args: {
 
   if (tagKeyCounts.size > 0) {
     lines.push('## Memory by tag')
+    lines.push('- [all tags](tags.md)')
     for (const [key, count] of tagKeyCounts) {
       lines.push(`- [${key}](tags/${slugify(key)}.md) — ${count} entries`)
     }
+    lines.push('')
+  }
+
+  if (args.signalsCount && args.signalsCount > 0) {
+    lines.push('## Machine signals')
+    lines.push(
+      `- [signals](signals.md) — ${args.signalsCount} auto-detected (hot files, missed knowledge, friction)`
+    )
     lines.push('')
   }
 

--- a/core/services/wiki/memory-builder.ts
+++ b/core/services/wiki/memory-builder.ts
@@ -19,14 +19,18 @@ import {
   type FormatMemoryMdOptions,
   formatMemoryMd,
   linkifyMemRefs,
+  MACHINE_TAG_KEYS,
 } from '../../memory/format'
 import type { ShippedFeature } from '../../types/storage'
 import { chunkEntries, slugify } from './_shared'
+import { isSignalEntry } from './signals-builder'
 
 /**
  * Types rendered as their own per-entry note. Ephemeral GTD types
  * (`inbox`/`todo`/`idea`) stay aggregated — they churn and would just
  * add noise nodes — but still resolve via the index (block anchor).
+ * Machine signals (`improvement-signal`, detector output) never get a
+ * note regardless of type — they render on `signals.md` only.
  */
 export const PER_ENTRY_TYPES: ReadonlySet<string> = new Set([
   'decision',
@@ -39,17 +43,17 @@ export const PER_ENTRY_TYPES: ReadonlySet<string> = new Set([
   'spec',
   'feedback',
   'improvement-idea',
-  'improvement-signal',
   'question',
   'source',
   'person',
+  'retro',
 ])
 
 /**
  * Tag keys that encode an entry→entry RELATION, not a category. These
- * must NOT spawn `tags/<rel>/<value>.md` pages (that fragmented the
- * graph into orphan stubs); they become real wikilink edges in each
- * note's `## Relations` section instead.
+ * must NOT spawn tag pages (that fragmented the graph into orphan
+ * stubs); they become real wikilink edges in each note's `## Relations`
+ * section instead.
  */
 const RELATION_KEYS: ReadonlySet<string> = new Set([
   'relates',
@@ -59,6 +63,7 @@ const RELATION_KEYS: ReadonlySet<string> = new Set([
   'duplicates',
   'blocks',
   'depends',
+  'corrects',
 ])
 
 /**
@@ -71,10 +76,12 @@ export function buildIndexMaps(allEntries: MemoryEntry[]): {
   idTypeIndex: Map<string, string>
   idTitleIndex: Map<string, string>
   idSlugIndex: Map<string, string>
+  signalIds: Set<string>
 } {
   const idTypeIndex = new Map<string, string>()
   const idTitleIndex = new Map<string, string>()
   const idSlugIndex = new Map<string, string>()
+  const signalIds = new Set<string>()
   // SINGLE SOURCE OF TRUTH for per-entry note basenames. The link
   // target (linkifyMemRefs) and the emitted filename
   // (buildMemoryEntryNotes) MUST be byte-identical or the graph edge
@@ -86,6 +93,11 @@ export function buildIndexMaps(allEntries: MemoryEntry[]): {
     idTypeIndex.set(e.id, e.type)
     const title = deriveTitle(e)
     idTitleIndex.set(e.id, title)
+    if (isSignalEntry(e)) {
+      // Telemetry — anchored on signals.md, never a note of its own.
+      signalIds.add(e.id)
+      continue
+    }
     if (PER_ENTRY_TYPES.has(e.type)) {
       let slug = slugify(title)
       if (usedSlugs.has(slug)) slug = `${slug}-${rowId(e.id)}`.slice(0, 80)
@@ -93,31 +105,33 @@ export function buildIndexMaps(allEntries: MemoryEntry[]): {
       idSlugIndex.set(e.id, slug)
     }
   }
-  return { idTypeIndex, idTitleIndex, idSlugIndex }
+  return { idTypeIndex, idTitleIndex, idSlugIndex, signalIds }
 }
 
 function vaultOpts(
   idTypeIndex: Map<string, string>,
   idTitleIndex: Map<string, string>,
-  idSlugIndex: Map<string, string>
+  idSlugIndex: Map<string, string>,
+  signalIds: Set<string>
 ): FormatMemoryMdOptions {
   return {
     vault: true,
     idTypeIndex,
     idTitleIndex,
     idSlugIndex,
+    signalIds,
     perEntryTypes: PER_ENTRY_TYPES,
   }
 }
 
 /**
  * Shared vault linkify options built once from the FULL entry set —
- * so every builder (memory, tags, specs) resolves `mem_N` refs to the
- * same slug-targeted, legible links (graph-visible, not alias-only).
+ * so every builder (memory, tags, specs, signals) resolves `mem_N` refs
+ * to the same slug-targeted, legible links (graph-visible, not alias-only).
  */
 export function buildVaultOpts(allEntries: MemoryEntry[]): FormatMemoryMdOptions {
-  const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
-  return vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
+  const { idTypeIndex, idTitleIndex, idSlugIndex, signalIds } = buildIndexMaps(allEntries)
+  return vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex, signalIds)
 }
 
 export function formatShipBody(ship: ShippedFeature): string {
@@ -146,12 +160,25 @@ function dateOnly(iso: string): string {
   return m ? m[1] : ''
 }
 
-/** YAML flow map of tags with quoted values; '' when no tags. */
+/**
+ * Native Obsidian tag list (`tags: [topic/daemon, trap/lazy-rejection]`).
+ * The previous YAML flow-map form was invisible to Obsidian — tags must
+ * be a list of strings to power graph coloring/filtering and the tag
+ * pane. Nested `key/value` syntax keeps the dimension browsable.
+ * Machine bookkeeping and relation keys are excluded (relations are
+ * wikilink edges; machine keys live in SQLite).
+ */
 function frontmatterTags(tags: Record<string, string>): string {
-  const pairs = Object.entries(tags)
-  if (pairs.length === 0) return ''
-  const body = pairs.map(([k, v]) => `${k}: ${JSON.stringify(String(v))}`).join(', ')
-  return `tags: { ${body} }`
+  const items: string[] = []
+  for (const [k, v] of Object.entries(tags)) {
+    if (MACHINE_TAG_KEYS.has(k) || RELATION_KEYS.has(k)) continue
+    const key = slugify(k, 40)
+    const value = slugify(String(v), 60)
+    if (key === 'unnamed' || value === 'unnamed') continue
+    items.push(`${key}/${value}`)
+  }
+  if (items.length === 0) return ''
+  return `tags: [${items.join(', ')}]`
 }
 
 /**
@@ -193,7 +220,7 @@ export function buildMemoryEntryNotes(
   const titleByType = new Map<string, Array<{ id: string; title: string; slug: string }>>()
 
   for (const e of entries) {
-    if (!PER_ENTRY_TYPES.has(e.type)) continue
+    if (!PER_ENTRY_TYPES.has(e.type) || isSignalEntry(e)) continue
     const title = deriveTitle(e)
     // Slug comes from the shared index (buildIndexMaps) so the filename
     // is byte-identical to every link target. Fallback only if an entry
@@ -253,20 +280,24 @@ export function buildMemoryFiles(
 ): Map<string, string> {
   // Substantive types → one note per entry + a `memory/<type>.md` MOC
   // that wikilinks every note (the hub node). Ephemeral types keep the
-  // aggregated/chunked file. Index maps are built from the FULL entry
-  // set so every cross-ref resolves (Defect B).
+  // aggregated/chunked file. Machine signals are quarantined to
+  // signals.md (built by the orchestrator) — without this gate the
+  // graph drowned in hot-file/skill-miss telemetry nodes (45% of all
+  // entries). Index maps are built from the FULL entry set so every
+  // cross-ref resolves (Defect B).
   const files = new Map<string, string>()
-  const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
-  const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
+  const { idTypeIndex, idTitleIndex, idSlugIndex, signalIds } = buildIndexMaps(allEntries)
+  const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex, signalIds)
+  const knowledge = entries.filter((e) => !isSignalEntry(e))
 
   const byType = new Map<string, MemoryEntry[]>()
-  for (const e of entries) {
+  for (const e of knowledge) {
     const bucket = byType.get(e.type) ?? []
     bucket.push(e)
     byType.set(e.type, bucket)
   }
 
-  const { files: noteFiles, titleByType } = buildMemoryEntryNotes(entries, opts)
+  const { files: noteFiles, titleByType } = buildMemoryEntryNotes(knowledge, opts)
   for (const [rel, body] of noteFiles) files.set(rel, body)
 
   for (const [type, items] of byType) {
@@ -317,76 +348,68 @@ export function buildMemoryFiles(
 }
 
 /**
- * Tag keys that are machine bookkeeping, not browsable categories — their
- * values are opaque hashes / uuids / counters that spawned hundreds of vault
- * pages nobody reads (tags/key/<hash>.md, tags/session/<uuid>.md, …). We skip
- * generating pages for them; the entries are still reachable via memory/<type>
- * and search. Human dimensions (topic, type, pr, file, domain, …) still get
- * pages.
+ * Tag keys that don't deserve a browsable page: machine bookkeeping
+ * (MACHINE_TAG_KEYS — hashes, counters, session ids) — their values are
+ * opaque noise that once spawned hundreds of vault pages nobody reads.
+ * Human dimensions (topic, type, pr, file, domain, …) get an index page.
  */
-const NOISE_TAG_KEYS = new Set([
-  'key',
-  'hash',
-  'content-hash',
-  'content_hash',
-  'session',
-  'window-days',
-  'window_days',
-  'touches',
-  'occurrences',
-  'phrase',
-  'slug',
-  'spec-id',
-  'spec_id',
-  'kind',
-])
+const NOISE_TAG_KEYS: ReadonlySet<string> = MACHINE_TAG_KEYS
+
+/** Wikilink for one entry: the note basename when it has its own note,
+ *  the aggregated file's block anchor otherwise. */
+function entryLink(e: MemoryEntry, opts: FormatMemoryMdOptions): string {
+  const title = (opts.idTitleIndex?.get(e.id) ?? deriveTitle(e)).replace(/[[\]|]/g, '')
+  const slug = opts.idSlugIndex?.get(e.id)
+  if (slug) return `[[${slug}|${title}]]`
+  return `[[${e.type}#^mem-${rowId(e.id)}|${title}]]`
+}
 
 export function buildTagFiles(
   entries: MemoryEntry[],
   allEntries: MemoryEntry[] = entries
 ): Map<string, string> {
-  // One page per distinct tag pair (`tags/<key>/<value>.md`) + an index
-  // per tag key (`tags/<key>.md`). Relation tags are excluded — they're
-  // graph edges, not categories (Defect C). Opaque machine keys (NOISE_TAG_KEYS)
-  // are skipped so the vault stays browsable signal, not hash sprawl.
+  // One LINK-ONLY index page per tag key (`tags/<key>.md`): values as
+  // sections, entries as wikilinks. The old model emitted a page per
+  // tag PAIR with every entry's full content copied in — 54% of vault
+  // files were duplicated-content tag pages, and every one was a noise
+  // node in the graph. Relation tags are excluded (graph edges, not
+  // categories — Defect C); machine keys are excluded (hash sprawl);
+  // machine-signal entries are excluded (they live on signals.md).
   const files = new Map<string, string>()
-  const { idTypeIndex, idTitleIndex, idSlugIndex } = buildIndexMaps(allEntries)
-  const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex)
-  const byPair = groupByTagPair(entries)
+  const { idTypeIndex, idTitleIndex, idSlugIndex, signalIds } = buildIndexMaps(allEntries)
+  const opts = vaultOpts(idTypeIndex, idTitleIndex, idSlugIndex, signalIds)
+  const byPair = groupByTagPair(entries.filter((e) => !isSignalEntry(e)))
 
-  for (const [key, byValue] of byPair) {
+  const keyIndexLines = [`# Tags`, '']
+  const sortedKeys = [...byPair.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  for (const [key, byValue] of sortedKeys) {
     if (NOISE_TAG_KEYS.has(key)) continue
+    // A dimension used once is not a browsable dimension — a 1-entry
+    // page is just another orphan node. The entry stays reachable via
+    // its type MOC and its frontmatter tag.
+    const total = [...byValue.values()].reduce((n, items) => n + items.length, 0)
+    if (total < 2) continue
     const keySlug = slugify(key)
-    const indexLines = [`# Tag: ${key}`, '']
+    const lines = [`# Tag: ${key}`, '']
     const sortedValues = [...byValue.entries()].sort((a, b) => a[0].localeCompare(b[0]))
-
+    let entryCount = 0
     for (const [value, items] of sortedValues) {
-      const valueSlug = slugify(value)
-      const chunks = chunkEntries(items)
-      if (chunks.length === 1) {
-        const body = [`# ${key}: ${value}`, '', formatMemoryMd(items, opts), ''].join('\n')
-        files.set(`tags/${keySlug}/${valueSlug}.md`, body)
-        indexLines.push(`- [${value}](${keySlug}/${valueSlug}.md) — ${items.length} entries`)
-      } else {
-        for (let i = 0; i < chunks.length; i++) {
-          const body = [
-            `# ${key}: ${value} — chunk ${i + 1}/${chunks.length}`,
-            '',
-            formatMemoryMd(chunks[i], opts),
-            '',
-          ].join('\n')
-          files.set(`tags/${keySlug}/${valueSlug}-${i + 1}.md`, body)
-        }
-        indexLines.push(`- **${value}** — ${items.length} entries across ${chunks.length} chunks`)
-        for (let i = 0; i < chunks.length; i++) {
-          indexLines.push(`  - [chunk ${i + 1}](${keySlug}/${valueSlug}-${i + 1}.md)`)
-        }
-      }
+      lines.push(`## ${value}`, '')
+      for (const item of items) lines.push(`- ${entryLink(item, opts)}`)
+      lines.push('')
+      entryCount += items.length
     }
-
-    indexLines.push('')
-    files.set(`tags/${keySlug}.md`, `${indexLines.join('\n')}\n`)
+    files.set(`tags/${keySlug}.md`, `${lines.join('\n')}\n`)
+    // Path-qualified target: a bare [[topic]] could collide with an
+    // entry note that happens to slug to the same basename.
+    keyIndexLines.push(
+      `- [[tags/${keySlug}|${key}]] — ${sortedValues.length} values, ${entryCount} entries`
+    )
   }
 
+  if (files.size > 0) {
+    keyIndexLines.push('')
+    files.set('tags.md', `${keyIndexLines.join('\n')}\n`)
+  }
   return files
 }

--- a/core/services/wiki/signals-builder.ts
+++ b/core/services/wiki/signals-builder.ts
@@ -1,0 +1,164 @@
+/**
+ * Machine-signal quarantine + `signals.md` dashboard.
+ *
+ * Auto-detectors (hot-file churn, skill-miss, friction, recurring bugs)
+ * write their output into project memory as regular entries. That is
+ * right for the DB — recall and the hooks feed on them — but rendering
+ * each one as its own vault note drowned the knowledge graph in dozens
+ * of `hot-file-NNN` / `skill-miss-...-NNN` nodes (45% of all entries
+ * are machine telemetry). The vault is for KNOWLEDGE; telemetry gets
+ * exactly one page.
+ *
+ * Every rendered row keeps its `^mem-N` block anchor so cross-refs
+ * resolve as `[[signals#^mem-N|title]]` — one hub node in the graph
+ * instead of a dust cloud.
+ */
+
+import type { MemoryEntry } from '../../memory/entries'
+import { type FormatMemoryMdOptions, linkifyMemRefs } from '../../memory/format'
+import { truncate } from './_shared'
+
+/** `tags.source` values produced by automatic detectors, not by an agent/user. */
+export const MACHINE_SOURCES: ReadonlySet<string> = new Set([
+  'pattern-detector-auto',
+  'pattern-detector-recurring',
+  'skill-miss-detector',
+  'friction-detector',
+])
+
+/**
+ * Telemetry, not knowledge: everything typed `improvement-signal` plus
+ * any entry stamped by a machine detector (hot-file churn entries are
+ * stored as type `learning` but are pure telemetry).
+ */
+export function isSignalEntry(e: Pick<MemoryEntry, 'type' | 'tags'>): boolean {
+  if (e.type === 'improvement-signal') return true
+  const source = e.tags?.source
+  return source !== undefined && MACHINE_SOURCES.has(source)
+}
+
+function rowId(id: string): string {
+  return id.replace(/^mem[_-]/, '')
+}
+
+function dateOnly(iso: string): string {
+  const m = (iso || '').match(/^(\d{4}-\d{2}-\d{2})/)
+  return m ? m[1] : ''
+}
+
+function oneLine(content: string, max = 220): string {
+  return truncate((content.split('\n')[0] ?? content).replace(/\s+/g, ' ').trim(), max)
+}
+
+type Section = { title: string; intro: string; rows: string[] }
+
+/**
+ * Single dashboard page for all machine signals. Returns null when the
+ * project has none (the page simply doesn't exist — no empty stub).
+ */
+export function buildSignalsFile(
+  signals: MemoryEntry[],
+  opts: FormatMemoryMdOptions
+): string | null {
+  if (signals.length === 0) return null
+
+  const hotFiles: MemoryEntry[] = []
+  const recurring: MemoryEntry[] = []
+  const skillMisses: MemoryEntry[] = []
+  const friction: MemoryEntry[] = []
+  const other: MemoryEntry[] = []
+  for (const e of signals) {
+    const source = e.tags?.source
+    if (source === 'pattern-detector-auto') hotFiles.push(e)
+    else if (source === 'pattern-detector-recurring') recurring.push(e)
+    else if (source === 'skill-miss-detector') skillMisses.push(e)
+    else if (source === 'friction-detector') friction.push(e)
+    else other.push(e)
+  }
+
+  const anchor = (e: MemoryEntry) => `^mem-${rowId(e.id)}`
+  const stamp = (e: MemoryEntry) => {
+    const d = dateOnly(e.rememberedAt)
+    return d ? ` _(${d})_` : ''
+  }
+
+  const sections: Section[] = []
+
+  if (hotFiles.length > 0) {
+    // Newest entry per file leads; older churn entries for the same
+    // file stay listed (their anchors must exist) but compactly.
+    const byFile = new Map<string, MemoryEntry[]>()
+    for (const e of hotFiles) {
+      const file = e.tags?.file ?? '(unknown file)'
+      const bucket = byFile.get(file) ?? []
+      bucket.push(e)
+      byFile.set(file, bucket)
+    }
+    const rows: string[] = []
+    const sorted = [...byFile.entries()].sort((a, b) => b[1].length - a[1].length)
+    for (const [file, items] of sorted) {
+      const [latest, ...older] = items
+      const touches = latest.tags?.touches ? `${latest.tags.touches} touches` : 'churning'
+      const win = latest.tags?.window_days ?? latest.tags?.['window-days']
+      const window = win ? ` in ${win}d` : ''
+      rows.push(`- \`${file}\` — ${touches}${window}${stamp(latest)} ${anchor(latest)}`)
+      for (const o of older) rows.push(`    - earlier sighting${stamp(o)} ${anchor(o)}`)
+    }
+    sections.push({
+      title: 'Hot files',
+      intro: 'Files that keep churning — refactor candidates or deliberate hubs.',
+      rows,
+    })
+  }
+
+  if (recurring.length > 0) {
+    sections.push({
+      title: 'Recurring patterns',
+      intro: 'The same class of change keeps happening.',
+      rows: recurring.map((e) => `- ${oneLine(e.content)}${stamp(e)} ${anchor(e)}`),
+    })
+  }
+
+  if (skillMisses.length > 0) {
+    sections.push({
+      title: 'Knowledge being missed',
+      intro: 'Project knowledge existed but was not applied in a session.',
+      rows: skillMisses.map(
+        (e) => `- ${linkifyMemRefs(oneLine(e.content), opts)}${stamp(e)} ${anchor(e)}`
+      ),
+    })
+  }
+
+  if (friction.length > 0) {
+    sections.push({
+      title: 'Friction',
+      intro: 'Moments the developer pushed back — do not repeat.',
+      rows: friction.map((e) => `- ${oneLine(e.content)}${stamp(e)} ${anchor(e)}`),
+    })
+  }
+
+  if (other.length > 0) {
+    sections.push({
+      title: 'Other signals',
+      intro: '',
+      rows: other.map(
+        (e) => `- ${linkifyMemRefs(oneLine(e.content), opts)}${stamp(e)} ${anchor(e)}`
+      ),
+    })
+  }
+
+  const lines: string[] = [
+    '# Signals (machine telemetry)',
+    '',
+    '> Auto-detected by prjct — churn, missed knowledge, friction. This is',
+    '> telemetry, not curated knowledge: act on it, then let it expire.',
+    `> ${signals.length} signal${signals.length === 1 ? '' : 's'} recorded.`,
+  ]
+  for (const s of sections) {
+    lines.push('', `## ${s.title}`, '')
+    if (s.intro) lines.push(`_${s.intro}_`, '')
+    lines.push(...s.rows)
+  }
+  lines.push('')
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Why

The generated vault wasn't serving anyone (user report, with graph-view screenshot):
- **45% of memory entries are machine telemetry** (hot-file churn ×23, skill-miss ×14, friction ×5, recurring ×3 on this repo) — each rendered as its own note, drowning the knowledge graph in `hot-file-NNN` / `skill-miss-...-NNN` nodes.
- **54% of vault files were tag pages** (`tags/<key>/<value>.md`) that **duplicated every entry's full content**, spawning noise nodes like `2-36-0`, `none`, `unnamed`.
- Frontmatter tags used a YAML flow map Obsidian can't read; slugs truncated mid-word; `_(source=… touches=3)_` machine metadata inline in bodies; index.md was a counter, not a hub.

## What

- **`signals-builder.ts` (new)**: `isSignalEntry` gate (type `improvement-signal` or `tags.source` ∈ detectors) + a single `signals.md` dashboard — hot files deduped per path, sections for recurring/skill-miss/friction, every row block-anchored so `[[signals#^mem-N|title]]` cross-refs resolve to one hub node.
- **Tags v2**: link-only `tags/<key>.md` per dimension + `tags.md` master index; no per-value pages, no content duplication; dimensions with <2 entries get no page; `corrects` joins RELATION_KEYS.
- **Native Obsidian tags**: `tags: [topic/daemon-lazy-loading]` — graph coloring/filtering works; `MACHINE_TAG_KEYS` (source/session/touches/hash/…) hidden from bodies and frontmatter (still in SQLite).
- **index.md dashboard**: recent decisions + known traps as wikilinks, signals section.
- **Readable filenames**: word-boundary slug cuts; `retro` added to per-entry types.

## Result (this repo, regenerated)

326 → **113 files** (tags 177→9, telemetry notes 42→0), zero information loss — SQLite and recall untouched; `developer.md`/digests still consume friction signals.

## Tests

`signals-builder.test.ts` (new, 8) + memory-builder locks updated to the v2 contract. Full suite: 1507 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)