### PR TITLE
feat: sync specs + full analysis to the cloud vault

### DIFF
--- a/core/__tests__/sync/entity-map.test.ts
+++ b/core/__tests__/sync/entity-map.test.ts
@@ -32,6 +32,10 @@ describe('toCloudTable', () => {
     ['paused_task', 'tasks'],
     ['subtask', 'subtasks'],
     ['task', 'tasks'],
+    // Previously unmapped → silently dropped. Now first-class.
+    ['analysis', 'analysis'],
+    ['specs', 'specs'],
+    ['spec', 'specs'],
   ]
 
   it.each(PRODUCER_ENTITY_TYPES)('resolves producer %s → table %s', (producer, table) => {
@@ -60,7 +64,12 @@ describe('isTableIncluded', () => {
     expect(isTableIncluded('archives')).toBe(false)
     expect(DEFAULT_INCLUDE.user_prompts).toBe(false)
     expect(DEFAULT_INCLUDE.agent_sessions).toBe(false)
-    expect(DEFAULT_INCLUDE.analysis).toBe(false)
+    // Analysis + specs are project-understanding knowledge → on by default so
+    // the cloud vault is a complete picture (raw prompts/sessions stay off).
+    expect(DEFAULT_INCLUDE.analysis).toBe(true)
+    expect(DEFAULT_INCLUDE.specs).toBe(true)
+    expect(isTableIncluded('analysis')).toBe(true)
+    expect(isTableIncluded('specs')).toBe(true)
   })
 
   it('honors an explicit opt-out for a group', () => {

--- a/core/storage/analysis-storage.ts
+++ b/core/storage/analysis-storage.ts
@@ -17,6 +17,7 @@ import {
   semanticVerify,
 } from '../schemas/analysis'
 import { generateAnalysisDiff } from '../services/analysis-diff'
+import { publishCRUDSync } from '../sync/publish-helper'
 import type { AnalysisDiff } from '../types/services/extracted'
 import { getTimestamp } from '../utils/date-helper'
 import { sha256 } from '../utils/hash'
@@ -91,9 +92,23 @@ class AnalysisStorage extends StorageManager<AnalysisStoreData> {
       lastUpdated: getTimestamp(),
     }))
 
-    await this.publishEntityEvent(projectId, 'analysis', 'drafted', {
-      commitHash: draft.commitHash,
-      fileCount: draft.fileCount,
+    this.publishAnalysis(projectId, draft)
+  }
+
+  /**
+   * Mirror the full analysis (patterns, anti-patterns, languages, frameworks,
+   * file counts) into the sync queue so the cloud vault holds the real
+   * project-understanding artifact — not just its commit hash. Analysis is a
+   * per-project singleton, so the project id is its stable entity id.
+   * Best-effort: `publishCRUDSync` swallows errors; the local seal never fails.
+   */
+  private publishAnalysis(projectId: string, analysis: AnalysisSchema): void {
+    publishCRUDSync({
+      projectId,
+      entityType: 'analysis',
+      entityId: projectId,
+      eventType: 'upsert',
+      data: { ...analysis, id: projectId },
     })
   }
 
@@ -133,10 +148,7 @@ class AnalysisStorage extends StorageManager<AnalysisStoreData> {
       lastUpdated: now,
     })
 
-    await this.publishEntityEvent(projectId, 'analysis', 'sealed', {
-      commitHash: sealed.commitHash,
-      signature,
-    })
+    this.publishAnalysis(projectId, sealed)
 
     return { success: true, signature }
   }
@@ -211,10 +223,7 @@ class AnalysisStorage extends StorageManager<AnalysisStoreData> {
       lastUpdated: now,
     })
 
-    await this.publishEntityEvent(projectId, 'analysis', 'rolled_back', {
-      restoredCommit: data.previousSealed.commitHash,
-      restoredSignature: data.previousSealed.signature,
-    })
+    this.publishAnalysis(projectId, data.previousSealed)
 
     return { success: true, restoredSignature: data.previousSealed.signature }
   }

--- a/core/storage/spec-storage.ts
+++ b/core/storage/spec-storage.ts
@@ -7,6 +7,7 @@
  */
 
 import { generateUUID } from '../schemas/schemas'
+import { publishCRUDSync } from '../sync/publish-helper'
 import {
   SPEC_STATUSES,
   type Spec,
@@ -85,7 +86,7 @@ class SpecStorage {
       now
     )
 
-    return {
+    const spec: Spec = {
       id,
       title: args.title,
       status: 'draft',
@@ -98,6 +99,8 @@ class SpecStorage {
       shippedSha: null,
       archivedAt: null,
     }
+    this.publishSync(projectId, spec)
+    return spec
   }
 
   get(projectId: string, id: string): Spec | null {
@@ -145,7 +148,9 @@ class SpecStorage {
       now,
       id
     )
-    return this.get(projectId, id)
+    const spec = this.get(projectId, id)
+    if (spec) this.publishSync(projectId, spec)
+    return spec
   }
 
   /**
@@ -174,7 +179,12 @@ class SpecStorage {
       id,
       expectedUpdatedAt
     )
-    return result.changes === 1
+    const ok = result.changes === 1
+    if (ok) {
+      const spec = this.get(projectId, id)
+      if (spec) this.publishSync(projectId, spec)
+    }
+    return ok
   }
 
   setStatus(projectId: string, id: string, status: SpecStatus): Spec | null {
@@ -195,7 +205,9 @@ class SpecStorage {
     const setClause = ['status = ?', 'updated_at = ?', ...extras].join(', ')
     params.push(id)
     prjctDb.run(projectId, `UPDATE specs SET ${setClause} WHERE id = ?`, ...params)
-    return this.get(projectId, id)
+    const spec = this.get(projectId, id)
+    if (spec) this.publishSync(projectId, spec)
+    return spec
   }
 
   setShippedPr(projectId: string, id: string, pr: number): Spec | null {
@@ -206,7 +218,9 @@ class SpecStorage {
       this.nextUpdatedAt(projectId, id),
       id
     )
-    return this.get(projectId, id)
+    const spec = this.get(projectId, id)
+    if (spec) this.publishSync(projectId, spec)
+    return spec
   }
 
   /**
@@ -222,7 +236,9 @@ class SpecStorage {
       this.nextUpdatedAt(projectId, id),
       id
     )
-    return this.get(projectId, id)
+    const spec = this.get(projectId, id)
+    if (spec) this.publishSync(projectId, spec)
+    return spec
   }
 
   /**
@@ -243,6 +259,7 @@ class SpecStorage {
     const before = this.get(projectId, id)
     if (!before) return false
     prjctDb.run(projectId, 'DELETE FROM specs WHERE id = ?', id)
+    this.publishSync(projectId, before, 'delete')
     return true
   }
 
@@ -258,6 +275,38 @@ class SpecStorage {
       if (r.status === 'shipped') out.shipped = r.n
     }
     return out
+  }
+
+  /**
+   * Mirror a spec write into the sync queue so the cloud vault stays a
+   * complete picture of the project (SDD specs are first-class knowledge).
+   * Best-effort — `publishCRUDSync` swallows errors; local CRUD never fails
+   * because of sync.
+   */
+  private publishSync(
+    projectId: string,
+    spec: Spec,
+    eventType: 'upsert' | 'delete' = 'upsert'
+  ): void {
+    publishCRUDSync({
+      projectId,
+      entityType: 'specs',
+      entityId: spec.id,
+      eventType,
+      data: {
+        id: spec.id,
+        title: spec.title,
+        status: spec.status,
+        content: spec.content,
+        tags: spec.tags,
+        created_at: spec.createdAt,
+        updated_at: spec.updatedAt,
+        shipped_at: spec.shippedAt,
+        shipped_pr: spec.shippedPr,
+        shipped_sha: spec.shippedSha,
+        archived_at: spec.archivedAt,
+      },
+    })
   }
 
   private rowToSpec(row: SpecRow): Spec {

--- a/core/sync/entity-map.ts
+++ b/core/sync/entity-map.ts
@@ -30,6 +30,11 @@ const TABLE_BY_ENTITY: Record<string, string> = {
   shipped_features: 'shipped_features',
   metrics_daily: 'metrics_daily',
   velocity_sprints: 'velocity_sprints',
+  // Project-understanding artifacts: the sealed analysis (patterns, anti-
+  // patterns, tech-debt, risk-areas, insights) and SDD specs. Previously
+  // unmapped, so their events were silently dropped on the wire.
+  analysis: 'analysis',
+  specs: 'specs',
   // Producer aliases (singular / variant) → canonical table.
   memory: 'memories',
   memory_entry: 'memories',
@@ -45,6 +50,7 @@ const TABLE_BY_ENTITY: Record<string, string> = {
   workflow_rule: 'workflow_rules',
   metric: 'metrics_daily',
   velocity: 'velocity_sprints',
+  spec: 'specs',
   project: 'projects',
   session: 'sessions',
   agent: 'agents',
@@ -76,6 +82,7 @@ export type IncludeGroup =
   | 'user_prompts'
   | 'agent_sessions'
   | 'analysis'
+  | 'specs'
 
 const GROUP_BY_TABLE: Record<string, IncludeGroup> = {
   memories: 'memories',
@@ -90,6 +97,8 @@ const GROUP_BY_TABLE: Record<string, IncludeGroup> = {
   metrics_daily: 'metrics',
   velocity_sprints: 'metrics',
   archives: 'archives',
+  analysis: 'analysis',
+  specs: 'specs',
 }
 
 /**
@@ -108,9 +117,13 @@ export const DEFAULT_INCLUDE: Record<IncludeGroup, boolean> = {
   // push data nothing consumes. Flip on once they round-trip.
   metrics: false,
   archives: false,
+  // Raw prompts + agent sessions stay opt-out by default (privacy-sensitive,
+  // heavy). Analysis + specs are project-understanding knowledge — on by
+  // default so the cloud vault is a complete picture of the project.
   user_prompts: false,
   agent_sessions: false,
-  analysis: false,
+  analysis: true,
+  specs: true,
 }
 
 /**


### PR DESCRIPTION
Closes two gaps where vault knowledge never reached the cloud.

## analysis
Was published lossily (commit hash + signature only) **and** its entity type was unmapped in `entity-map.ts` → `toCloudTable()` returned undefined → silently dropped. Now:
- Mapped (`analysis → analysis`).
- Publishes the **full sealed analysis** (patterns, anti-patterns, languages, frameworks, file counts) via `publishCRUDSync`, with a stable per-project entity id.

## specs
`spec-storage.ts` had **zero** publish calls. Now `publishCRUDSync`s the full spec on every mutation (create / updateContent / casUpdate / setStatus / setShippedPr/Sha / delete).

## defaults
`analysis` + `specs` default **ON** (project-understanding knowledge). Raw `user_prompts` + `agent_sessions` stay opt-out (privacy). The server enforces the same contract authoritatively (see prjct-cli-api PR).

Tests: full suite **1755 pass / 0 fail**; entity-map tests pin the new mappings + defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)