### PR TITLE
fix: make update tolerate legacy project DB issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.60.0] - 2026-06-22
+
+### Added
+- update tolerates legacy project dbs
+
 ## [2.59.0] - 2026-06-22
 
 ### Fixed

--- a/core/__tests__/commands/update-cleanup.test.ts
+++ b/core/__tests__/commands/update-cleanup.test.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { consolidateInstalls, planCleanup } from '../../commands/update/cleanup-installs'
+import { formatMdOutput } from '../../commands/update/output'
 import pathManager from '../../infrastructure/path-manager'
 import { getUpdateNotificationSync } from '../../infrastructure/update-checker'
 
@@ -68,5 +69,55 @@ describe('WS4 — consolidateInstalls', () => {
     expect(Array.isArray(plan.skipped)).toBe(true)
     // Safety invariant: nothing is ever removable without a winner.
     if (plan.winner === null) expect(plan.removable).toEqual([])
+  })
+})
+
+describe('prjct update — non-fatal legacy project warnings', () => {
+  const originalLog = console.log
+
+  afterEach(() => {
+    console.log = originalLog
+  })
+
+  it('does not fail the update when cleanup only has legacy migration warnings', () => {
+    console.log = () => {}
+
+    const result = formatMdOutput(
+      {
+        phase1: { success: true, details: ['package ok'], errors: [] },
+        phase2: {
+          success: true,
+          details: ['2 project(s) checked, 1 already on SQLite'],
+          errors: [],
+          warnings: ['legacy1: unable to open database file'],
+        },
+        phase3: { success: true, details: ['daemon ok'], errors: [] },
+      },
+      false
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.message).toBe('System updated')
+  })
+
+  it('still fails the update when cleanup has real errors', () => {
+    console.log = () => {}
+
+    const result = formatMdOutput(
+      {
+        phase1: { success: true, details: ['package ok'], errors: [] },
+        phase2: {
+          success: false,
+          details: ['cleanup ran'],
+          errors: ['Commands: permission denied'],
+          warnings: ['legacy1: unable to open database file'],
+        },
+        phase3: { success: true, details: ['daemon ok'], errors: [] },
+      },
+      false
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Updated with errors')
   })
 })

--- a/core/__tests__/storage/sqlite-migration.test.ts
+++ b/core/__tests__/storage/sqlite-migration.test.ts
@@ -16,7 +16,7 @@ import path from 'node:path'
 import pathManager from '../../infrastructure/path-manager'
 import { prjctDb } from '../../storage/database'
 import { indexStorage } from '../../storage/index-storage'
-import { migrateJsonToSqlite } from '../../storage/migrate-json'
+import { hasLegacyArtifacts, migrateJsonToSqlite } from '../../storage/migrate-json'
 import { StorageManager } from '../../storage/storage-manager'
 
 // Test Setup
@@ -88,6 +88,25 @@ describe('SQLite Migration', () => {
   })
 
   describe('migration correctness', () => {
+    it('does not treat a modern sessions directory as legacy by itself', async () => {
+      const projectPath = path.join(tmpRoot!, testProjectId)
+      await fs.mkdir(path.join(projectPath, 'sessions'), { recursive: true })
+      await fs.writeFile(path.join(projectPath, 'prjct.db'), 'not opened by this guard')
+
+      expect(hasLegacyArtifacts(testProjectId)).toBe(false)
+
+      await fs.writeFile(path.join(projectPath, 'sessions', 'current.json'), '{}')
+      expect(hasLegacyArtifacts(testProjectId)).toBe(true)
+
+      await fs.rm(path.join(projectPath, 'sessions', 'current.json'))
+      await fs.mkdir(path.join(projectPath, 'sessions', 'archive', '2026-06'), { recursive: true })
+      await fs.writeFile(
+        path.join(projectPath, 'sessions', 'archive', '2026-06', 'session.json'),
+        '{}'
+      )
+      expect(hasLegacyArtifacts(testProjectId)).toBe(true)
+    })
+
     it('should migrate state.json to kv_store', async () => {
       // Create source JSON
       const storagePath = path.join(tmpRoot!, testProjectId, 'storage')

--- a/core/commands/update.ts
+++ b/core/commands/update.ts
@@ -14,7 +14,7 @@ import { CommandInstaller } from '../infrastructure/command-installer'
 import editorsConfig from '../infrastructure/editors-config'
 import pathManager from '../infrastructure/path-manager'
 import UpdateChecker from '../infrastructure/update-checker'
-import { migrateJsonToSqlite, sweepLegacyJson } from '../storage/migrate-json'
+import { hasLegacyArtifacts, migrateJsonToSqlite, sweepLegacyJson } from '../storage/migrate-json'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { failFromError } from '../utils/md-aware'
@@ -63,9 +63,9 @@ export class UpdateCommands extends PrjctCommandsBase {
     const assumeYes = options.yes === true || options.y === true
 
     const results = {
-      phase1: { success: true, details: [], errors: [] } as PhaseResult,
-      phase2: { success: true, details: [], errors: [] } as PhaseResult,
-      phase3: { success: true, details: [], errors: [] } as PhaseResult,
+      phase1: { success: true, details: [], errors: [], warnings: [] } as PhaseResult,
+      phase2: { success: true, details: [], errors: [], warnings: [] } as PhaseResult,
+      phase3: { success: true, details: [], errors: [], warnings: [] } as PhaseResult,
     }
 
     try {
@@ -136,7 +136,7 @@ export class UpdateCommands extends PrjctCommandsBase {
   // ── Phase 1: Package Update ──
 
   private async phasePackageUpdate(dryRun: boolean): Promise<PhaseResult> {
-    const result: PhaseResult = { success: true, details: [], errors: [] }
+    const result: PhaseResult = { success: true, details: [], errors: [], warnings: [] }
     const installsBefore = getAllInstalledLocations()
 
     if (dryRun) {
@@ -263,7 +263,7 @@ export class UpdateCommands extends PrjctCommandsBase {
     cleanupMode: CleanupMode = 'auto',
     assumeYes = false
   ): Promise<PhaseResult> {
-    const result: PhaseResult = { success: true, details: [], errors: [] }
+    const result: PhaseResult = { success: true, details: [], errors: [], warnings: [] }
 
     // 2a. Migrate all projects
     const projectIds = await this.getAllProjectIds()
@@ -273,11 +273,18 @@ export class UpdateCommands extends PrjctCommandsBase {
     } else {
       let totalMigrated = 0
       let totalSwept = 0
+      let legacySkipped = 0
+      let legacyWarnings = 0
 
       for (const projectId of projectIds) {
         if (dryRun) continue
 
         try {
+          if (!hasLegacyArtifacts(projectId)) {
+            legacySkipped += 1
+            continue
+          }
+
           const migrationResult = await migrateJsonToSqlite(projectId)
           const swept = await sweepLegacyJson(projectId)
           totalMigrated += migrationResult.migratedFiles.length
@@ -285,11 +292,17 @@ export class UpdateCommands extends PrjctCommandsBase {
 
           if (migrationResult.errors.length > 0) {
             for (const err of migrationResult.errors) {
-              result.errors.push(`${projectId.slice(0, 8)}: ${err.file}: ${err.error}`)
+              legacyWarnings += 1
+              if ((result.warnings?.length ?? 0) < 10) {
+                result.warnings?.push(`${projectId.slice(0, 8)}: ${err.file}: ${err.error}`)
+              }
             }
           }
         } catch (err) {
-          result.errors.push(`${projectId.slice(0, 8)}: ${getErrorMessage(err)}`)
+          legacyWarnings += 1
+          if ((result.warnings?.length ?? 0) < 10) {
+            result.warnings?.push(`${projectId.slice(0, 8)}: ${getErrorMessage(err)}`)
+          }
         }
       }
 
@@ -297,9 +310,18 @@ export class UpdateCommands extends PrjctCommandsBase {
         result.details.push(`Would migrate ${projectIds.length} project(s)`)
       } else {
         const parts = [`${projectIds.length} project(s) checked`]
+        if (legacySkipped > 0) parts.push(`${legacySkipped} already on SQLite`)
         if (totalMigrated > 0) parts.push(`${totalMigrated} files migrated`)
         if (totalSwept > 0) parts.push(`${totalSwept} leftovers swept`)
         result.details.push(parts.join(', '))
+        if (legacyWarnings > 0) {
+          const hidden = legacyWarnings - (result.warnings?.length ?? 0)
+          result.details.push(
+            `Legacy migration skipped ${legacyWarnings} issue(s) without blocking update${
+              hidden > 0 ? ` (${hidden} more hidden)` : ''
+            }`
+          )
+        }
       }
     }
 
@@ -408,7 +430,7 @@ export class UpdateCommands extends PrjctCommandsBase {
   // ── Phase 3: Daemon Restart ──
 
   private async phaseDaemonRestart(dryRun: boolean): Promise<PhaseResult> {
-    const result: PhaseResult = { success: true, details: [], errors: [] }
+    const result: PhaseResult = { success: true, details: [], errors: [], warnings: [] }
 
     if (dryRun) {
       result.details.push('Would restart daemon')

--- a/core/commands/update/output.ts
+++ b/core/commands/update/output.ts
@@ -13,6 +13,7 @@ export interface PhaseResult {
   success: boolean
   details: string[]
   errors: string[]
+  warnings?: string[]
 }
 
 export interface PhaseResults {
@@ -39,6 +40,9 @@ export function formatTerminalOutput(results: PhaseResults, dryRun: boolean): Co
     console.log(`  ${icon} ${chalk.bold(label)}`)
     for (const detail of result.details) {
       console.log(`    ${chalk.dim(detail)}`)
+    }
+    for (const warning of result.warnings ?? []) {
+      console.log(`    ${chalk.yellow('⚠')} ${warning}`)
     }
     for (const err of result.errors) {
       console.log(`    ${chalk.yellow('⚠')} ${err}`)
@@ -79,6 +83,9 @@ export function formatMdOutput(results: PhaseResults, dryRun: boolean): CommandR
     lines.push(`## ${label} (${status})`)
     for (const detail of result.details) {
       lines.push(`- ${detail}`)
+    }
+    for (const warning of result.warnings ?? []) {
+      lines.push(`- WARNING: ${warning}`)
     }
     for (const err of result.errors) {
       lines.push(`- WARNING: ${err}`)

--- a/core/storage/migrate-json.ts
+++ b/core/storage/migrate-json.ts
@@ -22,7 +22,7 @@
  *
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import pathManager from '../infrastructure/path-manager'
@@ -44,6 +44,28 @@ import { populateIndexTables, populateNormalized } from './migrate-json/populate
  *  same set the migration consumes. */
 const LEGACY_INDEX_EXTRA = ['checksums.json', 'file-scores.json']
 const LEGACY_MEMORY_FILES = ['events.jsonl', 'learnings.jsonl']
+
+function hasLegacySessionArtifacts(sessionsPath: string): boolean {
+  if (existsSync(path.join(sessionsPath, 'current.json'))) return true
+
+  const archiveDir = path.join(sessionsPath, 'archive')
+  try {
+    for (const month of readdirSync(archiveDir, { withFileTypes: true })) {
+      if (!month.isDirectory()) continue
+      try {
+        const monthDir = path.join(archiveDir, month.name)
+        if (readdirSync(monthDir).some((file) => file.endsWith('.json'))) return true
+      } catch {
+        // Ignore unreadable archive subdirs; the migration will surface them
+        // only when another concrete legacy artifact requires a migration pass.
+      }
+    }
+  } catch {
+    // No archive dir, or unreadable archive dir without a concrete JSON file.
+  }
+
+  return false
+}
 
 /**
  * Fast filesystem check: does this project still have ANY legacy JSON/JSONL
@@ -76,10 +98,11 @@ export function hasLegacyArtifacts(projectId: string): boolean {
   for (const filename of LEGACY_MEMORY_FILES) {
     if (existsSync(path.join(memoryPath, filename))) return true
   }
-  // sessions/*.json — migrated via migrateSessionFiles. Treat a non-empty
-  // sessions dir as a legacy artifact (cheap dir read only when it exists).
+  // sessions/current.json + sessions/archive/*/*.json are migrated via
+  // migrateSessionFiles. A plain sessions/ directory is modern structure,
+  // not legacy; do not open the DB just because it exists.
   const sessionsPath = path.join(globalPath, 'sessions')
-  if (existsSync(sessionsPath)) return true
+  if (hasLegacySessionArtifacts(sessionsPath)) return true
 
   return false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.59.0",
+  "version": "2.60.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Skip per-project DB opens during prjct update unless concrete legacy JSON artifacts exist.
- Treat legacy migration issues as non-fatal warnings so one bad old project does not fail updates for all clients.
- Tighten legacy session detection so a modern sessions directory does not trigger migration.

## Verification
- bun test core/__tests__/commands/update-cleanup.test.ts core/__tests__/storage/sqlite-migration.test.ts
- bun run typecheck
- bun run check -- core/commands/update.ts core/commands/update/output.ts core/storage/migrate-json.ts core/__tests__/commands/update-cleanup.test.ts core/__tests__/storage/sqlite-migration.test.ts
- bun run build