### PR TITLE
test: isolate test runs from the real ~/.prjct-cli projects dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Internal
+- Test isolation (mem_1560): `pathManager.globalProjectsDir` now honors `PRJCT_PROJECTS_DIR` (resolved at access time), and a new bun preload points `PRJCT_CLI_HOME` at a throwaway temp dir for the whole run. The suite no longer leaks fixture projects into the real `~/.prjct-cli/projects` — verified: full suite (1580 tests) adds 0 dirs to the real projects dir (previously ~116/run). No production impact (prod never sets `PRJCT_PROJECTS_DIR`).
+
 ## [2.46.1] - 2026-06-19
 
 ### Fixed

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,11 @@
 [test]
-# Global test isolation: reset module-level singletons (circuit breakers)
-# before every test so one suite's failures can't cascade into another.
-# See core/__tests__/_setup/reset-singletons.ts for the rationale.
-preload = ["./core/__tests__/_setup/reset-singletons.ts"]
+# Global test isolation:
+#  1. isolate-cli-home: point PRJCT_CLI_HOME at a temp dir BEFORE any prjct
+#     module loads, so tests never write fixtures into the real ~/.prjct-cli
+#     (mem_1560). Must be first — pathManager resolves the home at import time.
+#  2. reset-singletons: reset module-level singletons (circuit breakers) before
+#     every test so one suite's failures can't cascade into another.
+preload = [
+  "./core/__tests__/_setup/isolate-cli-home.ts",
+  "./core/__tests__/_setup/reset-singletons.ts",
+]

--- a/core/__tests__/_setup/isolate-cli-home.ts
+++ b/core/__tests__/_setup/isolate-cli-home.ts
@@ -1,0 +1,19 @@
+/**
+ * Global test isolation (mem_1560 — test vault pollution root cause).
+ *
+ * Point PRJCT_CLI_HOME at a throwaway temp dir for the WHOLE test run, BEFORE
+ * any prjct module loads. pathManager reads PRJCT_CLI_HOME at construction
+ * (singleton import time), so setting it in a preload means every test that
+ * does NOT explicitly isolate (via PRJCT_PROJECTS_DIR or setGlobalBaseDir)
+ * writes its fixture projects/cache/state into the temp dir instead of the
+ * real ~/.prjct-cli. Must be the FIRST preload (before reset-singletons, which
+ * imports prjct modules). An explicit PRJCT_CLI_HOME (e.g. CI sandbox) wins.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+if (!process.env.PRJCT_CLI_HOME) {
+  process.env.PRJCT_CLI_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-test-home-'))
+}

--- a/core/__tests__/infrastructure/path-manager-projects-dir.test.ts
+++ b/core/__tests__/infrastructure/path-manager-projects-dir.test.ts
@@ -1,0 +1,34 @@
+/**
+ * pathManager.globalProjectsDir — PRJCT_PROJECTS_DIR override (mem_1560).
+ *
+ * The projects dir is resolved at ACCESS time and honors PRJCT_PROJECTS_DIR so
+ * a test run can point it at a temp dir instead of polluting the real
+ * ~/.prjct-cli/projects. ~18 test files already set this env var in beforeEach;
+ * before this it was silently ignored (code read only PRJCT_CLI_HOME, resolved
+ * at construction), so every run leaked fixture projects into the real dir.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+
+describe('pathManager.globalProjectsDir — PRJCT_PROJECTS_DIR override', () => {
+  const original = process.env.PRJCT_PROJECTS_DIR
+  afterEach(() => {
+    if (original === undefined) delete process.env.PRJCT_PROJECTS_DIR
+    else process.env.PRJCT_PROJECTS_DIR = original
+  })
+
+  it('honors PRJCT_PROJECTS_DIR at access time, resolved absolute', () => {
+    process.env.PRJCT_PROJECTS_DIR = '/tmp/prjct-test-projects-xyz'
+    expect(pathManager.globalProjectsDir).toBe(path.resolve('/tmp/prjct-test-projects-xyz'))
+    expect(pathManager.getGlobalProjectPath('abc-123')).toBe(
+      path.join(path.resolve('/tmp/prjct-test-projects-xyz'), 'abc-123')
+    )
+  })
+
+  it('falls back to <globalBaseDir>/projects when unset', () => {
+    delete process.env.PRJCT_PROJECTS_DIR
+    expect(pathManager.globalProjectsDir).toBe(path.join(pathManager.globalBaseDir, 'projects'))
+  })
+})

--- a/core/infrastructure/path-manager.ts
+++ b/core/infrastructure/path-manager.ts
@@ -33,7 +33,6 @@ import {
 
 class PathManager {
   globalBaseDir: string
-  globalProjectsDir: string
   globalConfigDir: string
 
   constructor() {
@@ -43,8 +42,20 @@ class PathManager {
     // per-call consumers (global-config, secure-key, …) use resolveCliHome()
     // directly so late mutation still works there.
     this.globalBaseDir = resolveCliHome()
-    this.globalProjectsDir = path.join(this.globalBaseDir, 'projects')
     this.globalConfigDir = path.join(this.globalBaseDir, 'config')
+  }
+
+  /**
+   * Global projects dir. Honors `PRJCT_PROJECTS_DIR` (test isolation — point it
+   * at a temp dir so a test run never writes into the real
+   * `~/.prjct-cli/projects`), else `<globalBaseDir>/projects`. Resolved at
+   * ACCESS time, so tests that set the env var in `beforeEach` (i.e. after
+   * import) are honored. Production never sets `PRJCT_PROJECTS_DIR`, so this is
+   * unchanged there. See mem_1560 (test vault pollution root cause).
+   */
+  get globalProjectsDir(): string {
+    const override = process.env.PRJCT_PROJECTS_DIR
+    return override ? path.resolve(override) : path.join(this.globalBaseDir, 'projects')
   }
 
   /**
@@ -52,7 +63,6 @@ class PathManager {
    */
   setGlobalBaseDir(globalBaseDir: string): void {
     this.globalBaseDir = path.resolve(globalBaseDir)
-    this.globalProjectsDir = path.join(this.globalBaseDir, 'projects')
     this.globalConfigDir = path.join(this.globalBaseDir, 'config')
   }
 


### PR DESCRIPTION
## Problem (mem_1560)

~18 test files set `PRJCT_PROJECTS_DIR` for isolation, but the code only ever read `PRJCT_CLI_HOME` (resolved at construction). The env var was **silently ignored**, so every `bun test` leaked fixture projects into the real `~/.prjct-cli/projects` — it had grown to **22k+ dirs (~17k test cruft)**.

## Fix

1. **`pathManager.globalProjectsDir`** → a getter that honors `PRJCT_PROJECTS_DIR` at access time (so tests setting it in `beforeEach` are respected). No-op in production, which never sets it.
2. **New bun preload `isolate-cli-home`** → points `PRJCT_CLI_HOME` at a throwaway temp dir for the whole run, BEFORE any prjct module loads — catching tests that isolate via *neither* mechanism.

## Verified

- Full suite: **1580 pass / 0 fail** under temp-home isolation (no test depends on real global state).
- Real `~/.prjct-cli/projects` delta after a full run: **0** (was ~116/run).
- Added `path-manager-projects-dir.test.ts` pinning the override.

No version bump — internal/test-only, zero user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)