### PR TITLE
feat: retrieval quality — superseded filter, proven-first digests, MCP parity, push-path ship credit, unicode keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,14 @@
 
 ## [Unreleased]
 
-### Performance
-- **Hot recall queries now use the type index.** Every `type LIKE 'memory.%'` filter (recall, vault index, embeddings backfill anti-join, memory cap, transcript dedup) was a full `SCAN events` — SQLite can't derive scan bounds from a parameterized LIKE. Rewritten as indexed range predicates with exact-parity tests; cost stays flat as the events table grows.
-- **Prompt hook git snapshot cached for 3s.** The UserPromptSubmit hook forked 3 git processes per turn (~40ms); agentic bursts forked hundreds. The daemon now reuses the snapshot within a 3s TTL per cwd.
-- **Upgrade migration no longer opens every project DB.** A `.cli-version` marker per project dir reduces the post-upgrade scan from a SQLite open per directory (~3ms × tens of thousands of dirs ≈ up to a minute) to one tiny file read each.
-- Vault writes skip redundant per-file `mkdir` syscalls (dir-ensured cache with delete-retry fallback).
-
 ### Fixed
-- **Vault can no longer go stale across upgrades.** The regen fingerprint now includes the CLI version: every upgrade forces one cheap full regen per project, so a builder/format change always renders (previously the old fingerprint blocked new output until unrelated inputs changed).
-- **Codex detected in non-interactive shells.** `detectCodex` accepts `~/.codex/auth.json` (a logged-in install) as evidence alongside binary-on-PATH — hooks/daemon run without the interactive PATH, which silently skipped Codex MCP wiring and skill repair.
-- Removed dead `memoryService.search()` (1,000-row JS substring scan, zero callers — `prjct search` uses the FTS5 + semantic blend).
-- Archive-storage tests no longer leak a real-path SQLite connection across the pathManager patch (stray async sync-publish could cache it and hijack the next test's isolation).
+- **Superseded knowledge can no longer surface as live advice.** `searchFts` (the per-prompt trap cue + the FTS leg of every recall) only filtered soft-deletes — an obsolete decision/gotcha could still inject as current. It now prunes author-declared retirements (`supersedes:` / `superseded-by:` / `duplicates:`) using a mirror-wide dead-id set, catching the case where BM25 never co-returns the superseding entry.
+- **Spanish prompts now produce real retrieval signal.** Keyword extraction was ASCII-only ("búsqueda" → mangled, "qué pasó" → nothing); it now tokenizes unicode, deburrs to match FTS5's diacritic-stripped index, and drops Spanish function words. FTS query sanitizing deburrs too.
+
+### Improved
+- **MCP memory tools retrieve like the CLI.** `prjct_mem_list` used plain recency recall and `prjct_mem_similar` a shared-keyword heuristic — subagents (who do the bulk of the editing) got strictly worse retrieval than `prjct context memory`. Both now run the shared `enrichedRecall` pipeline: FTS-first, semantic blend, usefulness rerank, link expansion, ship attribution.
+- **Digest slots are proven-first.** The session-start and subagent digests picked the 3 most RECENT gotchas/decisions; they now overfetch and rerank by the usefulness ledger, so knowledge that keeps paying off wins the slots.
+- **Push-surfaced knowledge earns ship credit.** The pre-edit guard hook, the prompt trap cue, `prjct guard`, and `prjct_guard` now log surfaced entries against the active task — previously only PULL recalls did, so the most effective gotchas decayed in ranking precisely because the push delivery worked.
 
 ## [2.43.4] - 2026-06-11
 

--- a/core/__tests__/hooks/_shared-keywords.test.ts
+++ b/core/__tests__/hooks/_shared-keywords.test.ts
@@ -85,3 +85,34 @@ describe('extractKeywords — minimum length', () => {
     expect(kw).toContain('down')
   })
 })
+
+describe('extractKeywords — unicode & Spanish prompts', () => {
+  it('deburrs accents so tokens match the FTS index (remove_diacritics)', () => {
+    const kw = extractKeywords('¿por qué falla la búsqueda semántica?')
+    expect(kw).toContain('busqueda')
+    expect(kw).toContain('semantica')
+    expect(kw).toContain('falla')
+    expect(kw).not.toContain('búsqueda')
+  })
+
+  it('drops Spanish function words but keeps technical terms', () => {
+    const kw = extractKeywords('cuando corre el daemon para todos los proyectos pero sin cache')
+    expect(kw).toContain('daemon')
+    expect(kw).toContain('cache')
+    expect(kw).toContain('proyectos')
+    expect(kw).not.toContain('cuando')
+    expect(kw).not.toContain('para')
+    expect(kw).not.toContain('todos')
+    expect(kw).not.toContain('pero')
+    expect(kw).not.toContain('sin')
+  })
+
+  it('mixed-language prompts keep signal from both sides', () => {
+    const kw = extractKeywords('el Stop hook está reescribiendo el vault otra vez')
+    expect(kw).toContain('stop')
+    expect(kw).toContain('hook')
+    expect(kw).toContain('vault')
+    expect(kw).toContain('reescribiendo')
+    expect(kw).not.toContain('esta')
+  })
+})

--- a/core/__tests__/hooks/session-start.test.ts
+++ b/core/__tests__/hooks/session-start.test.ts
@@ -232,3 +232,31 @@ describe('SessionStart hook — knowledge digest (cold-start only)', () => {
     expect(ctx).toContain('prjct search')
   })
 })
+
+describe('SessionStart hook — digest slots are proven-first (usefulness rerank)', () => {
+  test('a proven-useful old gotcha beats a newer unproven one for a digest slot', async () => {
+    await freshProject({ role: 'DEV' })
+    // 6 gotchas, oldest first. Pure recency would pick g5,g4,g3.
+    for (let i = 0; i < 6; i++) insertMemory('gotcha', `trap number ${i} in module-${i}`)
+
+    // The OLDEST entry is the only one with usefulness signal — it should
+    // climb into the 3 digest slots, displacing the 3rd-newest.
+    const { usefulnessService } = await import('../../services/usefulness')
+    const oldest = prjctDb.query<{ id: number }>(
+      projectId,
+      "SELECT id FROM events WHERE type = 'memory.remember.gotcha' ORDER BY id ASC LIMIT 1"
+    )[0]
+    // Three deliberate fetches (≈ a genuinely proven entry). A single
+    // fetch (0.4) stays under the rerank's normalization floor of 1 by
+    // design — weak signals shouldn't reshuffle the digest.
+    usefulnessService.recordFetch(projectId, `mem_${oldest.id}`)
+    usefulnessService.recordFetch(projectId, `mem_${oldest.id}`)
+    usefulnessService.recordFetch(projectId, `mem_${oldest.id}`)
+
+    const ctx = await buildSessionContext(projectPath, null, { digest: true })
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('trap number 0')
+    expect(ctx).toContain('trap number 5')
+    expect(ctx).not.toContain('trap number 3')
+  })
+})

--- a/core/__tests__/memory/enriched-recall.test.ts
+++ b/core/__tests__/memory/enriched-recall.test.ts
@@ -1,0 +1,95 @@
+/**
+ * enrichedRecall — the ONE retrieval pipeline every agent surface uses
+ * (CLI `prjct context memory`, MCP `prjct_mem_list` / `prjct_mem_similar`).
+ *
+ * Pins the parity contract introduced when the MCP tools stopped using
+ * plain recency recall: filters (types/tags) apply across legs, the FTS
+ * leg feeds relevance, and link expansion can be disabled.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { enrichedRecall } from '../../memory/enriched-recall'
+import prjctDb from '../../storage/database'
+
+let tmpRoot: string
+let projectPath: string
+let projectId: string
+
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origStorage = pathManager.getStoragePath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+function write(type: string, content: string, tags: Record<string, string> = {}): void {
+  prjctDb.appendEvent(projectId, `memory.remember.${type}`, {
+    content,
+    tags,
+    provenance: 'declared',
+  })
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-enriched-'))
+  projectPath = path.join(tmpRoot, 'repo')
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `test-enr-${Math.random().toString(36).slice(2, 8)}`
+  pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, 'global', id)
+  pathManager.getStoragePath = (id: string, filename: string) =>
+    path.join(tmpRoot, 'global', id, 'storage', filename)
+  pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+    path.join(tmpRoot, 'global', id, layer, filename)
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+})
+
+afterEach(async () => {
+  prjctDb.close()
+  pathManager.getGlobalProjectPath = origGlobal
+  pathManager.getStoragePath = origStorage
+  pathManager.getFilePath = origFile
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('enrichedRecall', () => {
+  it('returns recent entries without a topic (recall backfill leg)', async () => {
+    write('decision', 'use bun for everything')
+    write('gotcha', 'daemon caches stale code')
+    const got = await enrichedRecall(projectPath, projectId, { limit: 10 })
+    expect(got.length).toBe(2)
+  })
+
+  it('applies a types filter across legs', async () => {
+    write('decision', 'use bun for everything')
+    write('gotcha', 'daemon caches stale code')
+    const got = await enrichedRecall(projectPath, projectId, { types: ['gotcha'], limit: 10 })
+    expect(got.length).toBe(1)
+    expect(got[0].type).toBe('gotcha')
+  })
+
+  it('applies a tags filter across legs', async () => {
+    write('decision', 'auth uses oauth', { domain: 'auth' })
+    write('decision', 'billing uses stripe', { domain: 'billing' })
+    const got = await enrichedRecall(projectPath, projectId, {
+      tags: { domain: 'auth' },
+      limit: 10,
+    })
+    expect(got.length).toBe(1)
+    expect(got[0].tags.domain).toBe('auth')
+  })
+
+  it('expandLinks:false returns only the direct matches', async () => {
+    write('decision', 'standalone decision with no relations')
+    const got = await enrichedRecall(projectPath, projectId, {
+      topic: 'standalone',
+      limit: 10,
+      expandLinks: false,
+    })
+    expect(got.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/core/__tests__/memory/supersede-decay.test.ts
+++ b/core/__tests__/memory/supersede-decay.test.ts
@@ -97,3 +97,59 @@ describe('projectMemory.recall — supersede/duplicate compaction', () => {
     expect(got.length).toBe(2)
   })
 })
+
+describe('projectMemory.searchFts — superseded entries never surface', () => {
+  function seedMirror(
+    id: string,
+    type: string,
+    content: string,
+    tags: Record<string, string> = {}
+  ): void {
+    const now = new Date().toISOString()
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memories
+         (id, project_id, title, content, tags, type, provenance, user_triggered,
+          created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      id,
+      projectId,
+      content.slice(0, 80),
+      content,
+      JSON.stringify(tags),
+      type,
+      'declared',
+      0,
+      now,
+      now
+    )
+  }
+
+  it('drops an entry retired by a superseding entry that BM25 would not co-return', () => {
+    // The superseding entry shares NO keywords with the stale one — the
+    // exact case recall's window-scoped prune cannot catch.
+    seedMirror('mem_1', 'gotcha', 'the widget api requires manual flush', {})
+    seedMirror('mem_2', 'decision', 'migrated renderer to declarative pipeline', {
+      supersedes: 'mem_1',
+    })
+    const got = projectMemory.searchFts(projectId, ['widget'], 5)
+    expect(got.map((e) => e.id)).not.toContain('mem_1')
+  })
+
+  it('drops an entry that self-declares superseded-by', () => {
+    seedMirror('mem_3', 'decision', 'cache responses in redis', {
+      'superseded-by': 'mem_9',
+    })
+    seedMirror('mem_4', 'decision', 'cache responses locally', {})
+    const got = projectMemory.searchFts(projectId, ['cache'], 5)
+    const ids2 = got.map((e) => e.id)
+    expect(ids2).not.toContain('mem_3')
+    expect(ids2).toContain('mem_4')
+  })
+
+  it('live entries still surface, with accented-keyword queries deburred', () => {
+    seedMirror('mem_5', 'gotcha', 'semantic search needs normalized vectors', {})
+    const got = projectMemory.searchFts(projectId, ['semántic'], 5)
+    expect(got.map((e) => e.id)).toContain('mem_5')
+  })
+})

--- a/core/commands/guard.ts
+++ b/core/commands/guard.ts
@@ -18,6 +18,7 @@
 import type { MemoryEntry } from '../memory/entries'
 import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import { recordSurfacedForActiveTask } from '../services/usefulness/surface-attribution'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import out from '../utils/output'
@@ -63,6 +64,14 @@ export class GuardCommands extends PrjctCommandsBase {
     } catch {
       hits = []
     }
+
+    // Push-path ship attribution (see surface-attribution.ts): a guard
+    // that surfaced a trap during a task that ships earned its keep.
+    void recordSurfacedForActiveTask(
+      guard.value,
+      projectPath,
+      hits.map((e) => e.id)
+    )
 
     const base = file.split('/').pop() ?? file
 

--- a/core/commands/team.ts
+++ b/core/commands/team.ts
@@ -401,7 +401,7 @@ function teamClaudeMdBlock(cfg: TeamConfig): string {
     '- prjct stores project memory (decisions, learnings, gotchas, patterns) per project.',
     '- The vault lives at `~/Documents/prjct/<slug>/_generated/`.',
     '- Always lookup the vault before re-reading source for project context.',
-    '- Capture substantive analysis back via `prjct remember <type> "..."`.',
+    '- Capture substantive analysis back via `prjct remember <type> "..."` — authored in ENGLISH, whatever language the contributor speaks.',
     '',
     "Don't have prjct? Install once: `curl -sSL https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh | bash`",
     `${cfg.required ? 'This repo *requires* prjct — please install before contributing.' : ''}`,

--- a/core/hooks/_shared.ts
+++ b/core/hooks/_shared.ts
@@ -13,6 +13,8 @@
  *   - Keyword matcher — simple substring + regex over prompt text.
  */
 
+import { deburr } from '../utils/deburr'
+
 interface HookOutput {
   /** Top-level informational message. Accepted by every Claude Code hook
    *  event — the only safe channel for Stop, SubagentStart, and
@@ -91,46 +93,110 @@ export async function safeRun(fn: () => Promise<void>): Promise<void> {
  * (articles, demonstratives, pronouns) — coding-intent verbs like
  * `need`/`want`/`should` stay, since "should we cache responses?"
  * loses signal otherwise.
+ *
+ * Unicode-aware: tokens are deburred ("búsqueda" → "busqueda", matching
+ * FTS5 unicode61's remove_diacritics indexing) and split on any
+ * non-letter/digit, so Spanish/mixed-language prompts produce real
+ * keywords instead of mangled fragments (the old `[^a-z0-9]` split
+ * turned "qué pasó" into nothing). Spanish function words join the
+ * stopword list — the user prompts in Spanish even though stored
+ * memories are English, and technical terms (daemon, cache, sync) pass
+ * through either way.
  */
+const STOPWORDS = new Set([
+  // English noise
+  'this',
+  'that',
+  'with',
+  'from',
+  'have',
+  'your',
+  'please',
+  'would',
+  'about',
+  'there',
+  'these',
+  'those',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'will',
+  'been',
+  'were',
+  'they',
+  'them',
+  'their',
+  // Spanish noise (post-deburr forms; ≥3 chars — shorter never tokenizes)
+  'que',
+  'como',
+  'cuando',
+  'donde',
+  'porque',
+  'para',
+  'pero',
+  'por',
+  'con',
+  'sin',
+  'los',
+  'las',
+  'del',
+  'una',
+  'uno',
+  'unos',
+  'unas',
+  'este',
+  'esta',
+  'esto',
+  'estos',
+  'estas',
+  'eso',
+  'esos',
+  'esas',
+  'mas',
+  'muy',
+  'todo',
+  'toda',
+  'todos',
+  'todas',
+  'sobre',
+  'entre',
+  'hasta',
+  'desde',
+  'hace',
+  'hacer',
+  'tiene',
+  'tienen',
+  'debe',
+  'deben',
+  'puede',
+  'pueden',
+  'esta',
+  'estan',
+  'ser',
+  'son',
+  'algo',
+  'ahora',
+  'aqui',
+  'bien',
+  'cada',
+  'dale',
+])
+
 export function extractKeywords(text: string, maxCount = 8): string[] {
-  const stopwords = new Set([
-    'this',
-    'that',
-    'with',
-    'from',
-    'have',
-    'your',
-    'please',
-    'would',
-    'about',
-    'there',
-    'these',
-    'those',
-    'what',
-    'when',
-    'where',
-    'which',
-    'while',
-    'will',
-    'been',
-    'were',
-    'they',
-    'them',
-    'their',
-  ])
   // setupOAuthCallback → setup OAuth Callback → setup oauth callback,
   // then tokenize on every non-word boundary (dash, space, punctuation).
   // Yields atomic tokens ['setup', 'oauth', 'callback'] so an FTS5 MATCH
   // can OR them and still find a memory entry that mentions any one.
-  const normalized = text
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-    .toLowerCase()
+  const normalized = deburr(
+    text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+  ).toLowerCase()
   const seen = new Set<string>()
   const out: string[] = []
-  for (const tok of normalized.split(/[^a-z0-9]+/)) {
+  for (const tok of normalized.split(/[^\p{L}\p{N}]+/u)) {
     if (tok.length < 3) continue
-    if (stopwords.has(tok)) continue
+    if (STOPWORDS.has(tok)) continue
     if (seen.has(tok)) continue
     seen.add(tok)
     out.push(tok)

--- a/core/hooks/pre-edit.ts
+++ b/core/hooks/pre-edit.ts
@@ -23,6 +23,7 @@ import configManager from '../infrastructure/config-manager'
 import type { MemoryEntry } from '../memory/entries'
 import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import { recordSurfacedForActiveTask } from '../services/usefulness/surface-attribution'
 import { type HookIo, runHook } from './_runner'
 import { safeTruncate } from './_shared'
 
@@ -56,6 +57,14 @@ async function buildPreEditContext(projectPath: string, filePath: string): Promi
     return null
   }
   if (hits.length === 0) return null
+
+  // Push-path ship attribution: this gotcha just reached the agent at the
+  // moment it matters — if the task ships, it earned its keep.
+  void recordSurfacedForActiveTask(
+    config.projectId,
+    projectPath,
+    hits.map((e) => e.id)
+  )
 
   const base = filePath.split('/').pop() ?? filePath
   const lines = [`# prjct: heads-up before editing \`${base}\``, '']

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -26,6 +26,7 @@ import configManager from '../infrastructure/config-manager'
 import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
 import { collectActiveTasks } from '../services/task-overview'
+import { recordSurfacedForActiveTask } from '../services/usefulness/surface-attribution'
 import { shippedStorage } from '../storage/shipped-storage'
 import type { LocalConfig } from '../types/config'
 import { execFileAsync } from '../utils/exec'
@@ -133,13 +134,21 @@ export async function buildProjectState(
  * BM25-matches the prompt's keywords, as a one-line cue. Best-effort —
  * any failure returns null and the state block ships without it.
  */
-export function buildTopicalCue(projectId: string, prompt: string): string | null {
+export function buildTopicalCue(
+  projectId: string,
+  prompt: string,
+  projectPath?: string
+): string | null {
   try {
     const keywords = extractKeywords(prompt)
     if (keywords.length === 0) return null
     const hits = projectMemory.searchFts(projectId, keywords, CUE_CANDIDATES)
     const trap = hits.find((e) => e.type === 'gotcha' || e.type === 'anti-pattern')
     if (!trap) return null
+    // Push-path ship attribution: the cue surfaced this trap during the
+    // active task — if the task ships, it earned its keep (otherwise the
+    // most effective gotchas DECAY precisely because the push works).
+    if (projectPath) void recordSurfacedForActiveTask(projectId, projectPath, [trap.id])
     return `> Trap on this topic: ${deriveTitle(trap)}  \`${trap.id}\``
   } catch {
     return null
@@ -256,7 +265,7 @@ export function runPromptHook(projectPath: string = process.cwd(), io?: HookIo):
         // The ONE push exception: a single trap cue when the prompt's
         // keywords hit a gotcha/anti-pattern (see header). State leads;
         // the cue is appended and shares the same hard budget.
-        const cue = config?.projectId ? buildTopicalCue(config.projectId, prompt) : null
+        const cue = config?.projectId ? buildTopicalCue(config.projectId, prompt, p) : null
         return safeTruncate(cue ? `${state}\n\n${cue}` : state, STATE_BUDGET)
       },
     },

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -35,6 +35,7 @@ import { isSyncCurrent, runSelfHeal } from '../infrastructure/self-heal'
 import type { MemoryEntry } from '../memory/entries'
 import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import { usefulnessService } from '../services/usefulness'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import type { LocalConfig, ProjectPersona } from '../types/config'
 import { VERSION } from '../utils/version'
@@ -116,11 +117,25 @@ function buildKnowledgeDigest(projectId: string): string | null {
   let gotchas: MemoryEntry[] = []
   let decisions: MemoryEntry[] = []
   try {
-    gotchas = projectMemory.recall(projectId, {
-      types: ['gotcha', 'anti-pattern'],
-      limit: DIGEST_PER_TYPE,
-    })
-    decisions = projectMemory.recall(projectId, { types: ['decision'], limit: DIGEST_PER_TYPE })
+    // Overfetch recency-ordered candidates, then let the usefulness
+    // ledger reorder before taking the few digest slots: the 3 most
+    // PROVEN entries (referenced, fetched, shipped-with) beat the 3 most
+    // recently captured. Bounded rerank — recency still leads on ties.
+    gotchas = usefulnessService
+      .rerank(
+        projectId,
+        projectMemory.recall(projectId, {
+          types: ['gotcha', 'anti-pattern'],
+          limit: DIGEST_PER_TYPE * 4,
+        })
+      )
+      .slice(0, DIGEST_PER_TYPE)
+    decisions = usefulnessService
+      .rerank(
+        projectId,
+        projectMemory.recall(projectId, { types: ['decision'], limit: DIGEST_PER_TYPE * 4 })
+      )
+      .slice(0, DIGEST_PER_TYPE)
   } catch {
     return null
   }
@@ -228,10 +243,19 @@ export async function buildSubagentDigest(projectPath: string): Promise<string |
   }
 
   try {
-    const gotchas = projectMemory.recall(config.projectId, {
-      types: ['gotcha', 'anti-pattern'],
-      limit: SUBAGENT_GOTCHA_COUNT,
-    })
+    // Same proven-first selection as the session digest (see
+    // buildKnowledgeDigest) — subagents do the bulk of the editing, so
+    // their 2 trap slots should carry the entries that keep paying off,
+    // not just the newest.
+    const gotchas = usefulnessService
+      .rerank(
+        config.projectId,
+        projectMemory.recall(config.projectId, {
+          types: ['gotcha', 'anti-pattern'],
+          limit: SUBAGENT_GOTCHA_COUNT * 4,
+        })
+      )
+      .slice(0, SUBAGENT_GOTCHA_COUNT)
     if (gotchas.length > 0) {
       lines.push('Traps to avoid:')
       for (const e of gotchas) lines.push(`- ${deriveTitle(e)}  \`${e.id}\``)

--- a/core/hooks/subagent-start.ts
+++ b/core/hooks/subagent-start.ts
@@ -7,7 +7,7 @@
  * traps) rather than the full session context: SubagentStart emits via
  * `systemMessage` (its schema rejects `additionalContext`), which sits
  * outside the cached prompt prefix, so variable content is safe here.
- * Same rules: describe WHAT, never CÓMO.
+ * Same rules: describe WHAT, never HOW.
  */
 
 import { type HookIo, runHook } from './_runner'

--- a/core/infrastructure/command-installer/global-config.ts
+++ b/core/infrastructure/command-installer/global-config.ts
@@ -47,7 +47,7 @@ When you complete substantive work — analysis, decision, learning, gotcha disc
 - \`prjct remember fact "<verifiable claim>"\` — project facts (paths, conventions, IDs)
 - \`prjct capture "<text>" --tags type:analysis,topic:<x>\` — analytical dumps & inbox items
 
-Tag with \`--tags k:v,k:v\` for searchability. Memory persists to SQLite; vault auto-regenerates. **Default to capturing — under-capture is the failure mode that makes prjct useless.**
+Tag with \`--tags k:v,k:v\` for searchability. Memory persists to SQLite; vault auto-regenerates. **Default to capturing — under-capture is the failure mode that makes prjct useless.** **Author every persisted entry in ENGLISH**, whatever language the user speaks — translate the intent; one canonical language keeps retrieval sharp and token cost flat.
 
 ## Workflow
 

--- a/core/mcp/server.ts
+++ b/core/mcp/server.ts
@@ -37,7 +37,7 @@ Use when the user describes work, asks for project memory, or wants to run a reg
 
 ## Gotchas
 
-- Recognize intent in any language (es/en) — the verbs are language-agnostic.
+- Recognize intent in any language — the verbs are language-agnostic. But PERSIST in English only: every saved entry (memory, spec, capture) is authored in English regardless of the conversation language.
 - Memory is best-effort — never assume recall returned everything; it's a query, not a lookup.
 - Topic keys are free-form strings; don't invent new vocabularies when existing ones fit.
 - Not every project defines every memory type — if one is empty, that's fine.

--- a/core/mcp/tools/memory.ts
+++ b/core/mcp/tools/memory.ts
@@ -48,7 +48,7 @@ export function registerMemoryTools(server: McpServer) {
 
   s.tool(
     'prjct_mem_save',
-    `Save a memory entry. ${TYPE_DESCRIPTIONS} Secret-like content is refused unless force=true.`,
+    `Save a memory entry. Author content in ENGLISH regardless of the conversation language. ${TYPE_DESCRIPTIONS} Secret-like content is refused unless force=true.`,
     {
       projectPath: z.string().describe('Project directory path'),
       type: z.string().describe('Memory type (fact/decision/learning/... or user-defined)'),

--- a/core/mcp/tools/memory.ts
+++ b/core/mcp/tools/memory.ts
@@ -27,9 +27,11 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
-import { BASE_MEMORY_TYPES } from '../../memory/entries'
+import { enrichedRecall } from '../../memory/enriched-recall'
+import { BASE_MEMORY_TYPES, type MemoryType } from '../../memory/entries'
 import { formatMemoryMd } from '../../memory/format'
 import { projectMemory } from '../../memory/project-memory'
+import { recordSurfacedForActiveTask } from '../../services/usefulness/surface-attribution'
 import { scanForPromptInjection } from '../../utils/prompt-injection'
 import { scanForSecrets } from '../../utils/secret-scanner'
 import { resolveProjectId } from '../resolve'
@@ -145,9 +147,13 @@ export function registerMemoryTools(server: McpServer) {
         limit?: number
       }) => {
         const projectId = await resolveProjectId(args.projectPath)
-        const entries = projectMemory.recall(projectId, {
+        // Same pipeline as `prjct context memory` (FTS-first, semantic
+        // blend, usefulness rerank, link expansion, ship attribution).
+        // Subagents reach memory through THIS tool — a plain recency
+        // recall here gave them strictly worse retrieval than the CLI.
+        const entries = await enrichedRecall(args.projectPath, projectId, {
           topic: args.topic,
-          types: args.types,
+          types: args.types as MemoryType[] | undefined,
           tags: args.tags,
           limit: args.limit,
         })
@@ -168,7 +174,15 @@ export function registerMemoryTools(server: McpServer) {
       'prjct_mem_similar',
       async (args: { projectPath: string; description: string; limit?: number }) => {
         const projectId = await resolveProjectId(args.projectPath)
-        const entries = projectMemory.similar(projectId, args.description, args.limit)
+        // enrichedRecall with the description as topic: BM25 + semantic
+        // beat the old shared-keyword `similar()` heuristic. Link
+        // expansion off — similarity asks "does this exist?", not "give
+        // me its whole neighborhood".
+        const entries = await enrichedRecall(args.projectPath, projectId, {
+          topic: args.description,
+          limit: args.limit ?? 10,
+          expandLinks: false,
+        })
         if (entries.length === 0) {
           return { content: [{ type: 'text', text: 'No similar memories found.' }] }
         }
@@ -190,6 +204,12 @@ export function registerMemoryTools(server: McpServer) {
       async (args: { projectPath: string; file: string; limit?: number }) => {
         const projectId = await resolveProjectId(args.projectPath)
         const hits = projectMemory.recallForFile(projectId, args.file, args.limit ?? 3)
+        // Push-path ship attribution (see surface-attribution.ts).
+        void recordSurfacedForActiveTask(
+          projectId,
+          args.projectPath,
+          hits.map((e) => e.id)
+        )
         if (hits.length === 0) {
           const base = args.file.split('/').pop() ?? args.file
           return {

--- a/core/memory/enriched-recall.ts
+++ b/core/memory/enriched-recall.ts
@@ -1,0 +1,116 @@
+/**
+ * Enriched recall — the ONE retrieval pipeline every agent surface uses.
+ *
+ * FTS5 BM25 first (relevance beats recency), recency-recall backfill,
+ * optional semantic blend (when an embeddings provider is configured),
+ * bounded usefulness rerank, one hop of relationship-link expansion, and
+ * ship-success surface attribution.
+ *
+ * Extracted from `runMemoryTool` (the `prjct context memory` CLI path) so
+ * the MCP tools stop serving a strictly WORSE retrieval: `prjct_mem_list`
+ * used plain recency `recall()` — and subagents, who do the bulk of the
+ * editing, reach memory through MCP. One pipeline, every surface.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { embeddingService } from '../services/embeddings'
+import { usefulnessService } from '../services/usefulness'
+import { stateStorage } from '../storage/state-storage'
+import type { MemoryEntry, MemoryType } from './entries'
+import { matchesTags } from './entries'
+import { projectMemory } from './project-memory'
+
+export interface EnrichedRecallOpts {
+  topic?: string
+  types?: MemoryType[]
+  /** Require exact match on these k:v pairs (applies to every leg). */
+  tags?: Record<string, string>
+  limit?: number
+  /** Append one hop of resolves/relates/supersedes links. Default true. */
+  expandLinks?: boolean
+}
+
+export async function enrichedRecall(
+  projectPath: string,
+  projectId: string,
+  opts: EnrichedRecallOpts = {}
+): Promise<MemoryEntry[]> {
+  const { topic, types, tags } = opts
+  const limit = opts.limit ?? 30
+
+  let entries: MemoryEntry[] = []
+  if (topic) {
+    const keywords = topic.split(/\s+/).filter(Boolean)
+    try {
+      let fts = projectMemory.searchFts(projectId, keywords, limit)
+      if (types) fts = fts.filter((e) => types.includes(e.type as MemoryType))
+      if (tags) fts = fts.filter((e) => matchesTags(e, tags))
+      entries = fts
+    } catch {
+      entries = []
+    }
+  }
+
+  // Backfill with recency + substring recall so a fresh/unindexed DB or a
+  // cross-vocabulary topic still returns something.
+  if (entries.length < limit) {
+    const seen = new Set(entries.map((e) => e.id))
+    const pool = projectMemory.recall(projectId, { topic, types, tags, limit })
+    for (const e of pool) {
+      if (seen.has(e.id)) continue
+      entries.push(e)
+      if (entries.length >= limit) break
+    }
+  }
+
+  // Semantic layer (opt-in): blend cosine-ranked matches AHEAD of lexical
+  // results so a cross-vocabulary hit ("oauth" → an entry about
+  // "authentication") surfaces. Best-effort: failures leave BM25 standing.
+  if (topic) {
+    try {
+      const config = await configManager.readConfig(projectPath)
+      if (config && embeddingService.isEnabled(config)) {
+        const semantic = await embeddingService.semanticSearch(projectId, topic, config, 10)
+        if (semantic.length > 0) {
+          const seen = new Set(entries.map((e) => e.id))
+          let fresh = semantic.filter((e) => !seen.has(e.id))
+          if (types) fresh = fresh.filter((e) => types.includes(e.type as MemoryType))
+          if (tags) fresh = fresh.filter((e) => matchesTags(e, tags))
+          entries = [...fresh, ...entries].slice(0, limit)
+        }
+      }
+    } catch {
+      /* best-effort — lexical results stand */
+    }
+  }
+
+  // Reinforcement: nudge proven-useful entries up (bounded — relevance
+  // still leads). This is how recall gets smarter with use.
+  if (entries.length > 1) {
+    entries = usefulnessService.rerank(projectId, entries)
+  }
+
+  // One hop of relationship-graph traversal so a recall carries its own
+  // context instead of dangling `mem_N` pointers the agent must chase.
+  if (opts.expandLinks !== false && entries.length > 0) {
+    const linked = projectMemory.expandWithLinks(projectId, entries, 5)
+    if (linked.length > 0) entries = entries.concat(linked)
+  }
+
+  // Ship-success attribution: these entries were surfaced during the
+  // active task; if it ships, each earns the strong ship-credit.
+  try {
+    const task = await stateStorage.getCurrentTask(projectId)
+    if (task?.id) {
+      usefulnessService.recordSurfaced(
+        projectId,
+        entries.map((e) => e.id),
+        task.id
+      )
+    }
+  } catch {
+    /* best-effort — attribution telemetry must never break a recall */
+  }
+
+  return entries
+}

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -23,6 +23,7 @@
 
 import { memoryService } from '../services/memory-service'
 import prjctDb from '../storage/database'
+import { deburr } from '../utils/deburr'
 import { memoryFingerprint } from './content-fingerprint'
 import {
   collectSupersededIds,
@@ -74,6 +75,38 @@ const DEFAULT_RECALL_LIMIT = 25
 /** Row-count multiplier to give in-memory filters room to work. */
 const OVERFETCH_FACTOR = 4
 const MIN_OVERFETCH = 100
+
+/**
+ * Dead-id set for the FTS mirror: every entry retired by an author-declared
+ * relationship tag, regardless of result window. Scans only live rows whose
+ * tags mention a relationship key (LIKE pre-filter keeps it to a handful of
+ * rows on a hot path that runs per prompt). Best-effort: empty set on error.
+ */
+function collectMirrorSupersededIds(projectId: string): Set<string> {
+  try {
+    const rows = prjctDb.query<{ id: string; tags: string | null }>(
+      projectId,
+      `SELECT id, tags FROM memories
+        WHERE deleted_at IS NULL
+          AND (tags LIKE '%supersede%' OR tags LIKE '%duplicates%')`
+    )
+    const pseudo: Pick<MemoryEntry, 'id' | 'tags'>[] = []
+    for (const row of rows) {
+      if (!row.tags) continue
+      try {
+        const parsed = JSON.parse(row.tags) as unknown
+        if (parsed && typeof parsed === 'object') {
+          pseudo.push({ id: row.id, tags: parsed as Record<string, string> })
+        }
+      } catch {
+        // legacy non-JSON tags — skip
+      }
+    }
+    return collectSupersededIds(pseudo as MemoryEntry[])
+  } catch {
+    return new Set()
+  }
+}
 
 export const projectMemory = {
   /**
@@ -237,11 +270,13 @@ export const projectMemory = {
    */
   searchFts(projectId: string, keywords: string[], limit: number): MemoryEntry[] {
     if (keywords.length === 0 || limit <= 0) return []
-    // Sanitize: keep only token-friendly chars, drop FTS5-reserved
-    // operators so a user prompt with literal "OR"/"AND"/"NEAR" doesn't
-    // hijack the MATCH parse. Trailing-* allows prefix matching.
+    // Sanitize: deburr first (FTS5 unicode61 indexes with
+    // remove_diacritics, so "búsqueda" must query as "busqueda"), then
+    // keep only token-friendly chars and drop FTS5-reserved operators so
+    // a user prompt with literal "OR"/"AND"/"NEAR" doesn't hijack the
+    // MATCH parse. Trailing-* allows prefix matching.
     const sanitized = keywords
-      .map((kw) => kw.replace(/[^a-z0-9-]/gi, ''))
+      .map((kw) => deburr(kw).replace(/[^a-z0-9-]/gi, ''))
       .filter((kw) => kw.length >= 2)
     if (sanitized.length === 0) return []
     const matchExpr = sanitized.map((kw) => `"${kw}"*`).join(' OR ')
@@ -257,6 +292,9 @@ export const projectMemory = {
     }
     let rows: FtsRow[]
     try {
+      // Overfetch: superseded pruning below may drop rows, and this is
+      // the surface that feeds the per-prompt trap cue — a stale decision
+      // must not consume the only result slot.
       rows = prjctDb.query<FtsRow>(
         projectId,
         `SELECT m.id, m.title, m.content, m.tags, m.type, m.provenance, m.created_at
@@ -267,13 +305,13 @@ export const projectMemory = {
          ORDER BY bm25(memories_fts) ASC, m.created_at DESC
          LIMIT ?`,
         matchExpr,
-        limit
+        limit * 2
       )
     } catch {
       return []
     }
 
-    return rows.map((row) => {
+    let entries = rows.map((row) => {
       let tags: Record<string, string> = {}
       if (row.tags) {
         try {
@@ -292,6 +330,16 @@ export const projectMemory = {
         provenance: (row.provenance ?? 'declared') as MemoryProvenance,
       }
     })
+
+    // Author-declared compaction, same contract as recall(): a superseded
+    // or duplicated entry must not surface as live advice. Unlike recall's
+    // window-scoped prune, BM25 ordering rarely returns the SUPERSEDING
+    // entry alongside the stale one, so the dead-id set comes from a scan
+    // of all live mirror rows carrying relationship tags (small, indexed
+    // by the LIKE pre-filter) instead of just the result window.
+    const dead = collectMirrorSupersededIds(projectId)
+    if (dead.size > 0) entries = entries.filter((e) => !dead.has(e.id))
+    return entries.slice(0, limit)
   },
 
   /**

--- a/core/services/project-claude-md.ts
+++ b/core/services/project-claude-md.ts
@@ -28,7 +28,8 @@ that travel with this project:
 - **Routine captures auto-execute, no permission.** When the user mentions
   a decision, learning, gotcha, or random thought, save it via
   \`prjct remember <type>\` or \`prjct capture\` immediately and confirm in
-  one line. Asking "want me to save that?" is the failure mode.
+  one line. Asking "want me to save that?" is the failure mode. Author
+  every entry in ENGLISH, whatever language the user speaks.
 - **Destructive verbs suggest first.** \`ship\`, \`status done\`, \`prefs set\`,
   and the audit/security/investigate workflows surface a one-line plan
   ("I'll run \`prjct ship\` — bumps version, opens PR. Ok?") and wait for

--- a/core/services/skill-generator.ts
+++ b/core/services/skill-generator.ts
@@ -39,7 +39,7 @@ import type { ConditionContext, SkillContext, SkillDefinition } from './skill-ge
  *
  * The body is `Use when` + `What's here` + `Gotchas` — zero numbered
  * steps, zero "first X then Y", zero "pre-flight BLOCKING" language.
- * prjct describes state; Claude decides CÓMO.
+ * prjct describes state; Claude decides HOW.
  */
 const SKILL_DEFINITIONS: SkillDefinition[] = [
   {

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -3,7 +3,7 @@
  *
  * Anti-harness shape: `Use when` + `What's here` + `Gotchas` — zero
  * numbered steps, zero "first X then Y", zero "pre-flight BLOCKING"
- * language. prjct describes state; Claude decides CÓMO.
+ * language. prjct describes state; Claude decides HOW.
  *
  * CONTEXT BUDGET: the SKILL.md body stays in the host model's context for
  * the whole session (Anthropic: "every line is a recurring token cost").
@@ -23,7 +23,7 @@ import type { SkillContext } from './types'
 // rules live in the body, which loads on invoke. Keeping the methodology out
 // of here is the same pull-not-push rule the rest of the runtime follows.
 export const PRJCT_SKILL_DESCRIPTION =
-  'Project memory + spec-driven runtime: recall and capture decisions/learnings/gotchas, run registered workflows, frame and ship work. Recognize intent in any language (es/en) and run the verb yourself — never make the user type commands. Triage every turn: most work is SIMPLE → go direct (`prjct task` → ship); reserve the spec pipeline for genuinely complex or high-stakes work. Over-routing simple work through spec + reviewers is the main failure mode.'
+  'Project memory + spec-driven runtime: recall and capture decisions/learnings/gotchas, run registered workflows, frame and ship work. Recognize intent in any language and run the verb yourself — never make the user type commands. Triage every turn: most work is SIMPLE → go direct (`prjct task` → ship); reserve the spec pipeline for genuinely complex or high-stakes work. Over-routing simple work through spec + reviewers is the main failure mode.'
 
 export const PRJCT_SKILL_ALLOWED_TOOLS = [
   'Bash',
@@ -129,7 +129,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '',
     '## Act: default DIRECT — escalation is the rare exception',
     '',
-    '**The first move on almost every turn is to just do the work DIRECTLY.** A fix, a one-file change, a capture, a question, anything the user calls "fix"/"hoy"/"rápido"/"directo": `prjct task` → implement it yourself → `ship`. **NO spec, NO audit-spec, NO subagents, NO fan-out.** This is the common case and the safe default — when unsure, this is what you pick. Ask at most ONE line; never escalate just to be safe.',
+    '**The first move on almost every turn is to just do the work DIRECTLY.** A fix, a one-file change, a capture, a question, anything the user frames as quick/direct work (in any language): `prjct task` → implement it yourself → `ship`. **NO spec, NO audit-spec, NO subagents, NO fan-out.** This is the common case and the safe default — when unsure, this is what you pick. Ask at most ONE line; never escalate just to be safe.',
     '',
     'Escalate to the spec pipeline ONLY when the test is unambiguous: multi-file + new behavior AND ambiguous scope AND real/irreversible stakes (or the user explicitly frames goals/acceptance/risks). Then, and only then: `spec ─→ audit-spec ─→ task --spec <id> ─→ implement ─→ ship ─→ remember learning`. Forcing simple work through this pipeline is the #1 perf-killer — it burns tokens for zero protection.',
     '',
@@ -141,14 +141,14 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '',
     '## Verb intent map — you run the verb, the user never types it',
     '',
-    'On every turn ask: "what is the user trying to accomplish?" and match to a verb below. Bilingual (es/en) — the verbs are language-agnostic, the intent isn\'t. These are *signals*, not phrase templates. The **Tier** column governs whether you auto-run or confirm first (see Routing).',
+    'On every turn ask: "what is the user trying to accomplish?" and match to a verb below. The user may phrase intent in ANY language — the verbs are language-agnostic. These are *signals*, not phrase templates. The **Tier** column governs whether you auto-run or confirm first (see Routing).',
     '',
     '| Intent / signal | Verb | Tier |',
     '|---|---|---|',
-    '| starting a unit of work — "haceme X", a fix, a change, picking up a queue item (THE DEFAULT, most turns) | `prjct task "<desc>"` (add `--spec <id>` if a spec exists) | 2 |',
+    '| starting a unit of work — "do X for me", a fix, a change, picking up a queue item (THE DEFAULT, most turns) | `prjct task "<desc>"` (add `--spec <id>` if a spec exists) | 2 |',
     '| framing genuinely complex work WITH goals/stakes/acceptance criteria (the exception) | `prjct spec "<title>"` | 2 |',
     '| harden / pressure-test an existing spec before any code | `prjct audit-spec <id>` | 2 |',
-    '| need prior project knowledge — "what did we decide about X", "buscá lo de Y", recall before re-reading source | `prjct search "<query>"` | 1 |',
+    '| need prior project knowledge — "what did we decide about X", "find what we had on Y", recall before re-reading source | `prjct search "<query>"` | 1 |',
     '| an interesting thought to keep, no commitment yet | `prjct capture "<text>" --tags topic:<x>` | 1 |',
     '| a non-trivial choice just got resolved (+ its why) | `prjct remember decision "<choice + one-line why>"` | 1 |',
     '| an insight / "aha" / new mental model | `prjct remember learning "<insight>"` | 1 |',
@@ -161,12 +161,12 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '| "what did we accomplish?" | `prjct retro 7d --md` | 1 |',
     '| pause / resume the working context | `prjct context-save` / `prjct context-restore --md` | 1 |',
     '',
-    'Disambiguators: the "why" separates a `decision` from an `inbox` dump — if you can\'t state it in one line, capture as inbox. A bare "fix X"/"hoy" is `task`, never `spec`. `audit-spec` requires an existing spec. For `ship`, if the active task has a `linked_spec_id`, ship surfaces the spec\'s acceptance_criteria as a PR checklist — STOP on any unmet criterion (override: `prjct ship --no-spec-gate`).',
+    'Disambiguators: the "why" separates a `decision` from an `inbox` dump — if you can\'t state it in one line, capture as inbox. A bare "fix X" is `task`, never `spec`. `audit-spec` requires an existing spec. For `ship`, if the active task has a `linked_spec_id`, ship surfaces the spec\'s acceptance_criteria as a PR checklist — STOP on any unmet criterion (override: `prjct ship --no-spec-gate`).',
     '',
     '## Routing — Tier governs auto-run vs confirm (by blast radius)',
     '',
     '- **Tier 1 — auto-execute, one-line confirm.** `search`, `capture`, `tag`, `remember`, `guard`, `context-save`, `health`, `retro`, `prefs check/list`. Additive/read-only: run IMMEDIATELY, emit one line (`✓ saved as decision: …`). Do not ask "want me to save that?" — just save it; the user corrects afterward. Pausing for permission on routine captures is what makes prjct useless.',
-    '- **Tier 2 — suggest-and-confirm, ONE line.** `task`, `spec`, `audit-spec`, `ship`, `status done|paused`, `prefs set`. State intent + blast radius in one line and wait for a green light (yes/dale/confirma/silence). Never run `ship` without surfacing the plan first — it is un-doable without a force-push.',
+    '- **Tier 2 — suggest-and-confirm, ONE line.** `task`, `spec`, `audit-spec`, `ship`, `status done|paused`, `prefs set`. State intent + blast radius in one line and wait for a green light (an affirmative in any language, or silence). Never run `ship` without surfacing the plan first — it is un-doable without a force-push.',
     '- **Tier 3 — decision-brief** (hard forks costing >5 min to undo): `prjct prefs check <id>` first, then the decision-brief format. Both detailed in `workflows.md`.',
     '',
     '## Gotchas',
@@ -345,7 +345,7 @@ export function buildPrjctSkillReference(): string {
     '',
     'Stop condition: max 3 failed hypotheses per bug — escalate with what was tried. Persist `prjct remember learning "<root cause>"`, `prjct remember decision "<fix + why it works>"`, `prjct remember gotcha "<related bug surfaced>"`.',
     '',
-    '### `ship` (endurecido) — Coverage Gate + Auto-Document',
+    '### `ship` (hardened) — Coverage Gate + Auto-Document',
     '',
     'Use when: ship, deploy, merge, or finalize work.',
     '',

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -137,7 +137,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '',
     'Heavy quality workflows (`review`, `qa`, `security`, `investigate`, `audit`, `audit-spec`), the parallel-implementer fan-out rules, decision-briefs, the `prjct prefs` protocol, the spec stations and builder ethos all live in `workflows.md` — **read it on demand when (and only when) you actually run one.** Do not preload it; do not reach for the menu on simple work.',
     '',
-    '**CONTENT LANGUAGE — author every stored memory in ENGLISH**, regardless of the conversation language. When you `capture`/`remember`, translate the intent into a clean English entry (the user may speak Spanish; the persisted knowledge is English). LLMs comprehend English better and embeddings stay high-quality in one canonical language — mixed-language content produces cross-language retrieval noise.',
+    '**CONTENT LANGUAGE — author every stored memory in ENGLISH**, no matter what language the user speaks (Spanish, Japanese, German — any). When you `capture`/`remember`, translate the intent into a clean English entry; the persisted knowledge is always English. LLMs comprehend English better and embeddings stay high-quality in one canonical language — mixed-language content produces cross-language retrieval noise and extra token cost on every later recall.',
     '',
     '## Verb intent map — you run the verb, the user never types it',
     '',

--- a/core/services/usefulness/surface-attribution.ts
+++ b/core/services/usefulness/surface-attribution.ts
@@ -1,0 +1,29 @@
+/**
+ * Surface attribution for the PUSH paths.
+ *
+ * The pull path (`prjct context memory` / `prjct_mem_list`) records which
+ * entries were surfaced during the active task, so a successful ship
+ * credits them (+SHIP_WEIGHT). The push paths — the pre-edit guard hook,
+ * the per-prompt trap cue, `prjct guard` — surfaced knowledge at the
+ * exact moment it prevented a bug and earned NOTHING: an effective gotcha
+ * decayed in ranking precisely because the push delivery worked. This
+ * helper closes that asymmetry — resolve the active task (per-worktree)
+ * and log the surfaced ids. Fire-and-forget, never throws.
+ */
+
+import { usefulnessService } from './index'
+
+export async function recordSurfacedForActiveTask(
+  projectId: string,
+  projectPath: string,
+  memoryIds: string[]
+): Promise<void> {
+  if (memoryIds.length === 0) return
+  try {
+    const { resolveActiveTask } = await import('../task-service')
+    const task = await resolveActiveTask(projectId, projectPath)
+    if (task?.id) usefulnessService.recordSurfaced(projectId, memoryIds, task.id)
+  } catch {
+    /* best-effort — attribution must never break a hook or a guard */
+  }
+}

--- a/core/services/wiki/_shared.ts
+++ b/core/services/wiki/_shared.ts
@@ -61,14 +61,11 @@ export type ReleaseEntry = {
   body: string
 }
 
-/**
- * Strip diacritics so accented words slug cleanly:
- * "función detección" → "funcion deteccion" (not "funci-n detecci-n").
- * NFD splits a letter from its combining mark, then we drop the marks.
- */
-export function deburr(value: string): string {
-  return value.normalize('NFD').replace(/[̀-ͯ]/g, '')
-}
+// Moved to utils so retrieval (FTS keyword sanitizing) can share it
+// without importing wiki internals. Re-exported to keep this module's API.
+import { deburr } from '../../utils/deburr'
+
+export { deburr }
 
 export function slugify(value: string, max = 60): string {
   let slug = deburr(value)

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -13,12 +13,11 @@
  */
 
 import configManager from '../../infrastructure/config-manager'
-import type { MemoryEntry, MemoryType } from '../../memory/entries'
+import { enrichedRecall } from '../../memory/enriched-recall'
+import type { MemoryType } from '../../memory/entries'
 import { formatMemoryMd } from '../../memory/format'
 import { projectMemory } from '../../memory/project-memory'
-import { embeddingService } from '../../services/embeddings'
 import { usefulnessService } from '../../services/usefulness'
-import { stateStorage } from '../../storage/state-storage'
 import type { ContextToolOutput } from '../../types/context-tools'
 import { getErrorMessage } from '../../types/fs'
 
@@ -203,86 +202,11 @@ async function runMemoryTool(
   const LEARNINGS_TYPES: MemoryType[] = ['learning', 'anti-pattern', 'gotcha']
   const types = opts.kind === 'learnings' ? LEARNINGS_TYPES : undefined
 
-  // FTS5 BM25 first when a topic is present (relevance beats recency), then
-  // backfill with the recency + substring `recall()` so a fresh/unindexed DB
-  // or a cross-vocabulary topic still returns something. This mirrors the
-  // UserPromptSubmit hook's dual-path: previously this CLI/MCP path used
-  // `recall()` only, ignoring the BM25 index entirely — so on-demand lookups
-  // (the path Claude actually uses) were strictly worse than the hook's.
-  const LIMIT = 30
-  let entries: MemoryEntry[] = []
-  if (topic) {
-    const keywords = topic.split(/\s+/).filter(Boolean)
-    try {
-      const fts = projectMemory.searchFts(projectId, keywords, LIMIT)
-      entries = types ? fts.filter((e) => types.includes(e.type as MemoryType)) : fts
-    } catch {
-      entries = []
-    }
-  }
-  if (entries.length < LIMIT) {
-    const seen = new Set(entries.map((e) => e.id))
-    const pool = projectMemory.recall(projectId, { topic, types, limit: LIMIT })
-    for (const e of pool) {
-      if (seen.has(e.id)) continue
-      entries.push(e)
-      if (entries.length >= LIMIT) break
-    }
-  }
-  // Semantic layer (opt-in): when the project configured an embeddings
-  // provider, blend cosine-ranked matches AHEAD of the lexical results so a
-  // cross-vocabulary hit ("oauth" → an entry about "authentication") surfaces
-  // that BM25 would miss. Disabled by default → this whole block is a no-op
-  // and recall stays pure lexical. Best-effort: any failure leaves the BM25
-  // results standing.
-  if (topic) {
-    try {
-      const config = await configManager.readConfig(projectPath)
-      if (config && embeddingService.isEnabled(config)) {
-        const semantic = await embeddingService.semanticSearch(projectId, topic, config, 10)
-        if (semantic.length > 0) {
-          const seen = new Set(entries.map((e) => e.id))
-          const fresh = semantic.filter((e) => !seen.has(e.id))
-          entries = [...fresh, ...entries].slice(0, LIMIT)
-        }
-      }
-    } catch {
-      /* best-effort — lexical results stand */
-    }
-  }
-
-  // Reinforcement: nudge proven-useful entries up (bounded — relevance still
-  // leads). This is how recall gets smarter with use: knowledge the project
-  // keeps referencing / pulling rises over time; unused knowledge decays out
-  // of the boost on its own.
-  if (entries.length > 1) {
-    entries = usefulnessService.rerank(projectId, entries)
-  }
-
-  // One hop of relationship-graph traversal: append entries the results
-  // resolve / relate to / supersede so a recall carries its own context
-  // instead of dangling `mem_N` pointers the agent must chase manually.
-  if (entries.length > 0) {
-    const linked = projectMemory.expandWithLinks(projectId, entries, 5)
-    if (linked.length > 0) entries = entries.concat(linked)
-  }
-
-  // Ship-success attribution: note that these entries were surfaced during the
-  // active task. If that task reaches a successful `prjct ship`, each earns the
-  // strong ship-credit (see usefulnessService.creditShippedTask). No active
-  // task → nothing recorded.
-  try {
-    const task = await stateStorage.getCurrentTask(projectId)
-    if (task?.id) {
-      usefulnessService.recordSurfaced(
-        projectId,
-        entries.map((e) => e.id),
-        task.id
-      )
-    }
-  } catch {
-    /* best-effort — attribution telemetry must never break a recall */
-  }
+  // The full pipeline (FTS-first, recall backfill, semantic blend,
+  // usefulness rerank, link expansion, surface attribution) lives in
+  // enrichedRecall — shared with the MCP memory tools so every agent
+  // surface retrieves identically.
+  const entries = await enrichedRecall(projectPath, projectId, { topic, types, limit: 30 })
 
   return {
     tool: opts.kind,

--- a/core/utils/deburr.ts
+++ b/core/utils/deburr.ts
@@ -1,0 +1,12 @@
+/**
+ * Strip diacritics: "función detección" → "funcion deteccion".
+ * NFD splits a letter from its combining mark, then the marks drop.
+ *
+ * Lives in utils (not wiki/_shared, where it started) because retrieval
+ * needs it too: FTS5's unicode61 tokenizer indexes with
+ * remove_diacritics, so query keywords must be deburred the same way or
+ * accented Spanish prompts silently miss.
+ */
+export function deburr(value: string): string {
+  return value.normalize('NFD').replace(/[̀-ͯ]/g, '')
+}

--- a/templates/antigravity/SKILL.md
+++ b/templates/antigravity/SKILL.md
@@ -14,6 +14,7 @@ Other: run `prjct <command> --md` and follow CLI output
 Flow: idea → roadmap → next → task → done → ship → next (cycle until plan complete)
 
 Rules:
+- Persist everything (memories, captures, specs) in ENGLISH, whatever language the user speaks
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
 - All commits include footer: `Generated with [p/](https://www.prjct.app/)`
 - All storage through `prjct` CLI (SQLite internally)

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -8,7 +8,7 @@ description: Use when the user mentions p., prjct, tasks, specs, shipping, or pr
 Run `prjct <command> --md` and follow its output. Pull context on demand; never dump it all.
 
 - Flow: `task` → work → `done` → `ship`
-- Memory: `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct context memory <topic>` (recall), `prjct guard <file>` (preventive memory before editing)
+- Memory (write in ENGLISH always): `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct context memory <topic>` (recall), `prjct guard <file>` (preventive memory before editing)
 - Capture stray thoughts: `prjct capture "<text>"`
 - Worktrees: remove only AFTER the PR merges, from the main worktree; never with unpushed work.
 - Run `prjct --help` for the full command list; prefer the prjct MCP tools (`prjct_*`) when available.

--- a/templates/global/GEMINI.md
+++ b/templates/global/GEMINI.md
@@ -7,6 +7,7 @@ Other commands: run `prjct <command> --md` and follow CLI output
 Flow: idea → roadmap → next → task → done → ship → next (cycle until plan complete)
 
 Data:
+- Persist everything (memories, captures, specs) in ENGLISH, whatever language the user speaks
 - prjct runs → LLM generates relevant data → prjct stores it → LLM requests it from prjct → LLM uses it
 - prjct remembers and shows the path; the agent decides how to execute with its own native tools
 - Treat prjct output as signals, not a prescriptive harness


### PR DESCRIPTION
## PR-C of the full-system audit roadmap — the apply-loop gets sharper

Four asymmetries found by the retrieval audit, all closed:

### 1. Superseded knowledge surfaced as live advice (Fixed)
`searchFts` — which feeds the **per-prompt trap cue** and the FTS leg of every recall — only filtered soft-deletes. An obsolete decision could inject as current guidance. Now prunes author-declared retirements (`supersedes:`/`superseded-by:`/`duplicates:`) via a mirror-wide dead-id set: catches the case recall's window-scoped prune can't (BM25 rarely co-returns the superseding entry alongside the stale one). 2× overfetch so pruning never empties the result.

### 2. Subagents got strictly worse retrieval (MCP parity)
`prjct_mem_list` used plain recency `recall()`; `prjct_mem_similar` a shared-keyword heuristic. The CLI's full pipeline is now extracted to **`core/memory/enriched-recall.ts`** (FTS-first → recall backfill → semantic blend → usefulness rerank → link expansion → ship attribution) and serves both MCP tools and `prjct context memory`. One pipeline, every surface.

### 3. Recency beat proven-ness in the digests
Session-start and subagent digests picked the 3 most *recent* gotchas/decisions. Now they overfetch 4× and rerank by the usefulness ledger — entries that keep paying off (referenced, fetched, shipped-with) win the slots. Bounded boost: weak signals can't reshuffle (test pins both directions).

### 4. Effective gotchas decayed BECAUSE the push worked
Only PULL recalls recorded surface-attribution for ship credit. The push paths — pre-edit guard hook, prompt trap cue, `prjct guard`, `prjct_guard` — surfaced knowledge at the exact moment it prevented a bug and earned nothing, so the most effective entries sank in ranking. New `surface-attribution.ts` helper logs surfaced ids against the per-worktree active task from all four sites.

### 5. Spanish prompts gave near-zero signal (Fixed)
`extractKeywords` was ASCII-only: "búsqueda semántica" → mangled fragments, stopwords like "para/cuando/todos" polluted the FTS MATCH. Now: unicode tokenization, deburr (matching FTS5 unicode61's `remove_diacritics` indexing), Spanish stopword list; `searchFts` sanitizer deburrs too. `deburr` moved to `core/utils` (wiki re-exports).

## Verification
- 1542/1542 tests (11 new: Spanish/unicode keywords, searchFts superseded incl. the BM25-disjoint case, digest rerank both directions, enrichedRecall filters)
- typecheck + biome + knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)