### PR TITLE
feat: add transparent task auto-harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,21 @@
 
 ## [Unreleased]
 
+## [2.68.0] - 2026-06-24
+
+### Added
+- transparent auto-harness task start and Codex status line install
+- `prjct task` now creates a transparent auto-harness (H0-H3) with expected evidence and advisory completion warnings, shared by CLI and MCP task starts.
+
+### Fixed
+- `prjct install` now repairs detected Codex `~/.codex/config.toml` with the prjct MCP server and TUI `status_line`, matching the setup flow.
+
 ## [2.67.2] - 2026-06-24
 
 ### Bug Fixes
 
 - route upgrade alias through update (#465)
 - route upgrade alias through update
-
 
 ## [2.67.1] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ In a real terminal — branded, animated, colored:
 $ prjct task "add OAuth refresh"
 ⚡ prjct  ✓ Task started: add OAuth refresh
          branch: task/add-oauth-refresh · status: active
+         harness: H2 feature/medium · evidence: focused-tests, scope-check, spec-or-design
 ```
 
 Inside Claude Code / Codex / CI (non-TTY) — the same line, **static** (no
@@ -226,6 +227,7 @@ can consume directly:
 $ prjct task "add OAuth refresh" --md
 > Task started: **add OAuth refresh**
 > branch `task/add-oauth-refresh` · status `active`
+> harness `H2 feature/medium` · evidence `focused-tests, scope-check, spec-or-design`
 ```
 
 ## Quick start (post-install)
@@ -316,7 +318,7 @@ Slots ship **empty** — the human or the agent fills them on demand.
 
 ## Claude Hooks Adapter (opt-in)
 
-`prjct install` refreshes the universal project surface (`AGENTS.md`) when run inside a prjct project, and also writes the Claude Code hooks adapter to `~/.claude/settings.json`. The hooks inject `additionalContext`; none block by default. Other agents use the support level shown by `prjct agents doctor`.
+`prjct install` refreshes the universal project surface (`AGENTS.md`) when run inside a prjct project, writes the Claude Code hooks adapter to `~/.claude/settings.json`, and repairs detected Codex config in `~/.codex/config.toml` (prjct MCP + TUI `status_line`). The Claude hooks inject `additionalContext`; none block by default. Other agents use the support level shown by `prjct agents doctor`.
 
 | Event | Injects |
 |---|---|
@@ -350,7 +352,7 @@ The broker model: if you already have `linear`, `jira`, `posthog`, `gmail` MCPs 
 ```bash
 prjct start              First-time setup wizard (AI providers + commands)
 prjct init               Initialize project in current directory
-prjct install            Install Claude Code hooks (merge-safe)
+prjct install            Install agent surfaces, Claude hooks, Codex status line
 prjct uninstall          Complete system removal
 prjct sync               Sync project state, rebuild indexes
 prjct regen              Full vault rebuild from SQLite
@@ -518,15 +520,17 @@ the SQLite store at `~/.prjct-cli/projects/<projectId>/`, and generates the vaul
 
 **How do I add a development task?**
 Run `prjct task "<description>"` from the repo. It registers the task in SQLite,
-creates a branch, and marks it active — worked example:
+auto-classifies a lightweight harness (H0-H3) with expected evidence, and marks
+it active — worked example:
 
 ```bash
 $ prjct task "add OAuth refresh"
 ⚡ prjct  ✓ Task started: add OAuth refresh
          branch: task/add-oauth-refresh · status: active
+         harness: H2 feature/medium · evidence: focused-tests, scope-check, spec-or-design
 
 $ prjct tag type:feature domain:auth     # optional: categorize it
-$ prjct status done                       # close it when finished
+$ prjct status done                       # closes it; warns if harness evidence is missing
 $ prjct ship                              # bump version, commit, PR
 ```
 
@@ -584,9 +588,10 @@ sandbox is non-interactive/non-TTY, so prjct-cli emits the same static, prompt-f
 status line as any agent; add `--md` for fully markdown-structured output.
 
 **What does Codex get from prjct?**
-Three surfaces, all installed/healed automatically: a compact skill at
+Four surfaces, all installed/healed automatically: a compact skill at
 `~/.codex/skills/prjct/SKILL.md` (kept under Codex's ~1KB skill cap), the
-prjct MCP server wired into `~/.codex/config.toml` (`prjct_*` tools), and a
+prjct MCP server wired into `~/.codex/config.toml` (`prjct_*` tools), a Codex
+TUI `status_line` in that same config unless the user already set one, and a
 vendor-neutral routing block in the project's `AGENTS.md` written by
 `prjct init`. Codex has no lifecycle hooks, so AGENTS.md + MCP are its
 session-start context and live tool surface.

--- a/core/__tests__/commands/install-codex.test.ts
+++ b/core/__tests__/commands/install-codex.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { InstallCommands } from '../../commands/install'
+
+const ORIGINAL_HOME = process.env.HOME
+const ORIGINAL_TEST_MODE = process.env.PRJCT_TEST_MODE
+
+describe('prjct install Codex surface', () => {
+  let home: string
+  let projectPath: string
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-install-codex-home-'))
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-install-codex-project-'))
+    process.env.HOME = home
+    delete process.env.PRJCT_TEST_MODE
+    await fs.mkdir(path.join(home, '.codex'), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await fs.rm(home, { recursive: true, force: true })
+    await fs.rm(projectPath, { recursive: true, force: true })
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME
+    else process.env.HOME = ORIGINAL_HOME
+    if (ORIGINAL_TEST_MODE === undefined) delete process.env.PRJCT_TEST_MODE
+    else process.env.PRJCT_TEST_MODE = ORIGINAL_TEST_MODE
+  })
+
+  test('writes Codex config.toml with the prjct status line', async () => {
+    const cmd = new InstallCommands()
+    const result = await cmd.install(null, projectPath, { md: true })
+
+    expect(result.success).toBe(true)
+    expect(result.codexConfig).toMatchObject({
+      changed: true,
+      statusLineChanged: true,
+    })
+
+    const config = await fs.readFile(path.join(home, '.codex', 'config.toml'), 'utf-8')
+    expect(config).toContain('[mcp_servers.prjct]')
+    expect(config).toContain('[tui]')
+    expect(config).toContain(
+      'status_line = ["model-with-reasoning", "cwd", "git", "context-left", "five-hour-limit", "weekly-limit", "task-progress"]'
+    )
+  })
+})

--- a/core/__tests__/services/task-harness.test.ts
+++ b/core/__tests__/services/task-harness.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { CurrentTask } from '../../schemas/state'
+import { buildTaskHarness, evaluateHarnessCompletion } from '../../services/task-harness'
+import { execFileAsync } from '../../utils/exec'
+
+let dir: string
+
+async function git(args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd: dir })
+}
+
+async function currentTask(description: string): Promise<CurrentTask> {
+  return {
+    id: 'task-1',
+    description,
+    startedAt: new Date().toISOString(),
+    sessionId: 'session-1',
+    harness: buildTaskHarness(description),
+  }
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-task-harness-'))
+  await git(['init', '-q', '-b', 'main'])
+  await git(['config', 'user.email', 'test@example.com'])
+  await git(['config', 'user.name', 'Test'])
+  await git(['config', 'commit.gpgsign', 'false'])
+  await fs.mkdir(path.join(dir, 'src'), { recursive: true })
+  await fs.writeFile(path.join(dir, 'src', 'index.ts'), 'export const value = 1\n')
+  await git(['add', '.'])
+  await git(['commit', '-q', '-m', 'init'])
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('buildTaskHarness', () => {
+  test('classifies a Codex install bug as H1 with regression evidence', () => {
+    const harness = buildTaskHarness('bug en codex no se instala el statusbar eso es un must')
+
+    expect(harness.level).toBe('H1')
+    expect(harness.kind).toBe('bug')
+    expect(harness.risk).toBe('high')
+    expect(harness.expectedEvidence).toContain('regression-test')
+    expect(harness.expectedEvidence).toContain('docs-if-public-behavior')
+    expect(harness.gates).toContain('verify-before-done')
+  })
+
+  test('classifies a new implementation as H2 with scope-check evidence', () => {
+    const harness = buildTaskHarness('implement transparent auto-harness on task start')
+
+    expect(harness.level).toBe('H2')
+    expect(harness.kind).toBe('feature')
+    expect(harness.expectedEvidence).toContain('scope-check')
+    expect(harness.expectedEvidence).toContain('spec-or-design')
+  })
+
+  test('keeps docs-only work low friction', () => {
+    const harness = buildTaskHarness('docs typo in README')
+
+    expect(harness.level).toBe('H0')
+    expect(harness.kind).toBe('docs')
+    expect(harness.expectedEvidence).toEqual([])
+    expect(harness.gates).toEqual([])
+  })
+})
+
+describe('evaluateHarnessCompletion', () => {
+  test('warns when a bug task changes product code without a regression test', async () => {
+    await fs.writeFile(path.join(dir, 'src', 'index.ts'), 'export const value = 2\n')
+
+    const evaluation = await evaluateHarnessCompletion(
+      dir,
+      await currentTask('fix settings regression')
+    )
+
+    expect(evaluation.changedFiles).toContain('src/index.ts')
+    expect(evaluation.warnings.join('\n')).toContain('expects a regression test')
+  })
+
+  test('does not warn about regression evidence when a test file changed', async () => {
+    await fs.mkdir(path.join(dir, 'src', '__tests__'), { recursive: true })
+    await fs.writeFile(path.join(dir, 'src', '__tests__', 'index.test.ts'), 'test("x", () => {})\n')
+
+    const evaluation = await evaluateHarnessCompletion(
+      dir,
+      await currentTask('fix settings regression')
+    )
+
+    expect(evaluation.observedEvidence).toContain('tests-changed')
+    expect(evaluation.warnings.join('\n')).not.toContain('expects a regression test')
+  })
+})

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -51,7 +51,7 @@ export const COMMANDS: CommandMeta[] = [
     group: 'core',
     routing: { group: 'workflow', method: 'now' },
     optionSchema: { strings: ['spec'] },
-    description: 'Register a task (or show the active one)',
+    description: 'Register a task, auto-classify its harness, or show the active one',
     usage: { claude: 'p. task "<description>"', terminal: 'prjct task "<description>"' },
     params: '[description]',
     implemented: true,
@@ -59,6 +59,7 @@ export const COMMANDS: CommandMeta[] = [
     requiresProject: true,
     features: [
       'No arg → shows the active task (or none)',
+      'Auto-harness classifies H0-H3 and stores expected evidence on the task',
       'Writes to stateStorage; runs before/after workflow rules',
       'Optional Linear issue link when the arg matches `[A-Z]+-\\d+`',
     ],
@@ -274,7 +275,7 @@ export const COMMANDS: CommandMeta[] = [
     routing: { group: 'install', method: 'install' },
     routingMode: 'bin-only',
     optionSchema: {},
-    description: 'Install universal agent surfaces and the Claude hooks adapter',
+    description: 'Install universal agent surfaces, Claude hooks, and Codex config',
     usage: {
       claude: 'p. install',
       terminal: 'prjct install',
@@ -286,6 +287,7 @@ export const COMMANDS: CommandMeta[] = [
     features: [
       'Inside a prjct project, refreshes AGENTS.md as the portable baseline',
       'Writes Claude passive hooks: SessionStart, UserPromptSubmit, …',
+      'Repairs detected Codex config.toml with prjct MCP and TUI status_line',
       'Idempotent; existing non-prjct hooks stay intact',
       'Audit agent support with `prjct agents doctor`',
     ],

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -19,6 +19,7 @@ import {
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { ensureCodexMcpServer } from '../utils/codex-mcp'
 import { failFromError, failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
@@ -40,6 +41,8 @@ export class InstallCommands extends PrjctCommandsBase {
         : null
       const runtimes = await detectAgentRuntimes(projectPath)
       const detected = runtimes.filter((runtime) => runtime.detected)
+      const codexDetected = detected.some((runtime) => runtime.runtime.id === 'codex')
+      const codexConfig = codexDetected ? await ensureCodexMcpServer() : null
       const total = PRJCT_HOOKS.length
       const prunedNote = result.hooksPruned > 0 ? `, ${result.hooksPruned} retired removed` : ''
       const msg = `installed Claude hooks adapter: ${result.hooksWritten} new, ${result.alreadyPresent} already present${prunedNote} (total ${total} hooks)`
@@ -57,6 +60,20 @@ export class InstallCommands extends PrjctCommandsBase {
               : []),
             ...(projectSurfaces?.ideRules.length
               ? projectSurfaces.ideRules.map((rule) => `- project rule adapter: \`${rule}\``)
+              : []),
+            ...(codexConfig
+              ? [
+                  `- Codex config: ${
+                    codexConfig.skipped === 'user-managed'
+                      ? 'user-managed MCP preserved'
+                      : codexConfig.changed
+                        ? 'updated'
+                        : 'already ready'
+                  }`,
+                  `- Codex status line: ${
+                    codexConfig.statusLineChanged ? 'installed' : 'already configured'
+                  }`,
+                ]
               : []),
             ``,
             `## Claude hooks adapter`,
@@ -85,12 +102,32 @@ export class InstallCommands extends PrjctCommandsBase {
         } else {
           out.info('project surface: skipped (not inside an initialized prjct project)')
         }
+        if (codexConfig) {
+          const action =
+            codexConfig.skipped === 'user-managed'
+              ? 'user-managed MCP preserved'
+              : codexConfig.changed
+                ? 'updated'
+                : 'already ready'
+          out.info(`Codex config: ${action}`)
+          out.info(
+            `Codex status line: ${codexConfig.statusLineChanged ? 'installed' : 'already configured'}`
+          )
+        }
       }
       return {
         success: true,
         hooksWritten: result.hooksWritten,
         projectSurface: projectSurfaces?.agentsMd.action ?? 'skipped',
         detectedRuntimes: detected.length,
+        codexConfig: codexConfig
+          ? {
+              path: codexConfig.path,
+              changed: codexConfig.changed,
+              skipped: codexConfig.skipped,
+              statusLineChanged: codexConfig.statusLineChanged ?? false,
+            }
+          : null,
       }
     } catch (error) {
       const msg = getErrorMessage(error)

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -62,6 +62,15 @@ export class PrimitiveCommands extends PrjctCommandsBase {
         const msg = `status → ${value}`
         if (options.md) console.log(`✓ ${msg}`)
         else out.done(msg)
+        const warnings = outcome.verificationWarnings ?? []
+        if (warnings.length > 0) {
+          if (options.md) {
+            console.log('\n## Harness warnings')
+            for (const warning of warnings) console.log(`- ${warning}`)
+          } else {
+            for (const warning of warnings) out.warn(`Harness: ${warning}`)
+          }
+        }
         return { success: true, taskId: outcome.taskId, status: value }
       }
 
@@ -88,9 +97,16 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       // no-args `prjct status` reflects reality, not the task `type` tag.
       const lastStatus = await readLastStatus(pid.value, active.id)
       const line = `Task: ${active.id}  |  Type: ${active.type ?? 'unset'}  |  Status: ${lastStatus ?? 'active'}`
-      if (options.md) console.log(line)
-      else out.info(line)
-      return { success: true, taskId: active.id, status: lastStatus ?? 'active' }
+      const harness = active.harness
+        ? `Harness: ${active.harness.level} ${active.harness.kind}/${active.harness.risk}`
+        : null
+      if (options.md) {
+        console.log(harness ? `${line}\n${harness}` : line)
+      } else {
+        out.info(line)
+        if (harness) out.info(harness)
+      }
+      return { success: true, taskId: active.id, status: lastStatus ?? 'active', harness }
     } catch (error) {
       const msg = getErrorMessage(error)
       return failHard(msg)

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -90,6 +90,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const linearId = outcome.linearId
       const branch = outcome.branch ?? ''
       const beforeInstructions = outcome.instructions ?? []
+      const harness = outcome.harness
 
       if (options.md) {
         console.log(
@@ -102,6 +103,10 @@ export class WorkflowCommands extends PrjctCommandsBase {
                   `Task: \`${taskId}\``,
                   branch ? `Branch: \`${branch}\`` : null,
                   linearId ? `Linear: \`${linearId}\`` : null,
+                  harness ? `Harness: ${harness.level} ${harness.kind}/${harness.risk}` : null,
+                  harness?.expectedEvidence.length
+                    ? `Evidence: ${harness.expectedEvidence.join(', ')}`
+                    : null,
                   beforeInstructions.length > 0
                     ? `Agent instructions: ${beforeInstructions.length}`
                     : null,
@@ -121,11 +126,17 @@ export class WorkflowCommands extends PrjctCommandsBase {
         )
       } else {
         out.done(`Task: ${taskDescription}`)
+        if (harness) {
+          out.info(`Harness: ${harness.level} ${harness.kind}/${harness.risk}`)
+          if (harness.expectedEvidence.length > 0) {
+            out.info(`Evidence: ${harness.expectedEvidence.join(', ')}`)
+          }
+        }
         showStateInfo('working')
         showNextSteps('task')
       }
 
-      return { success: true, task: taskDescription, taskId }
+      return { success: true, task: taskDescription, taskId, harness }
     } catch (error) {
       const msg = getErrorMessage(error)
       if (options.md) console.log(`> ${msg}`)
@@ -174,6 +185,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
                 active.branch ? `Branch: \`${active.branch}\`` : null,
                 active.linearId ? `Linear: \`${active.linearId}\`` : null,
                 `Started: ${active.startedAt}`,
+                active.harness
+                  ? `Harness: ${active.harness.level} ${active.harness.kind}/${active.harness.risk}`
+                  : null,
                 others.length > 0 ? `Other active workspaces: ${others.length}` : null,
               ].filter((s): s is string => s !== null)
             )
@@ -189,6 +203,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
     } else {
       out.info(`Active: ${active.description}`)
       out.info(`Workspace: ${active.label}`)
+      if (active.harness) {
+        out.info(`Harness: ${active.harness.level} ${active.harness.kind}/${active.harness.risk}`)
+      }
       for (const v of others) out.info(`  other: ${v.label} — ${v.description}`)
     }
     return { success: true, currentTask: active }

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -101,6 +101,14 @@ export function registerProjectTools(server: McpServer) {
         if (outcome.branch) lines.push(`Branch: ${outcome.branch}`)
         if (outcome.linearId) lines.push(`Linear: ${outcome.linearId}`)
         if (outcome.linkedSpecId) lines.push(`Linked spec: ${outcome.linkedSpecId}`)
+        if (outcome.harness) {
+          lines.push(
+            `Harness: ${outcome.harness.level} ${outcome.harness.kind}/${outcome.harness.risk}`
+          )
+          if (outcome.harness.expectedEvidence.length > 0) {
+            lines.push(`Evidence: ${outcome.harness.expectedEvidence.join(', ')}`)
+          }
+        }
         if (outcome.instructions && outcome.instructions.length > 0) {
           lines.push('', 'Agent instructions:')
           for (const i of outcome.instructions) lines.push(`- ${i}`)
@@ -129,8 +137,14 @@ export function registerProjectTools(server: McpServer) {
             : 'No active task to update. Start one with prjct_task_start.'
         return { content: [{ type: 'text', text }] }
       }
+      const warnings = outcome.verificationWarnings ?? []
+      const text = [`✓ status → ${outcome.status} (task ${outcome.taskId})`]
+      if (warnings.length > 0) {
+        text.push('', 'Harness warnings:')
+        for (const warning of warnings) text.push(`- ${warning}`)
+      }
       return {
-        content: [{ type: 'text', text: `✓ status → ${outcome.status} (task ${outcome.taskId})` }],
+        content: [{ type: 'text', text: text.join('\n') }],
       }
     })
   )

--- a/core/schemas/state.ts
+++ b/core/schemas/state.ts
@@ -15,6 +15,32 @@ import { ModelMetadataSchema } from './model'
 export const PrioritySchema = z.enum(['low', 'medium', 'high', 'critical'])
 export const TaskTypeSchema = z.enum(['feature', 'bug', 'improvement', 'chore'])
 export const TaskSectionSchema = z.enum(['active', 'backlog', 'previously_active'])
+export const HarnessLevelSchema = z.enum(['H0', 'H1', 'H2', 'H3'])
+export const HarnessKindSchema = z.enum([
+  'bug',
+  'feature',
+  'refactor',
+  'docs',
+  'chore',
+  'security',
+  'unknown',
+])
+export const HarnessRiskSchema = z.enum(['low', 'medium', 'high'])
+export const HarnessEvidenceSchema = z.enum([
+  'regression-test',
+  'focused-tests',
+  'docs-if-public-behavior',
+  'config-preservation',
+  'spec-or-design',
+  'edge-cases',
+  'scope-check',
+])
+export const HarnessGateSchema = z.enum([
+  'verify-before-done',
+  'scope-check',
+  'review-before-ship',
+  'spec-before-implementation',
+])
 const TaskStatusSchema = z.enum([
   'pending',
   'in_progress',
@@ -72,6 +98,17 @@ const SubtaskProgressSchema = z.object({
   percentage: z.number(),
 })
 
+export const TaskHarnessSchema = z.object({
+  level: HarnessLevelSchema,
+  kind: HarnessKindSchema,
+  risk: HarnessRiskSchema,
+  expectedEvidence: z.array(HarnessEvidenceSchema),
+  scopeHints: z.array(z.string()),
+  gates: z.array(HarnessGateSchema),
+  rationale: z.string(),
+  createdAt: z.string(),
+})
+
 export const CurrentTaskSchema = z.object({
   id: z.string(), // task_xxxxxxxx
   description: z.string(),
@@ -101,6 +138,9 @@ export const CurrentTaskSchema = z.object({
   parentDescription: z.string().optional(), // Original parent task description
   branch: z.string().optional(), // Git branch used for this task
   prUrl: z.string().optional(), // PR URL if shipped
+  // Transparent auto-harness: created on task start so agents get the expected
+  // evidence/gates without the user running another command.
+  harness: TaskHarnessSchema.optional(),
 })
 
 export const PreviousTaskSchema = z.object({
@@ -125,6 +165,7 @@ export const PreviousTaskSchema = z.object({
   // Token usage tracking preserved across pause/resume
   tokensIn: z.number().optional(),
   tokensOut: z.number().optional(),
+  harness: TaskHarnessSchema.optional(),
 })
 
 // Task feedback captured during completion (PRJ-272)
@@ -164,6 +205,7 @@ export const TaskHistoryEntrySchema = z.object({
   linearUuid: z.string().optional(), // Linear internal UUID
   prUrl: z.string().optional(), // PR URL if shipped
   feedback: TaskFeedbackSchema.optional(), // Task-to-analysis feedback (PRJ-272)
+  harness: TaskHarnessSchema.optional(), // Auto-harness contract active during the task
   // Token usage totals at completion
   tokensIn: z.number().optional(), // Total input tokens consumed
   tokensOut: z.number().optional(), // Total output tokens generated
@@ -218,6 +260,12 @@ export const QueueJsonSchema = z.object({
 export type Priority = z.infer<typeof PrioritySchema>
 export type TaskType = z.infer<typeof TaskTypeSchema>
 export type TaskSection = z.infer<typeof TaskSectionSchema>
+export type HarnessLevel = z.infer<typeof HarnessLevelSchema>
+export type HarnessKind = z.infer<typeof HarnessKindSchema>
+export type HarnessRisk = z.infer<typeof HarnessRiskSchema>
+export type HarnessEvidence = z.infer<typeof HarnessEvidenceSchema>
+export type HarnessGate = z.infer<typeof HarnessGateSchema>
+export type TaskHarness = z.infer<typeof TaskHarnessSchema>
 
 export type Subtask = z.infer<typeof SubtaskSchema>
 export type SubtaskCompletionData = z.infer<typeof SubtaskCompletionDataSchema>

--- a/core/services/task-harness.ts
+++ b/core/services/task-harness.ts
@@ -1,0 +1,273 @@
+import type {
+  CurrentTask,
+  HarnessEvidence,
+  HarnessGate,
+  HarnessKind,
+  HarnessLevel,
+  HarnessRisk,
+  TaskHarness,
+} from '../schemas/state'
+import { getTimestamp } from '../utils/date-helper'
+import { execFileAsync } from '../utils/exec'
+
+const PUBLIC_SURFACE_TERMS = [
+  'cli',
+  'command',
+  'install',
+  'setup',
+  'doctor',
+  'mcp',
+  'codex',
+  'claude',
+  'statusline',
+  'statusbar',
+  'output',
+  'help',
+]
+
+const STOPWORDS = new Set([
+  'the',
+  'and',
+  'for',
+  'with',
+  'that',
+  'this',
+  'task',
+  'implement',
+  'implementa',
+  'fix',
+  'bug',
+  'add',
+  'agrega',
+  'crear',
+  'hacer',
+  'esto',
+  'debe',
+])
+
+export interface HarnessCompletionEvaluation {
+  changedFiles: string[]
+  observedEvidence: string[]
+  warnings: string[]
+}
+
+export function buildTaskHarness(description: string): TaskHarness {
+  const text = description.toLowerCase()
+  const kind = detectKind(text)
+  const publicSurface = PUBLIC_SURFACE_TERMS.some((term) => text.includes(term))
+  const highRisk = hasAny(text, [
+    'security',
+    'seguridad',
+    'auth',
+    'permission',
+    'secret',
+    'migration',
+    'sqlite',
+    'database',
+    'arquitectura',
+    'architecture',
+    'must',
+    'critical',
+    'critico',
+    'crítico',
+  ])
+
+  const level = detectLevel(kind, text, highRisk)
+  const risk = detectRisk(level, highRisk)
+  const expectedEvidence = expectedEvidenceFor(kind, level, publicSurface)
+  const gates = gatesFor(level)
+  const scopeHints = extractScopeHints(description)
+
+  return {
+    level,
+    kind,
+    risk,
+    expectedEvidence,
+    scopeHints,
+    gates,
+    rationale: rationaleFor(level, kind, risk),
+    createdAt: getTimestamp(),
+  }
+}
+
+export async function evaluateHarnessCompletion(
+  projectPath: string,
+  task: CurrentTask
+): Promise<HarnessCompletionEvaluation> {
+  const harness = task.harness
+  if (!harness || harness.level === 'H0') {
+    return { changedFiles: [], observedEvidence: [], warnings: [] }
+  }
+
+  const changedFiles = await readChangedFiles(projectPath)
+  const observedEvidence = observedEvidenceFromFiles(changedFiles)
+  const warnings: string[] = []
+
+  if (
+    harness.expectedEvidence.includes('regression-test') &&
+    !observedEvidence.includes('tests-changed')
+  ) {
+    warnings.push(`${harness.level} expects a regression test; no test file changed in the diff.`)
+  }
+
+  if (
+    harness.expectedEvidence.includes('docs-if-public-behavior') &&
+    touchesPublicSurface(changedFiles) &&
+    !observedEvidence.includes('docs-changed')
+  ) {
+    warnings.push('Public-facing files changed; no README/docs/changelog file changed.')
+  }
+
+  const diffSize = await readDiffSize(projectPath)
+  if (diffSize > 400) {
+    warnings.push(`Diff is ${diffSize} changed lines; consider splitting or justify the scope.`)
+  }
+
+  return { changedFiles, observedEvidence, warnings }
+}
+
+function detectKind(text: string): HarnessKind {
+  if (hasAny(text, ['security', 'seguridad', 'auth', 'permission', 'secret'])) return 'security'
+  if (hasAny(text, ['bug', 'fix', 'falla', 'fallo', 'error', 'broken', 'regression', 'no se'])) {
+    return 'bug'
+  }
+  if (hasAny(text, ['refactor', 'cleanup', 'split', 'restructure'])) return 'refactor'
+  if (hasAny(text, ['doc', 'readme', 'changelog', 'typo'])) return 'docs'
+  if (hasAny(text, ['chore', 'format', 'lint'])) return 'chore'
+  if (hasAny(text, ['add', 'agrega', 'crear', 'implement', 'implementa', 'feature', 'mejora'])) {
+    return 'feature'
+  }
+  return 'unknown'
+}
+
+function detectLevel(kind: HarnessKind, text: string, highRisk: boolean): HarnessLevel {
+  if (kind === 'docs' || kind === 'chore') return 'H0'
+  if (kind === 'security') return 'H3'
+  if (
+    highRisk &&
+    hasAny(text, ['migration', 'sqlite', 'database', 'architecture', 'arquitectura'])
+  ) {
+    return 'H3'
+  }
+  if (kind === 'feature' || kind === 'refactor') return 'H2'
+  if (kind === 'bug') return 'H1'
+  return 'H1'
+}
+
+function detectRisk(level: HarnessLevel, highRisk: boolean): HarnessRisk {
+  if (level === 'H3' || highRisk) return 'high'
+  if (level === 'H2' || level === 'H1') return 'medium'
+  return 'low'
+}
+
+function expectedEvidenceFor(
+  kind: HarnessKind,
+  level: HarnessLevel,
+  publicSurface: boolean
+): HarnessEvidence[] {
+  const evidence = new Set<HarnessEvidence>()
+  if (kind === 'bug') {
+    evidence.add('regression-test')
+    evidence.add('focused-tests')
+    evidence.add('edge-cases')
+  }
+  if (kind === 'feature' || kind === 'refactor') {
+    evidence.add('focused-tests')
+    evidence.add('scope-check')
+  }
+  if (publicSurface) evidence.add('docs-if-public-behavior')
+  if (level === 'H2' || level === 'H3') evidence.add('spec-or-design')
+  if (level === 'H3') evidence.add('config-preservation')
+  return [...evidence]
+}
+
+function gatesFor(level: HarnessLevel): HarnessGate[] {
+  if (level === 'H0') return []
+  if (level === 'H1') return ['verify-before-done']
+  if (level === 'H2') return ['verify-before-done', 'scope-check']
+  return ['spec-before-implementation', 'verify-before-done', 'scope-check', 'review-before-ship']
+}
+
+function rationaleFor(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): string {
+  if (level === 'H0') return `Low-risk ${kind}; keep the task direct and low-friction.`
+  return `${level} ${kind}/${risk}; define expected evidence up front and verify before closure.`
+}
+
+function extractScopeHints(description: string): string[] {
+  const terms = description
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .split(/[^a-z0-9_.-]+/u)
+    .filter((term) => term.length >= 3 && !STOPWORDS.has(term))
+  return [...new Set(terms)].slice(0, 8)
+}
+
+function hasAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(term))
+}
+
+function observedEvidenceFromFiles(files: string[]): string[] {
+  const observed = new Set<string>()
+  if (files.some(isTestFile)) observed.add('tests-changed')
+  if (files.some(isDocsFile)) observed.add('docs-changed')
+  return [...observed]
+}
+
+function isTestFile(file: string): boolean {
+  return /(^|\/)(__tests__|tests?|specs?)\//.test(file) || /\.(test|spec)\.[cm]?[tj]sx?$/.test(file)
+}
+
+function isDocsFile(file: string): boolean {
+  return /(^|\/)(README|CHANGELOG|docs\/)/i.test(file)
+}
+
+function touchesPublicSurface(files: string[]): boolean {
+  return files.some(
+    (file) =>
+      file.startsWith('core/commands/') ||
+      file.startsWith('core/mcp/') ||
+      file.startsWith('templates/') ||
+      file === 'README.md'
+  )
+}
+
+async function readChangedFiles(projectPath: string): Promise<string[]> {
+  const files = new Set<string>()
+  try {
+    const { stdout } = await execFileAsync('git', ['diff', '--name-only', 'HEAD'], {
+      cwd: projectPath,
+    })
+    for (const line of stdout.split('\n')) {
+      const value = line.trim()
+      if (value) files.add(value)
+    }
+  } catch {
+    return []
+  }
+  try {
+    const { stdout } = await execFileAsync('git', ['ls-files', '--others', '--exclude-standard'], {
+      cwd: projectPath,
+    })
+    for (const line of stdout.split('\n')) {
+      const value = line.trim()
+      if (value) files.add(value)
+    }
+  } catch {
+    // ignore untracked lookup failure
+  }
+  return [...files].sort()
+}
+
+async function readDiffSize(projectPath: string): Promise<number> {
+  try {
+    const { stdout } = await execFileAsync('git', ['diff', '--shortstat', 'HEAD'], {
+      cwd: projectPath,
+    })
+    const insertions = Number.parseInt(stdout.match(/(\d+) insertions?/)?.[1] ?? '0', 10)
+    const deletions = Number.parseInt(stdout.match(/(\d+) deletions?/)?.[1] ?? '0', 10)
+    return insertions + deletions
+  } catch {
+    return 0
+  }
+}

--- a/core/services/task-overview.ts
+++ b/core/services/task-overview.ts
@@ -8,6 +8,7 @@
  * the per-workspace state observable instead of silently singular.
  */
 
+import type { TaskHarness } from '../schemas/state'
 import { stateStorage } from '../storage/state-storage'
 import { deriveWorkspace, MAIN_WORKSPACE_ID } from './workspace-id'
 
@@ -22,6 +23,7 @@ export interface ActiveTaskView {
   branch?: string
   /** Linear issue id when the task is linked (preserved for `--md` output). */
   linearId?: string
+  harness?: TaskHarness
   startedAt: string
   /** True when this task belongs to the caller's current worktree. */
   isCurrent: boolean
@@ -64,6 +66,7 @@ export async function collectActiveTasks(
       label,
       branch: mainTask.branch,
       linearId: mainTask.linearId,
+      harness: mainTask.harness,
       startedAt: mainTask.startedAt,
       isCurrent: ws.workspaceId === MAIN_WORKSPACE_ID,
     })
@@ -82,6 +85,7 @@ export async function collectActiveTasks(
       label,
       branch: t.branch,
       linearId: t.linearId,
+      harness: t.harness,
       startedAt: t.startedAt,
       isCurrent: ws.workspaceId === t.workspaceId,
     })

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -19,13 +19,14 @@
 import configManager from '../infrastructure/config-manager'
 import { STATUS_CHANGE_ACTION } from '../memory/events'
 import { generateUUID } from '../schemas/schemas'
-import type { CurrentTask, TaskFeedback } from '../schemas/state'
+import type { CurrentTask, TaskFeedback, TaskHarness } from '../schemas/state'
 import { getGitBranch } from '../session/git-helpers'
 import { stateStorage } from '../storage/state-storage'
 import * as dateHelper from '../utils/date-helper'
 import { executeWorkflowRules } from '../workflow-engine/workflow-engine'
 import { memoryService } from './memory-service'
 import projectService from './project-service'
+import { buildTaskHarness, evaluateHarnessCompletion } from './task-harness'
 import { deriveWorkspace } from './workspace-id'
 
 /** Status values that mean "make this task the active one again". */
@@ -40,6 +41,7 @@ export interface StartTaskOutcome {
   branch?: string
   linearId?: string
   linkedSpecId?: string
+  harness?: TaskHarness
   /** Agent instructions emitted by `before_task` rules. */
   instructions?: string[]
 }
@@ -105,6 +107,7 @@ export async function startTask(
 
   const taskId = generateUUID()
   const linkedSpecId = options.spec
+  const harness = buildTaskHarness(description)
 
   // Multi-agent: a task in a child worktree lands in activeTasks[] keyed by
   // its workspaceId, so parallel agents don't clobber a shared currentTask.
@@ -117,6 +120,7 @@ export async function startTask(
     sessionId: generateUUID(),
     linearId,
     linkedSpecId,
+    harness,
   }
   if (ws.isMain) {
     await stateStorage.startTask(
@@ -151,7 +155,7 @@ export async function startTask(
   await memoryService.log(
     projectPath,
     'task_started',
-    { task: description, taskId, timestamp: dateHelper.getTimestamp() },
+    { task: description, taskId, harness, timestamp: dateHelper.getTimestamp() },
     author.name
   )
 
@@ -169,12 +173,13 @@ export async function startTask(
     branch,
     linearId,
     linkedSpecId,
+    harness,
     instructions: beforeResult.instructions,
   }
 }
 
 export type SetStatusOutcome =
-  | { ok: true; taskId: string; status: string }
+  | { ok: true; taskId: string; status: string; verificationWarnings?: string[] }
   /** No active task and no paused task to resume — caller emits the guard. */
   | { ok: false; reason: 'no-active-task' }
   /** The transition isn't supported in this context — caller prints `message`. */
@@ -207,14 +212,21 @@ export async function setTaskStatus(
     // leaving every other workspace's task untouched.
     if (normalized === 'done' || normalized === 'completed') {
       const lastStatus = await readLastStatus(projectId, wsTask.id)
+      const verification = await evaluateHarnessCompletion(projectPath, wsTask)
       await memoryService.log(projectPath, STATUS_CHANGE_ACTION, {
         taskId: wsTask.id,
         from: lastStatus ?? null,
         to: value,
         workspaceId: ws.workspaceId,
+        harnessWarnings: verification.warnings,
       })
       await stateStorage.completeTaskInWorkspace(projectId, ws.workspaceId)
-      return { ok: true, taskId: wsTask.id, status: value }
+      return {
+        ok: true,
+        taskId: wsTask.id,
+        status: value,
+        verificationWarnings: verification.warnings,
+      }
     }
 
     // Pause/resume PER worktree needs a per-workspace paused store (planned
@@ -249,11 +261,16 @@ export async function setTaskStatus(
   if (!active) return { ok: false, reason: 'no-active-task' }
 
   const lastStatus = await readLastStatus(projectId, active.id)
+  const verification =
+    normalized === 'done' || normalized === 'completed'
+      ? await evaluateHarnessCompletion(projectPath, active)
+      : { warnings: [] }
 
   await memoryService.log(projectPath, STATUS_CHANGE_ACTION, {
     taskId: active.id,
     from: lastStatus ?? null,
     to: value,
+    harnessWarnings: verification.warnings,
   })
 
   // Drive the real workflow state machine so state.json and the audit log
@@ -275,7 +292,7 @@ export async function setTaskStatus(
     // already-completed task). The audit log still captures intent.
   }
 
-  return { ok: true, taskId: active.id, status: value }
+  return { ok: true, taskId: active.id, status: value, verificationWarnings: verification.warnings }
 }
 
 /**

--- a/core/storage/state-storage.ts
+++ b/core/storage/state-storage.ts
@@ -223,6 +223,7 @@ class StateStorage extends StorageManager<StateJson> {
       linearId: task.linearId,
       linearUuid: task.linearUuid,
       prUrl: task.prUrl,
+      harness: task.harness,
     }
 
     // Attach feedback if provided (PRJ-272)

--- a/core/utils/codex-mcp.ts
+++ b/core/utils/codex-mcp.ts
@@ -11,8 +11,8 @@
  */
 
 import fs from 'node:fs/promises'
-import os from 'node:os'
 import path from 'node:path'
+import { resolveUserPath } from '../infrastructure/user-home'
 import type { MCPServerConfig } from '../types/utils.js'
 import { MCP_SERVER_PRESETS } from './mcp-config'
 
@@ -30,9 +30,9 @@ const CODEX_STATUS_LINE_ITEMS = [
 
 export function getCodexConfigTomlPath(): string {
   if (process.env.PRJCT_TEST_MODE === '1') {
-    return path.join(os.tmpdir(), 'prjct-codex-test', 'config.toml')
+    return path.join(resolveUserPath('.prjct-tests'), 'codex', 'config.toml')
   }
-  return path.join(os.homedir(), '.codex', 'config.toml')
+  return resolveUserPath('.codex', 'config.toml')
 }
 
 function tomlString(value: string): string {

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -83,16 +83,20 @@ declared capabilities — Claude has `mcp: true`, `filesystem: 'mcp'`,
 ## 2. OpenAI Codex detection
 
 Implemented in `core/infrastructure/ai-provider.ts` (`detectCodex()` +
-`CodexProvider`). Codex is considered installed when the **`codex` CLI binary is
-present on PATH**. A leftover `~/.codex/` directory alone is deliberately *not*
-sufficient — that would wrongly block other providers.
+`CodexProvider`) and the runtime registry. Provider selection treats Codex as
+installed when the **`codex` CLI binary is present on PATH** or
+`~/.codex/auth.json` exists. `prjct install` also treats an existing
+`~/.codex/` directory as enough evidence to repair Codex config without making
+Codex the primary setup provider.
 
 Codex specifics prjct relies on:
 
 - **Context file:** `AGENTS.md` (Codex's equivalent of `CLAUDE.md`).
 - **Skills:** `.agents/skills/` for the project, or `~/.codex/skills/` globally;
   the prjct skill marker is `~/.codex/skills/prjct/SKILL.md`.
-- **Config dir:** `~/.codex`. **Ignore file:** `.codexignore`.
+- **Config dir:** `~/.codex`; `prjct install`/`setup` ensure the prjct MCP server
+  and a Codex TUI `status_line` in `~/.codex/config.toml`, preserving a
+  user-managed `status_line`. **Ignore file:** `.codexignore`.
 
 ### Output in a Codex sandbox
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.67.2",
+  "version": "2.68.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- add transparent H0-H3 task auto-harness metadata on task start for CLI and MCP
- emit advisory harness warnings on task completion when observable evidence is missing
- repair Codex install to include MCP/status_line config and document the behavior

## Verification
- bun test core/__tests__/services/task-harness.test.ts core/__tests__/services/task-service-workspace.test.ts core/__tests__/commands/install-codex.test.ts
- bun run format
- bun run lint
- bun run build
- bun test
- pre-push tsc --noEmit -p core/tsconfig.json