### PR TITLE
feat: cloud sync — realtime WebSocket propagation (v2.48.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.48.0] - 2026-06-19
+
+### Added
+- **Cloud sync — realtime (WebSocket).** Linked projects now propagate changes across machines in near-real-time (target <5s), on top of the pull-based sync from 2.47.0. A new realtime client (`core/sync/realtime-client.ts`) uses the **platform global `WebSocket`** (RFC 6455, stable in Node ≥22.5 and Bun) — **no `ws` dependency and no backend SDK**; the token/device/project are passed as `wss://` query params (TLS-encrypted) since the WHATWG WebSocket API can't set headers. Connections live in the **warm daemon** (`RealtimeManager`), reopened on boot from a tiny linked-projects registry (`core/sync/cloud-registry.ts`) instead of scanning every project dir. `prjct cloud link` / `resume` open a connection; `pause` / `unlink` close it; `prjct cloud status` shows the live connection state. Inbound events apply through `syncManager.applyRealtimeEvent` with an **echo-loop guard** (events originating from this device are skipped) and cursor advance so a later pull doesn't re-fetch. Reconnect uses exponential backoff with jitter. Realtime runs only inside the daemon; in `PRJCT_NO_DAEMON` mode sync stays pull-based (no behavior change). The engine-agnostic CI guard now covers the realtime files too.
+
 ## [2.47.0] - 2026-06-19
 
 ### Added

--- a/core/__tests__/sync/cloud-registry.test.ts
+++ b/core/__tests__/sync/cloud-registry.test.ts
@@ -1,0 +1,56 @@
+/**
+ * cloud-registry — the small durable list of linked projects the daemon reads
+ * on boot (instead of scanning thousands of project dirs).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import {
+  addLinkedProject,
+  listLinkedProjects,
+  removeLinkedProject,
+} from '../../sync/cloud-registry'
+
+let tempHome: string
+let originalBase: string
+
+describe('cloud-registry', () => {
+  beforeEach(async () => {
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-cloud-reg-'))
+    // getStatePath() reads globalBaseDir at access time, so point it at a temp
+    // dir per test and restore after (the registry file lives under <base>/state).
+    originalBase = pathManager.getGlobalBasePath()
+    pathManager.setGlobalBaseDir(tempHome)
+  })
+
+  afterEach(async () => {
+    pathManager.setGlobalBaseDir(originalBase)
+    await fs.rm(tempHome, { recursive: true, force: true })
+  })
+
+  test('empty by default', async () => {
+    expect(await listLinkedProjects()).toEqual([])
+  })
+
+  test('add → list → remove round-trips', async () => {
+    await addLinkedProject('p1', '/repo/one')
+    await addLinkedProject('p2', '/repo/two')
+    let list = await listLinkedProjects()
+    expect(list.map((p) => p.projectId).sort()).toEqual(['p1', 'p2'])
+
+    await removeLinkedProject('p1')
+    list = await listLinkedProjects()
+    expect(list).toEqual([{ projectId: 'p2', projectPath: '/repo/two' }])
+  })
+
+  test('add is idempotent on projectId (no duplicates)', async () => {
+    await addLinkedProject('p1', '/repo/one')
+    await addLinkedProject('p1', '/repo/one-moved')
+    const list = await listLinkedProjects()
+    expect(list.length).toBe(1)
+    expect(list[0].projectPath).toBe('/repo/one-moved')
+  })
+})

--- a/core/__tests__/sync/realtime-apply.test.ts
+++ b/core/__tests__/sync/realtime-apply.test.ts
@@ -1,0 +1,82 @@
+/**
+ * syncManager.applyRealtimeEvent — the echo-loop guard + local apply path for
+ * events arriving over the realtime channel. And RealtimeManager gating: it
+ * must be a no-op outside the daemon.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import prjctDb from '../../storage/database'
+import authConfig from '../../sync/auth-config'
+import { realtimeManager } from '../../sync/realtime-manager'
+import syncManager from '../../sync/sync-manager'
+
+let tempDir: string
+let originalProjectsDir: string | undefined
+let projectId: string
+const origRead = authConfig.read.bind(authConfig)
+
+function memoryCount(): number {
+  return prjctDb.get<{ cnt: number }>(projectId, 'SELECT COUNT(*) as cnt FROM memories')?.cnt ?? 0
+}
+
+describe('syncManager.applyRealtimeEvent', () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-rt-apply-'))
+    originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+    process.env.PRJCT_PROJECTS_DIR = tempDir
+    projectId = `rt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+    // This device is "self"; events from it are echoes.
+    authConfig.read = mock(async () => ({ deviceId: 'self', userId: 'u1', apiKey: 'k' }) as never)
+  })
+
+  afterEach(async () => {
+    if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+    else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+    authConfig.read = origRead
+    authConfig.clearCache()
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('skips echoes from this device (origin === self)', async () => {
+    const applied = await syncManager.applyRealtimeEvent(projectId, {
+      entity_type: 'memories',
+      event_type: 'upsert',
+      origin_device_id: 'self',
+      data: { id: 'm1', type: 'decision', content: 'echo' },
+    })
+    expect(applied).toBe(false)
+    expect(memoryCount()).toBe(0)
+  })
+
+  test('applies events from other devices', async () => {
+    const applied = await syncManager.applyRealtimeEvent(projectId, {
+      entity_type: 'memories',
+      event_type: 'upsert',
+      origin_device_id: 'other-machine',
+      data: { id: 'm2', type: 'learning', content: 'from machine B' },
+    })
+    expect(applied).toBe(true)
+    expect(memoryCount()).toBe(1)
+  })
+})
+
+describe('RealtimeManager gating', () => {
+  test('not available outside the daemon', () => {
+    const prev = process.env.PRJCT_IN_DAEMON
+    delete process.env.PRJCT_IN_DAEMON
+    expect(realtimeManager.available()).toBe(false)
+    if (prev !== undefined) process.env.PRJCT_IN_DAEMON = prev
+  })
+
+  test('startAll is a no-op when not available; status is "disabled"', async () => {
+    const prev = process.env.PRJCT_IN_DAEMON
+    delete process.env.PRJCT_IN_DAEMON
+    await realtimeManager.startAll()
+    expect(realtimeManager.status('whatever')).toBe('disabled')
+    if (prev !== undefined) process.env.PRJCT_IN_DAEMON = prev
+  })
+})

--- a/core/__tests__/sync/realtime-client.test.ts
+++ b/core/__tests__/sync/realtime-client.test.ts
@@ -1,0 +1,167 @@
+/**
+ * RealtimeClient — connection + apply + reconnect logic, driven through an
+ * injected fake WebSocket (no real network). Covers the URL/backoff helpers,
+ * event dispatch, malformed-frame tolerance, reconnect-on-drop, and that
+ * stop() prevents further reconnects.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  backoffDelay,
+  buildRealtimeUrl,
+  RealtimeClient,
+  type WebSocketLike,
+} from '../../sync/realtime-client'
+
+class FakeWebSocket implements WebSocketLike {
+  readyState = 0
+  onopen: ((ev: unknown) => void) | null = null
+  onmessage: ((ev: { data: unknown }) => void) | null = null
+  onclose: ((ev: unknown) => void) | null = null
+  onerror: ((ev: unknown) => void) | null = null
+  closeCalls = 0
+
+  close(): void {
+    this.closeCalls += 1
+    this.readyState = 3
+  }
+
+  // Test drivers
+  open(): void {
+    this.readyState = 1
+    this.onopen?.(null)
+  }
+  message(data: unknown): void {
+    this.onmessage?.({ data })
+  }
+  drop(): void {
+    this.readyState = 3
+    this.onclose?.(null)
+  }
+}
+
+function makeClient(overrides: Partial<Parameters<typeof clientWith>[0]> = {}) {
+  return clientWith(overrides)
+}
+
+function clientWith(opts: {
+  apply?: (pid: string, ev: Record<string, unknown>) => Promise<boolean>
+  baseDelayMs?: number
+  maxDelayMs?: number
+}) {
+  const sockets: FakeWebSocket[] = []
+  const applied: Array<{ pid: string; ev: Record<string, unknown> }> = []
+  const client = new RealtimeClient({
+    projectId: 'proj-1',
+    apiUrl: 'https://api.example.test',
+    apiKey: 'pk_live_abc',
+    deviceId: 'dev-1',
+    apply:
+      opts.apply ??
+      (async (pid, ev) => {
+        applied.push({ pid, ev })
+        return true
+      }),
+    wsFactory: () => {
+      const ws = new FakeWebSocket()
+      sockets.push(ws)
+      return ws
+    },
+    baseDelayMs: opts.baseDelayMs ?? 1,
+    maxDelayMs: opts.maxDelayMs ?? 2,
+  })
+  return { client, sockets, applied }
+}
+
+const tick = (ms = 25) => new Promise((r) => setTimeout(r, ms))
+
+describe('buildRealtimeUrl', () => {
+  it('swaps https→wss and appends auth query params', () => {
+    const url = buildRealtimeUrl('https://api.prjct.app', 'p1', 'pk_live_x', 'd1')
+    expect(url.startsWith('wss://api.prjct.app/ws?')).toBe(true)
+    const q = new URL(url).searchParams
+    expect(q.get('key')).toBe('pk_live_x')
+    expect(q.get('device')).toBe('d1')
+    expect(q.get('project')).toBe('p1')
+  })
+
+  it('swaps http→ws and tolerates a trailing slash', () => {
+    expect(buildRealtimeUrl('http://localhost:3000/', 'p', 'k', 'd')).toContain(
+      'ws://localhost:3000/ws?'
+    )
+  })
+})
+
+describe('backoffDelay', () => {
+  it('never exceeds the ceiling and grows with attempt', () => {
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const d = backoffDelay(attempt, 1000, 30_000)
+      expect(d).toBeGreaterThanOrEqual(0)
+      expect(d).toBeLessThanOrEqual(Math.min(30_000, 1000 * 2 ** attempt))
+    }
+  })
+})
+
+describe('RealtimeClient', () => {
+  it('applies an inbound event frame to the apply callback', async () => {
+    const { client, sockets, applied } = makeClient({})
+    client.start()
+    sockets[0].open()
+    expect(client.state).toBe('open')
+
+    sockets[0].message(
+      JSON.stringify({ type: 'event', event: { entity_type: 'memories', data: { id: 'm1' } } })
+    )
+    await tick(5)
+
+    expect(applied.length).toBe(1)
+    expect(applied[0].pid).toBe('proj-1')
+    expect(applied[0].ev.entity_type).toBe('memories')
+    client.stop()
+  })
+
+  it('ignores non-event frames and malformed JSON', async () => {
+    const { client, sockets, applied } = makeClient({})
+    client.start()
+    sockets[0].open()
+    sockets[0].message(JSON.stringify({ type: 'ping' }))
+    sockets[0].message('not json {{{')
+    sockets[0].message(JSON.stringify({ type: 'event' })) // missing event payload
+    await tick(5)
+    expect(applied.length).toBe(0)
+    client.stop()
+  })
+
+  it('reconnects after an unexpected drop', async () => {
+    const { client, sockets } = makeClient({})
+    client.start()
+    sockets[0].open()
+    sockets[0].drop()
+    expect(client.state).toBe('reconnecting')
+
+    await tick(40)
+    expect(sockets.length).toBeGreaterThanOrEqual(2) // a fresh socket was created
+    client.stop()
+  })
+
+  it('stop() prevents any further reconnect', async () => {
+    const { client, sockets } = makeClient({})
+    client.start()
+    sockets[0].open()
+    client.stop()
+    sockets[0].drop() // a drop after stop must NOT spawn a new socket
+    await tick(40)
+    expect(sockets.length).toBe(1)
+    expect(client.state).toBe('closed')
+  })
+
+  it('start() is idempotent while connecting/open', () => {
+    const { client, sockets } = makeClient({})
+    client.start()
+    client.start()
+    sockets[0].open()
+    client.start()
+    expect(sockets.length).toBe(1)
+    client.stop()
+  })
+})

--- a/core/commands/cloud.ts
+++ b/core/commands/cloud.ts
@@ -20,7 +20,9 @@
 import { syncEventBus } from '../events/sync-events'
 import configManager from '../infrastructure/config-manager'
 import authConfig from '../sync/auth-config'
+import { addLinkedProject, removeLinkedProject } from '../sync/cloud-registry'
 import { DEFAULT_INCLUDE } from '../sync/entity-map'
+import realtimeManager from '../sync/realtime-manager'
 import syncManager from '../sync/sync-manager'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
@@ -85,6 +87,10 @@ export class CloudCommands extends PrjctCommandsBase {
       include: config.cloud?.include,
     }
     await configManager.writeConfig(projectPath, config)
+    await addLinkedProject(config.projectId, projectPath)
+    // Open the realtime connection (no-op outside the daemon — the daemon
+    // reopens it from the registry on its next boot).
+    await realtimeManager.start(config.projectId, projectPath).catch(() => undefined)
 
     const result = await syncManager.sync(config.projectId, { include: config.cloud.include ?? {} })
     return this.reportSync('Linked', result, options, {
@@ -103,6 +109,8 @@ export class CloudCommands extends PrjctCommandsBase {
     }
     config.cloud = { ...config.cloud, enabled: false, paused: false }
     await configManager.writeConfig(projectPath, config)
+    realtimeManager.stop(config.projectId)
+    await removeLinkedProject(config.projectId)
     const msg = 'Unlinked — this project is local-only again. Local data was not touched.'
     if (options.md) console.log(mdOutput('## Cloud', `> ${msg}`))
     else out.done(msg)
@@ -157,6 +165,8 @@ export class CloudCommands extends PrjctCommandsBase {
     }
     config.cloud = { ...config.cloud, paused }
     await configManager.writeConfig(projectPath, config)
+    if (paused) realtimeManager.stop(config.projectId)
+    else await realtimeManager.start(config.projectId, projectPath).catch(() => undefined)
     const msg = paused
       ? 'Cloud sync paused. Resume with `prjct cloud resume`.'
       : 'Cloud sync resumed.'
@@ -189,6 +199,14 @@ export class CloudCommands extends PrjctCommandsBase {
           ? 'linked, paused'
           : 'linked, active'
 
+    // Realtime only runs inside the daemon; report its live connection state
+    // there, otherwise say it needs the daemon (pull-based sync still works).
+    const realtime = !linked
+      ? 'n/a'
+      : realtimeManager.available()
+        ? realtimeManager.status(config.projectId)
+        : 'requires daemon'
+
     if (options.md) {
       console.log(
         mdOutput(
@@ -197,6 +215,7 @@ export class CloudCommands extends PrjctCommandsBase {
           [
             `- Authenticated: ${authed ? 'yes' : 'no'}`,
             `- Linked: ${linked ? 'yes' : 'no'}${cloud?.linkedAt ? ` (since ${cloud.linkedAt})` : ''}`,
+            `- Realtime: ${realtime}`,
             `- Pending events: ${pending}`,
             `- Last sync: ${lastSync?.timestamp ?? 'never'}`,
             `- Syncing groups: ${onGroups.join(', ')}`,
@@ -209,13 +228,14 @@ export class CloudCommands extends PrjctCommandsBase {
           `Cloud — ${state}`,
           `  Authenticated: ${authed ? 'yes' : 'no'}`,
           `  Linked: ${linked ? 'yes' : 'no'}${cloud?.linkedAt ? ` (since ${cloud.linkedAt})` : ''}`,
+          `  Realtime: ${realtime}`,
           `  Pending events: ${pending}`,
           `  Last sync: ${lastSync?.timestamp ?? 'never'}`,
           `  Syncing groups: ${onGroups.join(', ')}`,
         ].join('\n')
       )
     }
-    return { success: true, linked, paused, authed, pending }
+    return { success: true, linked, paused, authed, pending, realtime }
   }
 
   /** Shared gate for sync/pull: linked + not paused + authenticated. */

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -20,6 +20,7 @@ import { commandRegistry } from '../commands/registry'
 import type { HookIo } from '../hooks/_runner'
 import { getHookRunner } from '../hooks/registry'
 import prjctDb from '../storage/database'
+import { realtimeManager } from '../sync/realtime-manager'
 import type { DaemonRequest, DaemonResponse, DaemonState } from '../types/daemon'
 import { executeCommand } from './dispatch'
 import { DAEMON_PATHS, encodeMessage, IDLE_TIMEOUT_MS, MAX_BUFFER_SIZE } from './protocol'
@@ -137,6 +138,10 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
     if (entryPath) console.log(`  Watching: ${entryPath}`)
 
     resetIdleTimer()
+
+    // Open realtime connections for linked projects (cloud sync). Best-effort,
+    // non-blocking — a failure here must never stop the daemon from serving.
+    void realtimeManager.startAll().catch(() => undefined)
   })
 
   ipcServer.on('error', (err) => {
@@ -480,6 +485,13 @@ function resetIdleTimer(): void {
 
 function shutdown(exitCode: number): void {
   console.log('Daemon shutting down...')
+
+  // Close realtime connections before tearing down storage.
+  try {
+    realtimeManager.stopAll()
+  } catch {
+    /* ignore */
+  }
 
   if (state?.idleTimer) clearTimeout(state.idleTimer)
 

--- a/core/sync/cloud-registry.ts
+++ b/core/sync/cloud-registry.ts
@@ -1,0 +1,45 @@
+/**
+ * Cloud-linked project registry — a tiny durable list of the projects that
+ * have run `prjct cloud link`, so the daemon can reopen their realtime
+ * connections on boot WITHOUT scanning every project on disk (a machine can
+ * have thousands of project dirs; only a handful are ever linked).
+ *
+ * Stored at `<state>/cloud-linked.json`. `link` adds, `unlink` removes. Paused
+ * state is NOT tracked here — that lives in each project's config and is read
+ * per-project by the realtime manager (the list is small).
+ */
+
+import path from 'node:path'
+import pathManager from '../infrastructure/path-manager'
+import * as fileHelper from '../utils/file-helper'
+
+export interface LinkedProject {
+  projectId: string
+  projectPath: string
+}
+
+function registryPath(): string {
+  return path.join(pathManager.getStatePath(), 'cloud-linked.json')
+}
+
+export async function listLinkedProjects(): Promise<LinkedProject[]> {
+  const data = await fileHelper.readJson<LinkedProject[]>(registryPath(), [])
+  return Array.isArray(data) ? data.filter((p) => p?.projectId && p?.projectPath) : []
+}
+
+export async function addLinkedProject(projectId: string, projectPath: string): Promise<void> {
+  const list = await listLinkedProjects()
+  const next = list.filter((p) => p.projectId !== projectId)
+  next.push({ projectId, projectPath })
+  await fileHelper.ensureDir(pathManager.getStatePath())
+  await fileHelper.writeJson(registryPath(), next)
+}
+
+export async function removeLinkedProject(projectId: string): Promise<void> {
+  const list = await listLinkedProjects()
+  await fileHelper.ensureDir(pathManager.getStatePath())
+  await fileHelper.writeJson(
+    registryPath(),
+    list.filter((p) => p.projectId !== projectId)
+  )
+}

--- a/core/sync/realtime-client.ts
+++ b/core/sync/realtime-client.ts
@@ -1,0 +1,191 @@
+/**
+ * Realtime client — ONE project's live WebSocket connection to the storage
+ * API, for <5s cross-device propagation.
+ *
+ * Uses the PLATFORM global `WebSocket` (RFC 6455 — stable in Node ≥22.5 and
+ * Bun), NOT a backend SDK and NOT the `ws` package. The WHATWG WebSocket API
+ * can't set request headers, so the token + device + project are passed as
+ * query params over `wss://` (TLS-encrypted), matching the spec's auth model.
+ *
+ * Responsibilities: connect, parse inbound `{type:'event', event}` frames and
+ * hand them to `apply`, and reconnect with exponential backoff + jitter on
+ * drop. The WebSocket is injectable (`wsFactory`) so the reconnect / apply /
+ * echo logic is unit-testable without a real socket.
+ */
+
+/** Minimal subset of the WHATWG WebSocket we depend on (keeps it injectable). */
+export interface WebSocketLike {
+  readyState: number
+  close(code?: number, reason?: string): void
+  onopen: ((ev: unknown) => void) | null
+  onmessage: ((ev: { data: unknown }) => void) | null
+  onclose: ((ev: unknown) => void) | null
+  onerror: ((ev: unknown) => void) | null
+}
+
+export type WebSocketFactory = (url: string) => WebSocketLike
+
+export type RealtimeState = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'
+
+export interface RealtimeClientOptions {
+  projectId: string
+  /** REST base, e.g. `https://api.prjct.app` or `https://…/api`. */
+  apiUrl: string
+  apiKey: string
+  deviceId: string
+  /** Applies a received event locally (echo-guarded). Returns applied?. */
+  apply: (projectId: string, event: Record<string, unknown>) => Promise<boolean>
+  /** Injected for tests; defaults to the platform global WebSocket. */
+  wsFactory?: WebSocketFactory
+  baseDelayMs?: number
+  maxDelayMs?: number
+}
+
+/** Whether this runtime exposes a usable global WebSocket client. */
+export function hasGlobalWebSocket(): boolean {
+  return typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'function'
+}
+
+/** REST base → ws endpoint with auth query params. `https`→`wss`, `http`→`ws`. */
+export function buildRealtimeUrl(
+  apiUrl: string,
+  projectId: string,
+  apiKey: string,
+  deviceId: string
+): string {
+  const base = apiUrl.replace(/\/$/, '').replace(/^http/, 'ws')
+  const q = new URLSearchParams({ key: apiKey, device: deviceId, project: projectId })
+  return `${base}/ws?${q.toString()}`
+}
+
+/** Exponential backoff with full jitter, capped. Pure — unit tested. */
+export function backoffDelay(attempt: number, baseMs: number, maxMs: number): number {
+  const ceiling = Math.min(maxMs, baseMs * 2 ** attempt)
+  return Math.round(Math.random() * ceiling)
+}
+
+export class RealtimeClient {
+  private readonly opts: Required<Omit<RealtimeClientOptions, 'wsFactory'>> & {
+    wsFactory: WebSocketFactory
+  }
+  private ws: WebSocketLike | null = null
+  private _state: RealtimeState = 'idle'
+  private attempt = 0
+  private stopped = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(options: RealtimeClientOptions) {
+    this.opts = {
+      ...options,
+      wsFactory:
+        options.wsFactory ??
+        ((url: string) =>
+          new (globalThis as { WebSocket: new (u: string) => WebSocketLike }).WebSocket(url)),
+      baseDelayMs: options.baseDelayMs ?? 1000,
+      maxDelayMs: options.maxDelayMs ?? 30_000,
+    }
+  }
+
+  get state(): RealtimeState {
+    return this._state
+  }
+
+  /** Open the connection (idempotent — a no-op if already connecting/open). */
+  start(): void {
+    if (this.stopped) return
+    if (this._state === 'connecting' || this._state === 'open') return
+    this.connect()
+  }
+
+  /** Close for good — cancels any pending reconnect. */
+  stop(): void {
+    this.stopped = true
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    this.closeSocket()
+    this._state = 'closed'
+  }
+
+  private connect(): void {
+    this._state = this.attempt === 0 ? 'connecting' : 'reconnecting'
+    const url = buildRealtimeUrl(
+      this.opts.apiUrl,
+      this.opts.projectId,
+      this.opts.apiKey,
+      this.opts.deviceId
+    )
+    let ws: WebSocketLike
+    try {
+      ws = this.opts.wsFactory(url)
+    } catch {
+      this.scheduleReconnect()
+      return
+    }
+    this.ws = ws
+
+    ws.onopen = () => {
+      this._state = 'open'
+      this.attempt = 0
+    }
+    ws.onmessage = (ev) => {
+      void this.handleMessage(ev?.data)
+    }
+    ws.onerror = () => {
+      // A close event follows; reconnect is handled there.
+    }
+    ws.onclose = () => {
+      if (this.stopped) return
+      this.scheduleReconnect()
+    }
+  }
+
+  private async handleMessage(data: unknown): Promise<void> {
+    let parsed: unknown
+    try {
+      parsed = typeof data === 'string' ? JSON.parse(data) : data
+    } catch {
+      return
+    }
+    if (!parsed || typeof parsed !== 'object') return
+    const msg = parsed as { type?: string; event?: Record<string, unknown> }
+    if (msg.type === 'event' && msg.event && typeof msg.event === 'object') {
+      try {
+        await this.opts.apply(this.opts.projectId, msg.event)
+      } catch {
+        // apply is already best-effort internally; never let it kill the socket.
+      }
+    }
+    // Other frame types (ping/welcome/etc.) are ignored.
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return
+    this.closeSocket()
+    this._state = 'reconnecting'
+    const delay = backoffDelay(this.attempt, this.opts.baseDelayMs, this.opts.maxDelayMs)
+    this.attempt += 1
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (!this.stopped) this.connect()
+    }, delay)
+    // Don't keep the event loop alive just for a reconnect timer.
+    ;(this.reconnectTimer as { unref?: () => void })?.unref?.()
+  }
+
+  private closeSocket(): void {
+    if (!this.ws) return
+    const ws = this.ws
+    ws.onopen = null
+    ws.onmessage = null
+    ws.onclose = null
+    ws.onerror = null
+    try {
+      ws.close()
+    } catch {
+      // already closed
+    }
+    this.ws = null
+  }
+}

--- a/core/sync/realtime-manager.ts
+++ b/core/sync/realtime-manager.ts
@@ -1,0 +1,88 @@
+/**
+ * Realtime manager — one `RealtimeClient` per linked+active project, owned by
+ * the long-lived daemon.
+ *
+ * Lifecycle:
+ *  - daemon boot → `startAll()` reopens connections from the linked registry
+ *  - `prjct cloud link` / `resume` → `start(projectId, projectPath)`
+ *  - `prjct cloud pause` / `unlink` → `stop(projectId)`
+ *  - daemon shutdown → `stopAll()`
+ *
+ * Realtime only runs INSIDE the daemon (the sole long-lived process) and only
+ * when the runtime exposes a global WebSocket. In ephemeral (`PRJCT_NO_DAEMON`)
+ * mode every method is a no-op — the command still updates the registry/config,
+ * and the daemon picks it up on next boot. Pull-based sync covers that gap.
+ */
+
+import authConfig from './auth-config'
+import { listLinkedProjects } from './cloud-registry'
+import { hasGlobalWebSocket, RealtimeClient, type RealtimeState } from './realtime-client'
+import syncManager from './sync-manager'
+
+class RealtimeManager {
+  private clients = new Map<string, RealtimeClient>()
+
+  /** Realtime can run only inside the daemon with a usable global WebSocket. */
+  available(): boolean {
+    return process.env.PRJCT_IN_DAEMON === '1' && hasGlobalWebSocket()
+  }
+
+  /** Reopen connections for every linked project (daemon boot). Best-effort. */
+  async startAll(): Promise<void> {
+    if (!this.available()) return
+    const linked = await listLinkedProjects()
+    for (const p of linked) {
+      try {
+        await this.start(p.projectId, p.projectPath)
+      } catch {
+        // One bad project must not stop the rest.
+      }
+    }
+  }
+
+  /** Open a connection for one project if it's enabled, not paused, and authed. */
+  async start(projectId: string, projectPath: string): Promise<void> {
+    if (!this.available()) return
+    if (this.clients.has(projectId)) return
+
+    const { default: configManager } = await import('../infrastructure/config-manager')
+    const config = await configManager.readConfig(projectPath).catch(() => null)
+    if (!config?.cloud?.enabled || config.cloud.paused) return
+
+    const auth = await authConfig.read()
+    if (!auth.apiKey) return
+    const [apiUrl, deviceId] = await Promise.all([authConfig.getApiUrl(), authConfig.getDeviceId()])
+
+    const client = new RealtimeClient({
+      projectId,
+      apiUrl,
+      apiKey: auth.apiKey,
+      deviceId,
+      apply: (pid, ev) => syncManager.applyRealtimeEvent(pid, ev),
+    })
+    this.clients.set(projectId, client)
+    client.start()
+  }
+
+  /** Close one project's connection (pause/unlink). */
+  stop(projectId: string): void {
+    const client = this.clients.get(projectId)
+    if (!client) return
+    client.stop()
+    this.clients.delete(projectId)
+  }
+
+  /** Close every connection (daemon shutdown). */
+  stopAll(): void {
+    for (const client of this.clients.values()) client.stop()
+    this.clients.clear()
+  }
+
+  /** Connection state for `prjct cloud status` (or 'disabled' when not running). */
+  status(projectId: string): RealtimeState | 'disabled' {
+    return this.clients.get(projectId)?.state ?? 'disabled'
+  }
+}
+
+export const realtimeManager = new RealtimeManager()
+export default realtimeManager

--- a/core/sync/sync-manager.ts
+++ b/core/sync/sync-manager.ts
@@ -358,6 +358,50 @@ class SyncManager {
   }
 
   /**
+   * Apply a single event delivered over the realtime channel. Returns true
+   * if applied, false if skipped (echo from this device) or on apply error.
+   *
+   * Echo-loop guard: events whose `origin_device_id` is THIS device are
+   * skipped (the server already filters them; this is defence-in-depth). On
+   * success the pull cursor is advanced to the event's server id so a later
+   * pull doesn't re-fetch what realtime already applied.
+   */
+  async applyRealtimeEvent(projectId: string, event: Record<string, unknown>): Promise<boolean> {
+    try {
+      const auth = await authConfig.read()
+      const selfDevice = auth.deviceId ?? null
+      const origin =
+        (event.origin_device_id as string | undefined) ??
+        (event.originDeviceId as string | undefined)
+      if (selfDevice && origin && origin === selfDevice) return false
+
+      await this.applyEvent(projectId, event)
+
+      const evId =
+        typeof event.event_id === 'number'
+          ? event.event_id
+          : typeof event.eventId === 'number'
+            ? event.eventId
+            : null
+      if (evId !== null) {
+        const { syncCursorStorage } = await import('../storage/sync-cursor-storage')
+        const userId = auth.userId ?? null
+        const deviceId = auth.deviceId ?? null
+        if (deviceId) {
+          const cursor = syncCursorStorage.get(projectId, userId, deviceId)
+          if (!cursor || evId > cursor.lastEventId) {
+            syncCursorStorage.advance(projectId, evId, { userId, deviceId })
+          }
+        }
+      }
+      return true
+    } catch (error) {
+      console.error('[realtime] apply failed:', error instanceof Error ? error.message : error)
+      return false
+    }
+  }
+
+  /**
    * Apply a single pulled event to local storage.
    *
    * Phase 1.5 / B2 + handler-registry refactor:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

PR-2 of the cloud-sync plan: **near-real-time (<5s) propagation** across machines, on top of the pull-based foundation in #439.

> **Stacked on #439** — base is `feat/cloud-sync-client`, so this diff shows only the realtime delta. Merge #439 first (or merge them together); I'll retarget to `main` once #439 lands.

## How it works

- **`RealtimeClient`** (`core/sync/realtime-client.ts`) — one connection per project using the **platform global `WebSocket`** (RFC 6455, stable in Node ≥22.5 + Bun). **No `ws` dependency, no backend SDK.** Token/device/project go as `wss://` query params (TLS-encrypted) because the WHATWG WebSocket API can't set headers — matches the spec's auth model. Reconnect with exponential backoff + jitter. WebSocket is injectable (`wsFactory`) so the logic is unit-tested without a real socket.
- **`RealtimeManager`** (`core/sync/realtime-manager.ts`) — one client per linked+active project, owned by the **warm daemon**. Reopens connections on boot from a tiny **linked-projects registry** (`core/sync/cloud-registry.ts`) instead of scanning thousands of project dirs. Gated to the daemon + a present global WebSocket; a no-op in `PRJCT_NO_DAEMON` mode (pull-based sync still covers that).
- **Daemon**: `startAll()` on boot, `stopAll()` on shutdown.
- **Commands**: `cloud link`/`resume` open a connection, `pause`/`unlink` close it, `cloud status` shows the live connection state (`open`/`reconnecting`/`requires daemon`/…).
- **`syncManager.applyRealtimeEvent`**: echo-loop guard (skip events originating from this device) + apply + cursor advance (so a later pull doesn't re-fetch what realtime already applied).

## Engine-agnostic

The CI guard now also scans the realtime files — still zero backend-engine references.

## Verification

- `bun run check` · `bun run typecheck` · `bun run build` — all clean
- `bun test` — **1630 pass, 0 fail** (+15 new: client URL/backoff/apply/reconnect/stop, registry round-trip, echo-guard apply, manager gating)
- Smoke: `cloud status` shows the new `Realtime:` line

## Out of scope (PR-3)

Remaining pull-handlers (subtasks, workflows, archives, metrics), `prjct cloud` skill pointer, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)