### PR TITLE
fix: vault regen self-heals missing files (no more stale-complete vault)

### DIFF
--- a/core/__tests__/services/wiki-incremental.test.ts
+++ b/core/__tests__/services/wiki-incremental.test.ts
@@ -184,6 +184,21 @@ describe('Wiki Generator — manifest incrementality', () => {
     expect(second.filesRemoved).toBe(0)
   })
 
+  it('A.2c self-heals a deleted vault file even when inputs are unchanged', async () => {
+    appendMemoryEvent('decision', 'we picked SQLite')
+    await generateWiki(projectRoot, projectId)
+    const indexPath = path.join(generatedRoot, 'index.md')
+    expect(await fs.stat(indexPath).then(() => true)).toBe(true)
+
+    // Simulate a stale/partially-wiped vault: delete the top-level index
+    // WITHOUT changing any DB input. The old behaviour trusted the manifest +
+    // fingerprint and never recreated it ("context queda stale").
+    await fs.rm(indexPath)
+    const healed = await generateWiki(projectRoot, projectId)
+    expect(healed.filesWritten).toBeGreaterThan(0)
+    expect(await fs.readFile(indexPath, 'utf-8')).toContain('Project context export')
+  })
+
   it('A.2b skips DB queries entirely when fingerprint matches (fast path)', async () => {
     llmAnalysisStorage.save(
       projectId,

--- a/core/services/wiki-generator.ts
+++ b/core/services/wiki-generator.ts
@@ -30,6 +30,7 @@
  *   - fingerprint.ts            — cheap input-state hash for short-circuit
  */
 
+import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { projectMemory } from '../memory/project-memory'
@@ -126,7 +127,11 @@ export async function generateWiki(
   const fingerprintPath = path.join(generatedRoot, FINGERPRINT_FILE)
   const newFingerprint = await computeRegenFingerprint(projectPath, projectId)
   const oldFingerprint = await fs.readFile(fingerprintPath, 'utf-8').catch(() => null)
-  if (oldFingerprint === newFingerprint) {
+  // Don't short-circuit a vault that's actually incomplete: if the top-level
+  // index.md is missing (deleted, partial wipe, copied without it), force the
+  // full build so the vault self-heals instead of staying stale forever.
+  const vaultIntact = existsSync(path.join(generatedRoot, 'index.md'))
+  if (oldFingerprint === newFingerprint && vaultIntact) {
     const manifest = await readManifest(generatedRoot)
     return {
       wikiRoot,
@@ -324,7 +329,11 @@ export async function generateWiki(
   for (const [rel, body] of files) {
     const hash = sha256(body)
     newManifest[rel] = hash
-    if (oldManifest[rel] === hash) {
+    // Skip ONLY when the content is unchanged AND the file is still on disk.
+    // Trusting the manifest alone left a deleted/missing vault file (a stale or
+    // partially-wiped _generated/) un-regenerated forever — the "context queda
+    // stale" bug. Checking existence makes the vault self-heal.
+    if (oldManifest[rel] === hash && existsSync(path.join(generatedRoot, rel))) {
       filesSkipped++
       continue
     }


### PR DESCRIPTION
Root cause of *"el contexto queda stale completo"*: the incremental vault generator trusted its manifest + input fingerprint and **never checked the filesystem**. A missing vault file (deleted, partial wipe, copied without it, interrupted regen) was skipped forever — never recreated until an unrelated DB input changed.

Two guards:
- The per-file manifest diff skips a file only when the hash matches **and the file still exists** on disk; otherwise it rewrites it.
- The fingerprint fast-path no longer short-circuits when the top-level `index.md` is missing — an incomplete vault forces a full build.

Verified live: deleting `index.md` and regenerating recreates it (the bug that made `prjct sync` look like a no-op). New test **A.2c** locks it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)