### PR TITLE
fix: Codex first-class — skill under 1KB cap, MCP wiring, real AGENTS.md, doctor checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## [Unreleased]
 
 ### Fixed
-- **CRITICAL: the memory cap no longer deletes knowledge.** `capEntries` (runs on every `prjct sync`) counted ALL `memory.%` events against the 500-row cap — high-churn telemetry (`memory.post_edit` fires on every file edit) inflated the total and the age-ordered delete silently destroyed the OLDEST remembered decisions/gotchas/learnings while keeping hundreds of newer telemetry rows. `memory.remember.*` is now invisible to the cap (count and delete); knowledge leaves the log only via `prjct forget`. The delete is also exact-id based instead of an id-range sweep. If a past sync capped your project: the `memories` mirror table still holds the rows with their original ids — restorable.
+- **CRITICAL: Codex support actually works now.** The bin shim self-healed the ~9.5KB Claude skill baseline into `~/.codex/skills/prjct/SKILL.md` — 9× over Codex's HARD ~1024-byte cap, so Codex silently rejected the entire skill. The shim now installs the Codex-specific template (and only when Codex is present); the skill metadata marker was compacted and a size guard + tests keep the built artifact under the cap with headroom.
+- `prjct init` no longer logs `Generated: AGENTS.md` (and friends) for files it never wrote — it reports only what it actually writes.
+
+### Added
+- **Codex MCP wiring.** Setup and sync now ensure `[mcp_servers.prjct]` in `~/.codex/config.toml` (marker-managed TOML block; user-managed entries are never touched) — the `prjct_*` tools finally exist for Codex sessions.
+- **AGENTS.md generation.** `prjct init` writes a vendor-neutral prjct routing block to the project's `AGENTS.md` (marker-merged, user content preserved) when Codex is detected or wizard-selected — Codex has no hooks, so this block is its session-start context.
+- `prjct doctor` now checks the `codex` binary and the installed Claude hooks count.
 
 ## [2.43.2] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,14 @@ Codex is detected by the `codex` CLI on PATH (context file `AGENTS.md`). The
 sandbox is non-interactive/non-TTY, so prjct-cli emits the same static, prompt-free
 status line as any agent; add `--md` for fully markdown-structured output.
 
+**What does Codex get from prjct?**
+Three surfaces, all installed/healed automatically: a compact skill at
+`~/.codex/skills/prjct/SKILL.md` (kept under Codex's ~1KB skill cap), the
+prjct MCP server wired into `~/.codex/config.toml` (`prjct_*` tools), and a
+vendor-neutral routing block in the project's `AGENTS.md` written by
+`prjct init`. Codex has no lifecycle hooks, so AGENTS.md + MCP are its
+session-start context and live tool surface.
+
 **How do I quickly find the local `.prjct/` directory?**
 It's in your **project repo root** (created by `prjct init` / first `prjct`
 command) and is `.gitignore`d — that's why `git status` never shows it. Find it:

--- a/bin/prjct
+++ b/bin/prjct
@@ -91,15 +91,19 @@ ensure_setup() {
   # postinstall is unreliable (--ignore-scripts, npm policies), so the
   # bin shim self-heals on every invocation. mtime-based: source newer
   # than dest → overwrite. Common case (skill up-to-date) = two stats.
-  SKILL_SRC="$ROOT_DIR/templates/skills/prjct/SKILL.md"
-  if [ -f "$SKILL_SRC" ]; then
-    for SKILL_DEST in "$HOME/.claude/skills/prjct/SKILL.md" "$HOME/.codex/skills/prjct/SKILL.md"; do
-      SKILL_DIR=$(dirname "$SKILL_DEST")
-      if [ ! -f "$SKILL_DEST" ] || [ "$SKILL_SRC" -nt "$SKILL_DEST" ]; then
-        mkdir -p "$SKILL_DIR" 2>/dev/null
-        cp "$SKILL_SRC" "$SKILL_DEST" 2>/dev/null
-      fi
-    done
+  # Each agent gets ITS OWN template: Codex enforces a hard ~1KB limit
+  # on the whole SKILL.md and silently rejects the entire skill when
+  # the (much larger) Claude baseline lands there.
+  install_skill() {
+    if [ -f "$1" ] && { [ ! -f "$2" ] || [ "$1" -nt "$2" ]; }; then
+      mkdir -p "$(dirname "$2")" 2>/dev/null
+      cp "$1" "$2" 2>/dev/null
+    fi
+  }
+  install_skill "$ROOT_DIR/templates/skills/prjct/SKILL.md" "$HOME/.claude/skills/prjct/SKILL.md"
+  # Codex only if present — don't create ~/.codex on machines without it
+  if [ -d "$HOME/.codex" ] || command -v codex >/dev/null 2>&1; then
+    install_skill "$ROOT_DIR/templates/codex/SKILL.md" "$HOME/.codex/skills/prjct/SKILL.md"
   fi
 }
 

--- a/core/__tests__/infrastructure/codex-skill.test.ts
+++ b/core/__tests__/infrastructure/codex-skill.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Codex skill — the 1024-byte contract.
+ *
+ * Codex (codex-cli 0.135) enforces a HARD ~1024-byte limit on the whole
+ * SKILL.md file: one byte over and the ENTIRE skill is silently rejected
+ * (prjct disappears from Codex with no error). mem_969. These tests pin:
+ *   1. The built artifact (template + metadata marker) stays under the cap
+ *      with real headroom — version strings grow, hashes are appended.
+ *   2. The bin shim self-heals the CODEX template into ~/.codex, never the
+ *      ~9.5KB Claude baseline (the regression that broke Codex silently).
+ *   3. Metadata parse accepts both the compact format and the legacy
+ *      pre-2.44 format (so old installs verify-mismatch and repair, not
+ *      crash).
+ */
+
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { buildCodexSkillContent, CODEX_SKILL_MAX_BYTES } from '../../infrastructure/codex-skill'
+
+const ROOT = path.resolve(__dirname, '../../..')
+const TEMPLATE = fs.readFileSync(path.join(ROOT, 'templates/codex/SKILL.md'), 'utf-8')
+
+describe('codex skill size guard', () => {
+  test('built SKILL.md (template + metadata) stays under the Codex hard cap', () => {
+    const built = buildCodexSkillContent(TEMPLATE)
+    expect(Buffer.byteLength(built.content, 'utf-8')).toBeLessThanOrEqual(CODEX_SKILL_MAX_BYTES)
+  })
+
+  test('keeps ≥50 bytes of headroom for version growth', () => {
+    const built = buildCodexSkillContent(TEMPLATE)
+    expect(Buffer.byteLength(built.content, 'utf-8')).toBeLessThanOrEqual(
+      CODEX_SKILL_MAX_BYTES - 50
+    )
+  })
+
+  test('metadata marker is present and compact', () => {
+    const built = buildCodexSkillContent(TEMPLATE)
+    const marker = built.content.match(/<!--\s*prjct-codex-router:\s*(\{[\s\S]*?\})\s*-->/)
+    expect(marker).not.toBeNull()
+    const meta = JSON.parse(marker![1]) as { v?: string; h?: string }
+    expect(meta.v).toBeTruthy()
+    expect(meta.h).toBe(built.templateHash)
+    // Truncated hash — full sha256 hex would burn 52 extra bytes of cap.
+    expect(built.templateHash.length).toBeLessThanOrEqual(12)
+  })
+})
+
+describe('bin shim skill self-heal', () => {
+  const shim = fs.readFileSync(path.join(ROOT, 'bin/prjct'), 'utf-8')
+
+  test('Codex destination receives the Codex template, not the Claude baseline', () => {
+    // The exact regression: one loop copied templates/skills/prjct/SKILL.md
+    // (the ~9.5KB Claude baseline) into BOTH ~/.claude and ~/.codex.
+    expect(shim).toContain('templates/codex/SKILL.md')
+    for (const line of shim.split('\n')) {
+      if (line.includes('.codex/skills')) {
+        expect(line).not.toContain('templates/skills/prjct')
+      }
+      if (line.includes('templates/skills/prjct')) {
+        expect(line).not.toContain('.codex')
+      }
+    }
+  })
+
+  test('Claude destination still receives the Claude baseline', () => {
+    expect(shim).toContain('templates/skills/prjct/SKILL.md')
+    expect(shim).toContain('.claude/skills/prjct/SKILL.md')
+  })
+})

--- a/core/__tests__/services/project-agents-md.test.ts
+++ b/core/__tests__/services/project-agents-md.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Project AGENTS.md routing block — written by `prjct init` when Codex
+ * is detected (or wizard-selected). Mirrors the CLAUDE.md contract:
+ *   1. Missing AGENTS.md → created with the block.
+ *   2. Existing AGENTS.md without markers → block appended, user content
+ *      preserved (this repo's own handwritten AGENTS.md is the canary).
+ *   3. Stale markers → refreshed in place.
+ *   4. Re-run on current file → action='unchanged' (idempotent).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { _routing, writeProjectAgentsMd } from '../../services/project-agents-md'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-agents-md-test-'))
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+async function readAgentsMd(): Promise<string> {
+  return fs.readFile(path.join(dir, 'AGENTS.md'), 'utf-8')
+}
+
+describe('writeProjectAgentsMd', () => {
+  it('creates AGENTS.md when none exists', async () => {
+    const r = await writeProjectAgentsMd(dir)
+    expect(r.action).toBe('created')
+    const body = await readAgentsMd()
+    expect(body).toContain(_routing.START_MARKER)
+    expect(body).toContain(_routing.END_MARKER)
+    expect(body).toContain('## prjct — project memory & workflow')
+    expect(body).toContain('prjct task')
+  })
+
+  it('appends the block to an existing AGENTS.md without markers', async () => {
+    await fs.writeFile(
+      path.join(dir, 'AGENTS.md'),
+      '# Contributor guide\n\nHandwritten conventions.\n'
+    )
+    const r = await writeProjectAgentsMd(dir)
+    expect(r.action).toBe('updated')
+    const body = await readAgentsMd()
+    expect(body).toContain('# Contributor guide')
+    expect(body).toContain('Handwritten conventions.')
+    expect(body).toContain(_routing.START_MARKER)
+    expect(body.indexOf('Handwritten conventions.')).toBeLessThan(
+      body.indexOf(_routing.START_MARKER)
+    )
+  })
+
+  it('refreshes a stale block between markers, preserving outside content', async () => {
+    const stale = `# Mine\n\n${_routing.START_MARKER}\nOLD CONTENT\n${_routing.END_MARKER}\n\nTrailing notes.\n`
+    await fs.writeFile(path.join(dir, 'AGENTS.md'), stale)
+    const r = await writeProjectAgentsMd(dir)
+    expect(r.action).toBe('updated')
+    const body = await readAgentsMd()
+    expect(body).not.toContain('OLD CONTENT')
+    expect(body).toContain('# Mine')
+    expect(body).toContain('Trailing notes.')
+    expect(body).toContain('## prjct — project memory & workflow')
+  })
+
+  it('is idempotent — re-run reports unchanged', async () => {
+    await writeProjectAgentsMd(dir)
+    const first = await readAgentsMd()
+    const r = await writeProjectAgentsMd(dir)
+    expect(r.action).toBe('unchanged')
+    expect(await readAgentsMd()).toBe(first)
+  })
+
+  it('block is vendor-neutral — no Claude-only paths', async () => {
+    await writeProjectAgentsMd(dir)
+    const body = await readAgentsMd()
+    expect(body).not.toContain('.claude/')
+    expect(body).not.toContain('Claude Code')
+  })
+})

--- a/core/__tests__/utils/codex-mcp.test.ts
+++ b/core/__tests__/utils/codex-mcp.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Codex MCP wiring — `[mcp_servers.prjct]` in ~/.codex/config.toml.
+ *
+ * Pins the contract:
+ *   1. No config.toml → created with just the managed block.
+ *   2. Existing user config without our entry → block appended, user
+ *      content byte-preserved.
+ *   3. Existing managed block → replaced in place (upgrade path),
+ *      idempotent when nothing changed.
+ *   4. User-managed `[mcp_servers.prjct]` (no markers) → NEVER touched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildPrjctMcpTomlBlock, ensureCodexMcpServer } from '../../utils/codex-mcp'
+
+let dir: string
+let configPath: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-codex-mcp-test-'))
+  configPath = path.join(dir, 'config.toml')
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('ensureCodexMcpServer', () => {
+  it('creates config.toml with the prjct server when missing', async () => {
+    const r = await ensureCodexMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('[mcp_servers.prjct]')
+    expect(body).toContain('# prjct:mcp:start')
+    expect(body).toContain('# prjct:mcp:end')
+    expect(body).toMatch(/command = "/)
+  })
+
+  it('appends to an existing config without touching user content', async () => {
+    const user = '[projects."/Users/x/app"]\ntrust_level = "trusted"\n'
+    await fs.writeFile(configPath, user, 'utf-8')
+
+    const r = await ensureCodexMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('trust_level = "trusted"')
+    expect(body.indexOf('[projects.')).toBeLessThan(body.indexOf('[mcp_servers.prjct]'))
+  })
+
+  it('replaces a stale managed block in place', async () => {
+    await ensureCodexMcpServer(configPath)
+    const before = await fs.readFile(configPath, 'utf-8')
+    const stale = before.replace(/command = "[^"]*"/, 'command = "old-binary"')
+    await fs.writeFile(configPath, stale, 'utf-8')
+
+    const r = await ensureCodexMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    const after = await fs.readFile(configPath, 'utf-8')
+    expect(after).not.toContain('old-binary')
+    // Exactly one managed block — replacement, not accumulation.
+    expect(after.split('[mcp_servers.prjct]').length - 1).toBe(1)
+  })
+
+  it('is idempotent — second run reports unchanged', async () => {
+    await ensureCodexMcpServer(configPath)
+    const first = await fs.readFile(configPath, 'utf-8')
+    const r = await ensureCodexMcpServer(configPath)
+    expect(r.changed).toBe(false)
+    expect(await fs.readFile(configPath, 'utf-8')).toBe(first)
+  })
+
+  it('never touches a user-managed [mcp_servers.prjct] entry', async () => {
+    const user = '[mcp_servers.prjct]\ncommand = "my-custom-wrapper"\nargs = []\n'
+    await fs.writeFile(configPath, user, 'utf-8')
+
+    const r = await ensureCodexMcpServer(configPath)
+    expect(r.changed).toBe(false)
+    expect(r.skipped).toBe('user-managed')
+    expect(await fs.readFile(configPath, 'utf-8')).toBe(user)
+  })
+})
+
+describe('buildPrjctMcpTomlBlock', () => {
+  it('escapes TOML string values', () => {
+    const block = buildPrjctMcpTomlBlock({
+      command: 'C:\\node "x"',
+      args: ['a"b'],
+      description: 'ignored',
+    })
+    expect(block).toContain('command = "C:\\\\node \\"x\\""')
+    expect(block).toContain('args = ["a\\"b"]')
+    // description is a Claude mcp.json concept — Codex TOML must not get it.
+    expect(block).not.toContain('description')
+  })
+})

--- a/core/commands/planning.ts
+++ b/core/commands/planning.ts
@@ -7,6 +7,7 @@ import * as authorDetector from '../infrastructure/author-detector'
 import commandInstaller from '../infrastructure/command-installer'
 import configManager from '../infrastructure/config-manager'
 import pathManager from '../infrastructure/path-manager'
+import { writeProjectAgentsMd } from '../services/project-agents-md'
 import { writeProjectClaudeMd } from '../services/project-claude-md'
 import { workflowRuleStorage } from '../storage/workflow-rule-storage'
 import type { CommandResult, InitOptions } from '../types/commands'
@@ -162,9 +163,24 @@ export class PlanningCommands extends PrjctCommandsBase {
       // sessions in this directory pick up the prjct contract on cwd
       // entry. Best-effort — a missing/locked file degrades silently.
       await writeProjectClaudeMd(projectPath).catch(() => {})
+      // AGENTS.md is the cross-agent counterpart (Codex reads it at
+      // project load — it has no hooks, so this block is its only
+      // session-start context). Written when Codex is around or the
+      // wizard selected it.
+      let agentsMdWritten = false
+      try {
+        const { detectCodex } = await import('../infrastructure/ai-provider')
+        const codex = await detectCodex()
+        if (codex.installed || wizardResult?.agents.includes('codex')) {
+          await writeProjectAgentsMd(projectPath)
+          agentsMdWritten = true
+        }
+      } catch {
+        // best-effort, same contract as CLAUDE.md above
+      }
 
       out.done('initialized')
-      this._printNextSteps(wizardResult)
+      this._printNextSteps(wizardResult, { agentsMdWritten })
       return { success: true, projectId, wizard: wizardResult }
     } catch (error) {
       out.fail(getErrorMessage(error))
@@ -175,10 +191,16 @@ export class PlanningCommands extends PrjctCommandsBase {
   /**
    * Print next steps after initialization
    */
-  private _printNextSteps(wizardResult: import('../types/workflows').WizardResult | null): void {
+  private _printNextSteps(
+    wizardResult: import('../types/workflows').WizardResult | null,
+    written: { agentsMdWritten?: boolean } = {}
+  ): void {
     console.log('')
     console.log('  ✓ skill installed at ~/.claude/skills/prjct/')
     console.log('  ✓ project CLAUDE.md updated with routing block')
+    if (written.agentsMdWritten) {
+      console.log('  ✓ project AGENTS.md updated with routing block (Codex & friends)')
+    }
     console.log('')
     console.log("  You don't run prjct commands. Claude does.")
     console.log('')
@@ -193,32 +215,12 @@ export class PlanningCommands extends PrjctCommandsBase {
     console.log('    prjct hooks      Auto-sync on commit/checkout')
     console.log('')
 
-    if (wizardResult) {
-      const agentFiles = wizardResult.agents
-        .map((a) => {
-          switch (a) {
-            case 'claude':
-              return 'CLAUDE.md'
-            case 'cursor':
-              return '.cursorrules'
-            case 'windsurf':
-              return '.windsurfrules'
-            case 'copilot':
-              return '.github/copilot-instructions.md'
-            case 'gemini':
-              return 'GEMINI.md'
-            case 'codex':
-              return 'AGENTS.md'
-            default:
-              return null
-          }
-        })
-        .filter(Boolean)
-
-      if (agentFiles.length > 0) {
-        console.log(`  Generated: ${agentFiles.join(', ')}`)
-        console.log('')
-      }
+    // Honest reporting only: the wizard DETECTS agents, it does not
+    // generate their config files (CLAUDE.md/AGENTS.md writes are
+    // reported above, where they actually happen).
+    if (wizardResult && wizardResult.agents.length > 0) {
+      console.log(`  Detected agents: ${wizardResult.agents.join(', ')}`)
+      console.log('')
     }
 
     console.log('  Docs: https://prjct.app/docs')

--- a/core/commands/setup/mcp.ts
+++ b/core/commands/setup/mcp.ts
@@ -7,8 +7,10 @@
  *    setup commands.
  */
 
+import { detectCodex } from '../../infrastructure/ai-provider'
 import context7Service from '../../services/context7-service'
 import { getErrorMessage } from '../../types/fs'
+import { ensureCodexMcpServer } from '../../utils/codex-mcp'
 import {
   getClaudeMcpConfigPath,
   hasMcpServer,
@@ -64,6 +66,30 @@ export async function setupMcpServers(
         console.log(`⚠️  ${server.failed}: ${getErrorMessage(error)}`)
         console.log(server.manual)
       }
+    }
+  }
+
+  // Codex reads MCP servers from ~/.codex/config.toml — without this
+  // entry the prjct_* tools never exist for Codex sessions, even though
+  // its SKILL.md tells it to prefer them.
+  try {
+    const codex = await detectCodex()
+    if (codex.installed) {
+      const result = await ensureCodexMcpServer()
+      if (!options.silent) {
+        if (result.skipped === 'user-managed') {
+          console.log('✅ prjct MCP already configured for Codex (user-managed)')
+        } else if (result.changed) {
+          console.log('✅ prjct MCP added to ~/.codex/config.toml')
+        } else {
+          console.log('✅ prjct MCP already configured for Codex')
+        }
+      }
+    }
+  } catch (error) {
+    if (!options.silent) {
+      console.log(`⚠️  Codex MCP setup failed: ${getErrorMessage(error)}`)
+      console.log('   Run `prjct start` again to retry.')
     }
   }
 }

--- a/core/infrastructure/codex-skill.ts
+++ b/core/infrastructure/codex-skill.ts
@@ -20,14 +20,25 @@ import { detectCodex } from './ai-provider'
 
 const CODEX_SKILL_META_MARKER = 'prjct-codex-router'
 
+/**
+ * Codex enforces a HARD limit of ~1024 bytes on the whole SKILL.md file
+ * (not just the description field). Over the limit, the ENTIRE skill is
+ * silently rejected and prjct disappears from Codex. Everything written
+ * to ~/.codex/skills/prjct/SKILL.md must stay under this — enforced by
+ * the size guard below and by codex-skill tests.
+ */
+export const CODEX_SKILL_MAX_BYTES = 1024
+
 function getCodexSkillPath(): string {
   return path.join(os.homedir(), '.codex', 'skills', 'prjct', 'SKILL.md')
 }
 
+// Compact on purpose: every metadata byte counts against the 1024-byte
+// Codex cap, so keys are single letters and the hash is truncated.
 function getCodexSkillMetadata(templateHash: string): string {
   return `<!-- ${CODEX_SKILL_META_MARKER}: ${JSON.stringify({
-    version: VERSION,
-    templateHash,
+    v: VERSION,
+    h: templateHash,
   })} -->`
 }
 
@@ -39,14 +50,23 @@ function parseCodexSkillMetadata(
   )
   if (!match) return null
   try {
-    return JSON.parse(match[1]) as { version?: string; templateHash?: string }
+    const raw = JSON.parse(match[1]) as {
+      v?: string
+      h?: string
+      version?: string
+      templateHash?: string
+    }
+    return {
+      version: raw.v ?? raw.version,
+      templateHash: raw.h ?? raw.templateHash,
+    }
   } catch {
     return null
   }
 }
 
 function hashContent(content: string): string {
-  return sha256(content)
+  return sha256(content).slice(0, 12)
 }
 
 async function loadCodexSkillTemplate(): Promise<string | null> {
@@ -61,7 +81,7 @@ async function loadCodexSkillTemplate(): Promise<string | null> {
   return fs.readFile(templatePath, 'utf-8')
 }
 
-function buildCodexSkillContent(templateContent: string): {
+export function buildCodexSkillContent(templateContent: string): {
   content: string
   templateHash: string
 } {
@@ -101,6 +121,15 @@ export async function installCodexSkill(): Promise<{
     }
 
     const built = buildCodexSkillContent(templateContent)
+
+    const bytes = Buffer.byteLength(built.content, 'utf-8')
+    if (bytes > CODEX_SKILL_MAX_BYTES) {
+      // Install anyway (Codex may relax the cap), but surface it loudly:
+      // over the cap, Codex rejects the whole skill with no error shown.
+      log.warn(
+        `Codex SKILL.md is ${bytes} bytes — over Codex's ~${CODEX_SKILL_MAX_BYTES}-byte hard limit; the skill may be rejected. Trim templates/codex/SKILL.md.`
+      )
+    }
 
     if (skillExists) {
       const existing = await fs.readFile(skillMdPath, 'utf-8').catch(() => '')

--- a/core/services/doctor-service.ts
+++ b/core/services/doctor-service.ts
@@ -112,6 +112,9 @@ class DoctorService {
       this.checkCommand('gemini', 'gemini --version', /gemini ([\d.]+)/, true, 'Google Gemini CLI')
     )
 
+    // OpenAI Codex CLI (optional)
+    checks.push(this.checkCommand('codex', 'codex --version', /([\d.]+)/, true, 'OpenAI Codex CLI'))
+
     return checks
   }
 
@@ -163,7 +166,36 @@ class DoctorService {
     // Codex p. router
     checks.push(await this.checkCodexPRouter())
 
+    // Claude Code hooks (the capture/apply loop runs through them)
+    checks.push(await this.checkClaudeHooks())
+
     return checks
+  }
+
+  private async checkClaudeHooks(): Promise<CheckResult> {
+    try {
+      const settingsInstaller = await import('./settings-installer')
+      const { installed, expected } = await settingsInstaller.status()
+
+      if (installed === expected) {
+        return {
+          name: 'claude hooks',
+          status: 'ok',
+          message: `${installed}/${expected} installed`,
+        }
+      }
+      return {
+        name: 'claude hooks',
+        status: 'warn',
+        message: `${installed}/${expected} installed - run "prjct setup" to repair`,
+      }
+    } catch {
+      return {
+        name: 'claude hooks',
+        status: 'warn',
+        message: 'could not read ~/.claude/settings.json',
+      }
+    }
   }
 
   private async checkPrjctConfig(): Promise<CheckResult> {

--- a/core/services/project-agents-md.ts
+++ b/core/services/project-agents-md.ts
@@ -1,0 +1,81 @@
+/**
+ * Project AGENTS.md — routing block writer.
+ *
+ * AGENTS.md is the cross-agent convention (OpenAI Codex et al.) for
+ * project instructions. This writes (or refreshes between markers) a
+ * compact prjct block so non-Claude agents pick up the prjct contract
+ * on project load — the Codex counterpart of `writeProjectClaudeMd`.
+ * Vendor-neutral wording: Codex has no hooks injecting context, so the
+ * block must stand on its own. Idempotent via `mergeWithMarkers`; user
+ * content outside the markers is never touched.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { mergeWithMarkers } from '../infrastructure/ide-project-installer'
+import { getErrorMessage, isNotFoundError } from '../types/fs'
+
+const START_MARKER = '<!-- prjct:routing - do not edit between markers -->'
+const END_MARKER = '<!-- /prjct:routing - managed by prjct -->'
+
+const ROUTING_BODY = `## prjct — project memory & workflow
+
+This project uses prjct for persistent memory + workflow tracking.
+Recognize the user's intent and run the right verb yourself — do not
+ask them to type prjct commands.
+
+- Recall before re-reading source: \`prjct search "<query>"\` or
+  \`prjct context memory <topic>\` (decisions, gotchas, learnings).
+- Flow: \`prjct task "<desc>"\` → work → \`prjct status done\` → \`prjct ship\`.
+- Persist outcomes as you go: \`prjct remember <decision|gotcha|learning|fact> "<text>"\`
+  (author entries in English), \`prjct capture "<text>"\` for stray thoughts.
+- Before editing a risky file: \`prjct guard <file>\` surfaces known traps.
+- Prefer the \`prjct_*\` MCP tools when available; otherwise run the CLI
+  with \`--md\` for agent-readable output.
+
+Routine captures auto-execute (confirm in one line); \`ship\` and other
+destructive verbs surface a one-line plan and wait for a green light.`
+
+const FULL_BLOCK = `${START_MARKER}
+${ROUTING_BODY}
+${END_MARKER}
+`
+
+/**
+ * Write or refresh the prjct routing block at `<projectPath>/AGENTS.md`.
+ *
+ * - File missing → create with just the block + trailing newline.
+ * - File present without markers → append (with separator).
+ * - File present with markers → replace block content; user content
+ *   outside markers is preserved.
+ */
+export async function writeProjectAgentsMd(
+  projectPath: string
+): Promise<{ action: 'created' | 'updated' | 'unchanged'; path: string }> {
+  const file = path.join(projectPath, 'AGENTS.md')
+  let existing = ''
+  let fileExists = true
+  try {
+    existing = await fs.readFile(file, 'utf-8')
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw new Error(`Could not read ${file}: ${getErrorMessage(error)}`)
+    }
+    fileExists = false
+  }
+
+  const merged = mergeWithMarkers(fileExists ? existing : '', FULL_BLOCK, START_MARKER, END_MARKER)
+
+  if (fileExists && merged.content === existing) {
+    return { action: 'unchanged', path: file }
+  }
+
+  await fs.writeFile(file, merged.content, 'utf-8')
+  return {
+    action: fileExists ? 'updated' : 'created',
+    path: file,
+  }
+}
+
+// Exposed for test-only assertions on the exact block shape.
+export const _routing = { START_MARKER, END_MARKER, FULL_BLOCK }

--- a/core/utils/codex-mcp.ts
+++ b/core/utils/codex-mcp.ts
@@ -1,0 +1,89 @@
+/**
+ * Codex MCP wiring — ensures `~/.codex/config.toml` carries the prjct
+ * MCP server entry so Codex sessions get the `prjct_*` tool surface.
+ *
+ * Codex has no JSON mcp config like Claude's `~/.claude/mcp.json`; its
+ * MCP servers live as `[mcp_servers.<name>]` TOML tables in config.toml.
+ * We manage our entry between `# prjct:mcp` comment markers (TOML has no
+ * HTML comments) so re-runs replace our block and never touch user
+ * content. If the user defined `[mcp_servers.prjct]` themselves (no
+ * markers), we leave their config alone.
+ */
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { MCPServerConfig } from '../types/utils.js'
+import { MCP_SERVER_PRESETS } from './mcp-config'
+
+const START_MARKER = '# prjct:mcp:start - managed by prjct, do not edit between markers'
+const END_MARKER = '# prjct:mcp:end'
+
+export function getCodexConfigTomlPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(os.tmpdir(), 'prjct-codex-test', 'config.toml')
+  }
+  return path.join(os.homedir(), '.codex', 'config.toml')
+}
+
+function tomlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+export function buildPrjctMcpTomlBlock(server: MCPServerConfig = MCP_SERVER_PRESETS.prjct): string {
+  const args = (server.args ?? []).map(tomlString).join(', ')
+  return [
+    START_MARKER,
+    '[mcp_servers.prjct]',
+    `command = ${tomlString(server.command)}`,
+    `args = [${args}]`,
+    END_MARKER,
+    '',
+  ].join('\n')
+}
+
+/**
+ * Idempotently install/refresh the prjct MCP server in Codex's config.toml.
+ *
+ * - No file → create it with just our block.
+ * - File with our markers → replace the block in place.
+ * - File with a user-managed `[mcp_servers.prjct]` (no markers) → untouched.
+ * - Anything else → append our block.
+ */
+export async function ensureCodexMcpServer(
+  configPath = getCodexConfigTomlPath()
+): Promise<{ path: string; changed: boolean; skipped?: 'user-managed' }> {
+  let existing = ''
+  try {
+    existing = await fs.readFile(configPath, 'utf-8')
+  } catch {
+    // Missing file — we'll create it.
+  }
+
+  const block = buildPrjctMcpTomlBlock()
+
+  let next: string
+  const startIdx = existing.indexOf(START_MARKER)
+  const endIdx = existing.indexOf(END_MARKER)
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx)
+    let after = existing.slice(endIdx + END_MARKER.length)
+    if (after.startsWith('\n')) after = after.slice(1)
+    next = before + block + after
+  } else if (/^\s*\[mcp_servers\.prjct\]/m.test(existing)) {
+    return { path: configPath, changed: false, skipped: 'user-managed' }
+  } else if (existing.trim().length > 0) {
+    next = `${existing.trimEnd()}\n\n${block}`
+  } else {
+    next = block
+  }
+
+  if (next === existing) {
+    return { path: configPath, changed: false }
+  }
+
+  await fs.mkdir(path.dirname(configPath), { recursive: true })
+  await fs.writeFile(configPath, next, 'utf-8')
+  return { path: configPath, changed: true }
+}

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -10,7 +10,7 @@ Run `prjct <command> --md` and follow its output. Pull context on demand; never 
 - Flow: `task` → work → `done` → `ship`
 - Memory: `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct context memory <topic>` (recall), `prjct guard <file>` (preventive memory before editing)
 - Capture stray thoughts: `prjct capture "<text>"`
-- Worktree hygiene: if working in a git worktree, remove it AFTER its PR merges — `git worktree remove` from the main worktree; never with uncommitted/unpushed work, never `--force`.
+- Worktrees: remove only AFTER the PR merges, from the main worktree; never with unpushed work.
 - Run `prjct --help` for the full command list; prefer the prjct MCP tools (`prjct_*`) when available.
 
 Commit footer: `Generated with [p/](https://www.prjct.app/)`


### PR DESCRIPTION
## The bug class: Codex support was silently broken

From the full-system agent-compatibility audit (PR-A of the roadmap):

1. **The bin shim copied the ~9.5KB Claude skill baseline into `~/.codex/skills/prjct/SKILL.md`** on every invocation — 9× over Codex's HARD ~1024-byte whole-file cap (mem_969), so Codex rejected the entire skill silently. Verified live: the installed file was byte-identical to `templates/skills/prjct/SKILL.md`.
2. **MCP was never wired for Codex** — only `~/.claude/mcp.json` was written, while the Codex skill instructed the model to "prefer the `prjct_*` tools". They never existed.
3. **`prjct init` logged `Generated: AGENTS.md` without writing it** (the wizard only detects agents; nothing wrote any agent file).
4. Doctor never checked `codex` nor the installed hooks (`settings-installer.status()` existed for this and was never called).

## Fixes

- **bin/prjct**: per-agent templates — Codex gets `templates/codex/SKILL.md`, only when Codex is present (no more blind `~/.codex` creation).
- **codex-skill.ts**: compact metadata marker (`{"v","h"}`, 12-char hash; legacy format still parses → old installs verify-mismatch and self-repair), `CODEX_SKILL_MAX_BYTES` guard + warning. Built artifact: **926/1024 bytes**, tests pin ≥50B headroom + shim regression guard.
- **codex-mcp.ts** (new): idempotent marker-managed `[mcp_servers.prjct]` block in `~/.codex/config.toml`; user-managed entries untouched. Runs from `setupMcpServers` (setup + sync self-heal).
- **project-agents-md.ts** (new): vendor-neutral routing block marker-merged into `AGENTS.md` on `prjct init` when Codex detected/selected — Codex has no hooks, this is its session-start context.
- **planning.ts**: honest output — reports actual writes, lists detected agents as detected.
- **doctor**: `codex` binary check + Claude hooks `installed/expected` check.

## Verification

- 1524/1524 tests pass (3 new test files, 21 new assertions in the codex area)
- Shim logic sandbox-tested: Claude → 9,502B baseline, Codex → 862B template, machine without Codex → nothing created
- `bun run typecheck` + biome clean

Follow-up (out of scope, noted from the audit): `selectProvider()` still defaults Codex-only machines to the Claude install prompt; Codex session-transcript ingestion (learning loop parity) is a larger L-effort item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)