### PR TITLE
feat: desktop notifications + Pending/Next work-state (v2.53.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.53.0] - 2026-06-20
+
+### Added
+- **Desktop notifications + sharper work-state — never lose track of a background wait.** prjct now pings you (best-effort OS notification, **default on**) the moment **Claude is waiting on you** and when a **subagent finishes** — so a wait no longer hangs silently while you've tabbed away. New Claude Code hooks (`Notification`, `SubagentStop`) fire the ping with the active task + pending count; macOS (`osascript`) and Linux (`notify-send`) supported, silent elsewhere. Toggle with **`prjct notify on|off`** (`config.notify.mode`). Separately, the per-prompt "project state" block now shows a **`Pending: N · Next: "…"`** line (from the task queue) on top of the existing active-task + owner (worktree) + inbox lines — so "what's active, what's pending, who's working it" is always in view. Notifications are best-effort and `safeRun`-wrapped: they never disturb the session.
+
 ## [2.52.0] - 2026-06-20
 
 ### Added

--- a/core/__tests__/commands/notify.test.ts
+++ b/core/__tests__/commands/notify.test.ts
@@ -1,0 +1,38 @@
+/**
+ * `prjct notify` — desktop notifications toggle (default ON).
+ *
+ * Covers mode resolution (default-on; config + env override) and that `notify`
+ * is a registered verb. Mirrors the lean/tdd/sdd command test shape.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { REGISTERED_VERBS_SET } from '../../commands/verb-names'
+import { effectiveNotifyMode } from '../../utils/notify'
+
+describe('notify — mode resolution', () => {
+  it('effectiveNotifyMode: DEFAULT ON; config wins; env is the fallback', () => {
+    const saved = process.env.PRJCT_NOTIFY_MODE
+    delete process.env.PRJCT_NOTIFY_MODE
+    try {
+      // Default-on: absent config + no env → on.
+      expect(effectiveNotifyMode(null)).toBe('on')
+      expect(effectiveNotifyMode({} as never)).toBe('on')
+      // Config wins.
+      expect(effectiveNotifyMode({ notify: { mode: 'off' } } as never)).toBe('off')
+      expect(effectiveNotifyMode({ notify: { mode: 'on' } } as never)).toBe('on')
+      // Bogus config value → falls through to default-on.
+      expect(effectiveNotifyMode({ notify: { mode: 'bogus' } } as never)).toBe('on')
+      // Env fallback when config absent; config still wins over env.
+      process.env.PRJCT_NOTIFY_MODE = 'off'
+      expect(effectiveNotifyMode(null)).toBe('off')
+      expect(effectiveNotifyMode({ notify: { mode: 'on' } } as never)).toBe('on')
+    } finally {
+      if (saved === undefined) delete process.env.PRJCT_NOTIFY_MODE
+      else process.env.PRJCT_NOTIFY_MODE = saved
+    }
+  })
+
+  it('is a registered verb (so it never auto-captures to the inbox)', () => {
+    expect(REGISTERED_VERBS_SET.has('notify')).toBe(true)
+  })
+})

--- a/core/cli/bin-commands.ts
+++ b/core/cli/bin-commands.ts
@@ -407,6 +407,16 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
           await runSubagentStartHook(projectPath)
           break
         }
+        case 'subagent-stop': {
+          const { runSubagentStopHook } = await import('../hooks/subagent-stop')
+          await runSubagentStopHook(projectPath)
+          break
+        }
+        case 'notification': {
+          const { runNotificationHook } = await import('../hooks/notification')
+          await runNotificationHook(projectPath)
+          break
+        }
         case 'cwd-changed': {
           const { runCwdChangedHook } = await import('../hooks/cwd-changed')
           await runCwdChangedHook(projectPath)

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -398,6 +398,27 @@ export const COMMANDS: CommandMeta[] = [
     ],
   },
   {
+    name: 'notify',
+    group: 'optional',
+    routing: { group: 'notify', method: 'notify' },
+    optionSchema: {},
+    description: 'Desktop notifications (default on): ping on Claude-waiting + subagent-finished',
+    usage: {
+      claude: '/p:notify [on|off]',
+      terminal: 'prjct notify [on|off]',
+    },
+    params: '[on|off]',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: true,
+    isOptional: true,
+    features: [
+      'Default ON — pings when Claude is waiting or a subagent finishes',
+      'No arg → show mode + what fires',
+      'off silences OS notifications (per-prompt work-state block stays)',
+    ],
+  },
+  {
     name: 'cloud',
     group: 'optional',
     routing: { group: 'cloud', method: 'cloud' },

--- a/core/commands/notify.ts
+++ b/core/commands/notify.ts
@@ -1,0 +1,75 @@
+/**
+ * `prjct notify` — desktop notifications toggle (default ON).
+ *
+ *   prjct notify            → show mode + what fires
+ *   prjct notify on|off     → set config.notify.mode
+ *
+ * prjct pings you (best-effort OS notification) when Claude is waiting for
+ * input and when a subagent finishes — so a wait never hangs silently. The
+ * mode resolver + the desktop-notify primitive live in `utils/notify.ts` so
+ * the cold-path hooks share them without importing this command.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import type { MdOption } from '../types/cli'
+import type { CommandResult } from '../types/commands'
+import { failHard, failWith } from '../utils/md-aware'
+import { mdOutput } from '../utils/md-formatter'
+import { effectiveNotifyMode, NOTIFY_MODES, type NotifyMode } from '../utils/notify'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+export class NotifyCommands extends PrjctCommandsBase {
+  async notify(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: MdOption = {}
+  ): Promise<CommandResult> {
+    const sub = (input ?? '').trim().toLowerCase().split(/\s+/).filter(Boolean)[0] ?? ''
+    if (!sub || sub === 'status' || sub === 'show') return this.showStatus(projectPath, options)
+    if ((NOTIFY_MODES as readonly string[]).includes(sub)) {
+      return this.setMode(sub as NotifyMode, projectPath, options)
+    }
+    return failWith(`Unknown notify subcommand "${sub}". Use: ${NOTIFY_MODES.join('|')}.`, options)
+  }
+
+  private async showStatus(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const config = await configManager.readConfig(projectPath).catch(() => null)
+    if (!config?.projectId)
+      return failHard('No prjct project here — run `prjct init` first.', options)
+
+    const mode = effectiveNotifyMode(config)
+    const summary = [
+      `Mode: ${mode}${mode === 'on' ? ' (default)' : ''}`,
+      'Fires on: Claude waiting for input · a subagent finishing',
+      'Set: prjct notify on|off',
+    ]
+    if (options.md) {
+      console.log(mdOutput('## Notify', `> **Mode**: \`${mode}\``, summary.slice(1).join('\n')))
+    } else {
+      out.info(`Notify — ${summary.join('\n  ')}`)
+    }
+    return { success: true, mode }
+  }
+
+  private async setMode(
+    mode: NotifyMode,
+    projectPath: string,
+    options: MdOption
+  ): Promise<CommandResult> {
+    const config = await configManager.readConfig(projectPath).catch(() => null)
+    if (!config?.projectId)
+      return failHard('No prjct project here — run `prjct init` first.', options)
+
+    config.notify = { mode }
+    await configManager.writeConfig(projectPath, config)
+
+    const msg =
+      mode === 'on'
+        ? 'Desktop notifications ON — pings on Claude-waiting + subagent-finished.'
+        : 'Desktop notifications OFF — silenced (the per-prompt work-state block stays).'
+    if (options.md) console.log(mdOutput('## Notify', `> ${msg}`))
+    else out.done(msg)
+    return { success: true, mode }
+  }
+}

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -71,6 +71,7 @@ export const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = 
   cloud: lazy(async () => new (await import('./cloud')).CloudCommands()),
   tdd: lazy(async () => new (await import('./tdd')).TddCommands()),
   sdd: lazy(async () => new (await import('./sdd')).SddCommands()),
+  notify: lazy(async () => new (await import('./notify')).NotifyCommands()),
 }
 
 function registerCategories(): void {

--- a/core/hooks/notification.ts
+++ b/core/hooks/notification.ts
@@ -1,0 +1,39 @@
+/**
+ * Notification hook — Claude is waiting for the user (input or permission).
+ * Fire a best-effort desktop notification so a wait never hangs silently.
+ *
+ * Side-effect only: it emits no context (returns null → `{}`), it just pings.
+ * Gated by config.notify (default on). Best-effort + safeRun — never disturbs
+ * the session.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { collectActiveTasks } from '../services/task-overview'
+import { effectiveNotifyMode, notifyDesktop } from '../utils/notify'
+import { type HookIo, runHook } from './_runner'
+
+export function runNotificationHook(
+  projectPath: string = process.cwd(),
+  io?: HookIo
+): Promise<void> {
+  return runHook(
+    {
+      event: 'Notification',
+      projectPath,
+      build: async (_input, p) => {
+        const config = await configManager.readConfig(p).catch(() => null)
+        if (!config?.projectId || effectiveNotifyMode(config) === 'off') return null
+        let detail = 'Waiting for your input'
+        try {
+          const overview = await collectActiveTasks(config.projectId, p)
+          if (overview.current) detail = `Waiting — active: ${overview.current.description}`
+        } catch {
+          /* best-effort */
+        }
+        await notifyDesktop('prjct — Claude needs you', detail)
+        return null
+      },
+    },
+    io
+  )
+}

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -27,6 +27,7 @@ import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
 import { collectActiveTasks } from '../services/task-overview'
 import { recordSurfacedForActiveTask } from '../services/usefulness/surface-attribution'
+import { queueStorage } from '../storage/queue-storage'
 import { shippedStorage } from '../storage/shipped-storage'
 import type { LocalConfig } from '../types/config'
 import { execFileAsync } from '../utils/exec'
@@ -75,6 +76,19 @@ export async function buildProjectState(
     const others = overview.all.filter((v) => !v.isCurrent)
     if (others.length > 0) {
       lines.push(`- ${others.length} task(s) active in other workspace(s)`)
+      hasContent = true
+    }
+  } catch {
+    /* best-effort */
+  }
+
+  // Queue — what's pending + what's next, so "what's left / what's next" is
+  // always visible without asking. Active-section tasks only; backlog stays
+  // quiet. Omitted when the queue is empty (no noise).
+  try {
+    const pending = await queueStorage.getActiveTasks(config.projectId)
+    if (pending.length > 0) {
+      lines.push(`- Pending: ${pending.length} · Next: "${pending[0]!.description}"`)
       hasContent = true
     }
   } catch {

--- a/core/hooks/registry.ts
+++ b/core/hooks/registry.ts
@@ -14,6 +14,7 @@
 
 import type { HookIo } from './_runner'
 import { runCwdChangedHook } from './cwd-changed'
+import { runNotificationHook } from './notification'
 import { runPostEditHook } from './post-edit'
 import { runPreCommitHook } from './pre-commit'
 import { runPreEditHook } from './pre-edit'
@@ -21,6 +22,7 @@ import { runPromptHook } from './prompt'
 import { runSessionStartHook } from './session-start'
 import { runStopHook } from './stop'
 import { runSubagentStartHook } from './subagent-start'
+import { runSubagentStopHook } from './subagent-stop'
 
 /** A hook runner: runs the hook for `projectPath`. With `io` it runs in
  *  daemon (warm) mode; without, in process (cold) mode. */
@@ -34,6 +36,8 @@ export const HOOK_RUNNERS: Record<string, HookRunner> = {
   'post-edit': runPostEditHook,
   stop: runStopHook,
   'subagent-start': runSubagentStartHook,
+  'subagent-stop': runSubagentStopHook,
+  notification: runNotificationHook,
   'cwd-changed': runCwdChangedHook,
 }
 

--- a/core/hooks/subagent-stop.ts
+++ b/core/hooks/subagent-stop.ts
@@ -1,0 +1,46 @@
+/**
+ * SubagentStop hook — a subagent (Task tool) just finished. Fire a best-effort
+ * desktop notification so the user, who may have tabbed away during the wait,
+ * learns it's done and sees what's still active + pending.
+ *
+ * Side-effect only (returns null → `{}`). Gated by config.notify (default on).
+ * Best-effort + safeRun — never disturbs the session.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { collectActiveTasks } from '../services/task-overview'
+import { queueStorage } from '../storage/queue-storage'
+import { effectiveNotifyMode, notifyDesktop } from '../utils/notify'
+import { type HookIo, runHook } from './_runner'
+
+export function runSubagentStopHook(
+  projectPath: string = process.cwd(),
+  io?: HookIo
+): Promise<void> {
+  return runHook(
+    {
+      event: 'SubagentStop',
+      projectPath,
+      build: async (_input, p) => {
+        const config = await configManager.readConfig(p).catch(() => null)
+        if (!config?.projectId || effectiveNotifyMode(config) === 'off') return null
+        const bits: string[] = []
+        try {
+          const overview = await collectActiveTasks(config.projectId, p)
+          if (overview.current) bits.push(`active: ${overview.current.description}`)
+        } catch {
+          /* best-effort */
+        }
+        try {
+          const pending = await queueStorage.getActiveTasks(config.projectId)
+          if (pending.length > 0) bits.push(`pending: ${pending.length}`)
+        } catch {
+          /* best-effort */
+        }
+        await notifyDesktop('prjct — subagent finished', bits.join(' · ') || 'A subagent finished')
+        return null
+      },
+    },
+    io
+  )
+}

--- a/core/services/settings-installer.ts
+++ b/core/services/settings-installer.ts
@@ -46,6 +46,11 @@ export const PRJCT_HOOKS = [
   { event: 'PostToolUse', matcher: 'Edit|Write', subcommand: 'post-edit' },
   { event: 'Stop', matcher: '', subcommand: 'stop' },
   { event: 'SubagentStart', matcher: '', subcommand: 'subagent-start' },
+  // Ping the user (best-effort OS notification, default on) when a subagent
+  // finishes or Claude is waiting on them — so a background wait never hangs
+  // silently. Gated by config.notify; the handler no-ops when off.
+  { event: 'SubagentStop', matcher: '', subcommand: 'subagent-stop' },
+  { event: 'Notification', matcher: '', subcommand: 'notification' },
   { event: 'CwdChanged', matcher: '', subcommand: 'cwd-changed' },
 ] as const
 

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -171,6 +171,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '| reduce over-engineering — "make it leaner" / YAGNI review / cut complexity | `prjct lean review` (or `audit` / `debt`) | 1 |',
     '| enforce test-first / "use TDD" / run the tests before shipping | `prjct tdd` (off\\|assist\\|strict; `check` runs the test command) | 1 |',
     '| enforce spec-first / "use SDD" / "require a spec for every task" | `prjct sdd` (off\\|advisory\\|strict) | 1 |',
+    '| "notify me" / "stop the silent waits" / mute the pings | `prjct notify` (on\\|off; default on — pings on Claude-waiting + subagent-finished) | 1 |',
     '| sync this project across machines / "share with my other machine" / "is cloud on?" | `prjct cloud link` (then `status` / `sync` / `pull` / `pause`) | 2 |',
     '',
     'Disambiguators: the "why" separates a `decision` from an `inbox` dump — if you can\'t state it in one line, capture as inbox. A bare "fix X" is `task`, never `spec`. `audit-spec` requires an existing spec. For `ship`, if the active task has a `linked_spec_id`, ship surfaces the spec\'s acceptance_criteria as a PR checklist — STOP on any unmet criterion (override: `prjct ship --no-spec-gate`).',

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -351,6 +351,7 @@ export type CommandRoutingGroup =
   | 'cloud'
   | 'tdd'
   | 'sdd'
+  | 'notify'
 
 export interface CommandRouting {
   /** Which command-group instance owns the handler. */

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -96,6 +96,14 @@ export interface LocalConfig {
    */
   sdd?: { mode: 'off' | 'advisory' | 'strict' }
   /**
+   * Desktop notifications. **Default ON** (absent / `on`) — prjct pings you
+   * when Claude is waiting for input and when a subagent finishes, so a wait
+   * never hangs silently. `off` (via `prjct notify off`) silences the OS
+   * notifications (the per-prompt work-state block is unaffected). Best-effort:
+   * silent if the OS has no notifier. Resolved by `effectiveNotifyMode`.
+   */
+  notify?: { mode: 'on' | 'off' }
+  /**
    * Override for the Obsidian-compatible wiki vault location.
    * - Absolute path (e.g. "/Users/jj/Documents/prjct/my-app")
    * - Or tilde-prefixed ("~/Documents/prjct/my-app")

--- a/core/utils/notify.ts
+++ b/core/utils/notify.ts
@@ -1,0 +1,52 @@
+/**
+ * Desktop notifications + notify-mode resolution.
+ *
+ * The mode resolver lives here (not in the `notify` command) so the cold-path
+ * hooks can import it without pulling a command module's deps — keeping hook
+ * startup cheap. `notifyDesktop` is strictly best-effort: a missing notifier,
+ * a sandbox denial, or an unsupported platform must NEVER surface — a
+ * notification is a nicety, never a reason to disturb a hook or a command.
+ */
+
+import type { LocalConfig } from '../types/config'
+import { execFileAsync } from './exec'
+
+export type NotifyMode = 'on' | 'off'
+export const NOTIFY_MODES: readonly NotifyMode[] = ['on', 'off']
+
+/** Default-ON: config wins, then `PRJCT_NOTIFY_MODE`, else `on`. */
+export function effectiveNotifyMode(config: LocalConfig | null): NotifyMode {
+  const fromConfig = config?.notify?.mode
+  if (fromConfig === 'on' || fromConfig === 'off') return fromConfig
+  const fromEnv = process.env.PRJCT_NOTIFY_MODE?.toLowerCase()
+  if (fromEnv === 'on' || fromEnv === 'off') return fromEnv
+  return 'on'
+}
+
+/** Strip what would break the osascript string literal + clamp length. */
+function sanitize(s: string): string {
+  return s
+    .replace(/["\\]/g, '')
+    .replace(/[\r\n]+/g, ' ')
+    .trim()
+    .slice(0, 180)
+}
+
+/**
+ * Fire a best-effort OS desktop notification. macOS → `osascript`, Linux →
+ * `notify-send`, anything else → no-op. Never throws.
+ */
+export async function notifyDesktop(title: string, message: string): Promise<void> {
+  try {
+    const t = sanitize(title) || 'prjct'
+    const m = sanitize(message)
+    if (process.platform === 'darwin') {
+      await execFileAsync('osascript', ['-e', `display notification "${m}" with title "${t}"`])
+    } else if (process.platform === 'linux') {
+      await execFileAsync('notify-send', [t, m])
+    }
+    // Other platforms: no-op — best-effort by design.
+  } catch {
+    // Missing notifier / sandbox denial / anything — swallow. Never disturb.
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.52.0",
+  "version": "2.53.0",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

Stops background waits from hanging silently — prjct now **notifies** and keeps **what's active / pending / who** in view.

- **Default-on desktop notifications** via two new Claude Code hooks:
  - `Notification` → "prjct: Claude needs you" (the moment Claude waits on you).
  - `SubagentStop` → "prjct: subagent finished · active: X · pending: N".
  - macOS (`osascript`) + Linux (`notify-send`); silent elsewhere. Best-effort, `safeRun`-wrapped — never disturbs the session.
- **`prjct notify on|off`** (`config.notify.mode`, default on). Resolver lives in `core/utils/notify.ts` so the cold-path hooks share it cheaply.
- **Per-prompt "Pending: N · Next: …" line** (from the task queue), on top of the existing active-task + owner (worktree) + inbox lines — so "what's active, what's pending, who's working it" is always visible without asking.

Wired across **both** hook paths: `registry.ts` (warm/daemon) and the `bin-commands.ts` `hook` switch (cold) — the `hook-dispatcher-parity` test enforces they stay in sync.

## Why

The user kept losing track of in-flight work during waits (subagents, CI, test re-runs). prjct already knew the active task + owner; this adds the missing **notification** + **pending/next** so it's a true source of truth, for all clients. Default-on per the user's call; `prjct notify off` opts out.

## Verify

`bun run typecheck` · `bun run check` · `bun run build` clean; **1644 tests pass** (new: notify mode-resolution + registered-verb; settings-installer/hook-schema/dispatcher-parity/manifest-completeness all green).

## Caveat

prjct fires on Claude Code's own `Notification`/`SubagentStop` events; external waits the harness doesn't surface are covered by the assistant's own behavior (device push + clear pending/next at turn end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)