### PR TITLE
Fix daemon auth cache for cloud link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.73.0] - 2026-06-25
+
+### Added
+- fix daemon auth cache for cloud link
+
 ## [2.72.0] - 2026-06-25
 
 ### Added

--- a/core/__tests__/sync/auth-config.test.ts
+++ b/core/__tests__/sync/auth-config.test.ts
@@ -88,6 +88,26 @@ describe('AuthConfig', () => {
       expect(storedToken).toBe('legacy-key')
       expect(raw.apiKey).toBeNull()
     })
+
+    it('refreshes auth when another process writes the secure token after an unauthenticated read', async () => {
+      const before = await authConfig.read()
+      expect(before.apiKey).toBeNull()
+
+      storedToken = 'external-login-key'
+
+      expect(await authConfig.hasAuth()).toBe(true)
+      expect((await authConfig.read()).apiKey).toBe('external-login-key')
+    })
+
+    it('refreshes auth when another process clears the secure token after an authenticated read', async () => {
+      await authConfig.saveAuth('sk_test_123', 'u', 'e@x')
+      expect(await authConfig.hasAuth()).toBe(true)
+
+      storedToken = null
+
+      expect(await authConfig.hasAuth()).toBe(false)
+      expect((await authConfig.read()).apiKey).toBeNull()
+    })
   })
 
   describe('write + saveAuth', () => {

--- a/core/sync/auth-config.ts
+++ b/core/sync/auth-config.ts
@@ -66,6 +66,10 @@ class AuthConfigManager {
    */
   async read(): Promise<AuthConfig> {
     if (this.cachedConfig) {
+      this.cachedConfig = {
+        ...this.cachedConfig,
+        apiKey: await getAuthToken(),
+      }
       return this.cachedConfig
     }
 

--- a/core/sync/secure-auth-token.ts
+++ b/core/sync/secure-auth-token.ts
@@ -321,7 +321,9 @@ function activeStore(): AuthTokenStore {
 }
 
 export async function getAuthToken(): Promise<string | null> {
-  if (cached !== undefined) return cached
+  // Auth can change from a different `prjct` process while the daemon is
+  // alive. Do not let a long-running process keep a stale token or stale
+  // unauthenticated state in memory.
   cached = await activeStore().get()
   return cached
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Refresh secure auth token reads so long-running daemon processes see login/logout changes from other CLI processes
- Keep auth metadata cache but update apiKey from secure storage before each auth read
- Add regression tests for external secure-token write and clear flows

## Verification
- bun test core/__tests__/sync/auth-config.test.ts core/__tests__/sync/cloud-command.test.ts core/__tests__/sync/sync-client.test.ts core/__tests__/sync/sync-manager.test.ts
- bun run typecheck
- bun run build