### PR TITLE
feat: clear subscription-required notice when cloud backup is gated (v2.49.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.49.2] - 2026-06-20
+
+### Changed
+- **Clear "subscription required" message when cloud backup is gated.** The server's 402 paid gate now reaches `prjct cloud sync`/`pull` as a dedicated, friendly notice (`💳 Cloud backup paused — subscription required`) instead of a generic "synced with errors", and it's flagged as a soft failure so local-first work continues. The message text stays server-authored — the CLI keeps zero paywall logic (a `PAYMENT_REQUIRED` code is threaded through `SyncResult`/`PushResult`/`PullResult`).
+
 ## [2.49.1] - 2026-06-20
 
 ### Fixed

--- a/core/commands/cloud.ts
+++ b/core/commands/cloud.ts
@@ -138,6 +138,8 @@ export class CloudCommands extends PrjctCommandsBase {
     try {
       const result = await syncManager.pull(config.projectId)
       if (!result.success) {
+        if (result.code === 'PAYMENT_REQUIRED')
+          return this.subscriptionRequired(result.error, options)
         return failWith(`Pull failed: ${result.error ?? 'unknown error'}`, options)
       }
       const msg = `Pulled ${result.count ?? 0} change(s) (${result.applied ?? 0} applied).`
@@ -249,6 +251,25 @@ export class CloudCommands extends PrjctCommandsBase {
     return null
   }
 
+  /**
+   * Subscription lapsed/absent — the server's 402 paid gate. The message text
+   * is authored server-side (the CLI has zero paywall logic) and surfaced here
+   * as a clear, dedicated notice rather than a generic sync error.
+   */
+  private subscriptionRequired(reason: string | undefined, options: MdOption): CommandResult {
+    const msg =
+      reason ??
+      'Cloud sync needs an active prjct subscription. Your local data is safe — only cloud backup is paused.'
+    if (options.md) {
+      console.log(mdOutput('## Subscription required', `> 💳 ${msg}`))
+    } else {
+      out.warn('Cloud backup paused — subscription required')
+      out.info(msg)
+    }
+    // Not a hard failure: local-first work continues; only cloud sync is gated.
+    return { success: false, paymentRequired: true, message: msg }
+  }
+
   /** Render a push+pull SyncResult (also used by link). */
   private reportSync(
     label: string,
@@ -257,7 +278,10 @@ export class CloudCommands extends PrjctCommandsBase {
     opts?: { extra?: string }
   ): CommandResult {
     if (!result.success) {
-      // Server-side gating / errors surface verbatim (e.g. 402 upgrade text).
+      // The server's 402 paid gate gets a dedicated, friendly notice.
+      if (result.code === 'PAYMENT_REQUIRED')
+        return this.subscriptionRequired(result.error, options)
+      // Other server-side errors surface verbatim.
       return failWith(`${label} with errors: ${result.error ?? 'unknown error'}`, options)
     }
     const pushed = result.pushed?.count ?? 0

--- a/core/sync/sync-manager.ts
+++ b/core/sync/sync-manager.ts
@@ -11,6 +11,7 @@ import type {
   PullResult,
   PushResult,
   SyncBatchResult,
+  SyncErrorCode,
   SyncPullResult,
   SyncManagerResult as SyncResult,
   SyncStatus,
@@ -121,6 +122,19 @@ function errorMessage(error: unknown): string {
   return 'Unknown error'
 }
 
+/**
+ * Recover the SyncClientError `code` (e.g. PAYMENT_REQUIRED for the server's
+ * 402 paid gate) so the cloud command can show a tailored message instead of a
+ * generic error. Same caveat as errorMessage: the client rejects with a plain
+ * object, not an Error.
+ */
+function errorCode(error: unknown): SyncErrorCode | undefined {
+  if (error && typeof error === 'object' && 'code' in error) {
+    return (error as { code?: SyncErrorCode }).code
+  }
+  return undefined
+}
+
 class SyncManager {
   /**
    * Check if user is authenticated
@@ -182,6 +196,7 @@ class SyncManager {
     if (!pushResult.success || !pullResult.success) {
       result.success = false
       result.error = pushResult.error || pullResult.error
+      result.code = pushResult.code || pullResult.code
     }
 
     return result
@@ -254,6 +269,7 @@ class SyncManager {
         skipped: false,
         reason: 'error',
         error: errorMessage(error),
+        code: errorCode(error),
       }
     }
   }
@@ -329,6 +345,7 @@ class SyncManager {
         skipped: false,
         reason: 'error',
         error: errorMessage(error),
+        code: errorCode(error),
       }
     }
   }

--- a/core/types/sync.ts
+++ b/core/types/sync.ts
@@ -52,6 +52,8 @@ export interface SyncManagerResult {
     syncedAt: string
   }
   error?: string
+  /** Classified failure code (e.g. PAYMENT_REQUIRED) for tailored messaging. */
+  code?: SyncErrorCode
 }
 
 /**
@@ -64,6 +66,7 @@ export interface PushResult {
   count?: number
   syncedAt?: string
   error?: string
+  code?: SyncErrorCode
 }
 
 /**
@@ -77,6 +80,7 @@ export interface PullResult {
   applied?: number
   syncedAt?: string
   error?: string
+  code?: SyncErrorCode
 }
 
 // Sync Client Types
@@ -114,11 +118,19 @@ export interface SyncStatus {
   hasConflicts: boolean
 }
 
+/** Classified sync failure. PAYMENT_REQUIRED = the server's 402 paid gate. */
+export type SyncErrorCode =
+  | 'AUTH_REQUIRED'
+  | 'PAYMENT_REQUIRED'
+  | 'NETWORK_ERROR'
+  | 'API_ERROR'
+  | 'UNKNOWN'
+
 /**
  * Error from sync client
  */
 export interface SyncClientError {
-  code: 'AUTH_REQUIRED' | 'PAYMENT_REQUIRED' | 'NETWORK_ERROR' | 'API_ERROR' | 'UNKNOWN'
+  code: SyncErrorCode
   message: string
   status?: number
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.49.1",
+  "version": "2.49.2",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

When the server's 402 paid gate fires (an active subscription is required to push/realtime), `prjct cloud sync`/`pull` now shows a dedicated, friendly notice — **💳 Cloud backup paused — subscription required** plus the server's reactivation text — instead of a generic "synced with errors". It's a **soft** failure (`paymentRequired: true`) so local-first work continues; only cloud backup pauses.

## Why server-side stays the source of truth

The CLI is open source and could be forked, so it keeps **zero paywall logic** — enforcement is 100% in the API (`prjct-cli-api` checks `users.plan` on every push). This PR only threads the server's *classification* to the UI: `SyncClientError.code` → a shared `SyncErrorCode` reused on `SyncResult`/`PushResult`/`PullResult`, recovered in `sync-manager` and branched on in `cloud.ts`.

## Verify

`bun run check` · `bun run typecheck` · `bun run build` clean; **1636 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)