### PR TITLE
fix: post-upgrade setup no longer stalls the user's first command (~30s → 0.1s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **The first command after an upgrade no longer stalls.** The post-upgrade re-setup (provider installers, Context7 verification, the per-project migration over the whole projects dir) ran synchronously inside whatever command the user happened to run first — up to ~30s of silent blocking on machines with large project dirs. It now runs in a detached `__post-upgrade` child (the auto-updater pattern): the command returns immediately (measured 31.6s → 0.10s) and a one-line banner says setup is finishing in the background. Explicit `prjct update` keeps its synchronous, progress-printing behavior. Both detached-child internals are now in the daemon shim's skip set — routing them to the daemon silently failed them.
+
 ### Internal
 - **Dead-code and anti-pattern sweep** (no user-visible behavior change). Removed: 29 redundant `export default` aliases, the orphaned OAuth token validation/migration family (`tokens.ts` shrinks to the version pin; `system-database.ts` and its write-only MCP-health table die with it), `projectMemory.similar()`, `memoryService.getRecent`/`getByAction`, `hasIndexesAll`, `aggregateHookSignals`, `deriveWorkspaceId`, and five write-only `SkillContext` fields (task/backlog descriptions deliberately never enter the skill body). Deduplicated: the guard label/detail helpers (one canonical pair in `memory/format.ts`), the CLAUDE.md/AGENTS.md routing writers (shared `routing-block.ts` skeleton), and the pathManager test sandbox (one `_setup/path-manager-mock.ts` instead of eight hand-copied patch/restore blocks). Simplified: `selectProvider` (the never-built `userSelected` prompt path removed), static skill frontmatter takes no context by construction.
 

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -35,6 +35,25 @@ if (_fastCommand === '__internal-auto-update') {
   process.exit(0)
 }
 
+// Internal hook — `prjct __post-upgrade` is spawned as a detached child by
+// the auto-update block in main() after a version change. It runs the full
+// post-upgrade re-setup (provider installers, Context7 verification, the
+// per-project cliVersion migration over the whole projects dir) OFF the
+// user's critical path: this work took ~30s on machines with large project
+// dirs and used to stall the user's FIRST command after every upgrade.
+if (_fastCommand === '__post-upgrade') {
+  try {
+    const { run: runSetup } = await import('../core/infrastructure/setup')
+    await runSetup()
+  } catch {
+    // Detached child — never crash visibly. Every piece of this setup is
+    // also covered by an idempotent self-heal (shim skills, settings
+    // hooks, sync's MCP/codex repair), so a failed child converges on
+    // later invocations.
+  }
+  process.exit(0)
+}
+
 // Read all of stdin (the hook event JSON) as a string, with a timeout
 // safety net. Used only on the hook fast path to forward the event to the
 // daemon. Returns whatever arrived if stdin never closes.
@@ -498,18 +517,35 @@ ${chalk.cyan.bold('  Welcome to prjct!')}
           const isUpgrade = cmp(VERSION, lastVersion) > 0
 
           if (!userInvokedUpdate && isUpgrade) {
-            console.log(`\n${chalk.yellow('ℹ')} Updating prjct v${lastVersion} → v${VERSION}...\n`)
+            console.log(
+              `\n${chalk.yellow('ℹ')} prjct updated to v${VERSION} — finishing setup in the background\n`
+            )
           }
 
           try {
-            // PR #132 removed setup's default export but missed this site
-            // (bin/ is outside core's typecheck): `setup.run()` threw
-            // TypeError into the catch below on EVERY version change since
-            // 2026-02 — the post-upgrade re-setup silently never ran.
-            const { run: runSetup } = await import('../core/infrastructure/setup')
-            await runSetup()
+            if (userInvokedUpdate) {
+              // Explicit `prjct update`: the user asked for maintenance, so
+              // run the re-setup synchronously with its own progress output.
+              const { run: runSetup } = await import('../core/infrastructure/setup')
+              await runSetup()
+            } else {
+              // Any other command: the re-setup (installers, Context7
+              // verification, per-project migration over the whole projects
+              // dir) took ~30s on big machines and used to stall the user's
+              // FIRST command after every upgrade. Stamp the version FIRST so
+              // rapid consecutive invocations don't each spawn a child, then
+              // hand the work to a detached `__post-upgrade` child (same
+              // pattern as the auto-updater's `__internal-auto-update`).
+              await editorsConfig.updateVersion(VERSION).catch(() => {})
+              const { spawn } = await import('node:child_process')
+              const child = spawn(process.execPath, [process.argv[1], '__post-upgrade'], {
+                detached: true,
+                stdio: 'ignore',
+              })
+              child.unref()
+            }
           } catch {
-            // setup.run() may fail (e.g. provider detection) — stamp version anyway
+            // setup/spawn may fail (e.g. provider detection) — stamp version anyway
             await editorsConfig.updateVersion(VERSION).catch(() => {})
           }
         }

--- a/core/__tests__/infrastructure/daemon-shim-sync.test.ts
+++ b/core/__tests__/infrastructure/daemon-shim-sync.test.ts
@@ -56,6 +56,23 @@ describe('daemon-shim ↔ manifest sync', () => {
     expect(BIN_COMMANDS_SET.has('crew')).toBe(true)
     expect(extractShimSkip().has('crew')).toBe(true)
   })
+
+  test('detached-child internals are skipped by the shim (never routed to the daemon)', () => {
+    // `__internal-auto-update` and `__post-upgrade` are handled at the very
+    // top of bin/prjct.ts. The shim's default for unknown commands is the
+    // daemon — which has no registry handler for them, so routing there
+    // makes the detached children silently fail (stdio is ignored).
+    const shim = extractShimSkip()
+    expect(shim.has('__internal-auto-update')).toBe(true)
+    expect(shim.has('__post-upgrade')).toBe(true)
+
+    const src = extractBinUsage()
+    expect(src).toContain("_fastCommand === '__post-upgrade'")
+    // The upgrade block must NOT run setup synchronously on the user's
+    // command path (the regression this guards: ~30s stall on the first
+    // command after every upgrade).
+    expect(src).toContain("spawn(process.execPath, [process.argv[1], '__post-upgrade']")
+  })
 })
 
 /**

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -162,8 +162,12 @@ var __dirname = __pathDirname(__filename);`,
  * Legacy shim-only skips: inert orphans that pre-date the manifest and have
  * no handler anywhere. Everything real derives from the manifest
  * (routingMode 'bin-only' + 'cold-only' via SHIM_SKIP_SET).
+ *
+ * The `__`-prefixed internals are detached-child entry points handled at
+ * the very top of bin/prjct.ts — routing them to the daemon (the shim's
+ * default for unknown commands) would error: no registry handler exists.
  */
-const SHIM_EXTRA_SKIP = ['dev', 'web', 'serve']
+const SHIM_EXTRA_SKIP = ['dev', 'web', 'serve', '__internal-auto-update', '__post-upgrade']
 
 /**
  * Evaluate the command manifest (command-data.ts via verb-names.ts) at


### PR DESCRIPTION
## The last real "hinders the agent" finding from the live verification

Measured on a real machine: the first `prjct` command after an upgrade stalled **31.6 seconds** while the post-upgrade re-setup (provider installers, Context7 network verification, per-project cliVersion migration over ~19k project dirs) ran synchronously INSIDE the user's command — silent, no progress, in the worst possible moment.

### Fix
- Re-setup moves to a detached **`__post-upgrade`** child (same pattern as the auto-updater's `__internal-auto-update`). Version is stamped first (no duplicate children on rapid invocations); a dead child converges via the existing idempotent self-heals.
- **Measured: 31.6s → 0.10s**, with a one-line "finishing setup in the background" banner.
- Explicit `prjct update` keeps its synchronous, progress-printing behavior.
- **Bonus latent bug fixed:** both detached-child internals are now in the daemon shim's skip set — the shim's default for unknown commands is the daemon (no registry handler → silent failure with `stdio: 'ignore'`). `__internal-auto-update` had this routing bug too.

### Verification
- End-to-end smoke: stamp v2.43.0 → run `prjct status` → **0.10s**, banner printed, child re-stamps to v2.44.1 and completes setup ✓
- `bun bin/prjct.ts __post-upgrade` runs full setup, exit 0 ✓
- New shim-sync test pins the skip-set entries and that the upgrade block spawns instead of awaiting inline
- 1543/1543 tests, typecheck + biome clean

This `fix:` release also carries the #431 cleanup sweep (its `chore:` commit didn't cut a version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)