### PR TITLE
fix: fail unknown commands before capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.67.1] - 2026-06-23
+
+### Fixed
+- command routing fallback
+
 ## [2.67.0] - 2026-06-23
 
 ### Added

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -161,12 +161,13 @@ const { REGISTERED_VERBS_SET, BIN_COMMANDS_SET } = await import('../core/command
 const { isRemovedVerb } = await import('../core/commands/removed-verbs')
 const _binCommands = BIN_COMMANDS_SET
 
-// v2 auto-route: if the first positional isn't a known verb, treat the
-// whole argv as GTD-style inbox capture → `prjct capture "<argv>"`.
-// Explicit verbs still win. Capture is zero-ceremony; if the user
-// wanted a task (branch/worktree), they type `prjct task "..."`
-// explicitly. Must run BEFORE the daemon fast path so the rewritten
-// `capture` routes there.
+// v2 auto-route: if the first positional isn't a known verb, treat free-text
+// argv as GTD-style inbox capture → `prjct capture "<argv>"`.
+// A lone command-shaped token is different: it is almost always a typo or a
+// stale install that predates a real verb, so fail loudly instead of writing a
+// bogus inbox item. Explicit verbs still win. Capture remains zero-ceremony
+// for multi-word notes; tasks still use `prjct task "..."` explicitly. Must
+// run BEFORE the daemon fast path so rewritten `capture` routes there.
 if (
   _fastCommand &&
   !_binCommands.has(_fastCommand) &&
@@ -177,21 +178,19 @@ if (
   const description = positionals.join(' ')
   const flags = _fastArgs.filter((a) => a.startsWith('-'))
   // A single command-shaped token (e.g. `prjct upgrade`) is almost never a
-  // GTD note — it's a MISROUTED command: a typo, or a stale parallel
-  // install / long-lived daemon that predates the verb. Silently turning it
-  // into an inbox capture buries it with zero feedback (same silent-no-op
-  // class as the WS1 exit-0 bug). Still capture (don't break free-text GTD)
-  // but make it LOUD + actionable so it's never a silent surprise.
+  // GTD note — it is a MISROUTED command: a typo, a stale parallel install, or
+  // a long-lived daemon that predates the verb. Do not write it to memory.
   if (
     positionals.length === 1 &&
     /^[a-z][a-z0-9:-]+$/.test(positionals[0]) &&
     !isRemovedVerb(positionals[0])
   ) {
     process.stderr.write(
-      `prjct: '${positionals[0]}' is not a known command in this install — ` +
-        'saving it to the inbox instead. If you meant the command, this prjct ' +
-        'may be stale: run `prjct update`.\n'
+      `prjct: '${positionals[0]}' is not a known command in this install. ` +
+        'If you meant a command, upgrade prjct with `prjct upgrade` ' +
+        '(or `prjct update` on older installs).\n'
     )
+    process.exit(1)
   }
   _fastCommand = 'capture'
   _fastArgs = ['capture', description, ...flags]
@@ -330,8 +329,12 @@ if (_fastCommand && !_binCommands.has(_fastCommand) && process.env.PRJCT_NO_DAEM
       const safeRetry =
         code === 'ECONNREFUSED' ||
         code === 'ENOENT' ||
+        code === 'EACCES' ||
+        code === 'EPERM' ||
         msg.includes('ECONNREFUSED') ||
-        msg.includes('ENOENT')
+        msg.includes('ENOENT') ||
+        msg.includes('EACCES') ||
+        msg.includes('EPERM')
 
       if (!safeRetry) {
         console.error(
@@ -483,7 +486,14 @@ async function main(): Promise<void> {
     const routersInstalled = await checkRoutersInstalled()
 
     // Commands that work without full setup
-    const noSetupRequired = new Set(['auth', 'login', 'logout', 'init', 'eval'])
+    const noSetupRequired = new Set([
+      'auth',
+      'login',
+      'logout',
+      'init',
+      'eval',
+      'analysis-save-llm',
+    ])
 
     if (!noSetupRequired.has(args[0]) && (!(await fileExists(configPath)) || !routersInstalled)) {
       console.log(`

--- a/core/__tests__/e2e/cli-lifecycle.e2e.test.ts
+++ b/core/__tests__/e2e/cli-lifecycle.e2e.test.ts
@@ -9,6 +9,7 @@
 
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import { makeSandbox, REPO_ROOT, type Sandbox } from './_harness'
 
@@ -43,13 +44,16 @@ describe('e2e: unconfigured project fails LOUD (regression)', () => {
   })
 
   // A misrouted single command-shaped token (typo / stale parallel install
-  // or daemon that predates a verb like `upgrade`) must NOT be silently
-  // swallowed into the inbox — it has to say so, loudly + actionably.
-  test('an unknown command-shaped token is captured LOUDLY, not silently', async () => {
+  // or daemon that predates a verb like `upgrade`) must NOT be written to
+  // memory. It has to fail loudly so scripts and agents cannot miss it.
+  test('an unknown command-shaped token fails without capture', async () => {
     const r = await sb.cli(['definitelynotacommand'])
     const out = (r.stdout + r.stderr).toLowerCase()
+    expect(r.code).not.toBe(0)
     expect(out).toContain('not a known command')
-    expect(out).toContain('prjct update')
+    expect(out).toContain('prjct upgrade')
+    expect(out).not.toContain('captured')
+    expect(out).not.toContain('inbox')
   })
 
   // Free-text GTD capture (multi-word, first token not a verb) stays silent
@@ -58,6 +62,29 @@ describe('e2e: unconfigured project fails LOUD (regression)', () => {
   test('multi-word free-text capture stays silent (GTD preserved)', async () => {
     const r = await sb.cli(['buy', 'more', 'coffee', 'beans'])
     expect((r.stdout + r.stderr).toLowerCase()).not.toContain('not a known command')
+  })
+})
+
+describe('e2e: analysis-save-llm from sync --deep', () => {
+  let sb: Sandbox
+  beforeAll(async () => {
+    sb = await makeSandbox()
+    const init = await sb.cli(['init'], { timeoutMs: 90_000 })
+    expect(init.code).toBe(0)
+  })
+  afterAll(async () => {
+    await sb.cleanup()
+  })
+
+  test('accepts a file path with --md before provider setup', async () => {
+    const analysisFile = path.join(sb.dir, 'analysis-notes.md')
+    await fs.writeFile(analysisFile, '- Commands route through the manifest.\n', 'utf-8')
+    const r = await sb.cli(['analysis-save-llm', analysisFile, '--md'])
+    const out = (r.stdout + r.stderr).toLowerCase()
+    expect(r.code).toBe(0)
+    expect(out).toContain('llm analysis saved')
+    expect(out).toContain('input')
+    expect(out).not.toContain('not configured')
   })
 })
 
@@ -114,6 +141,13 @@ describe('e2e: CLI lifecycle (hermetic fake project)', () => {
     const r = await sb.cli(['review-risk', '--md'])
     expect(r.code).toBe(0)
     expect(r.stdout.toLowerCase()).toMatch(/review risk|no comparable|trivial|tier/)
+  })
+
+  test('generic command errors are printed, not silent', async () => {
+    const r = await sb.cli(['config', 'definitelybad', '--md'])
+    const out = (r.stdout + r.stderr).toLowerCase()
+    expect(r.code).not.toBe(0)
+    expect(out).toContain('unknown config subcommand')
   })
 
   test('status done closes the active task', async () => {

--- a/core/__tests__/infrastructure/daemon-shim-sync.test.ts
+++ b/core/__tests__/infrastructure/daemon-shim-sync.test.ts
@@ -104,10 +104,12 @@ describe('daemon-shim fallback policy', () => {
     }
   })
 
-  test('socket error path checks ECONNREFUSED / ENOENT before fallback', () => {
-    // Must whitelist the safe-retry conditions, matching bin/prjct.ts:238-242.
+  test('socket error path checks safe connect failures before fallback', () => {
+    // These mean the daemon request never reached a server, so cold fallback is safe.
     expect(buildSrc).toContain('ECONNREFUSED')
     expect(buildSrc).toContain('ENOENT')
+    expect(buildSrc).toContain('EACCES')
+    expect(buildSrc).toContain('EPERM')
     expect(buildSrc).toMatch(/isSafeRetry|safeRetry/)
   })
 

--- a/core/index.ts
+++ b/core/index.ts
@@ -18,7 +18,7 @@ import { detectAllProviders, detectAntigravity } from './infrastructure/ai-provi
 import configManager from './infrastructure/config-manager'
 import performanceTracker from './infrastructure/performance-tracker'
 import { sessionTracker } from './services/session-tracker'
-import type { CommandMeta } from './types/commands'
+import type { CommandMeta, CommandResult } from './types/commands'
 import { getErrorMessage, getErrorStack } from './types/fs'
 import { getError } from './utils/error-messages'
 import { fileExists } from './utils/file-helper'
@@ -28,11 +28,6 @@ import { providerStatusHeader, providerStatusLine } from './utils/provider-statu
 interface ParsedCommandArgs {
   parsedArgs: string[]
   options: Record<string, string | boolean>
-}
-
-interface CommandResult {
-  success?: boolean
-  message?: string
 }
 
 async function main(): Promise<void> {
@@ -296,6 +291,8 @@ async function main(): Promise<void> {
     // 8. Display result
     if (result?.message) {
       console.log(result.message)
+    } else if (result?.error) {
+      console.error(result.error)
     }
 
     // Show branding footer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -240,7 +240,7 @@ const args=process.argv.slice(2);
 const cmd=args.find(a=>!a.startsWith("-"));
 const skip=new Set(${JSON.stringify(deriveShimSkipSet())});
 function refuse(m){console.error("prjct: daemon dropped the request ("+m+"). Retry: prjct "+args.join(" "));process.exit(1)}
-function isSafeRetry(e){const c=e&&e.code||"",m=e&&e.message||"";return c==="ECONNREFUSED"||c==="ENOENT"||m.includes("ECONNREFUSED")||m.includes("ENOENT")}
+function isSafeRetry(e){const c=e&&e.code||"",m=e&&e.message||"";return c==="ECONNREFUSED"||c==="ENOENT"||c==="EACCES"||c==="EPERM"||m.includes("ECONNREFUSED")||m.includes("ENOENT")||m.includes("EACCES")||m.includes("EPERM")}
 // Hook fast path: forward the event (stdin) to the warm daemon and write its
 // response raw. Hooks must never disturb the host session, so ANY failure
 // (connect error, timeout, closed socket) degrades to the empty no-op {} and


### PR DESCRIPTION
## Summary
- Fail single-token unknown command-shaped input instead of writing it to capture/inbox
- Allow analysis-save-llm to run after init before provider setup, matching sync --deep guidance
- Print generic CommandResult.error values instead of exiting silently
- Treat daemon socket EACCES/EPERM as safe connect failures for cold fallback

## Tests
- bun run lint
- bun run typecheck
- bun run build
- bun test core/__tests__/e2e/cli-lifecycle.e2e.test.ts core/__tests__/infrastructure/daemon-shim-sync.test.ts core/__tests__/e2e/install-flow.e2e.test.ts core/__tests__/commands/analysis-save-llm.test.ts
- bun test