### PR TITLE
fix: prjct sync regenerates the vault (was leaving it stale)

### DIFF
--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -211,6 +211,17 @@ export class AnalysisCommands extends PrjctCommandsBase {
         return { success: false, error: result.error }
       }
 
+      // Refresh the readable vault on every sync — the index/overview is the
+      // human + agent second-brain snapshot, and `prjct sync` is documented as a
+      // regen trigger. Without this it went stale (sync only rebuilt the skill +
+      // analysis, never the vault). Incremental + best-effort; never blocks sync.
+      try {
+        const { generateWiki } = await import('../services/wiki-generator')
+        await generateWiki(projectPath, projectId)
+      } catch {
+        /* vault regen is best-effort — a sync must still succeed without it */
+      }
+
       if (!options.md) out.stop()
 
       if (options.md) {


### PR DESCRIPTION
`prjct sync` rebuilt the skill + analysis but **never regenerated the readable vault** (`_generated/`), so the index/overview went stale even though the vault header documents sync as a regen trigger. The human + agent second-brain snapshot lagged behind SQLite — exactly the 'context queda stale' problem.

Now sync runs `generateWiki` (incremental, best-effort) after a successful sync → the index, per-type pages (incl. the new `context.md`) and `developer.md` stay fresh on every sync. Verified: a source run wrote the changed file and skipped the 287 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)