### PR TITLE
Fix Context7 smoke check under daemon PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.57.0] - 2026-06-22
+
+### Added
+- context7 daemon path
+
 ## [2.56.0] - 2026-06-22
 
 ### Added

--- a/core/__tests__/commands/setup-mcp.test.ts
+++ b/core/__tests__/commands/setup-mcp.test.ts
@@ -3,9 +3,13 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { setupMcpServers } from '../../commands/setup/mcp'
+import { buildContext7SmokePath } from '../../services/context7-service'
 
 const TEST_MCP_PATH = path.join(os.tmpdir(), 'prjct-context7-test', 'mcp.json')
+const TEST_HOME = path.join(os.tmpdir(), 'prjct-context7-test', 'home')
 const ORIGINAL_TEST_MODE = process.env.PRJCT_TEST_MODE
+const ORIGINAL_NVM_DIR = process.env.NVM_DIR
+const ORIGINAL_FNM_DIR = process.env.FNM_DIR
 
 describe('setup MCP defaults', () => {
   beforeEach(async () => {
@@ -18,6 +22,16 @@ describe('setup MCP defaults', () => {
       delete process.env.PRJCT_TEST_MODE
     } else {
       process.env.PRJCT_TEST_MODE = ORIGINAL_TEST_MODE
+    }
+    if (ORIGINAL_NVM_DIR === undefined) {
+      delete process.env.NVM_DIR
+    } else {
+      process.env.NVM_DIR = ORIGINAL_NVM_DIR
+    }
+    if (ORIGINAL_FNM_DIR === undefined) {
+      delete process.env.FNM_DIR
+    } else {
+      process.env.FNM_DIR = ORIGINAL_FNM_DIR
     }
   })
 
@@ -34,6 +48,51 @@ describe('setup MCP defaults', () => {
     expect(config.mcpServers?.prjct?.command).toBeTruthy()
     expect(config.mcpServers?.linear).toBeUndefined()
     expect(config.mcpServers?.jira).toBeUndefined()
+  })
+
+  test('Context7 smoke PATH augments daemon-minimal PATH with common npx locations', async () => {
+    await fs.mkdir(path.join(TEST_HOME, '.nvm', 'versions', 'node', 'v24.0.0', 'bin'), {
+      recursive: true,
+    })
+    await fs.mkdir(
+      path.join(
+        TEST_HOME,
+        '.local',
+        'share',
+        'fnm',
+        'node-versions',
+        'v22.0.0',
+        'installation',
+        'bin'
+      ),
+      { recursive: true }
+    )
+
+    process.env.NVM_DIR = path.join(TEST_HOME, '.nvm')
+    process.env.FNM_DIR = path.join(TEST_HOME, '.local', 'share', 'fnm')
+
+    const smokePath = await buildContext7SmokePath('/usr/bin', TEST_HOME)
+    const dirs = smokePath.split(path.delimiter)
+
+    expect(dirs).toContain('/usr/bin')
+    expect(dirs).toContain('/opt/homebrew/bin')
+    expect(dirs).toContain('/usr/local/bin')
+    expect(dirs).toContain(path.join(TEST_HOME, '.bun', 'bin'))
+    expect(dirs).toContain(path.join(TEST_HOME, '.volta', 'bin'))
+    expect(dirs).toContain(path.join(TEST_HOME, '.nvm', 'versions', 'node', 'v24.0.0', 'bin'))
+    expect(dirs).toContain(
+      path.join(
+        TEST_HOME,
+        '.local',
+        'share',
+        'fnm',
+        'node-versions',
+        'v22.0.0',
+        'installation',
+        'bin'
+      )
+    )
+    expect(new Set(dirs).size).toBe(dirs.length)
   })
 
   test('repairs stale prjct MCP command instead of only checking presence', async () => {

--- a/core/services/context7-service.ts
+++ b/core/services/context7-service.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from 'node:fs'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -56,6 +57,25 @@ interface Context7TemplateConfig {
 const CONTEXT7_DEFAULT = MCP_SERVER_PRESETS.context7
 let cachedVerify: { at: number; status: Context7Status } | null = null
 
+const CONTEXT7_SMOKE_SYSTEM_PATH_DIRS = [
+  path.dirname(process.execPath),
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/opt/local/bin',
+  '/usr/bin',
+  '/bin',
+]
+
+const CONTEXT7_SMOKE_HOME_RELATIVE_PATH_DIRS = [
+  ['.bun', 'bin'],
+  ['.local', 'bin'],
+  ['.volta', 'bin'],
+  ['.asdf', 'shims'],
+  ['.local', 'share', 'mise', 'shims'],
+  ['.rtx', 'shims'],
+  ['.npm-global', 'bin'],
+]
+
 function parseTemplateConfig(): Context7TemplateConfig {
   const raw = getTemplateContent('mcp-config.json')
   if (!raw) return { mcpServers: { context7: CONTEXT7_DEFAULT } }
@@ -69,6 +89,84 @@ function parseTemplateConfig(): Context7TemplateConfig {
 function getContext7Config() {
   const template = parseTemplateConfig()
   return template.mcpServers?.context7 || CONTEXT7_DEFAULT
+}
+
+async function listChildDirs(parent: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(parent, { withFileTypes: true })
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name)
+  } catch {
+    return []
+  }
+}
+
+async function discoverNodeManagerBinDirs(homeDir: string): Promise<string[]> {
+  const dirs: string[] = []
+  const nvmRoot = process.env.NVM_DIR || path.join(homeDir, '.nvm')
+  const nvmVersions = path.join(nvmRoot, 'versions', 'node')
+  for (const version of await listChildDirs(nvmVersions)) {
+    dirs.push(path.join(nvmVersions, version, 'bin'))
+  }
+
+  const fnmRoot = process.env.FNM_DIR || path.join(homeDir, '.local', 'share', 'fnm')
+  const fnmVersions = path.join(fnmRoot, 'node-versions')
+  for (const version of await listChildDirs(fnmVersions)) {
+    dirs.push(path.join(fnmVersions, version, 'installation', 'bin'))
+  }
+
+  return dirs
+}
+
+export async function buildContext7SmokePath(
+  basePath: string = process.env.PATH || '',
+  homeDir: string = os.homedir()
+): Promise<string> {
+  const seen = new Set<string>()
+  const dirs: string[] = []
+  const homeDirs = CONTEXT7_SMOKE_HOME_RELATIVE_PATH_DIRS.map((segments) =>
+    path.join(homeDir, ...segments)
+  )
+  const extraDirs = [
+    ...CONTEXT7_SMOKE_SYSTEM_PATH_DIRS,
+    ...homeDirs,
+    ...(process.env.NVM_BIN ? [process.env.NVM_BIN] : []),
+    ...(process.env.VOLTA_HOME ? [path.join(process.env.VOLTA_HOME, 'bin')] : []),
+    ...(process.env.ASDF_DIR ? [path.join(process.env.ASDF_DIR, 'shims')] : []),
+    ...(process.env.MISE_DATA_DIR ? [path.join(process.env.MISE_DATA_DIR, 'shims')] : []),
+    ...(await discoverNodeManagerBinDirs(homeDir)),
+  ]
+
+  for (const raw of [...basePath.split(path.delimiter), ...extraDirs]) {
+    const dir = raw.trim()
+    if (!dir || seen.has(dir)) continue
+    seen.add(dir)
+    dirs.push(dir)
+  }
+  return dirs.join(path.delimiter)
+}
+
+async function resolveExecutable(command: string, searchPath: string): Promise<string> {
+  if (path.isAbsolute(command) || command.includes(path.sep)) return command
+
+  const extensions =
+    process.platform === 'win32'
+      ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';').filter(Boolean)
+      : ['']
+
+  for (const dir of searchPath.split(path.delimiter)) {
+    if (!dir) continue
+    for (const ext of extensions) {
+      const candidate = path.join(dir, command + ext)
+      try {
+        await fs.access(candidate, fsConstants.X_OK)
+        return candidate
+      } catch {
+        // keep searching
+      }
+    }
+  }
+
+  return command
 }
 
 function getConfigPath(): string {
@@ -94,7 +192,12 @@ async function runSmokeCheck(): Promise<void> {
 
   const cfg = getContext7Config()
   const args = [...(cfg.args || []), '--help']
-  await execFileAsync(cfg.command || 'npx', args, { timeout: 15000 })
+  const smokePath = await buildContext7SmokePath()
+  const command = await resolveExecutable(cfg.command || 'npx', smokePath)
+  await execFileAsync(command, args, {
+    timeout: 15000,
+    env: { ...process.env, PATH: smokePath },
+  })
 }
 
 class Context7Service {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary\n- Rebuild the Context7 smoke-check PATH with common system, Homebrew, Bun, Volta, asdf, mise, NVM, and FNM locations before resolving npx.\n- Resolve the smoke command before execFile and pass the rebuilt PATH to the child process.\n- Add coverage for daemon-minimal PATH reconstruction without depending on the developer machine.\n\n## Validation\n- bun test core/__tests__/commands/setup-mcp.test.ts\n- bun run typecheck\n- bun run lint\n- bun run build\n- PATH=/usr/bin smoke confirmed npx resolves through rebuilt PATH\n\nGenerated with [p/](https://www.prjct.app/)