### PR TITLE
feat: eval result publishing

### DIFF
--- a/.github/workflows/prjct-evals.yml
+++ b/.github/workflows/prjct-evals.yml
@@ -1,0 +1,79 @@
+name: prjct evals
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: Candidate label to store in eval history. Defaults to the commit SHA.
+        required: false
+        type: string
+      baseline:
+        description: Optional baseline label to compare against a previous run.
+        required: false
+        type: string
+      publish:
+        description: Publish JSON/Markdown results to the eval-results branch.
+        required: true
+        default: false
+        type: boolean
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: prjct-evals-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eval:
+    name: Product evals
+    runs-on: ubuntu-latest
+    env:
+      PRJCT_CLI_HOME: ${{ runner.temp }}/prjct-cli-home
+      GH_TOKEN: ${{ github.token }}
+      CANDIDATE_LABEL: ${{ inputs.candidate || github.sha }}
+      BASELINE_LABEL: ${{ inputs.baseline }}
+      SHOULD_PUBLISH: ${{ inputs.publish == true && github.event_name == 'workflow_dispatch' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI
+        run: bun run build
+
+      - name: Run prjct eval
+        run: |
+          if [ "$SHOULD_PUBLISH" = "true" ]; then
+            node dist/bin/prjct-core.mjs eval run --source ci --candidate "$CANDIDATE_LABEL" --publish --target github --json
+          else
+            node dist/bin/prjct-core.mjs eval run --source ci --candidate "$CANDIDATE_LABEL" --json
+          fi
+
+      - name: Compare against baseline
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.baseline != '' }}
+        run: |
+          if [ "$SHOULD_PUBLISH" = "true" ]; then
+            node dist/bin/prjct-core.mjs eval compare --baseline "$BASELINE_LABEL" --candidate "$CANDIDATE_LABEL" --publish --target github --json
+          else
+            node dist/bin/prjct-core.mjs eval compare --baseline "$BASELINE_LABEL" --candidate "$CANDIDATE_LABEL" --json
+          fi
+
+      - name: Upload eval artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prjct-evals-${{ github.run_id }}
+          path: ${{ env.PRJCT_CLI_HOME }}/evals/**
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.63.0] - 2026-06-23
+
+### Added
+- eval result publishing
+
 ## [2.62.0] - 2026-06-23
 
 ### Added

--- a/EVALS.md
+++ b/EVALS.md
@@ -1,0 +1,55 @@
+# prjct evals
+
+`prjct eval` is the product-evaluation harness for proving whether prjct-cli gets better or worse between versions. It is deterministic by default, local-first, and publishable to GitHub.
+
+## Commands
+
+```bash
+prjct eval run --candidate 2.62.0
+prjct eval report --md
+prjct eval compare --baseline 2.61.0 --candidate 2.62.0 --md
+prjct eval run --candidate "$GITHUB_SHA" --publish --target github
+prjct eval compare --baseline "$BASELINE" --candidate "$CANDIDATE" --publish --target github
+```
+
+## Local storage
+
+Runs and comparisons are written under:
+
+```text
+$PRJCT_CLI_HOME/evals/<owner-repo-or-local-hash>/
+  latest.json
+  latest-comparison.json
+  runs/<runId>.json
+  runs/<runId>.md
+  comparisons/<comparisonId>.json
+  comparisons/<comparisonId>.md
+```
+
+The JSON files are the source of truth. Markdown exists so humans can review the same evidence quickly.
+
+## GitHub publishing
+
+Publishing uses the GitHub CLI and writes to an `eval-results` branch:
+
+```text
+eval-results/
+  runs/YYYY-MM-DD/<runId>.json
+  runs/YYYY-MM-DD/<runId>.md
+  comparisons/YYYY-MM-DD/<comparisonId>.json
+  comparisons/YYYY-MM-DD/<comparisonId>.md
+  summary/latest.json
+  summary/latest-comparison.json
+```
+
+Every scenario and comparison carries actionables. Regressions are blocking actionables; improvements and unchanged scenarios still tell maintainers what to protect or keep measuring.
+
+## CI workflow
+
+This repo includes `.github/workflows/prjct-evals.yml` with manual inputs:
+
+- `candidate`: label to store as the candidate version; defaults to the commit SHA.
+- `baseline`: optional baseline label to compare against.
+- `publish`: when true, writes results to the `eval-results` branch.
+
+The workflow always uploads local eval artifacts to GitHub Actions, even when branch publishing is disabled.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,24 @@ command is idempotent and reports what changed.
 prjct should justify itself with project evidence, not vague claims. These
 read-only commands show whether the project is actually compounding:
 
+### Version evals
+
+Use `prjct eval` to measure product readiness between versions and publish the
+evidence to GitHub:
+
+```bash
+prjct eval run --candidate 2.62.0
+prjct eval compare --baseline 2.61.0 --candidate 2.62.0 --md
+prjct eval run --candidate "$GITHUB_SHA" --publish --target github
+prjct eval compare --baseline "$BASELINE" --candidate "$CANDIDATE" --publish --target github
+```
+
+Local artifacts live under `$PRJCT_CLI_HOME/evals/<repo>/`. GitHub publishing
+writes JSON + Markdown to an `eval-results` branch, including
+`summary/latest.json` and `summary/latest-comparison.json`. See
+[EVALS.md](./EVALS.md) and `.github/workflows/prjct-evals.yml` for the
+CI workflow.
+
 | Command | What it proves |
 |---|---|
 | `prjct value --md` | Durable memory, preventive guardrails, shipped work, sync metrics, and detected agent coverage. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,7 @@ We use minimal dependencies and audit them regularly:
 1. **Keep prjct-cli updated** - Run `npm update -g prjct-cli` regularly
 2. **Review before committing** - Check `.prjct/prjct.config.json` before pushing to public repos
 3. **Avoid storing secrets** - Don't put API keys or passwords in `now.md` or `ideas.md`
-4. **Use .gitignore** - The `.prjct/` directory should be in your `.gitignore` (auto-added by `/p:init`)
+4. **Use .gitignore** - The `.prjct/` directory should be in your `.gitignore` (auto-added by `prjct init`)
 
 ## Claude Integration Security
 

--- a/bin/prjct.cjs
+++ b/bin/prjct.cjs
@@ -316,6 +316,7 @@ function main() {
     '-h',
     '--help',
     'help',
+    'eval',
     'hook',
     '__internal-auto-update',
     '__post-upgrade',

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -473,7 +473,7 @@ async function main(): Promise<void> {
     const routersInstalled = await checkRoutersInstalled()
 
     // Commands that work without full setup
-    const noSetupRequired = new Set(['auth', 'login', 'logout', 'init'])
+    const noSetupRequired = new Set(['auth', 'login', 'logout', 'init', 'eval'])
 
     if (!noSetupRequired.has(args[0]) && (!(await fileExists(configPath)) || !routersInstalled)) {
       console.log(`

--- a/core/__tests__/commands/eval.test.ts
+++ b/core/__tests__/commands/eval.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { COMMANDS } from '../../commands/command-data'
+import { EvalCommands } from '../../commands/eval'
+import { REGISTERED_VERBS_SET } from '../../commands/verb-names'
+import { execFileAsync } from '../../utils/exec'
+
+let tmpRoot = ''
+let projectPath = ''
+let originalCliHome: string | undefined
+let spies: Array<ReturnType<typeof spyOn>> = []
+
+async function writeFile(relativePath: string, content: string): Promise<void> {
+  const filePath = path.join(projectPath, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf-8')
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-eval-command-'))
+  projectPath = path.join(tmpRoot, 'repo')
+  await fs.mkdir(projectPath, { recursive: true })
+  originalCliHome = process.env.PRJCT_CLI_HOME
+  process.env.PRJCT_CLI_HOME = path.join(tmpRoot, 'home')
+  spies.push(spyOn(console, 'log').mockImplementation(() => {}))
+  spies.push(spyOn(console, 'error').mockImplementation(() => {}))
+  await execFileAsync('git', ['init'], { cwd: projectPath })
+  await execFileAsync('git', ['config', 'user.email', 'eval-command@example.com'], {
+    cwd: projectPath,
+  })
+  await execFileAsync('git', ['config', 'user.name', 'Eval Command'], { cwd: projectPath })
+  await execFileAsync('git', ['remote', 'add', 'origin', 'git@github.com:acme/prjct-evals.git'], {
+    cwd: projectPath,
+  })
+  await writeFile('AGENTS.md', '# Agent contract\n')
+  await writeFile('.prjct/prjct.config.json', '{"projectId":"eval-command"}\n')
+  await writeFile(
+    'package.json',
+    JSON.stringify(
+      { name: 'eval-command', scripts: { test: 'bun test', lint: 'biome check .' } },
+      null,
+      2
+    )
+  )
+})
+
+afterEach(async () => {
+  for (const spy of spies) spy.mockRestore()
+  spies = []
+  if (originalCliHome === undefined) delete process.env.PRJCT_CLI_HOME
+  else process.env.PRJCT_CLI_HOME = originalCliHome
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => undefined)
+})
+
+describe('prjct eval command', () => {
+  test('is registered through the manifest with daemon-safe option mapping', () => {
+    const meta = COMMANDS.find((command) => command.name === 'eval')
+
+    expect(meta?.routing).toEqual({ group: 'eval', method: 'eval' })
+    expect(meta?.optionSchema).toEqual({
+      booleans: ['publish', 'dryRun', 'json'],
+      strings: ['baseline', 'candidate', 'source', 'target', 'file'],
+    })
+    expect(REGISTERED_VERBS_SET.has('eval')).toBe(true)
+  })
+
+  test('can run before provider setup so CI and external repos can publish metrics', async () => {
+    const binSource = await fs.readFile(path.join(process.cwd(), 'bin', 'prjct.ts'), 'utf-8')
+    const launcherSource = await fs.readFile(path.join(process.cwd(), 'bin', 'prjct.cjs'), 'utf-8')
+
+    expect(binSource).toContain("'eval'")
+    expect(launcherSource).toContain("'eval'")
+  })
+
+  test('runs, reports, and compares through the command surface', async () => {
+    const cmd = new EvalCommands()
+
+    const run = await cmd.eval('run', projectPath, { candidate: 'command-a', md: true })
+    const report = await cmd.eval('report', projectPath, { json: true })
+    const compare = await cmd.eval('compare', projectPath, { candidate: 'command-a' })
+
+    expect(run.success).toBe(true)
+    expect(run.runId).toBeString()
+    expect(report.success).toBe(true)
+    expect(compare.success).toBe(true)
+  })
+
+  test('compare --publish publishes comparison artifacts in dry-run mode', async () => {
+    const cmd = new EvalCommands()
+
+    await cmd.eval('run', projectPath, { candidate: 'baseline-command' })
+    await cmd.eval('run', projectPath, { candidate: 'candidate-command' })
+    const result = await cmd.eval('compare', projectPath, {
+      baseline: 'baseline-command',
+      candidate: 'candidate-command',
+      publish: true,
+      dryRun: true,
+      target: 'github',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.comparisonId).toBeString()
+    expect(result.publish).toMatchObject({ artifactType: 'comparison', dryRun: true })
+  })
+
+  test('ships docs and workflow for publishing eval history', async () => {
+    const docs = await fs.readFile(path.join(process.cwd(), 'EVALS.md'), 'utf-8')
+    const workflow = await fs.readFile(
+      path.join(process.cwd(), '.github', 'workflows', 'prjct-evals.yml'),
+      'utf-8'
+    )
+
+    expect(docs).toContain('summary/latest-comparison.json')
+    expect(workflow).toContain('workflow_dispatch')
+    expect(workflow).toContain('eval compare')
+    expect(workflow).toContain('actions/upload-artifact@v4')
+  })
+
+  test('publish subcommand supports dry-run GitHub output', async () => {
+    const cmd = new EvalCommands()
+
+    await cmd.eval('run', projectPath, { candidate: 'command-publish' })
+    const published = await cmd.eval('publish', projectPath, { dryRun: true, target: 'github' })
+
+    expect(published.success).toBe(true)
+    expect(published.dryRun).toBe(true)
+    expect(published.repo).toBe('acme/prjct-evals')
+  })
+})

--- a/core/__tests__/services/eval-service.test.ts
+++ b/core/__tests__/services/eval-service.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  compareEvalRuns,
+  formatEvalRunMarkdown,
+  loadLatestEvalComparison,
+  loadLatestEvalRun,
+  publishEvalComparison,
+  publishEvalRun,
+  runEval,
+} from '../../services/eval-service'
+import { execFileAsync } from '../../utils/exec'
+
+let tmpRoot = ''
+let projectPath = ''
+let originalCliHome: string | undefined
+
+async function writeFile(relativePath: string, content: string): Promise<void> {
+  const filePath = path.join(projectPath, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf-8')
+}
+
+async function setupGitProject(): Promise<void> {
+  await execFileAsync('git', ['init'], { cwd: projectPath })
+  await execFileAsync('git', ['config', 'user.email', 'eval@example.com'], { cwd: projectPath })
+  await execFileAsync('git', ['config', 'user.name', 'Eval Runner'], { cwd: projectPath })
+  await execFileAsync('git', ['remote', 'add', 'origin', 'git@github.com:acme/prjct-evals.git'], {
+    cwd: projectPath,
+  })
+}
+
+async function createHealthyProject(): Promise<void> {
+  await writeFile('AGENTS.md', '# Agent contract\n')
+  await writeFile('.prjct/prjct.config.json', '{"projectId":"eval-test"}\n')
+  await writeFile(
+    'package.json',
+    JSON.stringify(
+      { name: 'eval-test', version: '1.0.0', scripts: { test: 'bun test', lint: 'biome check .' } },
+      null,
+      2
+    )
+  )
+}
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-eval-test-'))
+  projectPath = path.join(tmpRoot, 'repo')
+  await fs.mkdir(projectPath, { recursive: true })
+  originalCliHome = process.env.PRJCT_CLI_HOME
+  process.env.PRJCT_CLI_HOME = path.join(tmpRoot, 'home')
+  await setupGitProject()
+})
+
+afterEach(async () => {
+  if (originalCliHome === undefined) delete process.env.PRJCT_CLI_HOME
+  else process.env.PRJCT_CLI_HOME = originalCliHome
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => undefined)
+})
+
+describe('eval-service', () => {
+  test('runs deterministic evals and stores portable artifacts', async () => {
+    await createHealthyProject()
+
+    const run = await runEval(projectPath, { candidate: 'candidate-a', source: 'agent' })
+    const latest = await loadLatestEvalRun(projectPath)
+
+    expect(run.schemaVersion).toBe(1)
+    expect(run.runner.source).toBe('agent')
+    expect(run.project.repo).toBe('acme/prjct-evals')
+    expect(run.summary.score).toBeGreaterThan(0)
+    expect(run.scenarios.length).toBeGreaterThanOrEqual(5)
+    expect(run.scenarios.every((scenario) => scenario.actionables.length > 0)).toBe(true)
+    expect(latest?.runId).toBe(run.runId)
+    expect(run.artifacts?.jsonPath).toBeTruthy()
+    expect(run.artifacts?.reportPath).toBeTruthy()
+
+    const json = await fs.readFile(run.artifacts?.jsonPath ?? '', 'utf-8')
+    const report = await fs.readFile(run.artifacts?.reportPath ?? '', 'utf-8')
+    expect(json).toContain(run.runId)
+    expect(report).toContain('## Actionables')
+  })
+
+  test('detects stale user-facing command guidance with concrete files', async () => {
+    await createHealthyProject()
+    await writeFile('docs/usage.md', 'Run /p: sync before shipping.\n')
+
+    const run = await runEval(projectPath, { candidate: 'stale-guidance' })
+    const staleScenario = run.scenarios.find((scenario) => scenario.id === 'stale-command-guidance')
+
+    expect(staleScenario?.status).toBe('warn')
+    expect(staleScenario?.metrics.staleHits).toBe(1)
+    expect(staleScenario?.actionables[0]?.files).toContain('docs/usage.md')
+  })
+
+  test('compares baseline and candidate runs with actionable version deltas', async () => {
+    await writeFile('package.json', JSON.stringify({ scripts: {} }, null, 2))
+    const baseline = await runEval(projectPath, { candidate: 'baseline-version' })
+
+    await createHealthyProject()
+    const candidate = await runEval(projectPath, { candidate: 'candidate-version' })
+    const comparison = await compareEvalRuns(projectPath, {
+      baseline: 'baseline-version',
+      candidate: 'candidate-version',
+    })
+
+    const latestComparison = await loadLatestEvalComparison(projectPath)
+
+    expect(comparison.comparisonId).toContain('baseline-version_to_candidate-version')
+    expect(comparison.baselineRunId).toBe(baseline.runId)
+    expect(comparison.candidateRunId).toBe(candidate.runId)
+    expect(comparison.baselineVersion).toBe('baseline-version')
+    expect(comparison.candidateVersion).toBe('candidate-version')
+    expect(comparison.summary.delta ?? 0).toBeGreaterThan(0)
+    expect(comparison.summary.improvements).toBeGreaterThan(0)
+    expect(comparison.scenarios.some((scenario) => scenario.status === 'improved')).toBe(true)
+    expect(comparison.scenarios.every((scenario) => scenario.actionables.length > 0)).toBe(true)
+    expect(latestComparison?.comparisonId).toBe(comparison.comparisonId)
+    expect(comparison.artifacts?.jsonPath).toBeTruthy()
+    expect(comparison.artifacts?.reportPath).toBeTruthy()
+  })
+
+  test('prepares GitHub publication without network writes in dry run', async () => {
+    await createHealthyProject()
+    const run = await runEval(projectPath, { candidate: 'publishable' })
+
+    const result = await publishEvalRun(projectPath, { dryRun: true })
+
+    expect(result.dryRun).toBe(true)
+    expect(result.repo).toBe('acme/prjct-evals')
+    expect(result.branch).toBe('eval-results')
+    expect(result.runId).toBe(run.runId)
+    expect(result.url).toBe('https://github.com/acme/prjct-evals/tree/eval-results/eval-results')
+    expect(result.files.map((file) => file.path)).toContain('eval-results/summary/latest.json')
+  })
+
+  test('prepares GitHub comparison publication without network writes in dry run', async () => {
+    await writeFile('package.json', JSON.stringify({ scripts: {} }, null, 2))
+    await runEval(projectPath, { candidate: 'baseline-publish' })
+    await createHealthyProject()
+    await runEval(projectPath, { candidate: 'candidate-publish' })
+    const comparison = await compareEvalRuns(projectPath, {
+      baseline: 'baseline-publish',
+      candidate: 'candidate-publish',
+    })
+
+    const result = await publishEvalComparison(projectPath, comparison, { dryRun: true })
+
+    expect(result.dryRun).toBe(true)
+    expect(result.artifactType).toBe('comparison')
+    expect(result.comparisonId).toBe(comparison.comparisonId)
+    expect(result.files.map((file) => file.path)).toContain(
+      'eval-results/summary/latest-comparison.json'
+    )
+    expect(result.files.some((file) => file.path.includes('/comparisons/'))).toBe(true)
+  })
+
+  test('formats markdown reports with scenario metrics and actionables', async () => {
+    await createHealthyProject()
+    const run = await runEval(projectPath, { candidate: 'markdown' })
+
+    const markdown = formatEvalRunMarkdown(run)
+
+    expect(markdown).toContain('# prjct eval run')
+    expect(markdown).toContain('| Scenario | Status | Score | Actionables |')
+    expect(markdown).toContain('## Actionables')
+  })
+})

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -112,6 +112,31 @@ export const COMMANDS: CommandMeta[] = [
     ],
   },
   {
+    name: 'eval',
+    group: 'optional',
+    routing: { group: 'eval', method: 'eval' },
+    optionSchema: {
+      booleans: ['publish', 'dryRun', 'json'],
+      strings: ['baseline', 'candidate', 'source', 'target', 'file'],
+    },
+    description: 'Run product evals, compare versions, and publish actionable results',
+    usage: {
+      claude: 'p. eval run [--candidate <version>] [--publish]',
+      terminal:
+        'prjct eval <run|compare|report|publish> [--baseline <version>] [--candidate <version>] [--target github] [--dry-run]',
+    },
+    params: '[run|compare|report|publish]',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: false,
+    requiresLlm: false,
+    features: [
+      'Deterministic local eval runs stored under PRJCT_CLI_HOME/evals',
+      'Version comparisons with regression/improvement actionables',
+      'GitHub publication to an eval-results branch for shared metrics history',
+    ],
+  },
+  {
     name: 'suggest',
     group: 'core',
     description: 'Smart recommendations based on project state',

--- a/core/commands/eval.ts
+++ b/core/commands/eval.ts
@@ -1,0 +1,172 @@
+/**
+ * `prjct eval` — deterministic product evals for version-to-version proof.
+ *
+ * This command is intentionally local-first. `run` stores structured results
+ * under PRJCT_CLI_HOME; `publish` can push sanitized run artifacts to GitHub.
+ */
+
+import {
+  compareEvalRuns,
+  type EvalCompareOptions,
+  type EvalPublishOptions,
+  type EvalRunOptions,
+  formatEvalComparisonMarkdown,
+  formatEvalRunMarkdown,
+  loadLatestEvalRun,
+  publishEvalComparison,
+  publishEvalRun,
+  runEval,
+} from '../services/eval-service'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { mdOutput, mdSection } from '../utils/md-formatter'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+interface EvalOptions extends EvalRunOptions, EvalCompareOptions, EvalPublishOptions {
+  md?: boolean
+  json?: boolean
+  publish?: boolean
+}
+
+export class EvalCommands extends PrjctCommandsBase {
+  async eval(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: EvalOptions = {}
+  ): Promise<CommandResult> {
+    const [sub = 'run'] = (input ?? '').trim().split(/\s+/).filter(Boolean)
+    try {
+      switch (sub) {
+        case 'run':
+          return this.run(projectPath, options)
+        case 'compare':
+          return this.compare(projectPath, options)
+        case 'report':
+          return this.report(projectPath, options)
+        case 'publish':
+          return this.publish(projectPath, options)
+        default:
+          return this.unknown(sub, options)
+      }
+    } catch (error) {
+      const message = getErrorMessage(error)
+      if (options.md) console.log(mdOutput(mdSection('Eval failed', message)))
+      else out.fail(message)
+      return { success: false, error: message }
+    }
+  }
+
+  private async run(projectPath: string, options: EvalOptions): Promise<CommandResult> {
+    const run = await runEval(projectPath, options)
+    if (options.publish) {
+      const publish = await publishEvalRun(projectPath, {
+        target: options.target,
+        dryRun: options.dryRun,
+        file: run.artifacts?.jsonPath,
+      })
+      if (options.json) console.log(JSON.stringify({ run, publish }, null, 2))
+      else if (options.md) {
+        console.log(
+          mdOutput(
+            formatEvalRunMarkdown(run),
+            mdSection('Published', `Target: \`${publish.target}\`\nURL: ${publish.url ?? '-'}`)
+          )
+        )
+      } else {
+        out.done(`eval run ${run.runId} saved and published to ${publish.target}`)
+      }
+      return { success: true, runId: run.runId, score: run.summary.score, publish }
+    }
+
+    if (options.json) console.log(JSON.stringify(run, null, 2))
+    else if (options.md) console.log(mdOutput(formatEvalRunMarkdown(run)))
+    else out.done(`eval run ${run.runId} saved — score ${run.summary.score}/100`)
+    return { success: true, runId: run.runId, score: run.summary.score }
+  }
+
+  private async compare(projectPath: string, options: EvalOptions): Promise<CommandResult> {
+    const comparison = await compareEvalRuns(projectPath, options)
+    if (options.publish) {
+      const publish = await publishEvalComparison(projectPath, comparison, {
+        target: options.target,
+        dryRun: options.dryRun,
+      })
+      if (options.json) console.log(JSON.stringify({ comparison, publish }, null, 2))
+      else if (options.md) {
+        console.log(
+          mdOutput(
+            formatEvalComparisonMarkdown(comparison),
+            mdSection(
+              'Published',
+              `Target: \`${publish.target}\`
+URL: ${publish.url ?? '-'}`
+            )
+          )
+        )
+      } else {
+        const delta = comparison.summary.delta ?? 'n/a'
+        out.done(`eval comparison ${comparison.comparisonId} saved and published — delta ${delta}`)
+      }
+      return {
+        success: true,
+        comparisonId: comparison.comparisonId,
+        publish,
+        ...comparison.summary,
+      }
+    }
+
+    if (options.json) console.log(JSON.stringify(comparison, null, 2))
+    else if (options.md) console.log(mdOutput(formatEvalComparisonMarkdown(comparison)))
+    else {
+      const delta = comparison.summary.delta ?? 'n/a'
+      out.done(`eval comparison complete — delta ${delta}`)
+    }
+    return { success: true, comparisonId: comparison.comparisonId, ...comparison.summary }
+  }
+
+  private async report(projectPath: string, options: EvalOptions): Promise<CommandResult> {
+    const run = await loadLatestEvalRun(projectPath)
+    if (!run) {
+      const message = 'No eval run found. Run `prjct eval run` first.'
+      if (options.md) console.log(mdOutput(mdSection('No eval report', message)))
+      else out.fail(message)
+      return { success: false, error: message }
+    }
+    if (options.json) console.log(JSON.stringify(run, null, 2))
+    else if (options.md) console.log(mdOutput(formatEvalRunMarkdown(run)))
+    else out.done(`latest eval ${run.runId} — score ${run.summary.score}/100`)
+    return { success: true, runId: run.runId, score: run.summary.score }
+  }
+
+  private async publish(projectPath: string, options: EvalOptions): Promise<CommandResult> {
+    const result = await publishEvalRun(projectPath, options)
+    if (options.json) console.log(JSON.stringify(result, null, 2))
+    else if (options.md) {
+      const files = result.files.map((file) => `- ${file.action}: \`${file.path}\``).join('\n')
+      console.log(
+        mdOutput(
+          mdSection(
+            result.dryRun ? 'Eval publish dry run' : 'Eval published',
+            `Target: \`${result.target}\`\nRepo: \`${result.repo}\`\nBranch: \`${result.branch}\`\nURL: ${result.url ?? '-'}`
+          ),
+          mdSection('Files', files)
+        )
+      )
+    } else {
+      out.done(
+        result.dryRun
+          ? `eval publish dry run prepared ${result.files.length} files`
+          : `eval published ${result.runId} to ${result.repo}`
+      )
+    }
+    return { success: true, ...result }
+  }
+
+  private unknown(sub: string, options: EvalOptions): CommandResult {
+    const message = `Unknown eval subcommand: ${sub}. Use run, compare, report, publish.`
+    if (options.md) console.log(mdOutput(mdSection('Unknown eval subcommand', message)))
+    else out.fail(message)
+    return { success: false, error: message }
+  }
+}

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -74,6 +74,7 @@ export const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = 
   notify: lazy(async () => new (await import('./notify')).NotifyCommands()),
   agents: lazy(async () => new (await import('./agents')).AgentsCommands()),
   product: lazy(async () => new (await import('./product')).ProductCommands()),
+  eval: lazy(async () => new (await import('./eval')).EvalCommands()),
 }
 
 function registerCategories(): void {

--- a/core/schemas/eval.ts
+++ b/core/schemas/eval.ts
@@ -1,0 +1,111 @@
+/**
+ * Eval run schemas.
+ *
+ * These records are intentionally portable: local storage, GitHub publishing,
+ * CI artifacts, and future dashboards all consume the same shape.
+ */
+
+import { z } from 'zod'
+
+export const EvalActionableSchema = z.object({
+  severity: z.enum(['info', 'warning', 'blocking']),
+  title: z.string(),
+  recommendation: z.string(),
+  files: z.array(z.string()).optional(),
+  command: z.string().optional(),
+})
+
+export const EvalScenarioSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(['pass', 'warn', 'fail']),
+  score: z.number().min(0).max(100),
+  durationMs: z.number().nonnegative(),
+  metrics: z.record(z.union([z.string(), z.number(), z.boolean()])),
+  actionables: z.array(EvalActionableSchema),
+})
+
+export const EvalRunSchema = z.object({
+  schemaVersion: z.literal(1),
+  runId: z.string(),
+  createdAt: z.string(),
+  runner: z.object({
+    source: z.enum(['local', 'ci', 'agent']),
+    user: z.string().optional(),
+    platform: z.string(),
+    node: z.string(),
+    bun: z.string().optional(),
+  }),
+  project: z.object({
+    repo: z.string(),
+    branch: z.string().optional(),
+    commit: z.string().optional(),
+    dirty: z.boolean(),
+  }),
+  versions: z.object({
+    current: z.string(),
+    baseline: z.string().optional(),
+    candidate: z.string().optional(),
+  }),
+  scenarios: z.array(EvalScenarioSchema),
+  summary: z.object({
+    score: z.number().min(0).max(100),
+    pass: z.number().nonnegative(),
+    warn: z.number().nonnegative(),
+    fail: z.number().nonnegative(),
+    improvements: z.number().nonnegative(),
+    regressions: z.number().nonnegative(),
+    actionables: z.number().nonnegative(),
+  }),
+  artifacts: z
+    .object({
+      jsonPath: z.string().optional(),
+      reportPath: z.string().optional(),
+    })
+    .optional(),
+})
+
+export const EvalComparisonSchema = z.object({
+  schemaVersion: z.literal(1),
+  comparisonId: z.string(),
+  createdAt: z.string(),
+  baselineRunId: z.string().optional(),
+  candidateRunId: z.string().optional(),
+  baselineVersion: z.string().optional(),
+  candidateVersion: z.string().optional(),
+  summary: z.object({
+    baselineScore: z.number().optional(),
+    candidateScore: z.number().optional(),
+    delta: z.number().optional(),
+    regressions: z.number().nonnegative(),
+    improvements: z.number().nonnegative(),
+    actionables: z.number().nonnegative(),
+  }),
+  artifacts: z
+    .object({
+      jsonPath: z.string().optional(),
+      reportPath: z.string().optional(),
+    })
+    .optional(),
+  scenarios: z.array(
+    z.object({
+      id: z.string(),
+      baselineScore: z.number().optional(),
+      candidateScore: z.number().optional(),
+      delta: z.number().optional(),
+      status: z.enum([
+        'improved',
+        'regressed',
+        'unchanged',
+        'missing-baseline',
+        'missing-candidate',
+      ]),
+      actionables: z.array(EvalActionableSchema),
+    })
+  ),
+})
+
+export type EvalActionable = z.infer<typeof EvalActionableSchema>
+export type EvalScenario = z.infer<typeof EvalScenarioSchema>
+export type EvalRun = z.infer<typeof EvalRunSchema>
+export type EvalComparison = z.infer<typeof EvalComparisonSchema>

--- a/core/services/eval-service.ts
+++ b/core/services/eval-service.ts
@@ -1,0 +1,976 @@
+/**
+ * Product eval harness.
+ *
+ * This is deliberately deterministic by default: every run yields structured
+ * metrics, actionables, and files that can be compared between versions or
+ * published to GitHub without invoking an LLM.
+ */
+
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { resolveCliHome } from '../infrastructure/cli-home'
+import type { EvalActionable, EvalComparison, EvalRun, EvalScenario } from '../schemas/eval'
+import { EvalComparisonSchema, EvalRunSchema } from '../schemas/eval'
+import { getErrorMessage } from '../types/fs'
+import { execFileAsync } from '../utils/exec'
+import { getVersion } from '../utils/version'
+
+export interface EvalRunOptions {
+  baseline?: string
+  candidate?: string
+  source?: 'local' | 'ci' | 'agent'
+}
+
+export interface EvalCompareOptions {
+  baseline?: string
+  candidate?: string
+}
+
+export interface EvalPublishOptions {
+  target?: string
+  file?: string
+  dryRun?: boolean
+}
+
+export interface EvalPublishResult {
+  target: string
+  dryRun: boolean
+  artifactType: 'run' | 'comparison'
+  artifactId: string
+  runId?: string
+  comparisonId?: string
+  repo: string
+  branch: string
+  files: Array<{ path: string; action: 'create' | 'update' | 'skip' }>
+  url?: string
+}
+
+interface GitInfo {
+  repo: string
+  ownerRepo?: string
+  branch?: string
+  commit?: string
+  dirty: boolean
+}
+
+interface ScenarioContext {
+  projectPath: string
+  git: GitInfo
+}
+
+const EVAL_SCHEMA_VERSION = 1
+const SCORE_REGRESSION_THRESHOLD = -5
+const SCORE_IMPROVEMENT_THRESHOLD = 5
+
+export async function runEval(projectPath: string, options: EvalRunOptions = {}): Promise<EvalRun> {
+  const createdAt = new Date().toISOString()
+  const git = await detectGit(projectPath)
+  const context: ScenarioContext = { projectPath, git }
+  const scenarios = await runScenarios(context)
+  const summary = summarizeScenarios(scenarios)
+  const run: EvalRun = {
+    schemaVersion: EVAL_SCHEMA_VERSION,
+    runId: runId(createdAt),
+    createdAt,
+    runner: {
+      source: options.source ?? detectSource(),
+      user: await detectRunnerUser(projectPath),
+      platform: `${process.platform}-${process.arch}`,
+      node: process.version,
+      bun: await detectBunVersion(),
+    },
+    project: {
+      repo: git.repo,
+      branch: git.branch,
+      commit: git.commit,
+      dirty: git.dirty,
+    },
+    versions: {
+      current: getVersion(),
+      baseline: options.baseline,
+      candidate: options.candidate ?? getVersion(),
+    },
+    scenarios,
+    summary,
+  }
+
+  return saveEvalRun(run)
+}
+
+export async function loadLatestEvalRun(projectPath: string): Promise<EvalRun | null> {
+  const latestPath = path.join(evalProjectDir(await detectGit(projectPath)), 'latest.json')
+  return readRunFile(latestPath)
+}
+
+export async function loadLatestEvalComparison(
+  projectPath: string
+): Promise<EvalComparison | null> {
+  const latestPath = path.join(
+    evalProjectDir(await detectGit(projectPath)),
+    'latest-comparison.json'
+  )
+  return readComparisonFile(latestPath)
+}
+
+export async function loadEvalRunByVersion(
+  projectPath: string,
+  version: string | undefined
+): Promise<EvalRun | null> {
+  if (!version) return loadLatestEvalRun(projectPath)
+  const dir = path.join(evalProjectDir(await detectGit(projectPath)), 'runs')
+  let entries: string[] = []
+  try {
+    entries = await fs.readdir(dir)
+  } catch {
+    return null
+  }
+
+  const runs = (
+    await Promise.all(
+      entries
+        .filter((entry) => entry.endsWith('.json'))
+        .map((entry) => readRunFile(path.join(dir, entry)))
+    )
+  ).filter((run): run is EvalRun => Boolean(run))
+
+  return (
+    runs
+      .filter((run) => run.versions.current === version || run.versions.candidate === version)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0] ?? null
+  )
+}
+
+export async function compareEvalRuns(
+  projectPath: string,
+  options: EvalCompareOptions = {}
+): Promise<EvalComparison> {
+  const baseline = await loadEvalRunByVersion(projectPath, options.baseline)
+  const candidate = options.candidate
+    ? await loadEvalRunByVersion(projectPath, options.candidate)
+    : await loadLatestEvalRun(projectPath)
+
+  const scenarioIds = new Set<string>([
+    ...(baseline?.scenarios.map((scenario) => scenario.id) ?? []),
+    ...(candidate?.scenarios.map((scenario) => scenario.id) ?? []),
+  ])
+
+  const scenarios = [...scenarioIds].sort().map((id) => {
+    const b = baseline?.scenarios.find((scenario) => scenario.id === id)
+    const c = candidate?.scenarios.find((scenario) => scenario.id === id)
+    const delta = b && c ? Math.round((c.score - b.score) * 10) / 10 : undefined
+    const actionables: EvalActionable[] = []
+    let status: EvalComparison['scenarios'][number]['status'] = 'unchanged'
+
+    if (!b) {
+      status = 'missing-baseline'
+      actionables.push({
+        severity: 'warning',
+        title: `No baseline result for ${id}`,
+        recommendation:
+          'Run `prjct eval run --candidate <baseline-version>` before comparing releases.',
+      })
+    } else if (!c) {
+      status = 'missing-candidate'
+      actionables.push({
+        severity: 'blocking',
+        title: `No candidate result for ${id}`,
+        recommendation:
+          'Run `prjct eval run` for the candidate version before publishing a comparison.',
+      })
+    } else if ((delta ?? 0) <= SCORE_REGRESSION_THRESHOLD) {
+      status = 'regressed'
+      actionables.push({
+        severity: 'blocking',
+        title: `${id} regressed by ${Math.abs(delta ?? 0)} points`,
+        recommendation: regressionRecommendation(id),
+      })
+    } else if ((delta ?? 0) >= SCORE_IMPROVEMENT_THRESHOLD) {
+      status = 'improved'
+      actionables.push({
+        severity: 'info',
+        title: `${id} improved by ${delta} points`,
+        recommendation: 'Keep this scenario in PR checks so the improvement is protected.',
+      })
+    } else if (b && c) {
+      actionables.push({
+        severity: 'info',
+        title: `${id} stayed within the regression threshold`,
+        recommendation:
+          'Keep collecting this scenario so future optimizations have a stable baseline.',
+      })
+    }
+
+    return {
+      id,
+      baselineScore: b?.score,
+      candidateScore: c?.score,
+      delta,
+      status,
+      actionables,
+    }
+  })
+
+  const regressions = scenarios.filter((scenario) => scenario.status === 'regressed').length
+  const improvements = scenarios.filter((scenario) => scenario.status === 'improved').length
+  const createdAt = new Date().toISOString()
+  const baselineVersion =
+    baseline?.versions.candidate ?? baseline?.versions.current ?? options.baseline
+  const candidateVersion =
+    candidate?.versions.candidate ?? candidate?.versions.current ?? options.candidate
+  const comparison: EvalComparison = {
+    schemaVersion: EVAL_SCHEMA_VERSION,
+    comparisonId: comparisonId(createdAt, baselineVersion, candidateVersion),
+    createdAt,
+    baselineRunId: baseline?.runId,
+    candidateRunId: candidate?.runId,
+    baselineVersion,
+    candidateVersion,
+    summary: {
+      baselineScore: baseline?.summary.score,
+      candidateScore: candidate?.summary.score,
+      delta:
+        baseline && candidate
+          ? Math.round((candidate.summary.score - baseline.summary.score) * 10) / 10
+          : undefined,
+      regressions,
+      improvements,
+      actionables: scenarios.reduce((sum, scenario) => sum + scenario.actionables.length, 0),
+    },
+    scenarios,
+  }
+  return saveEvalComparison(projectPath, comparison)
+}
+
+interface EvalPublishFile {
+  path: string
+  content: string
+  action: 'create' | 'update'
+}
+
+export async function publishEvalRun(
+  projectPath: string,
+  options: EvalPublishOptions = {}
+): Promise<EvalPublishResult> {
+  const target = options.target ?? 'github'
+  if (target !== 'github') {
+    throw new Error(`Unsupported eval publish target: ${target}`)
+  }
+
+  const run = options.file
+    ? await readRequiredRunFile(options.file)
+    : await loadLatestRequired(projectPath)
+  const report = formatEvalRunMarkdown(run)
+  const git = await detectGit(projectPath)
+  if (!git.ownerRepo) {
+    throw new Error('GitHub publish requires a GitHub remote.')
+  }
+
+  const date = run.createdAt.slice(0, 10)
+  const files: EvalPublishFile[] = [
+    {
+      path: `eval-results/runs/${date}/${run.runId}.json`,
+      content: `${JSON.stringify(run, null, 2)}\n`,
+      action: 'create',
+    },
+    {
+      path: `eval-results/runs/${date}/${run.runId}.md`,
+      content: report,
+      action: 'create',
+    },
+    {
+      path: 'eval-results/summary/latest.json',
+      content: `${JSON.stringify(run, null, 2)}\n`,
+      action: 'update',
+    },
+  ]
+
+  return publishFiles(git.ownerRepo, target, options.dryRun === true, files, {
+    artifactType: 'run',
+    artifactId: run.runId,
+    runId: run.runId,
+  })
+}
+
+export async function publishEvalComparison(
+  projectPath: string,
+  comparison: EvalComparison,
+  options: EvalPublishOptions = {}
+): Promise<EvalPublishResult> {
+  const target = options.target ?? 'github'
+  if (target !== 'github') {
+    throw new Error(`Unsupported eval publish target: ${target}`)
+  }
+
+  const git = await detectGit(projectPath)
+  if (!git.ownerRepo) {
+    throw new Error('GitHub publish requires a GitHub remote.')
+  }
+
+  const date = comparison.createdAt.slice(0, 10)
+  const files: EvalPublishFile[] = [
+    {
+      path: `eval-results/comparisons/${date}/${comparison.comparisonId}.json`,
+      content: `${JSON.stringify(comparison, null, 2)}\n`,
+      action: 'create',
+    },
+    {
+      path: `eval-results/comparisons/${date}/${comparison.comparisonId}.md`,
+      content: formatEvalComparisonMarkdown(comparison),
+      action: 'create',
+    },
+    {
+      path: 'eval-results/summary/latest-comparison.json',
+      content: `${JSON.stringify(comparison, null, 2)}\n`,
+      action: 'update',
+    },
+  ]
+
+  return publishFiles(git.ownerRepo, target, options.dryRun === true, files, {
+    artifactType: 'comparison',
+    artifactId: comparison.comparisonId,
+    comparisonId: comparison.comparisonId,
+  })
+}
+
+export function formatEvalRunMarkdown(run: EvalRun): string {
+  const actionables = run.scenarios.flatMap((scenario) =>
+    scenario.actionables.map((actionable) => ({ scenario: scenario.id, actionable }))
+  )
+  const scenarioRows = run.scenarios
+    .map(
+      (scenario) =>
+        `| \`${scenario.id}\` | ${scenario.status} | ${scenario.score} | ${scenario.actionables.length} |`
+    )
+    .join('\n')
+  const actionableRows =
+    actionables.length === 0
+      ? '_No actionables._'
+      : actionables
+          .map(
+            ({ scenario, actionable }) =>
+              `- **${actionable.severity}** \`${scenario}\`: ${actionable.title}. ${actionable.recommendation}`
+          )
+          .join('\n')
+
+  return `# prjct eval run
+
+Run: \`${run.runId}\`
+Version: \`${run.versions.current}\`
+Repo: \`${run.project.repo}\`
+Commit: \`${run.project.commit ?? 'unknown'}\`
+
+## Summary
+
+| Metric | Value |
+|---|---:|
+| Score | ${run.summary.score} |
+| Pass | ${run.summary.pass} |
+| Warn | ${run.summary.warn} |
+| Fail | ${run.summary.fail} |
+| Actionables | ${run.summary.actionables} |
+
+## Scenarios
+
+| Scenario | Status | Score | Actionables |
+|---|---|---:|---:|
+${scenarioRows}
+
+## Actionables
+
+${actionableRows}
+`
+}
+
+export function formatEvalComparisonMarkdown(comparison: EvalComparison): string {
+  const rows = comparison.scenarios
+    .map(
+      (scenario) =>
+        `| \`${scenario.id}\` | ${scenario.status} | ${scenario.baselineScore ?? '-'} | ${scenario.candidateScore ?? '-'} | ${scenario.delta ?? '-'} |`
+    )
+    .join('\n')
+  const actionables = comparison.scenarios.flatMap((scenario) =>
+    scenario.actionables.map(
+      (actionable) =>
+        `- **${actionable.severity}** \`${scenario.id}\`: ${actionable.title}. ${actionable.recommendation}`
+    )
+  )
+
+  return `# prjct eval comparison
+
+Comparison: \`${comparison.comparisonId}\`
+Baseline: \`${comparison.baselineVersion ?? 'missing'}\`
+Candidate: \`${comparison.candidateVersion ?? 'missing'}\`
+
+## Summary
+
+| Metric | Value |
+|---|---:|
+| Baseline score | ${comparison.summary.baselineScore ?? '-'} |
+| Candidate score | ${comparison.summary.candidateScore ?? '-'} |
+| Delta | ${comparison.summary.delta ?? '-'} |
+| Improvements | ${comparison.summary.improvements} |
+| Regressions | ${comparison.summary.regressions} |
+| Actionables | ${comparison.summary.actionables} |
+
+## Scenarios
+
+| Scenario | Status | Baseline | Candidate | Delta |
+|---|---|---:|---:|---:|
+${rows || '| _none_ | - | - | - | - |'}
+
+## Actionables
+
+${actionables.length > 0 ? actionables.join('\n') : '_No actionables._'}
+`
+}
+
+function summarizeScenarios(scenarios: EvalScenario[]): EvalRun['summary'] {
+  const score =
+    scenarios.length === 0
+      ? 0
+      : Math.round(scenarios.reduce((sum, scenario) => sum + scenario.score, 0) / scenarios.length)
+  return {
+    score,
+    pass: scenarios.filter((scenario) => scenario.status === 'pass').length,
+    warn: scenarios.filter((scenario) => scenario.status === 'warn').length,
+    fail: scenarios.filter((scenario) => scenario.status === 'fail').length,
+    improvements: 0,
+    regressions: scenarios.filter((scenario) => scenario.status === 'fail').length,
+    actionables: scenarios.reduce((sum, scenario) => sum + scenario.actionables.length, 0),
+  }
+}
+
+async function runScenarios(context: ScenarioContext): Promise<EvalScenario[]> {
+  return Promise.all([
+    scenario('agent-surface-readiness', 'Agent surface readiness', () =>
+      evalAgentSurface(context.projectPath)
+    ),
+    scenario('project-sync-readiness', 'Project sync readiness', () =>
+      evalProjectSyncReadiness(context.projectPath)
+    ),
+    scenario('stale-command-guidance', 'Stale command guidance', () =>
+      evalStaleCommandGuidance(context.projectPath)
+    ),
+    scenario('quality-command-readiness', 'Quality command readiness', () =>
+      evalQualityCommandReadiness(context.projectPath)
+    ),
+    scenario('github-publish-readiness', 'GitHub publish readiness', () =>
+      evalGithubPublishReadiness(context.git)
+    ),
+  ])
+}
+
+async function scenario(
+  id: string,
+  name: string,
+  run: () => Promise<Omit<EvalScenario, 'id' | 'name' | 'durationMs'>>
+): Promise<EvalScenario> {
+  const started = Date.now()
+  const result = await run()
+  return { id, name, durationMs: Date.now() - started, ...result }
+}
+
+async function evalAgentSurface(
+  projectPath: string
+): Promise<Omit<EvalScenario, 'id' | 'name' | 'durationMs'>> {
+  const agents = await exists(path.join(projectPath, 'AGENTS.md'))
+  const claude = await exists(path.join(projectPath, 'CLAUDE.md'))
+  const score = agents ? 100 : claude ? 70 : 20
+  return {
+    status: score >= 90 ? 'pass' : 'warn',
+    score,
+    metrics: { agentsMd: agents, claudeMd: claude },
+    actionables:
+      score >= 90
+        ? [
+            {
+              severity: 'info',
+              title: 'Portable agent surface is present',
+              recommendation: 'Keep `prjct agents doctor --fix` in release smoke checks.',
+              command: 'prjct agents doctor --fix',
+            },
+          ]
+        : [
+            {
+              severity: 'warning',
+              title: 'Portable AGENTS.md surface is missing',
+              recommendation:
+                'Run `prjct agents doctor --fix` so future agents start with the same project contract.',
+              command: 'prjct agents doctor --fix',
+            },
+          ],
+  }
+}
+
+async function evalProjectSyncReadiness(
+  projectPath: string
+): Promise<Omit<EvalScenario, 'id' | 'name' | 'durationMs'>> {
+  const config = await exists(path.join(projectPath, '.prjct', 'prjct.config.json'))
+  return {
+    status: config ? 'pass' : 'warn',
+    score: config ? 100 : 40,
+    metrics: { projectConfig: config },
+    actionables: [
+      config
+        ? {
+            severity: 'info',
+            title: 'Project has a prjct identity',
+            recommendation:
+              'Use `prjct sync --md` in eval smoke runs to keep generated context measurable.',
+            command: 'prjct sync --md',
+          }
+        : {
+            severity: 'warning',
+            title: 'Project is not registered with prjct',
+            recommendation:
+              'Run `prjct sync` before comparing eval runs so metrics map to a stable project id.',
+            command: 'prjct sync',
+          },
+    ],
+  }
+}
+
+async function evalStaleCommandGuidance(
+  projectPath: string
+): Promise<Omit<EvalScenario, 'id' | 'name' | 'durationMs'>> {
+  const files = await collectTextFiles(projectPath, 250)
+  const staleCommandPattern = /\/p:\s*[a-z][a-z0-9-]*/i
+  const staleHits: string[] = []
+  await Promise.all(
+    files.map(async (file) => {
+      const text = await fs.readFile(path.join(projectPath, file), 'utf-8').catch(() => '')
+      if (staleCommandPattern.test(text)) staleHits.push(file)
+    })
+  )
+  return {
+    status: staleHits.length === 0 ? 'pass' : 'warn',
+    score: staleHits.length === 0 ? 100 : Math.max(20, 100 - staleHits.length * 10),
+    metrics: { scannedFiles: files.length, staleHits: staleHits.length },
+    actionables:
+      staleHits.length === 0
+        ? [
+            {
+              severity: 'info',
+              title: 'No stale `/p:` command guidance found',
+              recommendation: 'Keep this scan in evals to prevent user-facing command drift.',
+            },
+          ]
+        : [
+            {
+              severity: 'warning',
+              title: `Found ${staleHits.length} stale command guidance file(s)`,
+              recommendation: 'Replace stale `/p:` examples with `p. <verb>` or `prjct <verb>`.',
+              files: staleHits.slice(0, 10),
+            },
+          ],
+  }
+}
+
+async function evalQualityCommandReadiness(
+  projectPath: string
+): Promise<Omit<EvalScenario, 'id' | 'name' | 'durationMs'>> {
+  const pkgPath = path.join(projectPath, 'package.json')
+  let scripts: Record<string, unknown> = {}
+  try {
+    const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8')) as {
+      scripts?: Record<string, unknown>
+    }
+    scripts = pkg.scripts ?? {}
+  } catch {
+    // Non-JS projects can still use evals, but this scenario becomes advisory.
+  }
+  const hasTest = typeof scripts.test === 'string'
+  const hasCheck = typeof scripts.check === 'string' || typeof scripts.lint === 'string'
+  const score = (hasTest ? 50 : 0) + (hasCheck ? 50 : 0)
+  return {
+    status: score >= 100 ? 'pass' : 'warn',
+    score,
+    metrics: { hasTest, hasCheck },
+    actionables:
+      score >= 100
+        ? [
+            {
+              severity: 'info',
+              title: 'Quality commands are discoverable',
+              recommendation:
+                'Use these commands as eval scenario gates before publishing results.',
+            },
+          ]
+        : [
+            {
+              severity: 'warning',
+              title: 'Quality commands are incomplete',
+              recommendation:
+                'Expose `test` and `check`/`lint` scripts so eval reports can tie regressions to real verification.',
+              files: ['package.json'],
+            },
+          ],
+  }
+}
+
+async function evalGithubPublishReadiness(
+  git: GitInfo
+): Promise<Omit<EvalScenario, 'id' | 'name' | 'durationMs'>> {
+  const gh = await commandExists('gh')
+  const score = (git.ownerRepo ? 50 : 0) + (gh ? 50 : 0)
+  return {
+    status: score >= 100 ? 'pass' : 'warn',
+    score,
+    metrics: { githubRemote: Boolean(git.ownerRepo), gh },
+    actionables:
+      score >= 100
+        ? [
+            {
+              severity: 'info',
+              title: 'GitHub publishing is available',
+              recommendation:
+                'Run `prjct eval publish --target github` to store this run on the eval-results branch.',
+              command: 'prjct eval publish --target github',
+            },
+          ]
+        : [
+            {
+              severity: 'warning',
+              title: 'GitHub publishing is not fully configured',
+              recommendation:
+                'Configure a GitHub remote and authenticate `gh` before publishing eval history.',
+            },
+          ],
+  }
+}
+
+async function saveEvalRun(run: EvalRun): Promise<EvalRun> {
+  const projectDir = evalProjectDir({ repo: run.project.repo })
+  const runsDir = path.join(projectDir, 'runs')
+  await fs.mkdir(runsDir, { recursive: true })
+  const jsonPath = path.join(runsDir, `${run.runId}.json`)
+  const reportPath = path.join(runsDir, `${run.runId}.md`)
+  const withArtifacts: EvalRun = {
+    ...run,
+    artifacts: { jsonPath, reportPath },
+  }
+  EvalRunSchema.parse(withArtifacts)
+  await fs.writeFile(jsonPath, `${JSON.stringify(withArtifacts, null, 2)}\n`, 'utf-8')
+  await fs.writeFile(reportPath, formatEvalRunMarkdown(withArtifacts), 'utf-8')
+  await fs.writeFile(
+    path.join(projectDir, 'latest.json'),
+    `${JSON.stringify(withArtifacts, null, 2)}\n`,
+    'utf-8'
+  )
+  return withArtifacts
+}
+
+async function saveEvalComparison(
+  projectPath: string,
+  comparison: EvalComparison
+): Promise<EvalComparison> {
+  const projectDir = evalProjectDir(await detectGit(projectPath))
+  const comparisonsDir = path.join(projectDir, 'comparisons')
+  await fs.mkdir(comparisonsDir, { recursive: true })
+  const jsonPath = path.join(comparisonsDir, `${comparison.comparisonId}.json`)
+  const reportPath = path.join(comparisonsDir, `${comparison.comparisonId}.md`)
+  const withArtifacts: EvalComparison = {
+    ...comparison,
+    artifacts: { jsonPath, reportPath },
+  }
+  EvalComparisonSchema.parse(withArtifacts)
+  await fs.writeFile(jsonPath, `${JSON.stringify(withArtifacts, null, 2)}\n`, 'utf-8')
+  await fs.writeFile(reportPath, formatEvalComparisonMarkdown(withArtifacts), 'utf-8')
+  await fs.writeFile(
+    path.join(projectDir, 'latest-comparison.json'),
+    `${JSON.stringify(withArtifacts, null, 2)}\n`,
+    'utf-8'
+  )
+  return withArtifacts
+}
+
+function evalProjectDir(git: Pick<GitInfo, 'repo'>): string {
+  const slug = git.repo.replace(/[^a-zA-Z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown'
+  return path.join(resolveCliHome(), 'evals', slug)
+}
+
+async function readRunFile(filePath: string): Promise<EvalRun | null> {
+  try {
+    return EvalRunSchema.parse(JSON.parse(await fs.readFile(filePath, 'utf-8')))
+  } catch {
+    return null
+  }
+}
+
+async function readComparisonFile(filePath: string): Promise<EvalComparison | null> {
+  try {
+    return EvalComparisonSchema.parse(JSON.parse(await fs.readFile(filePath, 'utf-8')))
+  } catch {
+    return null
+  }
+}
+
+async function readRequiredRunFile(filePath: string): Promise<EvalRun> {
+  const run = await readRunFile(filePath)
+  if (!run) throw new Error(`Invalid or missing eval run file: ${filePath}`)
+  return run
+}
+
+async function loadLatestRequired(projectPath: string): Promise<EvalRun> {
+  const latest = await loadLatestEvalRun(projectPath)
+  if (!latest) throw new Error('No eval run found. Run `prjct eval run` first.')
+  return latest
+}
+
+async function detectGit(projectPath: string): Promise<GitInfo> {
+  const [branch, commit, remote, status] = await Promise.all([
+    git(projectPath, ['branch', '--show-current']),
+    git(projectPath, ['rev-parse', 'HEAD']),
+    git(projectPath, ['config', '--get', 'remote.origin.url']),
+    git(projectPath, ['status', '--porcelain']),
+  ])
+  const ownerRepo = parseGitHubOwnerRepo(remote)
+  return {
+    repo: ownerRepo ?? hashedRepo(projectPath),
+    ownerRepo,
+    branch: branch || undefined,
+    commit: commit || undefined,
+    dirty: status.trim().length > 0,
+  }
+}
+
+async function git(projectPath: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd: projectPath })
+    return String(stdout).trim()
+  } catch {
+    return ''
+  }
+}
+
+function parseGitHubOwnerRepo(remote: string): string | undefined {
+  const trimmed = remote.trim()
+  const https = trimmed.match(/github\.com[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/)
+  if (!https) return undefined
+  return `${https[1]}/${https[2]}`
+}
+
+function hashedRepo(projectPath: string): string {
+  return `local-${crypto.createHash('sha256').update(path.resolve(projectPath)).digest('hex').slice(0, 12)}`
+}
+
+function runId(createdAt: string): string {
+  const stamp = createdAt.replace(/[-:.TZ]/g, '').slice(0, 14)
+  return `eval_${stamp}_${crypto.randomBytes(4).toString('hex')}`
+}
+
+function comparisonId(
+  createdAt: string,
+  baselineVersion: string | undefined,
+  candidateVersion: string | undefined
+): string {
+  const stamp = createdAt.replace(/[-:.TZ]/g, '').slice(0, 14)
+  const baseline = slugPart(baselineVersion ?? 'missing-baseline')
+  const candidate = slugPart(candidateVersion ?? 'missing-candidate')
+  return `comparison_${stamp}_${baseline}_to_${candidate}`
+}
+
+function slugPart(value: string): string {
+  return (
+    value
+      .replace(/[^a-zA-Z0-9_.-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80) || 'unknown'
+  )
+}
+
+function detectSource(): 'local' | 'ci' | 'agent' {
+  if (process.env.GITHUB_ACTIONS === 'true' || process.env.CI === 'true') return 'ci'
+  if (process.env.CODEX_SANDBOX || process.env.CLAUDECODE) return 'agent'
+  return 'local'
+}
+
+async function detectRunnerUser(projectPath: string): Promise<string | undefined> {
+  const gh = await execFileMaybe('gh', ['api', 'user', '--jq', '.login'], projectPath)
+  if (gh) return `github:${gh}`
+  const email = await git(projectPath, ['config', 'user.email'])
+  return email ? `git:${email}` : undefined
+}
+
+async function detectBunVersion(): Promise<string | undefined> {
+  return execFileMaybe('bun', ['--version'], process.cwd())
+}
+
+async function execFileMaybe(
+  cmd: string,
+  args: string[],
+  cwd: string
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, { cwd })
+    const value = String(stdout).trim()
+    return value || undefined
+  } catch {
+    return undefined
+  }
+}
+
+async function commandExists(cmd: string): Promise<boolean> {
+  return Boolean(await execFileMaybe('which', [cmd], process.cwd()))
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function collectTextFiles(projectPath: string, maxFiles: number): Promise<string[]> {
+  const result: string[] = []
+  const skip = new Set([
+    '.git',
+    'node_modules',
+    'dist',
+    'build',
+    'coverage',
+    '.prjct',
+    '__tests__',
+    '__fixtures__',
+    'fixtures',
+  ])
+
+  async function walk(dir: string): Promise<void> {
+    if (result.length >= maxFiles) return
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (result.length >= maxFiles) break
+      if (skip.has(entry.name)) continue
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) await walk(fullPath)
+      else if (
+        entry.isFile() &&
+        !entry.name.includes('.test.') &&
+        !entry.name.includes('.spec.') &&
+        /\.(md|mdc|txt|toml|json|ya?ml|sh|ts|tsx|js|jsx)$/.test(entry.name)
+      ) {
+        result.push(path.relative(projectPath, fullPath))
+      }
+    }
+  }
+
+  await walk(projectPath)
+  return result
+}
+
+function regressionRecommendation(id: string): string {
+  if (id.includes('sync'))
+    return 'Inspect sync incrementality and generated context freshness before shipping.'
+  if (id.includes('github')) return 'Check GitHub remote/authentication and eval publisher setup.'
+  if (id.includes('command'))
+    return 'Audit user-facing command copy and generated templates for stale instructions.'
+  return 'Open the latest eval report, inspect scenario metrics, and add a focused regression test.'
+}
+
+async function publishFiles(
+  ownerRepo: string,
+  target: string,
+  dryRun: boolean,
+  files: EvalPublishFile[],
+  artifact: Pick<EvalPublishResult, 'artifactType' | 'artifactId' | 'runId' | 'comparisonId'>
+): Promise<EvalPublishResult> {
+  if (!dryRun) {
+    await ensureEvalResultsBranch(ownerRepo)
+    for (const file of files) {
+      await putGitHubFile(ownerRepo, file.path, file.content, file.action)
+    }
+  }
+
+  return {
+    target,
+    dryRun,
+    ...artifact,
+    repo: ownerRepo,
+    branch: 'eval-results',
+    files: files.map(({ path: filePath, action }) => ({ path: filePath, action })),
+    url: `https://github.com/${ownerRepo}/tree/eval-results/eval-results`,
+  }
+}
+
+async function ensureEvalResultsBranch(ownerRepo: string): Promise<void> {
+  const existsRef = await ghApi(ownerRepo, ['repos/:owner/:repo/git/ref/heads/eval-results'])
+  if (existsRef.ok) return
+
+  const repo = await ghApi(ownerRepo, ['repos/:owner/:repo', '--jq', '.default_branch'])
+  const defaultBranch = repo.ok ? repo.stdout.trim() || 'main' : 'main'
+  const defaultRef = await ghApi(ownerRepo, [`repos/:owner/:repo/git/ref/heads/${defaultBranch}`])
+  if (!defaultRef.ok)
+    throw new Error(`Cannot resolve ${defaultBranch} branch ref for eval-results branch.`)
+  const parsed = JSON.parse(defaultRef.stdout) as { object?: { sha?: string } }
+  const sha = parsed.object?.sha
+  if (!sha) throw new Error(`Cannot resolve ${defaultBranch} branch sha for eval-results branch.`)
+  await ghApi(ownerRepo, [
+    'repos/:owner/:repo/git/refs',
+    '-X',
+    'POST',
+    '-f',
+    'ref=refs/heads/eval-results',
+    '-f',
+    `sha=${sha}`,
+  ])
+}
+
+async function putGitHubFile(
+  ownerRepo: string,
+  filePath: string,
+  content: string,
+  action: 'create' | 'update'
+): Promise<void> {
+  const existing = await ghApi(ownerRepo, [
+    `repos/:owner/:repo/contents/${filePath}`,
+    '-X',
+    'GET',
+    '-f',
+    'ref=eval-results',
+  ])
+  let sha: string | undefined
+  if (existing.ok) {
+    const parsed = JSON.parse(existing.stdout) as { sha?: string }
+    sha = parsed.sha
+  } else if (action === 'update') {
+    // Updating a summary file that does not exist yet is a create.
+    sha = undefined
+  }
+
+  const args = [
+    `repos/:owner/:repo/contents/${filePath}`,
+    '-X',
+    'PUT',
+    '-f',
+    `message=chore(eval): publish ${path.basename(filePath)}`,
+    '-f',
+    `branch=eval-results`,
+    '-f',
+    `content=${Buffer.from(content, 'utf-8').toString('base64')}`,
+  ]
+  if (sha) args.push('-f', `sha=${sha}`)
+  const result = await ghApi(ownerRepo, args)
+  if (!result.ok) throw new Error(result.stderr || `Failed to publish ${filePath}`)
+}
+
+async function ghApi(
+  ownerRepo: string,
+  args: string[]
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  const [owner, repo] = ownerRepo.split('/')
+  const expanded = args.map((arg) => arg.replace(':owner', owner).replace(':repo', repo))
+  try {
+    const { stdout, stderr } = await execFileAsync('gh', ['api', ...expanded])
+    return { ok: true, stdout: String(stdout), stderr: String(stderr) }
+  } catch (error) {
+    const maybe = error as { stdout?: unknown; stderr?: unknown }
+    return {
+      ok: false,
+      stdout: String(maybe.stdout ?? ''),
+      stderr: String(maybe.stderr ?? getErrorMessage(error)),
+    }
+  }
+}

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -354,6 +354,7 @@ export type CommandRoutingGroup =
   | 'notify'
   | 'agents'
   | 'product'
+  | 'eval'
 
 export interface CommandRouting {
   /** Which command-group instance owns the handler. */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.62.0",
+  "version": "2.63.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- add prjct eval run/report/compare/publish commands with local JSON/Markdown artifacts
- publish run and comparison history to GitHub eval-results branch
- add CI workflow and docs for collecting eval metrics

## Verification
- bun run check:fix
- bun run typecheck
- bun run knip
- bun run build
- bun test
- dist smoke: eval run + compare --publish --dry-run