### PR TITLE
fix: forward --lenses override through audit-spec dispatch paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.46.1] - 2026-06-19
+
+### Fixed
+- `prjct spec audit <id> --lenses a,b,c` now actually overrides the lens set. The flag was dropped by every CLI dispatch path (`route-spec`, daemon `dispatch`, and the `audit-spec` alias), which forwarded only `{ md }` — so the documented override silently fell back to the deterministic baseline (shipped that way in 2.46.0). Now forwarded through all paths, with a router-level test that drives `routeSpec` (the earlier tests called the method directly and missed the gap).
+
 ## [2.46.0] - 2026-06-19
 
 ### Added

--- a/core/__tests__/commands/spec-audit-dynamic-lenses.test.ts
+++ b/core/__tests__/commands/spec-audit-dynamic-lenses.test.ts
@@ -49,6 +49,16 @@ afterEach(async () => {
   if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
   else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
   if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  // PRJCT_PROJECTS_DIR is not honored by pathManager (mem_1560), so project
+  // data lands in ~/.prjct-cli/projects/<id>; clean it to avoid polluting the
+  // real projects dir.
+  if (projectId)
+    await fs
+      .rm(path.join(os.homedir(), '.prjct-cli', 'projects', projectId), {
+        recursive: true,
+        force: true,
+      })
+      .catch(() => {})
   prjctDb.close()
 })
 

--- a/core/__tests__/commands/spec-audit-lenses-routing.test.ts
+++ b/core/__tests__/commands/spec-audit-lenses-routing.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `prjct spec audit --lenses` routing.
+ *
+ * Pins the bug that shipped in v2.46.0: the override flag must reach the
+ * audit method THROUGH routeSpec. The router forwarded only `{ md }` and
+ * dropped `lenses`, so `--lenses a,b` silently fell back to the deterministic
+ * baseline. The earlier tests called `cmd.audit({lenses})` directly, bypassing
+ * the router — so they missed it. This drives the real dispatch path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { PrjctCommands } from '../../commands/commands'
+import { routeSpec } from '../../commands/route-spec'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { specService } from '../../services/spec-service'
+import prjctDb from '../../storage/database'
+
+let projectPath: string
+let projectId: string
+let originalProjectsDir: string | undefined
+
+async function freshProject(): Promise<void> {
+  const tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-lensroute-pd-'))
+  originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+  process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-lensroute-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `lensroute-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+}
+
+beforeEach(async () => {
+  prjctDb.close()
+  await freshProject()
+})
+
+afterEach(async () => {
+  if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+  else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+  if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  // PRJCT_PROJECTS_DIR is not honored by pathManager (mem_1560), so project
+  // data actually lands in ~/.prjct-cli/projects/<id>. Clean it so this test
+  // does not pollute the real projects dir.
+  if (projectId)
+    await fs
+      .rm(path.join(os.homedir(), '.prjct-cli', 'projects', projectId), {
+        recursive: true,
+        force: true,
+      })
+      .catch(() => {})
+  prjctDb.close()
+})
+
+const authMigrationSpec = () =>
+  specService.create(projectPath, {
+    title: 'auth + migration',
+    content: { goal: 'Add token auth and a DB schema migration', scope: ['core/auth/x.ts'] },
+    autoContext: false,
+  })
+
+describe('routeSpec — audit forwards --lenses to the method', () => {
+  test('--lenses overrides the baseline (persists exactly the given set)', async () => {
+    const spec = await authMigrationSpec()
+    const res = await routeSpec(
+      new PrjctCommands(),
+      ['audit', spec.id],
+      { lenses: 'architecture,security' },
+      projectPath
+    )
+    expect(res.success).toBe(true)
+    const after = await specService.get(projectPath, spec.id)
+    expect(after?.content.selected_reviewers).toEqual(['architecture', 'security'])
+  })
+
+  test('without --lenses, the deterministic baseline is used (security + data here)', async () => {
+    const spec = await authMigrationSpec()
+    await routeSpec(new PrjctCommands(), ['audit', spec.id], {}, projectPath)
+    const after = await specService.get(projectPath, spec.id)
+    expect(after?.content.selected_reviewers).toContain('security')
+    expect(after?.content.selected_reviewers).toContain('data')
+    expect(after?.content.selected_reviewers).not.toEqual(['architecture', 'security'])
+  })
+})

--- a/core/commands/commands.ts
+++ b/core/commands/commands.ts
@@ -568,7 +568,7 @@ class PrjctCommands {
   async specAudit(
     id: string | null = null,
     projectPath: string = process.cwd(),
-    options: { md?: boolean } = {}
+    options: { md?: boolean; lenses?: string } = {}
   ): Promise<CommandResult> {
     return (await this.specCmdsG()).audit(id, projectPath, options)
   }

--- a/core/commands/route-spec.ts
+++ b/core/commands/route-spec.ts
@@ -105,7 +105,10 @@ export async function routeSpec(
         pr: options.pr ? String(options.pr) : undefined,
       })
     case 'audit':
-      return commands.specAudit(rest, cwd, { md })
+      return commands.specAudit(rest, cwd, {
+        md,
+        lenses: options.lenses ? String(options.lenses) : undefined,
+      })
     case 'breakdown':
       return commands.specBreakdown(rest, cwd, { md, force: options.force === true })
     case 'inventory':

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -88,7 +88,10 @@ export async function executeCommand(
       if (!param) {
         return { success: false, error: 'audit-spec requires a spec id' }
       }
-      return commands.specAudit(param, request.cwd, { md })
+      return commands.specAudit(param, request.cwd, {
+        md,
+        lenses: opts.lenses ? String(opts.lenses) : undefined,
+      })
     case 'analyze':
       return commands.analyze(opts, request.cwd)
     case 'analysis-save-llm':

--- a/core/index.ts
+++ b/core/index.ts
@@ -214,7 +214,10 @@ async function main(): Promise<void> {
             ),
           'audit-spec': (p) =>
             p
-              ? commands.specAudit(p, process.cwd(), { md })
+              ? commands.specAudit(p, process.cwd(), {
+                  md,
+                  lenses: options.lenses ? String(options.lenses) : undefined,
+                })
               : Promise.resolve({ success: false, error: 'audit-spec requires a spec id' }),
           // Planning — init accepts --pack / --persona / --yes to pre-seed
           // packs and persona without the interactive wizard.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.46.0",
+  "version": "2.46.1",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Bug

`prjct spec audit <id> --lenses a,b,c` (shipped in #435 / v2.46.0) was **documented in the dispatch output** but silently did nothing — it always fell back to the deterministic baseline.

**Root cause:** every CLI dispatch path forwarded only `{ md }` to `specAudit`, dropping `lenses`:
- `core/commands/route-spec.ts` (`prjct spec audit`)
- `core/daemon/dispatch.ts` + `core/index.ts` (the `audit-spec` alias)
- `core/commands/commands.ts` — `specAudit` even typed its options as `{ md? }` only

The #435 tests called the `audit()` method directly with `{ lenses }`, bypassing the router — so they never exercised the broken path.

## Fix

Forward `lenses` through all four sites + widen `specAudit`'s option type. Added `spec-audit-lenses-routing.test.ts` that drives `routeSpec(['audit', id], { lenses })` and asserts the override persists (would have caught this). Also made the audit tests self-clean their `~/.prjct-cli/projects/<id>` dir (the `PRJCT_PROJECTS_DIR`-not-honored pollution, mem_1560).

## Verified end-to-end (real CLI, repo build)

```
prjct spec audit <id> --lenses architecture,security
→ Selected lenses for this spec: architecture, security   (was: architecture, security, data)
→ record architecture → draft;  record security → "all selected lenses passed → status: reviewed"
```

Gate now promotes over the overridden set. Full suite: 1578 pass / 0 fail.