### PR TITLE
Fix auth commands bypass stale daemon state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.72.0] - 2026-06-25
+
+### Added
+- auth bin only logout
+
 ## [2.71.0] - 2026-06-25
 
 ### Added

--- a/core/__tests__/daemon/dispatch-option-parity.test.ts
+++ b/core/__tests__/daemon/dispatch-option-parity.test.ts
@@ -82,7 +82,7 @@ describe('cold ↔ daemon option-forwarding parity', () => {
     expect(dropped).toEqual([])
   })
 
-  test('the historically-broken commands are schema-covered or explicitly cased', () => {
+  test('the historically-broken commands are schema-covered, bin-only, or explicitly cased', () => {
     const cased = dispatchCaseLabels()
     const schema = schemaCoveredCommands()
     // embeddings/capture lost flags via the daemon in 2.34.0/2.37.x —
@@ -90,8 +90,12 @@ describe('cold ↔ daemon option-forwarding parity', () => {
     for (const c of ['embeddings', 'capture', 'ship', 'task', 'team', 'guard', 'remember']) {
       expect(schema.has(c)).toBe(true)
     }
-    for (const c of ['init', 'regen', 'login', 'logout', 'auth']) {
+    for (const c of ['init', 'regen']) {
       expect(cased.has(c)).toBe(true)
+    }
+    for (const c of ['login', 'logout', 'auth']) {
+      expect(BIN_COMMANDS_SET.has(c)).toBe(true)
+      expect(cased.has(c)).toBe(false)
     }
   })
 

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -614,6 +614,7 @@ export const COMMANDS: CommandMeta[] = [
     implemented: true,
     hasTemplate: false,
     requiresProject: false,
+    routingMode: 'bin-only',
   },
   {
     name: 'logout',
@@ -624,6 +625,7 @@ export const COMMANDS: CommandMeta[] = [
     implemented: true,
     hasTemplate: false,
     requiresProject: false,
+    routingMode: 'bin-only',
   },
   {
     name: 'auth',
@@ -635,6 +637,7 @@ export const COMMANDS: CommandMeta[] = [
     implemented: true,
     hasTemplate: false,
     requiresProject: false,
+    routingMode: 'bin-only',
   },
   {
     name: 'context',

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -250,12 +250,6 @@ export class SetupCommands extends PrjctCommandsBase {
    * Logout — clear auth credentials
    */
   async logout(): Promise<CommandResult> {
-    const status = await authConfig.getStatus()
-    if (!status.authenticated) {
-      out.info('Already logged out')
-      return { success: true, message: '' }
-    }
-
     await authConfig.clearAuth()
     out.done('Logged out')
     return { success: true, message: '' }

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -115,12 +115,6 @@ export async function executeCommand(
       )
     case 'regen':
       return commands.regenVault(request.cwd, { md })
-    case 'login':
-      return commands.login({ md })
-    case 'logout':
-      return commands.logout()
-    case 'auth':
-      return commands.auth(param, { md })
     default:
       // Standard commands without special option handling
       return commandRegistry.execute(request.command, param, request.cwd)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.71.0",
+  "version": "2.72.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary\n- route prjct login/logout/auth as bin-only commands so stale daemons cannot answer auth state\n- make prjct logout always clear local credentials instead of trusting current status\n- keep daemon parity tests aligned with auth commands being bin-only\n\n## Validation\n- bun test core/__tests__/daemon/dispatch-option-parity.test.ts core/__tests__/commands/manifest-completeness.test.ts core/__tests__/sync/auth-config.test.ts core/__tests__/sync/sync-client.test.ts\n- bun run typecheck\n- bun run build\n\n## Release\n- version bumped to 2.72.0 by prjct ship