### PR TITLE
Ship v2.62.0 CLI metadata update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.62.0] - 2026-06-23
+
+### Added
+- Point CLI metadata to cli site
+
 ## [2.61.0] - 2026-06-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.61.0",
+  "version": "2.62.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Ship v2.62.0 for the CLI metadata/homepage update
- Update changelog for the public CLI site metadata change

## Verification
- prjct ship completed successfully
- pre-commit check passed during ship commit