### PR TITLE
feat: deterministic project id, stable deviceId, local-safe sync

### DIFF
--- a/core/__tests__/sync/auth-config.test.ts
+++ b/core/__tests__/sync/auth-config.test.ts
@@ -202,5 +202,13 @@ describe('AuthConfig', () => {
       expect(storedToken).toBeNull()
       expect(cfg.userId).toBeNull()
     })
+
+    it('preserves the deviceId across logout (machine identity is not session state)', async () => {
+      await authConfig.saveAuth('sk_test_123', 'u', 'e@x')
+      const before = await authConfig.getDeviceId()
+      await authConfig.clearAuth()
+      const after = await authConfig.getDeviceId()
+      expect(after).toBe(before)
+    })
   })
 })

--- a/core/__tests__/sync/entity-handlers.test.ts
+++ b/core/__tests__/sync/entity-handlers.test.ts
@@ -44,6 +44,7 @@ describe('entity-handlers registry', () => {
         'queue_tasks',
         'shipped_features',
         'shipped_items',
+        'specs',
         'tasks',
         'workflow_rules',
       ].sort()
@@ -76,14 +77,15 @@ describe('entity-handlers registry', () => {
     expect(all[0].text).toBe('rate limit auth (updated)')
   })
 
-  test('ideas handler delete soft-archives the row (no hard delete)', async () => {
+  test('ideas handler delete is a no-op — local is never modified by a remote delete', async () => {
     const handler = entityHandlers.ideas
-    await handler.upsert(projectId, { id: 'idea-2', text: 'will archive', status: 'active' })
+    await handler.upsert(projectId, { id: 'idea-2', text: 'keep me', status: 'active' })
     await handler.delete(projectId, { id: 'idea-2' })
 
+    // The local idea stays exactly as it was — sync never touches it.
     const after = await ideasStorage.getById(projectId, 'idea-2')
     expect(after).toBeTruthy()
-    expect(after?.status).toBe('archived')
+    expect(after?.status).toBe('pending')
   })
 
   test('shipped handler delete is a no-op (append-only history)', async () => {

--- a/core/__tests__/sync/memories-handler.test.ts
+++ b/core/__tests__/sync/memories-handler.test.ts
@@ -92,17 +92,18 @@ describe('memories entity handler', () => {
     expect(after).toBe(before)
   })
 
-  test('delete tombstones by content identity', async () => {
-    const data = { id: 'mem-d', type: 'fact', content: 'tombstone me' }
+  test('delete is a no-op — local is never destroyed by a remote delete', async () => {
+    const data = { id: 'mem-d', type: 'fact', content: 'keep me local' }
     await memoriesHandler.upsert(projectId, data)
     expect(memoryRows()[0].deleted_at).toBeNull()
 
+    // A delete event pulled from another machine must NOT touch the local row.
     await memoriesHandler.delete(projectId, data)
     const rows = prjctDb.query<{ deleted_at: string | null }>(
       projectId,
       'SELECT deleted_at FROM memories'
     )
-    expect(rows[0].deleted_at).not.toBeNull()
+    expect(rows[0].deleted_at).toBeNull()
   })
 
   test('ignores events missing content or type', async () => {

--- a/core/__tests__/sync/project-identity.test.ts
+++ b/core/__tests__/sync/project-identity.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Deterministic project identity — the SAME repo must derive the SAME cloud id
+ * on every machine, so linking from two machines never duplicates the project.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { uuidv5 } from '../../services/sync/project-identity'
+
+describe('uuidv5 (deterministic project id)', () => {
+  it('is stable for the same key', () => {
+    const a = uuidv5('github:jlopezlira/prjct-cli-app')
+    const b = uuidv5('github:jlopezlira/prjct-cli-app')
+    expect(a).toBe(b)
+  })
+
+  it('differs for different repos', () => {
+    expect(uuidv5('github:jlopezlira/prjct-cli-app')).not.toBe(
+      uuidv5('github:jlopezlira/prjct-cli-api')
+    )
+  })
+
+  it('produces a valid RFC 4122 v5 UUID', () => {
+    const id = uuidv5('github:jlopezlira/prjct-cli-app')
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+})

--- a/core/__tests__/sync/workflow-handlers.test.ts
+++ b/core/__tests__/sync/workflow-handlers.test.ts
@@ -58,7 +58,7 @@ describe('workflow entity handlers', () => {
     expect(rows[0].description).toBe('ship it (v2)')
   })
 
-  test('custom_workflows delete soft-disables', async () => {
+  test('custom_workflows delete is a no-op — local stays enabled', async () => {
     await customWorkflowsHandler.upsert(projectId, { name: 'temp', enabled: 1, is_builtin: 0 })
     await customWorkflowsHandler.delete(projectId, { name: 'temp' })
     const row = prjctDb.get<{ enabled: number }>(
@@ -66,7 +66,8 @@ describe('workflow entity handlers', () => {
       'SELECT enabled FROM custom_workflows WHERE name = ?',
       'temp'
     )
-    expect(row?.enabled).toBe(0)
+    // A remote delete never disables the local workflow.
+    expect(row?.enabled).toBe(1)
   })
 
   test('custom_workflows handler does not echo to the sync queue', async () => {
@@ -106,7 +107,7 @@ describe('workflow entity handlers', () => {
     expect(rows[0].action).toBe('run tests AND lint')
   })
 
-  test('workflow_rules delete removes by id', async () => {
+  test('workflow_rules delete is a no-op — local row is never removed', async () => {
     await workflowRulesHandler.upsert(projectId, {
       id: 7,
       type: 'step',
@@ -120,7 +121,8 @@ describe('workflow entity handlers', () => {
       'SELECT id FROM workflow_rules WHERE id = ?',
       7
     )
-    expect(row).toBeNull()
+    // A remote delete never drops the local rule.
+    expect(row?.id).toBe(7)
   })
 
   test('ignores malformed events (missing name / id)', async () => {

--- a/core/commands/cloud.ts
+++ b/core/commands/cloud.ts
@@ -129,6 +129,8 @@ export class CloudCommands extends PrjctCommandsBase {
     await configManager.writeConfig(projectPath, config)
     realtimeManager.stop(config.projectId)
     await removeLinkedProject(config.projectId)
+    // Reflect the unlink on the cloud (soft — keeps records). Best-effort.
+    await syncClient.setCloudLifecycle(config.projectId, 'unlink').catch(() => undefined)
     const msg = 'Unlinked — this project is local-only again. Local data was not touched.'
     if (options.md) console.log(mdOutput('## Cloud', `> ${msg}`))
     else out.done(msg)
@@ -187,6 +189,10 @@ export class CloudCommands extends PrjctCommandsBase {
     await configManager.writeConfig(projectPath, config)
     if (paused) realtimeManager.stop(config.projectId)
     else await realtimeManager.start(config.projectId, projectPath).catch(() => undefined)
+    // Reflect the pause/resume on the cloud (soft). Best-effort.
+    await syncClient
+      .setCloudLifecycle(config.projectId, paused ? 'pause' : 'resume')
+      .catch(() => undefined)
     const msg = paused
       ? 'Cloud sync paused. Resume with `prjct cloud resume`.'
       : 'Cloud sync resumed.'

--- a/core/infrastructure/config-manager.ts
+++ b/core/infrastructure/config-manager.ts
@@ -13,6 +13,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import * as jsonc from 'jsonc-parser'
 import { getErrorMessage } from '../errors'
+import { deriveProjectId } from '../services/sync/project-identity'
 import type { Author } from '../types/commands'
 import type { GlobalConfig, LocalConfig } from '../types/config'
 import { isNotFoundError } from '../types/fs'
@@ -128,7 +129,11 @@ class ConfigManager {
     projectPath: string,
     author: { name?: string; email?: string; github?: string }
   ): Promise<LocalConfig> {
-    const projectId = pathManager.generateProjectId(projectPath)
+    // Prefer a deterministic id derived from the git remote so the SAME repo
+    // gets the SAME cloud project on every machine (no duplicates). Repos with
+    // no remote fall back to a random id (can't be deduplicated cross-machine).
+    const projectId =
+      (await deriveProjectId(projectPath)) ?? pathManager.generateProjectId(projectPath)
     const globalPath = pathManager.getGlobalProjectPath(projectId)
     const displayPath = pathManager.getDisplayPath(globalPath)
     const now = getTimestamp()

--- a/core/services/sync/project-identity.ts
+++ b/core/services/sync/project-identity.ts
@@ -1,0 +1,61 @@
+/**
+ * Deterministic project identity.
+ *
+ * A project's cloud id must be the SAME on every machine that works the same
+ * repository — otherwise linking the repo from two machines creates duplicate
+ * cloud projects. We derive a stable UUIDv5 from the normalized git remote
+ * (`<provider>:<org/repo>`), so the id is reproducible from the repo alone and
+ * never depends on a random value committed to `.prjct/prjct.config.json`.
+ *
+ * Repos with NO remote (purely local) can't be deduplicated across machines,
+ * so the caller falls back to a random UUID for those.
+ */
+
+import { execFile } from 'node:child_process'
+import crypto from 'node:crypto'
+import { promisify } from 'node:util'
+import { parseRemote } from './project-meta'
+
+const execFileAsync = promisify(execFile)
+
+// Fixed namespace for prjct project ids (a constant random UUID). Changing this
+// would re-key every derived id, so it must stay stable forever.
+const PRJCT_NAMESPACE = '6f9b2c1a-3d4e-5f60-8a7b-1c2d3e4f5a6b'
+
+/** RFC 4122 v5 (SHA-1, name-based) UUID — deterministic for a given name. */
+export function uuidv5(name: string, namespace = PRJCT_NAMESPACE): string {
+  const ns = Buffer.from(namespace.replace(/-/g, ''), 'hex')
+  const hash = crypto.createHash('sha1').update(ns).update(name, 'utf8').digest()
+  const b = hash.subarray(0, 16)
+  b[6] = (b[6] & 0x0f) | 0x50 // version 5
+  b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+  const h = b.toString('hex')
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`
+}
+
+/** The stable, machine-independent key for a repo, or null if it has no remote. */
+export async function repoKey(projectPath: string): Promise<string | null> {
+  let url: string | undefined
+  try {
+    const { stdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], {
+      cwd: projectPath,
+    })
+    url = stdout.trim() || undefined
+  } catch {
+    return null
+  }
+  if (!url) return null
+  const { provider, repoSlug } = parseRemote(url)
+  if (!provider || !repoSlug) return null
+  return `${provider}:${repoSlug}`.toLowerCase()
+}
+
+/**
+ * The deterministic cloud project id for a repo, or null when the repo has no
+ * usable remote (caller should fall back to a random id). The same repo yields
+ * the same id on every machine.
+ */
+export async function deriveProjectId(projectPath: string): Promise<string | null> {
+  const key = await repoKey(projectPath)
+  return key ? uuidv5(key) : null
+}

--- a/core/storage/shipped-storage.ts
+++ b/core/storage/shipped-storage.ts
@@ -53,12 +53,15 @@ class ShippedStorage extends StorageManager<ShippedJson> {
    */
   async addShipped(
     projectId: string,
-    feature: Omit<ShippedFeature, 'id' | 'shippedAt'>
+    feature: Omit<ShippedFeature, 'id' | 'shippedAt'>,
+    // Optional authored time — when applying a pulled ship from another machine,
+    // preserve its original date instead of stamping "now".
+    shippedAt?: string
   ): Promise<ShippedFeature> {
     const shipped: ShippedFeature = {
       ...feature,
       id: generateUUID(),
-      shippedAt: getTimestamp(),
+      shippedAt: shippedAt || getTimestamp(),
     }
 
     await this.update(projectId, (data) => ({

--- a/core/storage/spec-storage.ts
+++ b/core/storage/spec-storage.ts
@@ -263,6 +263,51 @@ class SpecStorage {
     return true
   }
 
+  /**
+   * Apply a spec pulled from the cloud — ADDITIVE ONLY. Inserts a spec that
+   * doesn't exist locally yet; if the id already exists locally it is left
+   * UNTOUCHED. Local data is sacred: sync never modifies or deletes a local
+   * record, it only fills in what's missing. Does NOT re-publish (no echo) and
+   * preserves the remote timestamps. Used by the sync apply handler only.
+   */
+  applyRemote(
+    projectId: string,
+    spec: {
+      id: string
+      title?: string
+      status?: string
+      content: unknown
+      tags?: Record<string, string> | string | null
+      created_at?: string
+      updated_at?: string
+    }
+  ): void {
+    if (!spec.id) return
+    const content =
+      typeof spec.content === 'string' ? spec.content : JSON.stringify(spec.content ?? {})
+    const status = SPEC_STATUSES.includes(spec.status as SpecStatus) ? spec.status : 'draft'
+    const tags =
+      spec.tags == null
+        ? null
+        : typeof spec.tags === 'string'
+          ? spec.tags
+          : JSON.stringify(spec.tags)
+    const now = getTimestamp()
+    prjctDb.run(
+      projectId,
+      `INSERT INTO specs (id, title, status, content, tags, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO NOTHING`,
+      spec.id,
+      spec.title ?? '',
+      status,
+      content,
+      tags,
+      spec.created_at || now,
+      spec.updated_at || now
+    )
+  }
+
   count(projectId: string): { total: number; draft: number; shipped: number } {
     const rows = prjctDb.query<{ status: string; n: number }>(
       projectId,

--- a/core/sync/auth-config.ts
+++ b/core/sync/auth-config.ts
@@ -198,7 +198,15 @@ class AuthConfigManager {
    */
   async clearAuth(): Promise<void> {
     await clearAuthToken()
-    this.cachedConfig = { ...DEFAULT_CONFIG }
+    // Preserve the machine's install identity (deviceId/hostname) across logout
+    // — it is NOT session state. Wiping it made every logout/login look like a
+    // brand-new machine to the cloud, inflating the "machines" count.
+    const prev = this.cachedConfig ?? (await fileHelper.readJson<AuthConfig>(this.configPath))
+    this.cachedConfig = {
+      ...DEFAULT_CONFIG,
+      deviceId: prev?.deviceId ?? freshDeviceId(),
+      hostname: prev?.hostname ?? os.hostname(),
+    }
     await fileHelper.ensureDir(path.dirname(this.configPath))
     await fileHelper.writeJson(this.configPath, metadataOnly(this.cachedConfig))
     await fs.chmod(this.configPath, 0o600)

--- a/core/sync/entity-handlers/custom-workflows.ts
+++ b/core/sync/entity-handlers/custom-workflows.ts
@@ -56,15 +56,8 @@ export const customWorkflowsHandler: EntityHandler = {
     )
   },
 
-  async delete(projectId, data) {
-    const name = (data.name as string) || ''
-    if (!name) return
-    // Soft delete (matches customWorkflowStorage.deleteWorkflow); never builtins.
-    prjctDb.run(
-      projectId,
-      'UPDATE custom_workflows SET enabled = 0 WHERE name = ? AND is_builtin = 0',
-      name
-    )
+  async delete(_projectId, _data) {
+    // No-op by design: sync never deletes or modifies a local record.
   },
 }
 

--- a/core/sync/entity-handlers/ideas.ts
+++ b/core/sync/entity-handlers/ideas.ts
@@ -25,7 +25,11 @@ export const ideasHandler: EntityHandler = {
         text,
         priority,
         status: desiredStatus,
-        addedAt: ideas.ideas[existingIdx]?.addedAt ?? new Date().toISOString(),
+        addedAt:
+          ideas.ideas[existingIdx]?.addedAt ??
+          (data.created_at as string) ??
+          (data.addedAt as string) ??
+          new Date().toISOString(),
         tags: ideas.ideas[existingIdx]?.tags ?? [],
       } as (typeof ideas.ideas)[number]
       const list =
@@ -36,14 +40,7 @@ export const ideasHandler: EntityHandler = {
     })
   },
 
-  async delete(projectId, data) {
-    const id = (data.id as string) || ''
-    if (!id) return
-    await ideasStorage.update(projectId, (ideas) => ({
-      ...ideas,
-      ideas: ideas.ideas.map((idea) =>
-        idea.id === id ? { ...idea, status: 'archived' as const } : idea
-      ),
-    }))
+  async delete(_projectId, _data) {
+    // No-op by design: sync never deletes or modifies a local record.
   },
 }

--- a/core/sync/entity-handlers/index.ts
+++ b/core/sync/entity-handlers/index.ts
@@ -16,6 +16,7 @@ import { ideasHandler } from './ideas'
 import { memoriesHandler } from './memories'
 import { queueTasksHandler } from './queue-tasks'
 import { shippedHandler } from './shipped'
+import { specsHandler } from './specs'
 import { tasksHandler } from './tasks'
 import type { EntityHandler } from './types'
 import { workflowRulesHandler } from './workflow-rules'
@@ -33,6 +34,7 @@ export const entityHandlers: Record<string, EntityHandler> = {
   shipped_features: shippedHandler,
   custom_workflows: customWorkflowsHandler,
   workflow_rules: workflowRulesHandler,
+  specs: specsHandler,
 }
 
 /** Read-only list of supported entity types — useful for telemetry. */
@@ -65,6 +67,11 @@ export const UNKNOWN_ENTITY_TYPES: ReadonlySet<string> = new Set([
   'subtasks',
   'metrics_daily',
   'velocity_sprints',
+  // analysis: pushed to the cloud (for the web view) but NOT applied locally.
+  // It's a derived, regenerable artifact (`prjct sync` rebuilds it) and its rich
+  // camelCase schema doesn't round-trip cleanly through the snake_case wire, so
+  // reconstructing it locally would be lossy. Specs (authored) DO apply.
+  'analysis',
 ])
 
 export type { EntityHandler } from './types'

--- a/core/sync/entity-handlers/memories.ts
+++ b/core/sync/entity-handlers/memories.ts
@@ -70,6 +70,11 @@ export const memoriesHandler: EntityHandler = {
 
     // FTS mirror — same INSERT shape as project-memory.remember().
     const memId = `mem_${eventId}`
+    // Preserve the authored time from the remote event so chronology survives
+    // the round trip (machine A's 10:00 memory shows as 10:00 on machine B,
+    // not "now"). Falls back to now only when the event omits it.
+    const authored =
+      (data.created_at as string) || (data.createdAt as string) || new Date().toISOString()
     const now = new Date().toISOString()
     const title = (content.split('\n')[0] ?? content).slice(0, 80)
     try {
@@ -88,7 +93,7 @@ export const memoriesHandler: EntityHandler = {
         provenance,
         contentHash,
         0,
-        now,
+        authored,
         now
       )
     } catch {
@@ -96,22 +101,9 @@ export const memoriesHandler: EntityHandler = {
     }
   },
 
-  async delete(projectId, data) {
-    // Tombstone by content identity (stable across machines).
-    const content = field(data, 'content', 'content')
-    const type = field(data, 'type', 'type')
-    if (!content || !type) return
-    const contentHash = memoryFingerprint(content)
-    try {
-      prjctDb.run(
-        projectId,
-        'UPDATE memories SET deleted_at = ? WHERE content_hash = ? AND type = ? AND deleted_at IS NULL',
-        new Date().toISOString(),
-        contentHash,
-        type
-      )
-    } catch {
-      // Best-effort tombstone.
-    }
+  async delete(_projectId, _data) {
+    // No-op by design: sync NEVER deletes or modifies a local record. A memory
+    // removed on another machine stays in this machine's vault — local is the
+    // source of truth and is never destroyed by a pull.
   },
 }

--- a/core/sync/entity-handlers/queue-tasks.ts
+++ b/core/sync/entity-handlers/queue-tasks.ts
@@ -40,12 +40,7 @@ export const queueTasksHandler: EntityHandler = {
     })
   },
 
-  async delete(projectId, data) {
-    const id = (data.id as string) || ''
-    if (!id) return
-    await queueStorage.update(projectId, (queue) => ({
-      ...queue,
-      tasks: queue.tasks.filter((t) => t.id !== id),
-    }))
+  async delete(_projectId, _data) {
+    // No-op by design: sync never deletes or modifies a local record.
   },
 }

--- a/core/sync/entity-handlers/shipped.ts
+++ b/core/sync/entity-handlers/shipped.ts
@@ -12,11 +12,16 @@ import type { EntityHandler } from './types'
 
 export const shippedHandler: EntityHandler = {
   async upsert(projectId, data) {
-    await shippedStorage.addShipped(projectId, {
-      name: (data.name as string) || (data.title as string) || '',
-      version: (data.version as string) || '',
-      description: (data.description as string) || '',
-    })
+    await shippedStorage.addShipped(
+      projectId,
+      {
+        name: (data.name as string) || (data.title as string) || '',
+        version: (data.version as string) || '',
+        description: (data.description as string) || '',
+      },
+      // Preserve the original ship date through the round trip.
+      (data.created_at as string) || (data.shippedAt as string) || (data.shipped_at as string)
+    )
   },
 
   async delete(_projectId, _data) {

--- a/core/sync/entity-handlers/specs.ts
+++ b/core/sync/entity-handlers/specs.ts
@@ -1,0 +1,33 @@
+/**
+ * Specs entity handler.
+ *
+ * Specs are SDD documents (migration 16, `specs` table). Apply is ADDITIVE:
+ * `specStorage.applyRemote` inserts a spec missing locally and leaves an
+ * existing one untouched (local data is never modified by sync), writes WITHOUT
+ * re-publishing (no echo), and preserves the remote timestamps. Delete is a
+ * NO-OP — a remote delete never removes a local record.
+ */
+
+import { specStorage } from '../../storage/spec-storage'
+import type { EntityHandler } from './types'
+
+export const specsHandler: EntityHandler = {
+  async upsert(projectId, data) {
+    const id = (data.id as string) || ''
+    if (!id) return
+    specStorage.applyRemote(projectId, {
+      id,
+      title: data.title as string,
+      status: data.status as string,
+      content: (data.content as Record<string, unknown> | string) ?? {},
+      tags: data.tags as Record<string, string> | string | null,
+      created_at: data.created_at as string,
+      updated_at: data.updated_at as string,
+    })
+  },
+
+  async delete(_projectId, _data) {
+    // No-op by design: sync never deletes a local record. A spec removed on
+    // another machine stays in this machine's vault.
+  },
+}

--- a/core/sync/entity-handlers/tasks.ts
+++ b/core/sync/entity-handlers/tasks.ts
@@ -63,14 +63,7 @@ export const tasksHandler: EntityHandler = {
     })
   },
 
-  async delete(projectId, data) {
-    const id = (data.id as string) || ''
-    if (!id) return
-    await stateStorage.update(projectId, (state) => {
-      if (state.currentTask?.id === id) {
-        return { ...state, currentTask: null }
-      }
-      return state
-    })
+  async delete(_projectId, _data) {
+    // No-op by design: sync never deletes or modifies a local record.
   },
 }

--- a/core/sync/entity-handlers/workflow-rules.ts
+++ b/core/sync/entity-handlers/workflow-rules.ts
@@ -41,9 +41,7 @@ export const workflowRulesHandler: EntityHandler = {
     )
   },
 
-  async delete(projectId, data) {
-    const id = Number(data.id)
-    if (!Number.isFinite(id) || id <= 0) return
-    prjctDb.run(projectId, 'DELETE FROM workflow_rules WHERE id = ?', id)
+  async delete(_projectId, _data) {
+    // No-op by design: sync never deletes or modifies a local record.
   },
 }

--- a/core/sync/sync-client.ts
+++ b/core/sync/sync-client.ts
@@ -169,6 +169,28 @@ class SyncClient {
   }
 
   /**
+   * Reflect a soft lifecycle action on the cloud (pause/resume/unlink). All are
+   * non-destructive — they keep every record. Best-effort: returns false on any
+   * failure so the local action still completes (the CLI never blocks on cloud).
+   */
+  async setCloudLifecycle(
+    projectId: string,
+    action: 'pause' | 'resume' | 'unlink'
+  ): Promise<boolean> {
+    try {
+      const { apiUrl, apiKey, deviceId } = await this.getAuthHeaders()
+      if (!apiKey) return false
+      const response = await this.fetchWithRetry(`${apiUrl}/sync/projects/${projectId}/${action}`, {
+        method: 'POST',
+        headers: { ...this.authHeaders(apiKey, deviceId) },
+      })
+      return response.ok
+    } catch {
+      return false
+    }
+  }
+
+  /**
    * Publish a product benchmark to the cloud API.
    *
    * This is intentionally a cloud operation, not a GitHub write. The server is


### PR DESCRIPTION
Architecture fixes paired with the prjct-cli-api + prjct-cli-app PRs.

## Deterministic project identity
`core/services/sync/project-identity.ts` derives the cloud `projectId` as a **UUIDv5 of the git remote** (`provider:org/repo`), so the same repo gets the same id on every machine — no more duplicate cloud projects. `createConfig` uses it; a repo with no remote falls back to a random id. Existing projects keep their committed id (local untouched).

## Stable device identity ("14 máquinas" fix)
`clearAuth()` now **preserves `deviceId`/`hostname`** across logout — machine identity isn't session state, so a logout/login cycle stops looking like a brand-new machine.

## Local is sacred — sync never deletes or modifies a local record
- **Every apply delete handler is now a NO-OP** (memories, ideas, tasks, queue, custom_workflows, workflow_rules, specs). A delete on another machine never touches your local vault. Local deletes still propagate *out*; destruction never propagates *in*.
- New **specs** apply handler is additive (`INSERT … ON CONFLICT DO NOTHING`).
- Apply preserves **authored timestamps** (memories/ideas/ships) instead of `now()`.

## Lifecycle
`cloud pause/resume/unlink` now reflect cloud state via api-key endpoints (`setCloudLifecycle`, best-effort — local always completes). Definitive delete stays web + OTP only.

Tests: full suite **1759 pass / 0 fail** (delete-no-op + deviceId-persist + uuidv5 tests updated/added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)