### PR TITLE
Fix stale /p:sync guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.58.0] - 2026-06-22
+
+### Added
+- stale sync slash copy
+
 ## [2.57.0] - 2026-06-22
 
 ### Added

--- a/core/__tests__/commands/sync-copy.test.ts
+++ b/core/__tests__/commands/sync-copy.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { COMMANDS } from '../../commands/command-data'
+
+const ROOT = process.cwd()
+
+describe('sync command copy', () => {
+  test('does not suggest the removed /p:sync slash command', () => {
+    const sync = COMMANDS.find((command) => command.name === 'sync')
+    expect(sync?.usage?.claude).toBe('p. sync')
+
+    const setupSource = fs.readFileSync(path.join(ROOT, 'core', 'commands', 'setup.ts'), 'utf-8')
+    expect(setupSource).not.toContain('Run /p:sync')
+    expect(setupSource).toContain('Run p. sync')
+  })
+})

--- a/core/commands/analysis-helpers.ts
+++ b/core/commands/analysis-helpers.ts
@@ -394,11 +394,11 @@ export function generateAnalysisSummary(
   }
 
   lines.push('## Recommendations\n')
-  lines.push('Based on detected stack, consider generating specialized agents using `/p:sync`.\n')
+  lines.push('Based on detected stack, consider generating specialized agents using `p. sync`.\n')
 
   lines.push('---\n')
   lines.push(
-    '*This analysis was generated automatically. For updated information, run `/p:analyze` again.*\n'
+    '*This analysis was generated automatically. For updated information, run `p. analyze` again.*\n'
   )
 
   return lines.join('\n')

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -92,8 +92,8 @@ export class AnalysisCommands extends PrjctCommandsBase {
       console.log('✅ Analysis complete!\n')
       console.log(`📄 Full report: ${pathManager.getDisplayPath(summaryPath)}\n`)
       console.log('Next steps:')
-      console.log('• /p:sync → Generate agents based on stack')
-      console.log('• /p:feature → Add a new feature')
+      console.log('• p. sync → Generate agents based on stack')
+      console.log('• p. feature → Add a new feature')
 
       return {
         success: true,
@@ -107,7 +107,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
   }
 
   /**
-   * /p:sync - Comprehensive project sync with diff preview
+   * p. sync - Comprehensive project sync with diff preview
    *
    * Uses syncService to do ALL operations in one TypeScript execution:
    * - Git analysis

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -82,7 +82,7 @@ export const COMMANDS: CommandMeta[] = [
     group: 'core',
     routing: { group: 'analysis', method: 'sync' },
     description: 'Sync project state and update workflow agents',
-    usage: { claude: '/p:sync', terminal: 'prjct sync [--package=<name>] [--full]' },
+    usage: { claude: 'p. sync', terminal: 'prjct sync [--package=<name>] [--full]' },
     implemented: true,
     hasTemplate: true,
     requiresProject: true,

--- a/core/commands/registry.ts
+++ b/core/commands/registry.ts
@@ -365,7 +365,7 @@ class CommandRegistry {
     const projectId = await configManager.getProjectId(projectPath)
 
     if (!projectId) {
-      throw new Error('No prjct project found. Run /p:init first.')
+      throw new Error('No prjct project found. Run p. init first.')
     }
 
     return {

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -695,12 +695,12 @@ if [[ -f "$CONFIG" ]]; then
 
       # If no cliVersion or different version, show update notice
       if [[ -z "$PROJECT_VERSION" ]] || [[ "$PROJECT_VERSION" != "$CLI_VERSION" ]]; then
-        echo "⚠️ prjct v$CLI_VERSION available! Run /p:sync"
+        echo "⚠️ prjct v$CLI_VERSION available! Run p. sync"
         exit 0
       fi
     else
       # No project.json means project needs sync
-      echo "⚠️ prjct v$CLI_VERSION available! Run /p:sync"
+      echo "⚠️ prjct v$CLI_VERSION available! Run p. sync"
       exit 0
     fi
 

--- a/core/errors.ts
+++ b/core/errors.ts
@@ -32,7 +32,7 @@ export class ProjectError extends PrjctError {
   }
 
   static notInitialized(): ProjectError {
-    return new ProjectError('Project not initialized. Run /p:init first.', 'PROJECT_NOT_INIT')
+    return new ProjectError('Project not initialized. Run p. init first.', 'PROJECT_NOT_INIT')
   }
 
   static notFound(projectId: string): ProjectError {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prjct-cli",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prjct-cli",
-      "version": "2.57.0",
+      "version": "2.58.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary\n- Replace user-facing /p:sync guidance with the current conversational p. sync command.\n- Update analysis recommendations and init-not-found errors away from removed slash command copy.\n- Add regression coverage so the sync metadata and status-line source do not suggest Run /p:sync again.\n\n## Validation\n- bun test core/__tests__/commands/sync-copy.test.ts\n- bun run typecheck\n- bun run lint\n- bun run build\n\nGenerated with [p/](https://www.prjct.app/)