### PR TITLE
fix: route upgrade alias through update

### DIFF
--- a/core/__tests__/commands/manifest-completeness.test.ts
+++ b/core/__tests__/commands/manifest-completeness.test.ts
@@ -44,6 +44,14 @@ describe('command manifest — completeness', () => {
     expect(both).toEqual([])
   })
 
+  test('upgrade is both bin-only and registry-routed to update', () => {
+    const meta = COMMANDS.find((c) => c.name === 'upgrade')
+    expect(meta?.routingMode).toBe('bin-only')
+    expect(meta?.routing).toEqual({ group: 'update', method: 'update' })
+    expect(BIN_COMMANDS_SET.has('upgrade')).toBe(true)
+    expect(REGISTERED_VERBS_SET.has('upgrade')).toBe(true)
+  })
+
   test('schema-covered commands declare routing (the generic path needs a handler)', () => {
     const broken = COMMANDS.filter((c) => c.optionSchema && !c.routing).map((c) => c.name)
     expect(broken).toEqual([])
@@ -63,6 +71,7 @@ describe('command manifest — completeness', () => {
       'start',
       'setup',
       'update',
+      'upgrade',
       'uninstall',
       'login',
       'logout',

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -856,7 +856,7 @@ export const COMMANDS: CommandMeta[] = [
       ['daemon', 'Run the prjct daemon in the foreground'],
       ['stop', 'Stop the running prjct daemon'],
       ['restart', 'Restart the prjct daemon'],
-      ['upgrade', 'Alias of `prjct update`'],
+      ['upgrade', 'Alias of `prjct update`', { group: 'update', method: 'update' }],
       ['hook', 'Run a Claude Code hook event (internal; called by the hook scripts)'],
       ['hooks', 'Inspect or reinstall the Claude Code hooks'],
       ['claude', 'Claude Code integration management (install/uninstall)'],
@@ -873,10 +873,11 @@ export const COMMANDS: CommandMeta[] = [
       ['context-restore', 'Restore a previously saved working context'],
     ] as const
   ).map(
-    ([name, description]): CommandMeta => ({
+    ([name, description, routing]): CommandMeta => ({
       name,
       group: 'setup',
       description,
+      routing,
       usage: { claude: null, terminal: `prjct ${name}` },
       implemented: true,
       hasTemplate: false,


### PR DESCRIPTION
## Summary
- Register `upgrade` with the command registry as a bin-only alias routed to `update.update`
- Add a manifest invariant so `upgrade` remains both daemon-skipped and cold-path routable
- Verified the built artifact runs `upgrade --dry-run --md` through update instead of capture

## Tests
- bun run format
- bun test core/__tests__/commands/manifest-completeness.test.ts core/__tests__/e2e/install-flow.e2e.test.ts
- bun run lint
- bun run typecheck
- bun run build
- node dist/bin/prjct-core.mjs upgrade --dry-run --md
- node dist/bin/prjct-core.mjs definitelynotacommand
- bun test
