### PR TITLE
feat: cloud sync — workflows round-trip + hardening (v2.49.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,10 +464,23 @@ jobs:
 
       - name: Verify npm publication
         if: ${{ !inputs.dry_run && steps.push.outputs.superseded != 'true' }}
+        # Registry propagation after publish (especially with --provenance) can
+        # lag well past a single short sleep — a flat `sleep 15` then one
+        # `npm view` showed v2.48.0's release red even though the publish
+        # succeeded. Poll with backoff (up to ~90s) so a slow-but-successful
+        # publish doesn't report a false failure.
         run: |
-          sleep 15
-          npm view prjct-cli@${{ steps.version.outputs.new }} version
-          echo "✅ Published prjct-cli@${{ steps.version.outputs.new }}"
+          VERSION=${{ steps.version.outputs.new }}
+          for attempt in 1 2 3 4 5 6; do
+            if npm view "prjct-cli@$VERSION" version >/dev/null 2>&1; then
+              echo "✅ Published prjct-cli@$VERSION (visible after ~$(( (attempt - 1) * 15 ))s)"
+              exit 0
+            fi
+            echo "not visible yet (attempt $attempt/6) — waiting 15s…"
+            sleep 15
+          done
+          echo "::error title=Verify failed::prjct-cli@$VERSION not visible on npm after ~90s"
+          exit 1
 
       - name: Create tarball
         if: ${{ steps.push.outputs.superseded != 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.49.0] - 2026-06-20
+
+### Added
+- **Cloud sync — workflows round-trip + hardening.** Added pull handlers for `custom_workflows` (keyed by the stable workflow `name`) and `workflow_rules` (mirrored by source id via `INSERT OR REPLACE`, matching the cloud's upsert-by-id model), so a project's custom workflows + their hooks/gates/steps now sync across machines (both write directly to the tables — no echo back to the queue). A one-line `prjct cloud` pointer was added to the generated skill so agents surface it.
+
+### Changed
+- Cloud `include` defaults: `metrics` and `archives` are now **off by default** (opt-in). Neither round-trips yet — `metrics` has no producer, and `archives` ships a lossy summary (no `entity_data`) with no local apply handler — so they're not pushed by default rather than sending data nothing consumes. `archives`/`subtasks`/`metrics_daily`/`velocity_sprints` are now listed as known-skipped entity types (no "no local handler" warn on pull).
+
 ## [2.48.0] - 2026-06-19
 
 ### Added

--- a/core/__tests__/sync/entity-handlers.test.ts
+++ b/core/__tests__/sync/entity-handlers.test.ts
@@ -37,7 +37,16 @@ describe('entity-handlers registry', () => {
 
   test('exposes the canonical entity_types as keys', () => {
     expect(SUPPORTED_ENTITY_TYPES.sort()).toEqual(
-      ['ideas', 'memories', 'queue_tasks', 'shipped_features', 'shipped_items', 'tasks'].sort()
+      [
+        'custom_workflows',
+        'ideas',
+        'memories',
+        'queue_tasks',
+        'shipped_features',
+        'shipped_items',
+        'tasks',
+        'workflow_rules',
+      ].sort()
     )
     for (const type of SUPPORTED_ENTITY_TYPES) {
       expect(entityHandlers[type]).toBeDefined()

--- a/core/__tests__/sync/entity-map.test.ts
+++ b/core/__tests__/sync/entity-map.test.ts
@@ -55,7 +55,9 @@ describe('isTableIncluded', () => {
     expect(isTableIncluded('subtasks')).toBe(true)
     expect(isTableIncluded('queue_tasks')).toBe(true)
     expect(isTableIncluded('custom_workflows')).toBe(true)
-    expect(isTableIncluded('metrics_daily')).toBe(true)
+    // metrics + archives have no round-trip yet → opt-in (off by default).
+    expect(isTableIncluded('metrics_daily')).toBe(false)
+    expect(isTableIncluded('archives')).toBe(false)
     expect(DEFAULT_INCLUDE.user_prompts).toBe(false)
     expect(DEFAULT_INCLUDE.agent_sessions).toBe(false)
     expect(DEFAULT_INCLUDE.analysis).toBe(false)

--- a/core/__tests__/sync/sync-manager-unknown-entity.test.ts
+++ b/core/__tests__/sync/sync-manager-unknown-entity.test.ts
@@ -154,11 +154,19 @@ describe('exhaustiveness: every wire entity_type is categorized', () => {
     // job is to FAIL when a new entry is added — that's the trigger
     // for someone to register a handler or list it as unknown.
     const wireEntityTypes = [
+      'memories',
       'tasks',
+      'subtasks',
       'ideas',
       'roadmap_features',
       'shipped_items',
+      'shipped_features',
       'queue_tasks',
+      'custom_workflows',
+      'workflow_rules',
+      'archives',
+      'metrics_daily',
+      'velocity_sprints',
       'projects',
       'sessions',
       'agents',

--- a/core/__tests__/sync/workflow-handlers.test.ts
+++ b/core/__tests__/sync/workflow-handlers.test.ts
@@ -1,0 +1,140 @@
+/**
+ * custom_workflows + workflow_rules pull handlers — completing the workflows
+ * group round-trip. custom_workflows keys by name (stable across machines);
+ * workflow_rules mirrors by source id (INSERT OR REPLACE). Neither echoes.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import prjctDb from '../../storage/database'
+import { syncPendingStorage } from '../../storage/sync-pending-storage'
+import { customWorkflowsHandler } from '../../sync/entity-handlers/custom-workflows'
+import { workflowRulesHandler } from '../../sync/entity-handlers/workflow-rules'
+
+let tempDir: string
+let originalProjectsDir: string | undefined
+let projectId: string
+
+describe('workflow entity handlers', () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-wf-handler-'))
+    originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+    process.env.PRJCT_PROJECTS_DIR = tempDir
+    projectId = `wf-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+  })
+
+  afterEach(async () => {
+    if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+    else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('custom_workflows upserts by name (insert then update, no dupe)', async () => {
+    await customWorkflowsHandler.upsert(projectId, {
+      id: 9,
+      name: 'deploy',
+      description: 'ship it',
+      metadata: { steps: 2 },
+      enabled: 1,
+      is_builtin: 0,
+    })
+    await customWorkflowsHandler.upsert(projectId, {
+      id: 99, // different source id, same name → still one row
+      name: 'deploy',
+      description: 'ship it (v2)',
+      enabled: 1,
+      is_builtin: 0,
+    })
+
+    const rows = prjctDb.query<{ name: string; description: string }>(
+      projectId,
+      'SELECT name, description FROM custom_workflows WHERE name = ?',
+      'deploy'
+    )
+    expect(rows.length).toBe(1)
+    expect(rows[0].description).toBe('ship it (v2)')
+  })
+
+  test('custom_workflows delete soft-disables', async () => {
+    await customWorkflowsHandler.upsert(projectId, { name: 'temp', enabled: 1, is_builtin: 0 })
+    await customWorkflowsHandler.delete(projectId, { name: 'temp' })
+    const row = prjctDb.get<{ enabled: number }>(
+      projectId,
+      'SELECT enabled FROM custom_workflows WHERE name = ?',
+      'temp'
+    )
+    expect(row?.enabled).toBe(0)
+  })
+
+  test('custom_workflows handler does not echo to the sync queue', async () => {
+    const before = syncPendingStorage.list(projectId).length
+    await customWorkflowsHandler.upsert(projectId, { name: 'noecho', enabled: 1, is_builtin: 0 })
+    expect(syncPendingStorage.list(projectId).length).toBe(before)
+  })
+
+  test('workflow_rules upserts by explicit id (replace on re-apply)', async () => {
+    await workflowRulesHandler.upsert(projectId, {
+      id: 42,
+      type: 'gate',
+      command: 'ship',
+      position: 'before',
+      action: 'run tests',
+      enabled: 1,
+      timeout_ms: 5000,
+      sort_order: 0,
+    })
+    await workflowRulesHandler.upsert(projectId, {
+      id: 42,
+      type: 'gate',
+      command: 'ship',
+      position: 'before',
+      action: 'run tests AND lint',
+      enabled: 1,
+      timeout_ms: 5000,
+      sort_order: 0,
+    })
+
+    const rows = prjctDb.query<{ id: number; action: string }>(
+      projectId,
+      'SELECT id, action FROM workflow_rules WHERE id = ?',
+      42
+    )
+    expect(rows.length).toBe(1)
+    expect(rows[0].action).toBe('run tests AND lint')
+  })
+
+  test('workflow_rules delete removes by id', async () => {
+    await workflowRulesHandler.upsert(projectId, {
+      id: 7,
+      type: 'step',
+      command: 'task',
+      position: 'after',
+      action: 'note',
+    })
+    await workflowRulesHandler.delete(projectId, { id: 7 })
+    const row = prjctDb.get<{ id: number }>(
+      projectId,
+      'SELECT id FROM workflow_rules WHERE id = ?',
+      7
+    )
+    expect(row).toBeNull()
+  })
+
+  test('ignores malformed events (missing name / id)', async () => {
+    const cw = () =>
+      prjctDb.get<{ c: number }>(projectId, 'SELECT COUNT(*) c FROM custom_workflows')?.c ?? 0
+    const wr = () =>
+      prjctDb.get<{ c: number }>(projectId, 'SELECT COUNT(*) c FROM workflow_rules')?.c ?? 0
+    const beforeCw = cw()
+    const beforeWr = wr()
+
+    await customWorkflowsHandler.upsert(projectId, { description: 'no name' })
+    await workflowRulesHandler.upsert(projectId, { type: 'step' }) // no id
+
+    expect(cw()).toBe(beforeCw)
+    expect(wr()).toBe(beforeWr)
+  })
+})

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -156,6 +156,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '| "what did we accomplish?" | `prjct retro 7d --md` | 1 |',
     '| pause / resume the working context | `prjct context-save` / `prjct context-restore --md` | 1 |',
     '| reduce over-engineering — "make it leaner" / YAGNI review / cut complexity | `prjct lean review` (or `audit` / `debt`) | 1 |',
+    '| sync this project across machines / "share with my other machine" / "is cloud on?" | `prjct cloud link` (then `status` / `sync` / `pull` / `pause`) | 2 |',
     '',
     'Disambiguators: the "why" separates a `decision` from an `inbox` dump — if you can\'t state it in one line, capture as inbox. A bare "fix X" is `task`, never `spec`. `audit-spec` requires an existing spec. For `ship`, if the active task has a `linked_spec_id`, ship surfaces the spec\'s acceptance_criteria as a PR checklist — STOP on any unmet criterion (override: `prjct ship --no-spec-gate`).',
     '',

--- a/core/sync/entity-handlers/custom-workflows.ts
+++ b/core/sync/entity-handlers/custom-workflows.ts
@@ -1,0 +1,80 @@
+/**
+ * Custom-workflows entity handler — applies a pulled `custom_workflows` event.
+ *
+ * Identity is the workflow `name` (unique, human-chosen), NOT the local
+ * autoincrement id which differs per machine. Built-in workflows
+ * (task/done/ship/sync) are never touched. Writes directly to the table —
+ * no `customWorkflowStorage` call, which would re-publish and echo.
+ */
+
+import prjctDb from '../../storage/database'
+import type { ApplyData, EntityHandler } from './types'
+
+export const customWorkflowsHandler: EntityHandler = {
+  async upsert(projectId, data) {
+    const name = (data.name as string) || ''
+    if (!name) return
+
+    const description = (data.description as string) ?? null
+    const metadata = serializeMetadata(data.metadata)
+    const enabled = data.enabled === 0 ? 0 : 1
+    const isBuiltin = data.is_builtin === 1 ? 1 : 0
+    const now = new Date().toISOString()
+
+    const existing = prjctDb.get<{ id: number; is_builtin: number }>(
+      projectId,
+      'SELECT id, is_builtin FROM custom_workflows WHERE name = ?',
+      name
+    )
+
+    if (existing) {
+      // Never overwrite a built-in definition.
+      if (existing.is_builtin === 1) return
+      prjctDb.run(
+        projectId,
+        'UPDATE custom_workflows SET description = ?, metadata = ?, enabled = ?, updated_at = ? WHERE name = ? AND is_builtin = 0',
+        description,
+        metadata,
+        enabled,
+        now,
+        name
+      )
+      return
+    }
+
+    prjctDb.run(
+      projectId,
+      `INSERT INTO custom_workflows (name, description, created_at, updated_at, is_builtin, enabled, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      name,
+      description,
+      (data.created_at as string) || now,
+      now,
+      isBuiltin,
+      enabled,
+      metadata
+    )
+  },
+
+  async delete(projectId, data) {
+    const name = (data.name as string) || ''
+    if (!name) return
+    // Soft delete (matches customWorkflowStorage.deleteWorkflow); never builtins.
+    prjctDb.run(
+      projectId,
+      'UPDATE custom_workflows SET enabled = 0 WHERE name = ? AND is_builtin = 0',
+      name
+    )
+  },
+}
+
+/** metadata arrives as an object (round-tripped) or null; store as JSON text. */
+function serializeMetadata(value: ApplyData['metadata']): string | null {
+  if (value == null) return null
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return null
+  }
+}

--- a/core/sync/entity-handlers/index.ts
+++ b/core/sync/entity-handlers/index.ts
@@ -11,12 +11,14 @@
  * is generic over the registry.
  */
 
+import { customWorkflowsHandler } from './custom-workflows'
 import { ideasHandler } from './ideas'
 import { memoriesHandler } from './memories'
 import { queueTasksHandler } from './queue-tasks'
 import { shippedHandler } from './shipped'
 import { tasksHandler } from './tasks'
 import type { EntityHandler } from './types'
+import { workflowRulesHandler } from './workflow-rules'
 
 /**
  * Map of canonical `entity_type` → handler. The keys mirror the
@@ -29,6 +31,8 @@ export const entityHandlers: Record<string, EntityHandler> = {
   queue_tasks: queueTasksHandler,
   shipped_items: shippedHandler,
   shipped_features: shippedHandler,
+  custom_workflows: customWorkflowsHandler,
+  workflow_rules: workflowRulesHandler,
 }
 
 /** Read-only list of supported entity types — useful for telemetry. */
@@ -52,6 +56,15 @@ export const UNKNOWN_ENTITY_TYPES: ReadonlySet<string> = new Set([
   'projects',
   'sessions',
   'agents',
+  // Pushed by a producer but intentionally not applied locally yet:
+  //  - archives: the wire payload omits `entity_data` (lossy); default-off.
+  //  - subtasks / metrics_daily / velocity_sprints: no producer emits them
+  //    today, but they're in the canonical table map — list them so the
+  //    exhaustiveness test treats them as known-skipped, not a missed handler.
+  'archives',
+  'subtasks',
+  'metrics_daily',
+  'velocity_sprints',
 ])
 
 export type { EntityHandler } from './types'

--- a/core/sync/entity-handlers/workflow-rules.ts
+++ b/core/sync/entity-handlers/workflow-rules.ts
@@ -1,0 +1,49 @@
+/**
+ * Workflow-rules entity handler — applies a pulled `workflow_rules` event
+ * (the hooks/gates/steps that belong to a custom workflow).
+ *
+ * These rows have an autoincrement id with no natural key, so we mirror by
+ * the source id via `INSERT OR REPLACE` — exactly the upsert-by-id model the
+ * cloud spec defines (the server preserves the CLI's id). Last-write-wins is
+ * the accepted v1 conflict policy; two machines creating distinct rules
+ * offline could collide on an id (rare, low-churn config) — documented
+ * limitation, resolved later by a stable-id migration. Writes directly (no
+ * `workflowRuleStorage` call → no echo).
+ */
+
+import prjctDb from '../../storage/database'
+import type { EntityHandler } from './types'
+
+export const workflowRulesHandler: EntityHandler = {
+  async upsert(projectId, data) {
+    const id = Number(data.id)
+    if (!Number.isFinite(id) || id <= 0) return
+
+    prjctDb.run(
+      projectId,
+      `INSERT OR REPLACE INTO workflow_rules
+         (id, type, command, position, action, description, enabled, timeout_ms,
+          created_at, sort_order, when_expr, parallel, trust_source)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      id,
+      (data.type as string) || 'step',
+      (data.command as string) || '',
+      (data.position as string) || '',
+      (data.action as string) || '',
+      (data.description as string) ?? null,
+      data.enabled === 0 ? 0 : 1,
+      typeof data.timeout_ms === 'number' ? data.timeout_ms : 0,
+      (data.created_at as string) || new Date().toISOString(),
+      typeof data.sort_order === 'number' ? data.sort_order : 0,
+      (data.when_expr as string) ?? null,
+      data.parallel === 0 ? 0 : 1,
+      (data.trust_source as string) || 'imported'
+    )
+  },
+
+  async delete(projectId, data) {
+    const id = Number(data.id)
+    if (!Number.isFinite(id) || id <= 0) return
+    prjctDb.run(projectId, 'DELETE FROM workflow_rules WHERE id = ?', id)
+  },
+}

--- a/core/sync/entity-map.ts
+++ b/core/sync/entity-map.ts
@@ -103,8 +103,11 @@ export const DEFAULT_INCLUDE: Record<IncludeGroup, boolean> = {
   ideas: true,
   shipped: true,
   workflows: true,
-  metrics: true,
-  archives: true,
+  // `metrics` has no producer yet and `archives` syncs a lossy summary with
+  // no local apply handler — keep both off by default (opt-in) so we don't
+  // push data nothing consumes. Flip on once they round-trip.
+  metrics: false,
+  archives: false,
   user_prompts: false,
   agent_sessions: false,
   analysis: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.48.0",
+  "version": "2.49.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

PR-3 (hardening) of cloud sync: completes the **workflows** round-trip and tightens the include defaults to only push what actually round-trips.

## Added

- **`custom_workflows` pull handler** — keyed by the stable workflow **`name`** (the local autoincrement id differs per machine). Never overwrites built-ins (task/done/ship/sync). Writes directly to the table — no echo.
- **`workflow_rules` pull handler** — mirrors by **source id** via `INSERT OR REPLACE`, matching the cloud's upsert-by-id model. So a workflow's hooks/gates/steps sync alongside its definition. (LWW is the accepted v1 conflict policy; concurrent offline rule-creates could collide on an id — documented, resolved later by a stable-id migration.)
- **Skill pointer**: a one-line `prjct cloud` row in the generated verb map so agents surface it.

## Changed

- **`metrics` + `archives` now default OFF** (opt-in). Neither round-trips yet — `metrics` has no producer, `archives` ships a lossy summary (no `entity_data`) with no apply handler — so we don't push data nothing consumes. `archives`/`subtasks`/`metrics_daily`/`velocity_sprints` are marked known-skipped, so a pull no longer logs "no local handler".

## Coverage now

Round-trips end-to-end: **memories, tasks, ideas, queue, shipped, custom_workflows, workflow_rules**. Opt-in / future: metrics, archives, subtasks, user_prompts, agent_sessions, analysis.

## Verification

- `bun run check` · `bun run typecheck` · `bun run build` — clean
- `bun test` — **1636 pass, 0 fail** (+ workflow-handler round-trip tests; exhaustiveness + defaults updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)