### PR TITLE
fix: embeddings work with OpenRouter (auto-namespace the model) (v2.53.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.53.1] - 2026-06-21
+
+### Fixed
+- **Embeddings now work with OpenRouter out of the box.** OpenRouter namespaces every model as `vendor/model`, so a bare OpenAI-style id (`text-embedding-3-small`) returned "model not found" — even though zero-config correctly auto-detected the OpenRouter base URL from an `sk-or-…` key. prjct now auto-prefixes the implied vendor (`text-embedding-3-small` → `openai/text-embedding-3-small`) whenever the base URL is OpenRouter, applied on read, on `embeddings set`, and on the wire (so existing, per-project, and global configs all resolve correctly). No-op for OpenAI / Ollama / any other base, and an already-namespaced id is left untouched. (OpenRouter *does* serve `/embeddings`; the earlier assumption it didn't was wrong.)
+
 ## [2.53.0] - 2026-06-20
 
 ### Added

--- a/core/__tests__/services/embeddings-auth.test.ts
+++ b/core/__tests__/services/embeddings-auth.test.ts
@@ -7,13 +7,14 @@
 
 import { describe, expect, test } from 'bun:test'
 import { buildEmbeddingsRequest } from '../../services/embeddings'
+import { normalizeModelForBaseUrl } from '../../services/embeddings/global'
 
 function headers(init: RequestInit): Record<string, string> {
   return init.headers as Record<string, string>
 }
 
 describe('buildEmbeddingsRequest', () => {
-  test('default: OpenAI/OpenRouter shape — Bearer on authorization', () => {
+  test('default: OpenRouter shape — Bearer auth + model namespaced to openai/', () => {
     const { url, init } = buildEmbeddingsRequest(
       'https://openrouter.ai/api/v1',
       'text-embedding-3-small',
@@ -23,10 +24,34 @@ describe('buildEmbeddingsRequest', () => {
     expect(url).toBe('https://openrouter.ai/api/v1/embeddings')
     expect(headers(init).authorization).toBe('Bearer sk-or-v1-abc')
     expect(headers(init)['content-type']).toBe('application/json')
+    // OpenRouter requires `vendor/model`; the bare id is prefixed on the wire.
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: 'openai/text-embedding-3-small',
+      input: ['hi'],
+    })
+  })
+
+  test('OpenAI base: bare model is sent as-is (no namespacing)', () => {
+    const { init } = buildEmbeddingsRequest(
+      'https://api.openai.com/v1',
+      'text-embedding-3-small',
+      ['hi'],
+      'sk-abc'
+    )
     expect(JSON.parse(init.body as string)).toEqual({
       model: 'text-embedding-3-small',
       input: ['hi'],
     })
+  })
+
+  test('OpenRouter base: an already-namespaced model is left untouched', () => {
+    const { init } = buildEmbeddingsRequest(
+      'https://openrouter.ai/api/v1',
+      'qwen/qwen3-embedding',
+      ['hi'],
+      'sk-or-v1-abc'
+    )
+    expect(JSON.parse(init.body as string).model).toBe('qwen/qwen3-embedding')
   })
 
   test('trailing slashes on baseUrl are normalized', () => {
@@ -83,5 +108,26 @@ describe('buildEmbeddingsRequest', () => {
     )
     expect(headers(init).authorization).toBeUndefined()
     expect(headers(init)['content-type']).toBe('application/json')
+  })
+})
+
+describe('normalizeModelForBaseUrl', () => {
+  test('OpenRouter + bare OpenAI id → prefixes openai/', () => {
+    expect(normalizeModelForBaseUrl('text-embedding-3-small', 'https://openrouter.ai/api/v1')).toBe(
+      'openai/text-embedding-3-small'
+    )
+  })
+  test('OpenRouter + already-namespaced id → unchanged', () => {
+    expect(
+      normalizeModelForBaseUrl('openai/text-embedding-3-large', 'https://openrouter.ai/api/v1')
+    ).toBe('openai/text-embedding-3-large')
+  })
+  test('non-OpenRouter base → unchanged', () => {
+    expect(normalizeModelForBaseUrl('text-embedding-3-small', 'https://api.openai.com/v1')).toBe(
+      'text-embedding-3-small'
+    )
+    expect(normalizeModelForBaseUrl('nomic-embed-text', 'http://localhost:11434/v1')).toBe(
+      'nomic-embed-text'
+    )
   })
 })

--- a/core/__tests__/services/embeddings-detect.test.ts
+++ b/core/__tests__/services/embeddings-detect.test.ts
@@ -65,7 +65,9 @@ describe('setGlobalEmbeddings partial-update preservation', () => {
     setGlobalEmbeddings({ model: 'text-embedding-3-large' })
     const g = resolveGlobalEmbeddings()
     expect(g?.baseUrl).toBe('https://openrouter.ai/api/v1')
-    expect(g?.model).toBe('text-embedding-3-large')
+    // Base URL preserved across the partial set; the model is namespaced for
+    // OpenRouter (bare id → `openai/…`).
+    expect(g?.model).toBe('openai/text-embedding-3-large')
   })
 
   test('a set with neither base URL nor model on first config uses defaults', () => {

--- a/core/services/embeddings/global.ts
+++ b/core/services/embeddings/global.ts
@@ -15,6 +15,22 @@ export const DEFAULT_EMBEDDINGS_BASE_URL = 'https://api.openai.com/v1'
 export const DEFAULT_EMBEDDINGS_MODEL = 'text-embedding-3-small'
 
 /**
+ * OpenRouter namespaces EVERY model as `vendor/model`; a bare OpenAI-style id
+ * (e.g. `text-embedding-3-small`) returns "model not found" there. Prefix the
+ * implied vendor so a zero-config OpenRouter setup (`--key sk-or-…`, which
+ * auto-detects the OpenRouter base URL) just works — the user shouldn't need to
+ * know OpenRouter's namespacing. No-op for any other base URL or an
+ * already-namespaced (`vendor/…`) model. Applied on read, on set, and on the
+ * wire so old, per-project, and global configs all resolve correctly.
+ */
+export function normalizeModelForBaseUrl(model: string, baseUrl: string): string {
+  if (/openrouter\.ai/i.test(baseUrl) && model && !model.includes('/')) {
+    return `openai/${model}`
+  }
+  return model
+}
+
+/**
  * Infer the provider's base URL from an API-key prefix, so users can paste just
  * `--key` and skip `--base-url`. API keys are provider-stamped at the prefix:
  * `sk-or-…` is OpenRouter, `sk-ant-…` is Anthropic, etc. Returns undefined when
@@ -81,10 +97,11 @@ export function resolveGlobalEmbeddings(): GlobalEmbeddingsSettings | null {
   const authScheme = getConfig(K_AUTH_SCHEME)
   const authHeader = getConfig(K_AUTH_HEADER)
   const query = getConfig(K_QUERY)
+  const baseUrl = String(getConfig(K_BASE_URL) ?? DEFAULT_EMBEDDINGS_BASE_URL)
   return {
     provider: 'openai-compatible',
-    baseUrl: String(getConfig(K_BASE_URL) ?? DEFAULT_EMBEDDINGS_BASE_URL),
-    model: String(model),
+    baseUrl,
+    model: normalizeModelForBaseUrl(String(model), baseUrl),
     authHeader: authHeader != null ? String(authHeader) : undefined,
     authScheme: authScheme != null ? String(authScheme) : undefined,
     extraHeaders: parseHeaders(getConfig(K_HEADERS)),
@@ -127,7 +144,12 @@ export function setGlobalEmbeddings(opts: {
 
   const settings = resolveGlobalEmbeddings()
   // resolveGlobalEmbeddings can't be null here — we just set provider+model.
-  return settings as GlobalEmbeddingsSettings
+  // It also normalizes the model for the base URL (e.g. OpenRouter needs the
+  // `openai/` prefix); persist that so the stored config reflects what we'll
+  // actually send, instead of the bare id the user (or the default) provided.
+  const resolved = settings as GlobalEmbeddingsSettings
+  if (resolved.model !== getConfig(K_MODEL)) setConfig(K_MODEL, resolved.model)
+  return resolved
 }
 
 /** Forget the global embeddings settings (semantic falls back to local). */

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -23,7 +23,7 @@ import { isModelMemory, type MemoryEntry } from '../../memory/entries'
 import { projectMemory } from '../../memory/project-memory'
 import prjctDb from '../../storage/database'
 import type { LocalConfig } from '../../types/config'
-import { resolveGlobalEmbeddings } from './global'
+import { normalizeModelForBaseUrl, resolveGlobalEmbeddings } from './global'
 import { getEmbeddingsKey } from './secure-key'
 
 // Global BYOT config surface — re-exported so callers use one import path.
@@ -103,6 +103,10 @@ export function buildEmbeddingsRequest(
   const root = baseUrl.replace(/\/+$/, '')
   const q = auth.query?.trim().replace(/^\?/, '')
   const url = `${root}/embeddings${q ? `?${q}` : ''}`
+  // Wire-level safety net: normalize the model for the base URL (OpenRouter
+  // needs `vendor/model`), so even an older/per-project config that stored a
+  // bare id reaches OpenRouter correctly. No-op for OpenAI/Ollama/etc.
+  const wireModel = normalizeModelForBaseUrl(model, root)
 
   const headers: Record<string, string> = {
     'content-type': 'application/json',
@@ -116,7 +120,7 @@ export function buildEmbeddingsRequest(
 
   return {
     url,
-    init: { method: 'POST', headers, body: JSON.stringify({ model, input: texts }) },
+    init: { method: 'POST', headers, body: JSON.stringify({ model: wireModel, input: texts }) },
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.53.0",
+  "version": "2.53.1",
   "description": "Context layer for AI agents. Project context for Claude Code, Gemini CLI, and more.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

Embeddings silently failed against **OpenRouter**: zero-config correctly detects the OpenRouter base URL from an `sk-or-…` key, but the model was sent as a bare `text-embedding-3-small` — and OpenRouter namespaces every model as `vendor/model`, so it 404s with "model not found".

**Fix:** `normalizeModelForBaseUrl(model, baseUrl)` prefixes the implied vendor (`text-embedding-3-small` → `openai/text-embedding-3-small`) when the base is OpenRouter and the id has no `/`. Applied at **read** (`resolveGlobalEmbeddings` → status/global provider), **set** (`setGlobalEmbeddings` → clean stored config), and **wire** (`buildEmbeddingsRequest` → the guarantee for per-project & pre-existing configs). No-op for OpenAI/Ollama/any other base; an already-namespaced id is untouched.

## Note

I was wrong earlier that "OpenRouter has no embeddings" — verified its live `/embeddings` endpoint (401 = exists) and a working reference. The only gap was the model namespacing, now fixed.

## Verify

`bun run typecheck` · `bun run check` · `bun run build` clean; **1649 tests pass** (new: `normalizeModelForBaseUrl` unit + `buildEmbeddingsRequest` OpenRouter/OpenAI/already-namespaced cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)