### PR TITLE
fix: prjct login targets the cloud web SPA's /auth/cli flow (v2.49.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.49.1] - 2026-06-20
+
+### Fixed
+- **`prjct login` now targets the prjct cloud web app's device-authorization flow.** It opens the SPA's `/auth/cli?port=…&device_id=…&hostname=…` route (was the old `/login?redirect=/api/auth/cli-login` shape) and passes this machine's stable `deviceId` + `hostname`, so the key the web mints is bound to the same device id the CLI later sends as `X-Device-Id` — no "device mismatch" rejection on first sync. Default web URL is now `http://localhost:5173` (the web SPA); override with `--url` or `PRJCT_WEB_URL`.
+
 ## [2.49.0] - 2026-06-20
 
 ### Added

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -137,7 +137,7 @@ export class SetupCommands extends PrjctCommandsBase {
       }
     }
 
-    const webUrl = options.url || process.env.PRJCT_WEB_URL || 'http://localhost:3000'
+    const webUrl = options.url || process.env.PRJCT_WEB_URL || 'http://localhost:5173'
 
     return new Promise<CommandResult>((resolve) => {
       const server = http.createServer(async (req, res) => {
@@ -215,7 +215,17 @@ export class SetupCommands extends PrjctCommandsBase {
         }
 
         const port = addr.port
-        const loginUrl = `${webUrl}/login?redirect=${encodeURIComponent(`/api/auth/cli-login?port=${port}`)}`
+        // Open the web SPA's device-authorization route, passing THIS device's
+        // stable id + hostname so the minted key is bound to the same deviceId
+        // the CLI sends as X-Device-Id (no "device mismatch" on later sync).
+        const deviceId = await authConfig.getDeviceId()
+        const hostname = await authConfig.getHostname()
+        const loginParams = new URLSearchParams({
+          port: String(port),
+          device_id: deviceId,
+          hostname,
+        })
+        const loginUrl = `${webUrl}/auth/cli?${loginParams.toString()}`
 
         out.step(1, 3, 'Opening browser...')
         out.stop()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.49.0",
+  "version": "2.49.1",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

`prjct login` opened the old Next.js-style URL (`/login?redirect=/api/auth/cli-login`). The web is now a Vite + TanStack SPA whose device-authorization route is **`/auth/cli`**, and prjct-cli-api mints **device-scoped** keys — so the minted key must carry the same `deviceId` the CLI sends as `X-Device-Id`, or the first sync 403s with "device mismatch".

## Change

- Open `${webUrl}/auth/cli?port=&device_id=&hostname=` with this machine's stable `deviceId` + `hostname` (`authConfig.getDeviceId()/getHostname()`).
- Default `webUrl` → `http://localhost:5173` (the SPA); still overridable with `--url` / `PRJCT_WEB_URL`.
- The loopback callback contract (`/callback?key=&email=&user_id=`) is unchanged.

Closes the documented gap (`prjct-cli-api/docs/billing-integration.md` §4). The web SPA's `/auth/cli` reads these params and mints via `POST /web/devices`.

## Verify

`bun run check` · `bun run typecheck` · `bun run build` clean; **1636 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)