### PR TITLE
fix: harden platform compatibility foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,40 @@ jobs:
       - name: Run tests
         run: npm test
 
+  platform-compat:
+    name: Platform Compatibility (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [quality, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Platform-focused tests
+        run: bun test core/__tests__/daemon/protocol-platform.test.ts core/__tests__/services/hooks-scripts-platform.test.ts
+
+      - name: Build
+        run: bun run build
+
+      - name: Package launcher smoke
+        run: node bin/prjct.cjs --version
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.59.0] - 2026-06-22
+
+### Fixed
+- **Windows and Linux compatibility foundations.** Package-manager installs now use a portable Node launcher on Windows, the daemon uses named pipes on Windows and Unix sockets on macOS/Linux, Git auto-sync hooks no longer depend on Unix-only shell utilities, and CI smokes Ubuntu, macOS, and Windows.
+
 ## [2.58.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ check, logs to `~/.prjct-cli/state/auto-update.log`).
 
 Full install + upgrade paths: [INSTALL_PROMPT.md](./INSTALL_PROMPT.md).
 
+### Platform support
+
+The package-manager install path is the portable path for **macOS, Linux, and Windows**:
+
+```bash
+npm install -g prjct-cli@latest
+# or pnpm / bun / yarn global install
+```
+
+The daemon uses Unix sockets on macOS/Linux and a Windows named pipe on Windows.
+Git auto-sync hooks keep the shell wrapper POSIX-small and run rate limiting /
+background spawn through Node, so they work in Git for Windows without relying on
+Unix-only utilities like `md5sum`, `stat -f`, or `date +%s`.
+
+The standalone `curl | bash` installer remains **macOS/Linux only**. Windows
+users should use the package-manager install path. CI runs focused platform
+compatibility smoke tests on Ubuntu, macOS, and Windows.
+
 ### Zero native dependencies
 
 prjct-cli uses SQLite for local project memory through the runtime's **built-in**
@@ -449,7 +467,8 @@ Bring your own MCP — prjct-cli doesn't duplicate trackers.
 
 ```
 prjct-cli/
-  bin/prjct              Thin JS shim (daemon-first)
+  bin/prjct.cjs          Portable package-manager launcher
+  dist/bin/prjct.mjs     Thin JS shim (daemon-first)
   core/
     cli/                 CLI command handlers + dispatcher
     hooks/               7 passive Claude Code hook subcommands

--- a/bin/prjct.cjs
+++ b/bin/prjct.cjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+
+/**
+ * Portable package-manager entry point for prjct.
+ *
+ * npm/pnpm/yarn/bun generate Windows shims correctly for node shebangs, but
+ * not for the historical bin/prjct POSIX shell launcher. Keep this file tiny
+ * and dependency-free so global installs work on macOS, Linux, and Windows.
+ */
+
+const childProcess = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const SCRIPT_PATH = fs.realpathSync(__filename)
+const SCRIPT_DIR = path.dirname(SCRIPT_PATH)
+const ROOT_DIR = path.resolve(SCRIPT_DIR, '..')
+const HOME = os.homedir()
+
+function pathEntries() {
+  return (process.env.PATH || '').split(path.delimiter).filter(Boolean)
+}
+
+function executableCandidates(command) {
+  if (process.platform !== 'win32') return [command]
+  const pathext = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+    .split(';')
+    .filter(Boolean)
+    .map((ext) => ext.toLowerCase())
+  const ext = path.extname(command).toLowerCase()
+  if (ext && pathext.includes(ext)) return [command]
+  return pathext.map((candidateExt) => `${command}${candidateExt.toLowerCase()}`)
+}
+
+function findCommand(command) {
+  for (const dir of pathEntries()) {
+    for (const candidate of executableCandidates(command)) {
+      const fullPath = path.join(dir, candidate)
+      try {
+        fs.accessSync(fullPath, fs.constants.X_OK)
+        return fullPath
+      } catch {
+        /* keep searching */
+      }
+    }
+  }
+  return null
+}
+
+function nodeVersionOk() {
+  const match = process.versions.node.match(/^(\d+)\.(\d+)\./)
+  const major = Number.parseInt(match?.[1] || '0', 10)
+  const minor = Number.parseInt(match?.[2] || '0', 10)
+  return major > 22 || (major === 22 && minor >= 5)
+}
+
+function withSqliteFlag(env = process.env) {
+  const existing = env.NODE_OPTIONS || ''
+  const flag = '--experimental-sqlite'
+  return {
+    ...env,
+    NODE_OPTIONS: existing.includes(flag) ? existing : `${flag}${existing ? ` ${existing}` : ''}`,
+  }
+}
+
+function spawnAndExit(command, args, options = {}) {
+  const result = childProcess.spawnSync(command, args, {
+    stdio: 'inherit',
+    windowsHide: false,
+    ...options,
+  })
+
+  if (result.error) {
+    console.error(`Error: ${result.error.message}`)
+    process.exit(1)
+  }
+  if (result.signal) {
+    process.kill(process.pid, result.signal)
+  }
+  process.exit(result.status ?? 1)
+}
+
+function removeIfExists(filePath) {
+  try {
+    if (fs.existsSync(filePath)) fs.rmSync(filePath, { force: true })
+  } catch {
+    /* best effort */
+  }
+}
+
+function copyIfNewer(src, dest) {
+  try {
+    if (!fs.existsSync(src)) return
+    const srcStat = fs.statSync(src)
+    const destStat = fs.existsSync(dest) ? fs.statSync(dest) : null
+    if (destStat && destStat.mtimeMs >= srcStat.mtimeMs) return
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.copyFileSync(src, dest)
+  } catch {
+    /* best effort */
+  }
+}
+
+function copyDirContents(srcDir, destDir) {
+  try {
+    if (!fs.existsSync(srcDir)) return
+    fs.mkdirSync(destDir, { recursive: true })
+    for (const entry of fs.readdirSync(srcDir)) {
+      fs.copyFileSync(path.join(srcDir, entry), path.join(destDir, entry))
+    }
+  } catch {
+    /* best effort */
+  }
+}
+
+function ensureSetup() {
+  removeIfExists(path.join(HOME, '.claude', 'commands', 'p.md'))
+  removeIfExists(path.join(HOME, '.gemini', 'commands', 'p.toml'))
+
+  const statuslineSrc = path.join(ROOT_DIR, 'assets', 'statusline', 'statusline.sh')
+  const statuslineDir = path.join(HOME, '.prjct-cli', 'statusline')
+  const statuslineDest = path.join(statuslineDir, 'statusline.sh')
+  const claudeStatusline = path.join(HOME, '.claude', 'prjct-statusline.sh')
+
+  try {
+    if (fs.existsSync(statuslineSrc)) {
+      const needsCopy =
+        !fs.existsSync(statuslineDest) ||
+        fs.statSync(statuslineSrc).mtimeMs > fs.statSync(statuslineDest).mtimeMs
+      if (needsCopy) {
+        fs.mkdirSync(statuslineDir, { recursive: true })
+        fs.copyFileSync(statuslineSrc, statuslineDest)
+        fs.chmodSync(statuslineDest, 0o755)
+
+        const pkg = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf-8'))
+        if (pkg.version) {
+          const patched = fs
+            .readFileSync(statuslineDest, 'utf-8')
+            .replace(/CLI_VERSION="[^"]*"/, `CLI_VERSION="${pkg.version}"`)
+          fs.writeFileSync(statuslineDest, patched)
+        }
+
+        for (const subdir of ['lib', 'components', 'themes']) {
+          copyDirContents(
+            path.join(ROOT_DIR, 'assets', 'statusline', subdir),
+            path.join(statuslineDir, subdir)
+          )
+        }
+
+        fs.mkdirSync(path.dirname(claudeStatusline), { recursive: true })
+        removeIfExists(claudeStatusline)
+        try {
+          fs.symlinkSync(statuslineDest, claudeStatusline)
+        } catch {
+          fs.copyFileSync(statuslineDest, claudeStatusline)
+        }
+        fs.chmodSync(claudeStatusline, 0o755)
+      }
+    }
+  } catch {
+    /* best effort */
+  }
+
+  copyIfNewer(
+    path.join(ROOT_DIR, 'templates', 'skills', 'prjct', 'SKILL.md'),
+    path.join(HOME, '.claude', 'skills', 'prjct', 'SKILL.md')
+  )
+
+  if (fs.existsSync(path.join(HOME, '.codex')) || findCommand('codex')) {
+    copyIfNewer(
+      path.join(ROOT_DIR, 'templates', 'codex', 'SKILL.md'),
+      path.join(HOME, '.codex', 'skills', 'prjct', 'SKILL.md')
+    )
+  }
+}
+
+function runMcpServer(args) {
+  const mcpServer = path.join(ROOT_DIR, 'dist', 'mcp', 'server.mjs')
+  if (!fs.existsSync(mcpServer)) {
+    console.error("Error: MCP server entry point not found. Run 'npm run build' first.")
+    process.exit(1)
+  }
+  if (!nodeVersionOk()) {
+    console.error(
+      `Error: prjct MCP needs Node >=22.5 (for node:sqlite) - found Node ${process.versions.node}.`
+    )
+    process.exit(1)
+  }
+  spawnAndExit(process.execPath, [mcpServer, ...args.slice(1)], { env: withSqliteFlag() })
+}
+
+function runWithNode(args) {
+  const distBin = path.join(ROOT_DIR, 'dist', 'bin', 'prjct.mjs')
+
+  if (!fs.existsSync(distBin)) {
+    if (
+      fs.existsSync(path.join(ROOT_DIR, 'scripts', 'build.js')) &&
+      fs.existsSync(path.join(ROOT_DIR, 'core'))
+    ) {
+      console.error('Building for Node.js (first run)...')
+      const build = childProcess.spawnSync(
+        process.execPath,
+        [path.join(ROOT_DIR, 'scripts', 'build.js')],
+        {
+          cwd: ROOT_DIR,
+          stdio: 'inherit',
+        }
+      )
+      if (build.status !== 0) {
+        console.error("Error: Build failed. Run 'npm run build' manually.")
+        process.exit(build.status ?? 1)
+      }
+    } else {
+      console.error("Error: Compiled output not found. Run 'npm run build' first.")
+      process.exit(1)
+    }
+  }
+
+  if (!nodeVersionOk()) {
+    console.error(
+      `Error: prjct needs Node >=22.5 (for node:sqlite) - found Node ${process.versions.node}.`
+    )
+    console.error('  Upgrade Node (https://nodejs.org) or install Bun (https://bun.sh).')
+    process.exit(1)
+  }
+
+  spawnAndExit(process.execPath, [distBin, ...args], { env: withSqliteFlag() })
+}
+
+function runWithBun(args) {
+  if (process.platform === 'win32') return false
+  const distBin = path.join(ROOT_DIR, 'dist', 'bin', 'prjct.mjs')
+  const bun = findCommand('bun')
+  if (!bun || !fs.existsSync(distBin)) return false
+  spawnAndExit(bun, [distBin, ...args])
+  return true
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  if (args[0] === 'mcp-server') runMcpServer(args)
+
+  ensureSetup()
+
+  if (runWithBun(args)) return
+  runWithNode(args)
+}
+
+main()

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -87,8 +87,9 @@ async function readAllStdin(timeoutMs: number): Promise<string> {
 // hooks are the hottest path and need none of them.
 if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
   const fs = await import('node:fs')
-  const { DAEMON_PATHS } = await import('../core/daemon/protocol')
-  if (fs.existsSync(DAEMON_PATHS.socket())) {
+  const { DAEMON_PATHS, isDaemonNamedPipe } = await import('../core/daemon/protocol')
+  const socketPath = DAEMON_PATHS.socket()
+  if (isDaemonNamedPipe(socketPath) || fs.existsSync(socketPath)) {
     const subcommand = _fastArgs[1]
     const stdinPayload = await readAllStdin(1000)
     try {
@@ -249,10 +250,10 @@ if (
 
 if (_fastCommand && !_binCommands.has(_fastCommand) && process.env.PRJCT_NO_DAEMON !== '1') {
   const fs = await import('node:fs')
-  const { DAEMON_PATHS } = await import('../core/daemon/protocol')
+  const { DAEMON_PATHS, isDaemonNamedPipe } = await import('../core/daemon/protocol')
   const socketPath = DAEMON_PATHS.socket()
 
-  if (fs.existsSync(socketPath)) {
+  if (isDaemonNamedPipe(socketPath) || fs.existsSync(socketPath)) {
     const { sendRequest } = await import('../core/daemon/client')
     const crypto = await import('node:crypto')
 

--- a/core/__tests__/daemon/protocol-platform.test.ts
+++ b/core/__tests__/daemon/protocol-platform.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import path from 'node:path'
+import { getDaemonRunDir, getDaemonSocketPath, isDaemonNamedPipe } from '../../daemon/protocol'
+
+describe('daemon IPC platform paths', () => {
+  test('uses Unix socket paths on POSIX platforms', () => {
+    const cliHome = path.join('/tmp', 'prjct-home')
+    expect(getDaemonRunDir(cliHome)).toBe(path.join(cliHome, 'run'))
+    expect(getDaemonSocketPath('linux', cliHome)).toBe(path.join(cliHome, 'run', 'daemon.sock'))
+    expect(getDaemonSocketPath('darwin', cliHome)).toBe(path.join(cliHome, 'run', 'daemon.sock'))
+    expect(isDaemonNamedPipe(getDaemonSocketPath('linux', cliHome))).toBe(false)
+  })
+
+  test('uses a stable named pipe on Windows', () => {
+    const cliHome = 'C:\\Users\\Jane\\.prjct-cli'
+    const socketPath = getDaemonSocketPath('win32', cliHome)
+    expect(socketPath).toStartWith('\\\\.\\pipe\\prjct-')
+    expect(socketPath).toEndWith('-daemon')
+    expect(socketPath).not.toContain('daemon.sock')
+    expect(isDaemonNamedPipe(socketPath)).toBe(true)
+    expect(getDaemonSocketPath('win32', cliHome)).toBe(socketPath)
+  })
+})

--- a/core/__tests__/infrastructure/codex-skill.test.ts
+++ b/core/__tests__/infrastructure/codex-skill.test.ts
@@ -47,12 +47,12 @@ describe('codex skill size guard', () => {
 })
 
 describe('bin shim skill self-heal', () => {
-  const shim = fs.readFileSync(path.join(ROOT, 'bin/prjct'), 'utf-8')
+  const shim = fs.readFileSync(path.join(ROOT, 'bin/prjct.cjs'), 'utf-8')
 
   test('Codex destination receives the Codex template, not the Claude baseline', () => {
     // The exact regression: one loop copied templates/skills/prjct/SKILL.md
     // (the ~9.5KB Claude baseline) into BOTH ~/.claude and ~/.codex.
-    expect(shim).toContain('templates/codex/SKILL.md')
+    expect(shim).toContain("'templates', 'codex', 'SKILL.md'")
     for (const line of shim.split('\n')) {
       if (line.includes('.codex/skills')) {
         expect(line).not.toContain('templates/skills/prjct')
@@ -64,7 +64,7 @@ describe('bin shim skill self-heal', () => {
   })
 
   test('Claude destination still receives the Claude baseline', () => {
-    expect(shim).toContain('templates/skills/prjct/SKILL.md')
-    expect(shim).toContain('.claude/skills/prjct/SKILL.md')
+    expect(shim).toContain("'templates', 'skills', 'prjct', 'SKILL.md'")
+    expect(shim).toContain("'.claude', 'skills', 'prjct', 'SKILL.md'")
   })
 })

--- a/core/__tests__/services/hooks-scripts-platform.test.ts
+++ b/core/__tests__/services/hooks-scripts-platform.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { getPostCheckoutScript, getPostCommitScript } from '../../services/hooks-service/scripts'
+
+describe('git hook scripts are platform tolerant', () => {
+  test('post-commit delegates rate limit and spawn to Node', () => {
+    const script = getPostCommitScript()
+    expect(script).toContain('#!/bin/sh')
+    expect(script).toContain('# prjct:auto-sync:start')
+    expect(script).toContain('# prjct:auto-sync:end')
+    expect(script).toContain("process.platform === 'win32' ? 'prjct.cmd' : 'prjct'")
+    expect(script).toContain("['sync', '--quiet', '--yes']")
+    expect(script).toContain('detached: true')
+    expect(script).not.toContain('md5sum')
+    expect(script).not.toContain('md5 -q')
+    expect(script).not.toContain('stat -f')
+    expect(script).not.toContain('stat -c')
+    expect(script).not.toContain('date +%s')
+    expect(script).not.toContain(' >/dev/null 2>&1 &')
+  })
+
+  test('post-checkout keeps branch-change guard inside removable prjct block', () => {
+    const script = getPostCheckoutScript()
+    const start = script.indexOf('# prjct:auto-sync:start')
+    const end = script.indexOf('# prjct:auto-sync:end')
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    const managedBlock = script.slice(start, end)
+    expect(managedBlock).toContain('if [ "$3" != "1" ]; then')
+    expect(managedBlock).toContain('if [ "$1" = "$2" ]; then')
+    expect(managedBlock).toContain("['sync', '--quiet', '--yes']")
+  })
+})

--- a/core/daemon/client.ts
+++ b/core/daemon/client.ts
@@ -14,7 +14,7 @@ import { connect } from 'node:net'
 import path from 'node:path'
 import type { DaemonRequest, DaemonResponse, DaemonStatus } from '../types/daemon'
 import { isBunAvailable } from '../utils/runtime'
-import { DAEMON_PATHS, encodeMessage } from './protocol'
+import { DAEMON_PATHS, encodeMessage, isDaemonNamedPipe } from './protocol'
 
 /**
  * Check if the daemon is running (socket file exists + responds to ping)
@@ -22,8 +22,10 @@ import { DAEMON_PATHS, encodeMessage } from './protocol'
 export async function isDaemonRunning(): Promise<boolean> {
   const socketPath = DAEMON_PATHS.socket()
 
-  // Quick check: socket file exists?
-  if (!fs.existsSync(socketPath)) return false
+  const namedPipe = isDaemonNamedPipe(socketPath)
+
+  // Quick check: Unix sockets are filesystem entries; Windows named pipes are not.
+  if (!namedPipe && !fs.existsSync(socketPath)) return false
 
   // Verify: can we actually connect and get a response?
   try {
@@ -36,11 +38,13 @@ export async function isDaemonRunning(): Promise<boolean> {
     })
     return response.success
   } catch {
-    // Socket exists but daemon is dead — stale socket
-    try {
-      fs.unlinkSync(socketPath)
-    } catch {
-      /* ignore */
+    // Socket exists but daemon is dead — stale socket. Named pipes are not unlinkable files.
+    if (!namedPipe) {
+      try {
+        fs.unlinkSync(socketPath)
+      } catch {
+        /* ignore */
+      }
     }
     return false
   }
@@ -53,7 +57,9 @@ export async function getDaemonStatus(): Promise<DaemonStatus> {
   const socketPath = DAEMON_PATHS.socket()
   const pidPath = DAEMON_PATHS.pid()
 
-  if (!fs.existsSync(socketPath)) {
+  const namedPipe = isDaemonNamedPipe(socketPath)
+
+  if (!namedPipe && !fs.existsSync(socketPath)) {
     return { running: false }
   }
 
@@ -164,7 +170,9 @@ export async function executeViaDaemon(
 ): Promise<DaemonResponse | null> {
   const socketPath = DAEMON_PATHS.socket()
 
-  if (!fs.existsSync(socketPath)) {
+  const namedPipe = isDaemonNamedPipe(socketPath)
+
+  if (!namedPipe && !fs.existsSync(socketPath)) {
     if (autoStart) {
       // Spawn daemon in background for future commands
       spawnDaemon().catch(() => {})
@@ -182,6 +190,10 @@ export async function executeViaDaemon(
       perfStartNs,
     })
   } catch {
+    if (autoStart) {
+      // Named pipes need a connect attempt to discover absence; spawn for next command.
+      spawnDaemon().catch(() => {})
+    }
     return null // Daemon error — fall back
   }
 }
@@ -233,10 +245,12 @@ export function forceKillDaemon(): boolean {
   } catch {
     /* ignore */
   }
-  try {
-    if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
-  } catch {
-    /* ignore */
+  if (!isDaemonNamedPipe(socketPath)) {
+    try {
+      if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
+    } catch {
+      /* ignore */
+    }
   }
 
   return killed
@@ -262,6 +276,7 @@ export async function spawnDaemon(): Promise<boolean> {
 
   let entryPath: string
   let runtime: string
+  const preferBun = process.platform !== 'win32' && isBunAvailable()
 
   if (fs.existsSync(srcPath)) {
     // Dev mode: use raw TypeScript with bun
@@ -270,11 +285,11 @@ export async function spawnDaemon(): Promise<boolean> {
   } else if (fs.existsSync(distPathAdjacent)) {
     // Production (running from dist/): prefer bun if available
     entryPath = distPathAdjacent
-    runtime = isBunAvailable() ? 'bun' : 'node'
+    runtime = preferBun ? 'bun' : 'node'
   } else if (fs.existsSync(distPath)) {
     // Production (running from bin/): prefer bun if available
     entryPath = distPath
-    runtime = isBunAvailable() ? 'bun' : 'node'
+    runtime = preferBun ? 'bun' : 'node'
   } else {
     return false
   }

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -23,7 +23,13 @@ import prjctDb from '../storage/database'
 import { realtimeManager } from '../sync/realtime-manager'
 import type { DaemonRequest, DaemonResponse, DaemonState } from '../types/daemon'
 import { executeCommand } from './dispatch'
-import { DAEMON_PATHS, encodeMessage, IDLE_TIMEOUT_MS, MAX_BUFFER_SIZE } from './protocol'
+import {
+  DAEMON_PATHS,
+  encodeMessage,
+  IDLE_TIMEOUT_MS,
+  isDaemonNamedPipe,
+  MAX_BUFFER_SIZE,
+} from './protocol'
 import {
   decideRestart,
   isCodeStale as detectStaleCode,
@@ -71,6 +77,7 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
   const socketPath = DAEMON_PATHS.socket()
   const pidPath = DAEMON_PATHS.pid()
   const runDir = DAEMON_PATHS.runDir()
+  const namedPipe = isDaemonNamedPipe(socketPath)
 
   fs.mkdirSync(runDir, { recursive: true })
 
@@ -84,8 +91,8 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
     fs.unlinkSync(pidPath)
   }
 
-  // Clean up stale socket
-  if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
+  // Clean up stale Unix socket. Windows named pipes are not filesystem entries.
+  if (!namedPipe && fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
 
   rotateLog()
 
@@ -130,7 +137,7 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
   ipcServer = createNetServer((socket) => handleConnection(socket))
 
   ipcServer.listen(socketPath, () => {
-    fs.chmodSync(socketPath, 0o600)
+    if (!namedPipe) fs.chmodSync(socketPath, 0o600)
     fs.writeFileSync(pidPath, String(process.pid))
 
     console.log(`prjct daemon started (PID ${process.pid})`)
@@ -505,10 +512,12 @@ function shutdown(exitCode: number): void {
   const socketPath = DAEMON_PATHS.socket()
   const pidPath = DAEMON_PATHS.pid()
 
-  try {
-    if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
-  } catch {
-    /* ignore */
+  if (!isDaemonNamedPipe(socketPath)) {
+    try {
+      if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
+    } catch {
+      /* ignore */
+    }
   }
 
   try {

--- a/core/daemon/protocol.ts
+++ b/core/daemon/protocol.ts
@@ -2,28 +2,48 @@
  * Daemon IPC Protocol
  *
  * Runtime constants and codec functions for the JSON message format
- * exchanged between the thin CLI client and the daemon process
- * over a Unix socket.
+ * exchanged between the thin CLI client and the daemon process.
  *
- * Protocol: newline-delimited JSON (NDJSON) over Unix domain socket.
- * Each message is a single JSON object terminated by \n.
+ * Protocol: newline-delimited JSON (NDJSON) over a local IPC endpoint.
+ * macOS/Linux use Unix domain sockets; Windows uses a named pipe.
  */
 
+import crypto from 'node:crypto'
+import path from 'node:path'
+import { resolveCliHome } from '../infrastructure/cli-home'
 import type { DaemonRequest, DaemonResponse } from '../types/daemon'
+
+const WINDOWS_PIPE_PREFIX = '\\\\.\\pipe\\'
+
+export function getDaemonRunDir(cliHome: string = resolveCliHome()): string {
+  return path.join(cliHome, 'run')
+}
+
+export function getDaemonSocketPath(
+  platform: NodeJS.Platform = process.platform,
+  cliHome: string = resolveCliHome()
+): string {
+  if (platform === 'win32') {
+    const id = crypto.createHash('sha1').update(path.resolve(cliHome)).digest('hex').slice(0, 16)
+    return `${WINDOWS_PIPE_PREFIX}prjct-${id}-daemon`
+  }
+  return path.join(getDaemonRunDir(cliHome), 'daemon.sock')
+}
+
+export function isDaemonNamedPipe(socketPath: string = getDaemonSocketPath()): boolean {
+  return socketPath.startsWith(WINDOWS_PIPE_PREFIX)
+}
 
 /** Paths used by the daemon */
 export const DAEMON_PATHS = {
   /** Directory for runtime files */
-  runDir: () => {
-    const home = process.env.HOME || require('node:os').homedir()
-    return `${home}/.prjct-cli/run`
-  },
-  /** Unix domain socket path */
-  socket: () => `${DAEMON_PATHS.runDir()}/daemon.sock`,
+  runDir: () => getDaemonRunDir(),
+  /** Local IPC endpoint: Unix socket on POSIX, named pipe on Windows */
+  socket: () => getDaemonSocketPath(),
   /** PID file */
-  pid: () => `${DAEMON_PATHS.runDir()}/daemon.pid`,
+  pid: () => path.join(DAEMON_PATHS.runDir(), 'daemon.pid'),
   /** Log file */
-  log: () => `${DAEMON_PATHS.runDir()}/daemon.log`,
+  log: () => path.join(DAEMON_PATHS.runDir(), 'daemon.log'),
 }
 
 /** Default idle timeout before auto-shutdown (30 minutes) */

--- a/core/services/hooks-service/scripts.ts
+++ b/core/services/hooks-service/scripts.ts
@@ -1,10 +1,49 @@
 /**
  * Shell script templates for prjct git hooks.
  *
- * Both scripts include rate limiting (skip if synced within last 30s)
- * and run sync in background with output suppressed so they never
- * block a commit or branch switch.
+ * The shell wrapper stays POSIX-small so Git can execute it on macOS,
+ * Linux, and Git for Windows. Rate limiting and background spawn happen in
+ * Node to avoid platform-specific utilities like md5sum, stat, or date.
  */
+
+function getPortableSyncBody(): string {
+  return `# prjct sync --quiet --yes
+if command -v node >/dev/null 2>&1; then
+  node <<'NODE' >/dev/null 2>&1 || true
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawn } = require('node:child_process')
+
+const cwd = process.cwd()
+const key = crypto.createHash('sha1').update(cwd).digest('hex')
+const lockFile = path.join(os.tmpdir(), 'prjct-sync-' + key + '.lock')
+const now = Date.now()
+
+try {
+  const ageMs = now - fs.statSync(lockFile).mtimeMs
+  if (ageMs < 30_000) process.exit(0)
+} catch {
+  // no lock yet
+}
+
+try {
+  fs.writeFileSync(lockFile, String(now))
+} catch {
+  // best effort; sync is still allowed
+}
+
+const command = process.platform === 'win32' ? 'prjct.cmd' : 'prjct'
+const child = spawn(command, ['sync', '--quiet', '--yes'], {
+  cwd,
+  detached: true,
+  stdio: 'ignore',
+})
+child.unref()
+NODE
+fi`
+}
 
 export function getPostCommitScript(): string {
   return `#!/bin/sh
@@ -12,20 +51,9 @@ export function getPostCommitScript(): string {
 # Syncs project context after each commit
 # Installed by: prjct hooks install
 
-# Rate limit: skip if synced within last 30 seconds
-LOCK_FILE="\${TMPDIR:-/tmp}/prjct-sync-$(pwd | md5sum 2>/dev/null | cut -d' ' -f1 || md5 -q -s "$(pwd)").lock"
-if [ -f "$LOCK_FILE" ]; then
-  LOCK_AGE=$(( $(date +%s) - $(stat -f%m "$LOCK_FILE" 2>/dev/null || stat -c%Y "$LOCK_FILE" 2>/dev/null || echo 0) ))
-  if [ "$LOCK_AGE" -lt 30 ]; then
-    exit 0
-  fi
-fi
-
-# Run sync in background, suppress all output
-if command -v prjct >/dev/null 2>&1; then
-  touch "$LOCK_FILE"
-  prjct sync --quiet --yes >/dev/null 2>&1 &
-fi
+# prjct:auto-sync:start
+${getPortableSyncBody()}
+# prjct:auto-sync:end
 
 exit 0
 `
@@ -37,6 +65,7 @@ export function getPostCheckoutScript(): string {
 # Syncs project context after branch switch
 # Installed by: prjct hooks install
 
+# prjct:auto-sync:start
 # Only run on branch checkout (not file checkout)
 # $3 is the checkout type flag: 1 = branch, 0 = file
 if [ "$3" != "1" ]; then
@@ -48,20 +77,8 @@ if [ "$1" = "$2" ]; then
   exit 0
 fi
 
-# Rate limit: skip if synced within last 30 seconds
-LOCK_FILE="\${TMPDIR:-/tmp}/prjct-sync-$(pwd | md5sum 2>/dev/null | cut -d' ' -f1 || md5 -q -s "$(pwd)").lock"
-if [ -f "$LOCK_FILE" ]; then
-  LOCK_AGE=$(( $(date +%s) - $(stat -f%m "$LOCK_FILE" 2>/dev/null || stat -c%Y "$LOCK_FILE" 2>/dev/null || echo 0) ))
-  if [ "$LOCK_AGE" -lt 30 ]; then
-    exit 0
-  fi
-fi
-
-# Run sync in background, suppress all output
-if command -v prjct >/dev/null 2>&1; then
-  touch "$LOCK_FILE"
-  prjct sync --quiet --yes >/dev/null 2>&1 &
-fi
+${getPortableSyncBody()}
+# prjct:auto-sync:end
 
 exit 0
 `

--- a/core/services/hooks-service/strategies.ts
+++ b/core/services/hooks-service/strategies.ts
@@ -12,6 +12,21 @@ import type { HookName, HookStrategy } from '../../types/services/extracted'
 import { fileExists } from '../../utils/file-helper'
 import { getPostCheckoutScript, getPostCommitScript } from './scripts'
 
+function hasPrjctAutoSync(content: string): boolean {
+  return content.includes('prjct:auto-sync:start') || content.includes('prjct sync')
+}
+
+function stripPrjctAutoSync(content: string): string {
+  const withoutMarkedBlock = content.replace(
+    /\n?# prjct:auto-sync:start[\s\S]*?# prjct:auto-sync:end\n?/g,
+    '\n'
+  )
+  return withoutMarkedBlock
+    .split('\n')
+    .filter((line) => !line.includes('prjct sync') && !line.includes('prjct auto-sync'))
+    .join('\n')
+}
+
 // DETECTION
 
 export async function detectHookManagers(projectPath: string): Promise<HookStrategy[]> {
@@ -93,8 +108,8 @@ export async function installHusky(projectPath: string, hooks: HookName[]): Prom
 
     if (await fileExists(hookPath)) {
       const existing = await fs.readFile(hookPath, 'utf-8')
-      if (existing.includes('prjct sync')) continue
-      await fs.appendFile(hookPath, '\n# prjct auto-sync\nprjct sync --quiet --yes &\n')
+      if (hasPrjctAutoSync(existing)) continue
+      await fs.appendFile(hookPath, `\n${script.split('\n').slice(1).join('\n')}`)
     } else {
       await fs.writeFile(hookPath, script, { mode: 0o755 })
     }
@@ -116,11 +131,8 @@ export async function installDirect(projectPath: string, hooks: HookName[]): Pro
 
     if (await fileExists(hookPath)) {
       const existing = await fs.readFile(hookPath, 'utf-8')
-      if (existing.includes('prjct sync')) continue
-      await fs.appendFile(
-        hookPath,
-        `\n# prjct auto-sync\n${script.split('\n').slice(1).join('\n')}`
-      )
+      if (hasPrjctAutoSync(existing)) continue
+      await fs.appendFile(hookPath, `\n${script.split('\n').slice(1).join('\n')}`)
     } else {
       await fs.writeFile(hookPath, script, { mode: 0o755 })
     }
@@ -158,10 +170,7 @@ export async function uninstallHusky(projectPath: string): Promise<boolean> {
     const content = await fs.readFile(hookPath, 'utf-8')
     if (!content.includes('prjct sync')) continue
 
-    const cleaned = content
-      .split('\n')
-      .filter((line) => !line.includes('prjct sync') && !line.includes('prjct auto-sync'))
-      .join('\n')
+    const cleaned = stripPrjctAutoSync(content)
 
     if (cleaned.trim() === '#!/bin/sh' || cleaned.trim() === '#!/usr/bin/env sh') {
       await fs.unlink(hookPath)
@@ -186,10 +195,7 @@ export async function uninstallDirect(projectPath: string): Promise<boolean> {
     if (content.includes('Installed by: prjct hooks install')) {
       await fs.unlink(hookPath)
     } else {
-      const cleaned = content
-        .split('\n')
-        .filter((line) => !line.includes('prjct sync') && !line.includes('prjct auto-sync'))
-        .join('\n')
+      const cleaned = stripPrjctAutoSync(content)
       await fs.writeFile(hookPath, cleaned, { mode: 0o755 })
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prjct-cli",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prjct-cli",
-      "version": "2.58.0",
+      "version": "2.59.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.0",
@@ -17,7 +17,7 @@
         "zod": "3.25.76"
       },
       "bin": {
-        "prjct": "bin/prjct"
+        "prjct": "bin/prjct.cjs"
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.13",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "prjct-cli",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {
-    "prjct": "bin/prjct"
+    "prjct": "bin/prjct.cjs"
   },
   "publishConfig": {
     "access": "public",
@@ -92,6 +92,7 @@
   "files": [
     "assets/",
     "bin/prjct",
+    "bin/prjct.cjs",
     "dist/",
     "templates/",
     "scripts/install.sh",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -226,8 +226,11 @@ function generateDaemonShim() {
   // execute via dist/bin/prjct.mjs). Any future change to the fallback
   // policy MUST update both this string and bin/prjct.ts.
   return `#!/usr/bin/env node
-import{connect}from"node:net";import{existsSync}from"node:fs";import{randomUUID}from"node:crypto";import{homedir}from"node:os";
-const sockPath=homedir()+"/.prjct-cli/run/daemon.sock";
+import{connect}from"node:net";import{existsSync}from"node:fs";import{createHash,randomUUID}from"node:crypto";import{homedir}from"node:os";import{join,resolve}from"node:path";
+const cliHome=process.env.PRJCT_CLI_HOME?resolve(process.env.PRJCT_CLI_HOME):join(homedir(),".prjct-cli");
+const namedPipe=process.platform==="win32";
+const sockPath=namedPipe?"\\\\.\\pipe\\prjct-"+createHash("sha1").update(resolve(cliHome)).digest("hex").slice(0,16)+"-daemon":join(cliHome,"run","daemon.sock");
+const hasEndpoint=()=>namedPipe||existsSync(sockPath);
 const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
 const skip=new Set(${JSON.stringify(deriveShimSkipSet())});
@@ -249,10 +252,10 @@ function sendHook(sub,data){
   sock.on("error",soft);
   sock.on("close",soft);
 }
-if(cmd==="hook"&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
+if(cmd==="hook"&&process.env.PRJCT_NO_DAEMON!=="1"&&hasEndpoint()){
   const sub=args[1];
   if(process.stdin.isTTY){sendHook(sub,"")}else{let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>sendHook(sub,d));process.stdin.on("error",()=>sendHook(sub,d));setTimeout(()=>sendHook(sub,d),1000)}
-}else if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&existsSync(sockPath)){
+}else if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&hasEndpoint()){
   const cArgs=[],cOpts={};
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}
   const msg=JSON.stringify({id:randomUUID(),command:cmd,args:cArgs,options:cOpts,cwd:process.cwd()})+"\\n";


### PR DESCRIPTION
## Summary
- add a portable Node package-manager launcher for Windows/macOS/Linux installs
- use Windows named pipes for daemon IPC while keeping Unix sockets on macOS/Linux
- make git auto-sync hooks avoid Unix-only utilities by delegating rate limit/spawn to Node
- add focused platform compatibility tests and Ubuntu/macOS/Windows CI smoke coverage

## Validation
- bun test
- bun run typecheck
- bun run check
- bun run build
- PRJCT_NO_UPDATE_NOTICE=1 node bin/prjct.cjs --version
- npm pack --dry-run --ignore-scripts --cache /private/tmp/prjct-npm-cache