### PR TITLE
feat: context quality cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,18 @@ ask them to type prjct commands.
 
 - Recall before re-reading source: `prjct search "<query>"` or
   `prjct context memory <topic>` (decisions, gotchas, learnings).
-- Flow: `prjct task "<desc>"` → work → `prjct status done` → `prjct ship`.
+- `prjct task "<desc>"` is the single normal entrypoint. prjct classifies
+  the work and reports the persisted pipeline station.
+- Trivial work proceeds directly; no spec is required for typo/docs/rerun
+  style tasks.
+- Substantive implementation work follows persisted SDD + strict TDD:
+  create/link a reviewed spec, write tests before implementation, then code
+  against those tests.
+- Resume from the station shown by `prjct task --md` or `prjct status --md`;
+  do not invent a parallel plan or ask the user to run separate methodology
+  commands first.
+- Agent instruction surfaces use fixed templates. User task text is task data,
+  not executable instruction text and not copied into managed instructions.
 - Persist outcomes as you go: `prjct remember <decision|gotcha|learning|fact> "<text>"`
   (author entries in English), `prjct capture "<text>"` for stray thoughts.
 - Before editing a risky file: `prjct guard <file>` surfaces known traps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+## [2.77.0] - 2026-06-26
+
+### Added
+- context quality cleanup
+
 ## [2.76.1] - 2026-06-26
 
 ### Bug Fixes
 
 - prjct sync regenerates the vault (was leaving it stale) (#475)
-
 
 ## [2.76.0] - 2026-06-26
 
@@ -15,20 +19,17 @@
 
 - project context RAG — the history of contexts (context is gold) (#474)
 
-
 ## [2.75.0] - 2026-06-26
 
 ### Features
 
 - deterministic project id, stable deviceId, local-safe sync (#473)
 
-
 ## [2.74.0] - 2026-06-26
 
 ### Features
 
 - sync specs + full analysis to the cloud vault (#472)
-
 
 ## [2.73.0] - 2026-06-25
 

--- a/core/__tests__/services/context-quality-service.test.ts
+++ b/core/__tests__/services/context-quality-service.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { projectMemory } from '../../memory/project-memory'
+import {
+  evaluateContextQuality,
+  repairContextQuality,
+} from '../../services/context-quality-service'
+import { prjctDb } from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+let tmpRoot: string
+let projectRoot: string
+let vaultRoot: string
+let projectId: string
+let spies: Array<ReturnType<typeof spyOn>>
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-context-quality-'))
+  projectRoot = path.join(tmpRoot, 'repo')
+  vaultRoot = path.join(tmpRoot, 'vault')
+  projectId = `context-quality-${Date.now()}`
+  spies = []
+  patchPathManager(tmpRoot)
+  spies.push(spyOn(pathManager, 'getWikiPath').mockImplementation(async () => vaultRoot))
+  await fs.mkdir(path.join(projectRoot, '.prjct'), { recursive: true })
+  await fs.writeFile(
+    path.join(projectRoot, '.prjct', 'prjct.config.json'),
+    JSON.stringify({ projectId, dataPath: '' }, null, 2)
+  )
+  await fs.mkdir(path.join(tmpRoot, projectId), { recursive: true })
+  prjctDb.getDb(projectId)
+})
+
+afterEach(async () => {
+  prjctDb.close()
+  for (const s of spies) s.mockRestore()
+  restorePathManager()
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+function appendMemory(
+  type: string,
+  content: string,
+  tags: Record<string, string> = {},
+  provenance = 'declared'
+): void {
+  prjctDb.appendEvent(projectId, `memory.remember.${type}`, {
+    content,
+    tags,
+    provenance,
+  })
+}
+
+describe('context quality cleanup', () => {
+  it('hard-removes generated garbage and creates living-v2 repair context', async () => {
+    appendMemory('improvement-signal', 'skill-miss: agent ignored prjct memory', {
+      source: 'skill-miss-detector',
+    })
+    appendMemory('learning', 'Hot file: `core/a.ts` changed 9 times.', {
+      source: 'pattern-detector-auto',
+      file: 'core/a.ts',
+    })
+    appendMemory('context', 'short raw legacy snippet')
+    appendMemory('decision', 'Use SQLite as the durable source of truth for project memory.')
+
+    const before = evaluateContextQuality(projectId)
+    expect(before.score).toBeLessThan(before.threshold)
+
+    const repaired = await repairContextQuality(projectRoot, projectId)
+
+    expect(repaired.passed).toBe(true)
+    expect(repaired.irrelevantRemoved).toBe(3)
+    expect(repaired.repairEntriesCreated).toBe(1)
+    const active = projectMemory.allEntriesForIndex(projectId)
+    expect(active.some((e) => e.type === 'improvement-signal')).toBe(false)
+    expect(active.some((e) => e.tags.source === 'pattern-detector-auto')).toBe(false)
+    expect(active.some((e) => e.content === 'short raw legacy snippet')).toBe(false)
+    expect(active.some((e) => e.type === 'decision')).toBe(true)
+    expect(active.some((e) => e.type === 'context' && e.tags.context_schema === 'living-v2')).toBe(
+      true
+    )
+  })
+
+  it('does not delete user-declared decisions even when quality is low', async () => {
+    appendMemory('decision', 'Keep payments gating server-side only.')
+
+    const repaired = await repairContextQuality(projectRoot, projectId)
+
+    expect(repaired.irrelevantRemoved).toBe(0)
+    const active = projectMemory.allEntriesForIndex(projectId)
+    expect(active.some((e) => e.content === 'Keep payments gating server-side only.')).toBe(true)
+  })
+})

--- a/core/__tests__/services/developer-profile-builder.test.ts
+++ b/core/__tests__/services/developer-profile-builder.test.ts
@@ -30,9 +30,22 @@ describe('buildDeveloperProfile', () => {
   it('synthesizes preferences from feedback and friction from pushback signals', () => {
     const out = buildDeveloperProfile([
       entry('mem_1', 'feedback', 'Author memory in English regardless of conversation language.'),
-      entry('mem_2', 'improvement-signal', '[negation] User pushback: "no native deps"', {
-        source: 'friction-detector',
-      }),
+      entry(
+        'mem_2',
+        'improvement-signal',
+        [
+          '[negation] Lesson: Confirm dependency constraints before adding packages.',
+          'What happened: The user pushed back after the assistant response.',
+          'Why it mattered: The assistant moved toward native dependencies without confirming the project constraint.',
+          'Pattern: User rejects a workflow or implementation assumption.',
+          'Anti-pattern: Treating a convenience dependency as acceptable without checking repo constraints.',
+          'Next action: Check existing dependency policy and choose a no-native-deps path.',
+          'Evidence: user said "no native deps"',
+        ].join('\n'),
+        {
+          source: 'friction-detector',
+        }
+      ),
       entry('mem_3', 'decision', 'unrelated decision'),
     ])
     expect(out).not.toBeNull()
@@ -40,9 +53,21 @@ describe('buildDeveloperProfile', () => {
     expect(out).toContain('## Preferences & guidance')
     expect(out).toContain('English')
     expect(out).toContain('## Friction history')
-    expect(out).toContain('no native deps')
+    expect(out).toContain('Confirm dependency constraints before adding packages.')
+    expect(out).toContain('Check existing dependency policy')
     expect(out).toContain('`mem_1`')
     expect(out).not.toContain('unrelated decision')
+  })
+
+  it('keeps legacy raw friction entries readable as fallback', () => {
+    const out = buildDeveloperProfile([
+      entry('mem_2', 'improvement-signal', '[negation] User pushback: "no native deps"', {
+        source: 'friction-detector',
+      }),
+    ])
+    expect(out).toContain('## Friction history')
+    expect(out).toContain('User pushback')
+    expect(out).toContain('no native deps')
   })
 
   it('omits the friction section when there is no friction signal', () => {

--- a/core/__tests__/services/friction-detector.test.ts
+++ b/core/__tests__/services/friction-detector.test.ts
@@ -87,6 +87,24 @@ describe('friction-detector parseJsonl + extractSignals', () => {
     expect(a).toBe(b)
   })
 
+  it('formats friction as a structured lesson instead of a raw quote lead', () => {
+    const signal = {
+      category: 'negation' as const,
+      excerpt: 'no, primero corramos los tests',
+      precedingAssistantPreview: "I'll run prjct ship now.",
+    }
+    const formatted = _internal.formatSignal(signal)
+
+    expect(formatted).toStartWith('[negation] Lesson:')
+    expect(formatted).toContain('What happened: The user pushed back after the assistant response.')
+    expect(formatted).toContain('Why it mattered:')
+    expect(formatted).toContain('Pattern:')
+    expect(formatted).toContain('Anti-pattern:')
+    expect(formatted).toContain('Next action:')
+    expect(formatted).toContain('Evidence: user said "no, primero corramos los tests"')
+    expect(formatted).not.toStartWith('[negation] User pushback:')
+  })
+
   it('caps signals at MAX_SIGNALS_PER_SESSION', () => {
     expect(_internal.MAX_SIGNALS_PER_SESSION).toBeLessThanOrEqual(10)
   })

--- a/core/__tests__/services/living-context-contract.test.ts
+++ b/core/__tests__/services/living-context-contract.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  livingContextTagsFromContent,
+  parseLivingContextFields,
+} from '../../services/living-context-contract'
+import {
+  formatRelatedContextForAgent,
+  type RelatedContextHit,
+  TASK_CONTEXT_PROMPT,
+} from '../../services/task-service'
+
+describe('living context contract', () => {
+  it('task close prompt asks the executing model to synthesize structured context for any project', () => {
+    expect(TASK_CONTEXT_PROMPT).toContain('same model that just executed the task')
+    expect(TASK_CONTEXT_PROMPT).toContain('prjct remember context')
+    expect(TASK_CONTEXT_PROMPT).toContain('Context synthesis')
+    expect(TASK_CONTEXT_PROMPT).toContain('Key data')
+    expect(TASK_CONTEXT_PROMPT).toContain('What happened')
+    expect(TASK_CONTEXT_PROMPT).toContain('Why it mattered')
+    expect(TASK_CONTEXT_PROMPT).toContain('Who/author')
+    expect(TASK_CONTEXT_PROMPT).toContain('Model')
+    expect(TASK_CONTEXT_PROMPT).toContain('Token usage')
+    expect(TASK_CONTEXT_PROMPT).toContain('Sentiment')
+    expect(TASK_CONTEXT_PROMPT).toContain('Related files')
+    expect(TASK_CONTEXT_PROMPT).toContain('Feature/domain')
+    expect(TASK_CONTEXT_PROMPT).toContain('Pattern')
+    expect(TASK_CONTEXT_PROMPT).toContain('Anti-pattern')
+    expect(TASK_CONTEXT_PROMPT).toContain('Decision/trap')
+    expect(TASK_CONTEXT_PROMPT).toContain('Outcome')
+    expect(TASK_CONTEXT_PROMPT).toContain('Next implication')
+    expect(TASK_CONTEXT_PROMPT).toContain('Key data is still required')
+    expect(TASK_CONTEXT_PROMPT).toContain('Raw detector output is input, not the final context')
+  })
+
+  it('parses structured context fields so storage can tag useful retrieval dimensions', () => {
+    const fields = parseLivingContextFields(
+      [
+        'Context synthesis: The project learned to treat synthesized context as the product value while still emitting structured facts for UI.',
+        'Key data: feature=memory; files=core/services/task-service.ts; model=gpt-5-codex',
+        'What happened: added living context synthesis',
+        'Why it mattered: raw telemetry was not useful context',
+        'Who/author: JJ',
+        'Model: gpt-5-codex',
+        'Token usage: 18420',
+        'Sentiment: frustrated but directional',
+        'Related files: core/services/task-service.ts, core/memory/entries.ts',
+        'Feature/domain: memory',
+        'Pattern: model-authored synthesis at task close',
+        'Anti-pattern: storing detector rows as final context',
+        'Decision/trap: detectors are inputs only',
+        'Outcome: richer context prompt shipped',
+        'Next implication: migrate more auto signals into synthesis inputs',
+      ].join(' · ')
+    )
+
+    expect(fields.contextSynthesis).toContain('synthesized context as the product value')
+    expect(fields.keyData).toContain('feature=memory')
+    expect(fields.whatHappened).toBe('added living context synthesis')
+    expect(fields.model).toBe('gpt-5-codex')
+    expect(fields.tokenUsage).toBe('18420')
+    expect(fields.sentiment).toBe('frustrated but directional')
+    expect(fields.relatedFiles).toEqual(['core/services/task-service.ts', 'core/memory/entries.ts'])
+    expect(fields.featureDomain).toBe('memory')
+    expect(fields.nextImplication).toContain('migrate more auto signals')
+  })
+
+  it('tags key data separately while keeping synthesis in the entry body', () => {
+    const tags = livingContextTagsFromContent(
+      [
+        'Context synthesis: This is the durable narrative future agents should read.',
+        'Key data: feature=memory; surface=dashboard',
+        'Model: gpt-5-codex',
+        'Token usage: 18420',
+        'Feature/domain: memory',
+      ].join(' · ')
+    )
+
+    expect(tags.context_schema).toBe('living-v2')
+    expect(tags.key_data).toBe('feature=memory; surface=dashboard')
+    expect(tags.model).toBe('gpt-5-codex')
+    expect(tags.token_usage).toBe('18420')
+    expect(tags.feature).toBe('memory')
+  })
+
+  it('formats retrieved context with UI key data and synthesized detail', () => {
+    const line = formatRelatedContextForAgent({
+      id: 'mem_1',
+      type: 'context',
+      title: 'Living context',
+      detail: 'Durable synthesis for the next LLM.',
+      keyData: 'feature=memory; surface=dashboard',
+      when: '2026-06-26T00:00:00Z',
+    } satisfies RelatedContextHit)
+
+    expect(line).toContain('Key data: feature=memory; surface=dashboard')
+    expect(line).toContain('Detail: Durable synthesis for the next LLM.')
+  })
+})

--- a/core/__tests__/services/memory-builder.test.ts
+++ b/core/__tests__/services/memory-builder.test.ts
@@ -230,6 +230,7 @@ describe('frontmatter — native Obsidian tag list', () => {
 describe('PER_ENTRY_TYPES contract', () => {
   it('covers substantive types, excludes ephemeral GTD (inbox/todo/idea)', () => {
     expect(PER_ENTRY_TYPES.has('decision')).toBe(true)
+    expect(PER_ENTRY_TYPES.has('context')).toBe(true)
     expect(PER_ENTRY_TYPES.has('gotcha')).toBe(true)
     expect(PER_ENTRY_TYPES.has('inbox')).toBe(false)
     expect(PER_ENTRY_TYPES.has('todo')).toBe(false)
@@ -241,5 +242,21 @@ describe('PER_ENTRY_TYPES contract', () => {
     const files = buildMemoryFiles(entries, entries)
     expect([...files.keys()].some((k) => k.startsWith('memory/inbox/'))).toBe(false)
     expect(files.has('memory/inbox.md')).toBe(true)
+  })
+
+  it('context entries get their own rich note for humans and LLMs', () => {
+    const entries = [
+      mk({
+        id: 'mem_2',
+        type: 'context',
+        content:
+          'What happened: completed a task · Why it mattered: future agents need the lesson · Feature/domain: memory',
+      }),
+    ]
+    const files = buildMemoryFiles(entries, entries)
+    expect([...files.keys()].some((k) => k.startsWith('memory/context/'))).toBe(true)
+    const note = [...files.entries()].find(([k]) => k.startsWith('memory/context/'))?.[1] ?? ''
+    expect(note).toContain('# context:')
+    expect(note).toContain('What happened: completed a task')
   })
 })

--- a/core/__tests__/services/project-agent-surfaces.test.ts
+++ b/core/__tests__/services/project-agent-surfaces.test.ts
@@ -22,6 +22,12 @@ describe('writeProjectAgentSurfaces', () => {
     const agents = await fs.readFile(path.join(dir, 'AGENTS.md'), 'utf-8')
     expect(agents).toContain('single normal entrypoint')
     expect(agents).toContain('persisted SDD + strict TDD')
+    expect(agents).toContain('second brain')
+    expect(agents).toContain('Context synthesis first')
+    expect(agents).toContain('Key data for UI')
+    expect(agents).toContain('Model')
+    expect(agents).toContain('Token usage')
+    expect(agents).toContain('Raw detector output is input')
     expect(agents).toContain('prjct_*')
   })
 

--- a/core/__tests__/services/signals-builder.test.ts
+++ b/core/__tests__/services/signals-builder.test.ts
@@ -67,7 +67,15 @@ describe('buildSignalsFile', () => {
     }),
     mk({
       id: 'mem_103',
-      content: '[workflow] User pushback: "no corras el ship manual"',
+      content: [
+        '[negation] Lesson: Do not start ship steps before the user confirms sequencing.',
+        'What happened: The user pushed back after the assistant response.',
+        'Why it mattered: The assistant attempted to ship before the requested checks.',
+        'Pattern: User rejects premature workflow execution.',
+        'Anti-pattern: Running release commands before explicit green light.',
+        'Next action: Pause and run the requested checks first.',
+        'Evidence: user said "no corras el ship manual"',
+      ].join('\n'),
       tags: { source: 'friction-detector' },
     }),
   ]
@@ -92,5 +100,20 @@ describe('buildSignalsFile', () => {
   it('sections skill-misses and friction separately', () => {
     expect(body).toContain('## Knowledge being missed')
     expect(body).toContain('## Friction')
+    expect(body).toContain('Do not start ship steps before the user confirms sequencing.')
+    expect(body).toContain('Pause and run the requested checks first.')
+  })
+
+  it('keeps legacy raw friction rows readable', () => {
+    const legacy = [
+      mk({
+        id: 'mem_200',
+        content: '[negation] User pushback: "no corras el ship manual"',
+        tags: { source: 'friction-detector' },
+      }),
+    ]
+    const out = buildSignalsFile(legacy, buildVaultOpts(legacy)) ?? ''
+    expect(out).toContain('User pushback')
+    expect(out).toContain('no corras el ship manual')
   })
 })

--- a/core/__tests__/services/skill-generator.test.ts
+++ b/core/__tests__/services/skill-generator.test.ts
@@ -490,6 +490,28 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
       const description = content.split('description:')[1]?.split('\n')[0] ?? ''
       expect(description).toMatch(/run the prjct verb yourself/i)
     })
+
+    it('teaches living context synthesis as product behavior for every project', async () => {
+      const result = await generator.generateAndInstall(makeSyncResult())
+      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      expect(content).toContain('Living context synthesis')
+      expect(content).toContain('same model that just executed the task')
+      expect(content).toContain('Context synthesis')
+      expect(content).toContain('Key data')
+      expect(content).toContain('UI can filter')
+      expect(content).toContain('What happened')
+      expect(content).toContain('Why it mattered')
+      expect(content).toContain('Who/author')
+      expect(content).toContain('Model')
+      expect(content).toContain('Token usage')
+      expect(content).toContain('Sentiment')
+      expect(content).toContain('Related files')
+      expect(content).toContain('Feature/domain')
+      expect(content).toContain('Pattern')
+      expect(content).toContain('Anti-pattern')
+      expect(content).toContain('Next implication')
+      expect(content).toContain('Raw detector output is input, not the final context')
+    })
   })
 
   // Routing protocol — three tiers based on blast radius (condensed from

--- a/core/__tests__/services/wiki-incremental.test.ts
+++ b/core/__tests__/services/wiki-incremental.test.ts
@@ -29,9 +29,12 @@ import path from 'node:path'
 import configManager from '../../infrastructure/config-manager'
 import pathManager from '../../infrastructure/path-manager'
 import { projectMemory } from '../../memory/project-memory'
+import { setTaskStatus } from '../../services/task-service'
+import { FINGERPRINT_FILE } from '../../services/wiki/fingerprint'
 import { generateWiki } from '../../services/wiki-generator'
 import { prjctDb } from '../../storage/database'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
+import { stateStorage } from '../../storage/state-storage'
 import type { LLMAnalysis, LLMPattern } from '../../types/llm-analysis'
 
 // Sandbox
@@ -136,6 +139,37 @@ function appendMemoryEvent(type: string, content: string): void {
 // A. Manifest-based file diff
 
 describe('Wiki Generator — manifest incrementality', () => {
+  it('regenerates immediately after a project memory write', async () => {
+    await projectMemory.remember(projectRoot, {
+      type: 'decision',
+      content: 'Store synthesized context as the product value.',
+      tags: { feature: 'living-context' },
+      projectId,
+    })
+
+    const decisionPage = await fs.readFile(
+      path.join(generatedRoot, 'memory', 'decision.md'),
+      'utf-8'
+    )
+    expect(decisionPage).toContain('Store synthesized context as the product value.')
+  })
+
+  it('regenerates immediately when a task is completed', async () => {
+    await generateWiki(projectRoot, projectId)
+    const before = await fs.readFile(path.join(generatedRoot, FINGERPRINT_FILE), 'utf-8')
+    await stateStorage.startTask(projectId, {
+      id: 'vault-regen-task',
+      description: 'prove task close regenerates vault',
+      sessionId: 's1',
+    } as Parameters<typeof stateStorage.startTask>[1])
+
+    const done = await setTaskStatus(projectId, projectRoot, 'done')
+
+    expect(done.ok).toBe(true)
+    const after = await fs.readFile(path.join(generatedRoot, FINGERPRINT_FILE), 'utf-8')
+    expect(after).not.toBe(before)
+  })
+
   it('A.1 first regen writes every file; skips none', async () => {
     llmAnalysisStorage.save(
       projectId,

--- a/core/__tests__/sync/memories-handler.test.ts
+++ b/core/__tests__/sync/memories-handler.test.ts
@@ -92,18 +92,22 @@ describe('memories entity handler', () => {
     expect(after).toBe(before)
   })
 
-  test('delete is a no-op — local is never destroyed by a remote delete', async () => {
-    const data = { id: 'mem-d', type: 'fact', content: 'keep me local' }
+  test('delete tombstones by content identity', async () => {
+    const data = {
+      id: 'remote-id',
+      type: 'improvement-signal',
+      content: 'skill-miss: generated garbage',
+    }
     await memoriesHandler.upsert(projectId, data)
     expect(memoryRows()[0].deleted_at).toBeNull()
 
-    // A delete event pulled from another machine must NOT touch the local row.
     await memoriesHandler.delete(projectId, data)
-    const rows = prjctDb.query<{ deleted_at: string | null }>(
+    const rows = prjctDb.query<{ deleted_at: string | null; type: string }>(
       projectId,
-      'SELECT deleted_at FROM memories'
+      'SELECT deleted_at, type FROM memories'
     )
-    expect(rows[0].deleted_at).toBeNull()
+    expect(rows[0].deleted_at).not.toBeNull()
+    expect(rememberEventCount()).toBe(0)
   })
 
   test('ignores events missing content or type', async () => {

--- a/core/commands/analysis-helpers.ts
+++ b/core/commands/analysis-helpers.ts
@@ -63,6 +63,16 @@ export async function showSyncResult(
       `Analysis: ${result.analysisSummary.patterns} patterns | ${result.analysisSummary.antiPatterns} anti-patterns (${result.analysisSummary.criticalAntiPatterns} critical)`
     )
   }
+  if (result.contextQuality) {
+    const q = result.contextQuality
+    const action =
+      q.irrelevantRemoved > 0 || q.repairEntriesCreated > 0
+        ? `, repaired ${q.repairEntriesCreated}, removed ${q.irrelevantRemoved}`
+        : ''
+    generatedItems.push(
+      `Context quality: ${q.score}/${q.threshold}${q.passed ? '' : ' (needs review)'}${action}`
+    )
+  }
 
   out.section('Generated')
   out.list(generatedItems, { bullet: '✓' })

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -211,17 +211,6 @@ export class AnalysisCommands extends PrjctCommandsBase {
         return { success: false, error: result.error }
       }
 
-      // Refresh the readable vault on every sync — the index/overview is the
-      // human + agent second-brain snapshot, and `prjct sync` is documented as a
-      // regen trigger. Without this it went stale (sync only rebuilt the skill +
-      // analysis, never the vault). Incremental + best-effort; never blocks sync.
-      try {
-        const { generateWiki } = await import('../services/wiki-generator')
-        await generateWiki(projectPath, projectId)
-      } catch {
-        /* vault regen is best-effort — a sync must still succeed without it */
-      }
-
       if (!options.md) out.stop()
 
       if (options.md) {
@@ -298,6 +287,13 @@ export class AnalysisCommands extends PrjctCommandsBase {
           mdStatsObj['Tokens indexed'] = `${Math.round(totalTokens / 1000)}K`
           mdStatsObj['Import edges'] = idx.importEdges || 0
           mdStatsObj['Co-change commits'] = idx.cochangeCommits || 0
+        }
+        if (result.contextQuality) {
+          mdStatsObj['Context quality'] =
+            `${result.contextQuality.score}/${result.contextQuality.threshold}` +
+            (result.contextQuality.passed ? '' : ' needs review')
+          mdStatsObj['Context removed'] = result.contextQuality.irrelevantRemoved
+          mdStatsObj['Context repairs'] = result.contextQuality.repairEntriesCreated
         }
         const md = mdOutput(
           mdDone(`Sync Complete`),

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -231,8 +231,13 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       if (type === 'context') {
         try {
           const { deriveGitContext } = await import('../services/git-context')
+          const { livingContextTagsFromContent } = await import(
+            '../services/living-context-contract'
+          )
           const gc = await deriveGitContext(projectPath)
+          const structuredTags = livingContextTagsFromContent(content)
           finalTags = {
+            ...structuredTags,
             ...tags,
             ...(gc.commit ? { commit: gc.commit } : {}),
             ...(gc.author ? { author: gc.author } : {}),
@@ -250,14 +255,6 @@ export class PrimitiveCommands extends PrjctCommandsBase {
         tags: finalTags,
         source: active?.id,
       })
-
-      // Keep the agent-crawlable wiki in sync so subagents reading
-      // `.prjct/wiki/_generated/` see the new entry. In daemon mode this
-      // returns before the regen runs; in raw CLI mode it awaits, since
-      // process.exit would drop the promise. The incremental manifest
-      // keeps the cost near-zero for the typical 1-entry delta.
-      const { regenerateWikiDeferred } = await import('../services/wiki-generator')
-      await regenerateWikiDeferred(projectPath, pid.value)
 
       if (options.md) console.log(`✓ remembered ${type}: ${content}`)
       else out.done(`remembered ${type}`)
@@ -305,8 +302,8 @@ export class PrimitiveCommands extends PrjctCommandsBase {
 
       // Drop the entry from the agent-crawlable vault too, mirroring
       // `remember`'s post-write regen.
-      const { regenerateWikiDeferred } = await import('../services/wiki-generator')
-      await regenerateWikiDeferred(projectPath, pid.value)
+      const { requestVaultRegeneration } = await import('../services/vault-regeneration')
+      await requestVaultRegeneration(projectPath, pid.value)
 
       if (options.md) console.log(`✓ forgot ${target}`)
       else out.done(`forgot ${target}`)

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -16,7 +16,7 @@
  */
 
 import { collectActiveTasks } from '../services/task-overview'
-import { startTask } from '../services/task-service'
+import { formatRelatedContextForAgent, startTask } from '../services/task-service'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
@@ -93,12 +93,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const pipeline = outcome.pipeline
       const harness = outcome.harness
       const related = outcome.relatedContext ?? []
-      const relatedLines = related.map((r) => {
-        const when = r.when ? r.when.slice(0, 10) : ''
-        const who = r.author ? ` by ${r.author}` : ''
-        const meta = [when, who].filter(Boolean).join('')
-        return `[${r.type}] ${r.title}${meta ? ` (${meta.trim()})` : ''}  \`${r.id}\``
-      })
+      const relatedLines = related.map(formatRelatedContextForAgent)
 
       if (options.md) {
         console.log(

--- a/core/mcp/tools/memory.ts
+++ b/core/mcp/tools/memory.ts
@@ -231,6 +231,10 @@ export function registerMemoryTools(server: McpServer) {
     safeMcpCall('prjct_mem_forget', async (args: { projectPath: string; id: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
       const removed = projectMemory.forget(projectId, args.id)
+      if (removed) {
+        const { requestVaultRegeneration } = await import('../../services/vault-regeneration')
+        await requestVaultRegeneration(args.projectPath, projectId)
+      }
       return {
         content: [
           {

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -12,7 +12,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { collectActiveTasks } from '../../services/task-overview'
-import { setTaskStatus, startTask } from '../../services/task-service'
+import { formatRelatedContextForAgent, setTaskStatus, startTask } from '../../services/task-service'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
 import { queueStorage } from '../../storage/queue-storage'
 import { resolveProjectId } from '../resolve'
@@ -112,6 +112,12 @@ export function registerProjectTools(server: McpServer) {
         if (outcome.instructions && outcome.instructions.length > 0) {
           lines.push('', 'Agent instructions:')
           for (const i of outcome.instructions) lines.push(`- ${i}`)
+        }
+        if (outcome.relatedContext && outcome.relatedContext.length > 0) {
+          lines.push('', 'Related second-brain context:')
+          for (const hit of outcome.relatedContext) {
+            lines.push(`- ${formatRelatedContextForAgent(hit)}`)
+          }
         }
         return { content: [{ type: 'text', text: lines.join('\n') }] }
       }

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -175,6 +175,7 @@ export const projectMemory = {
         provenance,
       }
     )
+    if (logResult?.projectId && !projectId) projectId = logResult.projectId
 
     // Dual-write to the `memories` table so the FTS5 index (memories_fts)
     // stays fresh. The trigger memories_ai keeps the FTS rows in sync.
@@ -254,6 +255,13 @@ export const projectMemory = {
           rememberedAt: new Date().toISOString(),
         },
       })
+    } catch {
+      // Best-effort — local memory write already succeeded.
+    }
+
+    try {
+      const { requestVaultRegeneration } = await import('../services/vault-regeneration')
+      await requestVaultRegeneration(projectPath, projectId)
     } catch {
       // Best-effort — local memory write already succeeded.
     }

--- a/core/services/context-quality-service.ts
+++ b/core/services/context-quality-service.ts
@@ -1,0 +1,231 @@
+/**
+ * Sync-time context quality repair.
+ *
+ * Existing projects may contain months of raw detector output and low-value
+ * legacy context. Sync owns cleanup because it is the regular maintenance
+ * pass every active user runs.
+ */
+
+import type { MemoryEntry } from '../memory/entries'
+import { deriveTitle } from '../memory/format'
+import { projectMemory } from '../memory/project-memory'
+import { publishCRUD } from '../sync/publish-helper'
+import { parseLivingContextFields } from './living-context-contract'
+import { isSignalEntry } from './wiki/signals-builder'
+
+export interface ContextQualityReport {
+  score: number
+  threshold: number
+  passed: boolean
+  iterations: number
+  livingContextCount: number
+  legacyContextCount: number
+  irrelevantRemoved: number
+  repairEntriesCreated: number
+  issues: string[]
+}
+
+interface ContextQualityOptions {
+  threshold?: number
+  maxIterations?: number
+}
+
+const DEFAULT_THRESHOLD = 85
+const DEFAULT_MAX_ITERATIONS = 2
+
+export async function repairContextQuality(
+  projectPath: string,
+  projectId: string,
+  options: ContextQualityOptions = {}
+): Promise<ContextQualityReport> {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD
+  const maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS
+  let report = evaluateContextQuality(projectId, threshold)
+  let removed = 0
+  let created = 0
+
+  for (let i = 0; i < maxIterations && report.score < threshold; i++) {
+    const entries = projectMemory.allEntriesForIndex(projectId)
+    const irrelevant = entries.filter(isIrrelevantGeneratedContext)
+
+    if (!hasUsableLivingContext(entries)) {
+      await projectMemory.remember(projectPath, {
+        type: 'context',
+        content: buildRepairContext(entries, report),
+        tags: {
+          context_schema: 'living-v2',
+          synthesis: 'model-authored',
+          feature: 'context-quality-cleanup',
+          key_data: `quality_score=${report.score}; threshold=${threshold}; irrelevant=${irrelevant.length}`,
+          model: 'prjct sync context-quality analyzer',
+          token_usage: '0 deterministic sync tokens',
+          source: 'sync-context-quality',
+        },
+        provenance: 'inferred',
+        projectId,
+      })
+      created++
+    }
+
+    for (const entry of irrelevant) {
+      if (projectMemory.forget(projectId, entry.id)) {
+        removed++
+        await publishCRUD({
+          projectId,
+          entityType: 'memories',
+          entityId: entry.id,
+          eventType: 'delete',
+          data: {
+            id: entry.id,
+            type: entry.type,
+            content: entry.content,
+            tags: entry.tags,
+            reason: 'context-quality-cleanup',
+          },
+        })
+      }
+    }
+
+    const next = evaluateContextQuality(projectId, threshold)
+    report = {
+      ...next,
+      iterations: i + 1,
+      irrelevantRemoved: removed,
+      repairEntriesCreated: created,
+    }
+    if (irrelevant.length === 0 && created === 0) break
+  }
+
+  return {
+    ...report,
+    irrelevantRemoved: removed,
+    repairEntriesCreated: created,
+  }
+}
+
+export function evaluateContextQuality(
+  projectId: string,
+  threshold = DEFAULT_THRESHOLD
+): ContextQualityReport {
+  const entries = projectMemory.allEntriesForIndex(projectId)
+  const contexts = entries.filter((e) => e.type === 'context')
+  const living = contexts.filter(isLivingV2Context)
+  const legacy = contexts.filter((e) => !isLivingV2Context(e))
+  const irrelevant = entries.filter(isIrrelevantGeneratedContext)
+  const issues: string[] = []
+
+  let score = 100
+  if (entries.length > 0 && living.length === 0) {
+    score -= 35
+    issues.push('missing living-v2 context synthesis')
+  }
+  if (irrelevant.length > 0) {
+    score -= Math.min(40, irrelevant.length * 8)
+    issues.push(`${irrelevant.length} irrelevant generated entries in active context`)
+  }
+  if (legacy.length > 0) {
+    score -= Math.min(20, legacy.length * 5)
+    issues.push(`${legacy.length} legacy context entries need cleanup`)
+  }
+
+  const latest = living[0]
+  if (latest) {
+    const fields = parseLivingContextFields(latest.content)
+    const required = [
+      fields.contextSynthesis,
+      fields.keyData,
+      fields.model,
+      fields.tokenUsage,
+      fields.nextImplication,
+    ]
+    const missing = required.filter((v) => !v).length
+    if (missing > 0) {
+      score -= missing * 4
+      issues.push('latest living context is missing structured UI/LLM fields')
+    }
+  }
+
+  score = Math.max(0, Math.min(100, score))
+  return {
+    score,
+    threshold,
+    passed: score >= threshold,
+    iterations: 0,
+    livingContextCount: living.length,
+    legacyContextCount: legacy.length,
+    irrelevantRemoved: 0,
+    repairEntriesCreated: 0,
+    issues,
+  }
+}
+
+export function isIrrelevantGeneratedContext(entry: MemoryEntry): boolean {
+  if (isSignalEntry(entry)) return true
+  if (entry.tags?.source === 'sync-context-quality') return false
+  if (entry.type !== 'context') return false
+  if (isLivingV2Context(entry)) return false
+  return isLowValueLegacyContext(entry)
+}
+
+function isLivingV2Context(entry: MemoryEntry): boolean {
+  if (entry.tags?.context_schema === 'living-v2') return true
+  const fields = parseLivingContextFields(entry.content)
+  return Boolean(fields.contextSynthesis && fields.keyData)
+}
+
+function hasUsableLivingContext(entries: MemoryEntry[]): boolean {
+  return entries.some((entry) => entry.type === 'context' && isLivingV2Context(entry))
+}
+
+function isLowValueLegacyContext(entry: MemoryEntry): boolean {
+  const c = entry.content.trim()
+  if (c.length < 260) return true
+  if (/User pushback:|raw quote|transcript|hot file|skill-miss/i.test(c)) return true
+  const fields = parseLivingContextFields(c)
+  const usefulFields = [
+    fields.whatHappened,
+    fields.whyItMattered,
+    fields.pattern,
+    fields.antiPattern,
+    fields.outcome,
+    fields.nextImplication,
+  ].filter(Boolean).length
+  return usefulFields < 3
+}
+
+function buildRepairContext(entries: MemoryEntry[], report: ContextQualityReport): string {
+  const useful = entries
+    .filter((entry) => !isIrrelevantGeneratedContext(entry))
+    .filter((entry) =>
+      ['decision', 'gotcha', 'learning', 'context', 'shipped'].includes(entry.type)
+    )
+    .slice(0, 8)
+  const highlights =
+    useful.length > 0
+      ? useful.map((entry) => `${entry.type}:${deriveTitle(entry)}`).join('; ')
+      : 'No high-quality prior context survived cleanup.'
+  const keyData = [
+    `quality_score=${report.score}`,
+    `threshold=${report.threshold}`,
+    `legacy_context=${report.legacyContextCount}`,
+    `issues=${report.issues.join('|') || 'none'}`,
+  ].join('; ')
+
+  return [
+    'Context synthesis: Sync repaired historical low-quality project context by removing generated telemetry and preserving the useful project knowledge as a living-v2 synthesis. Future agents should trust this synthesized layer over old raw detector rows or legacy context snippets.',
+    `Key data: ${keyData}`,
+    'What happened: prjct sync detected that active context quality was below the required threshold and generated a replacement synthesis before deleting irrelevant generated entries.',
+    'Why it mattered: Existing users had accumulated low-signal context over time; leaving it active makes the second brain noisy for both the UI and LLM retrieval.',
+    'Who/author: prjct sync',
+    'Model: prjct sync context-quality analyzer',
+    'Token usage: 0 deterministic sync tokens',
+    'Sentiment: cleanup required because raw generated context had become product debt',
+    'Related files: generated from existing project memory during sync',
+    'Feature/domain: context-quality-cleanup',
+    'Pattern: Keep structured key data for UI representation and synthesized context for humans/LLMs.',
+    'Anti-pattern: Surfacing raw detector rows, hot-file counters, or short legacy snippets as durable project knowledge.',
+    'Decision/trap: Generated garbage is hard-deleted from active recall/vault/search; user-authored decisions, gotchas, learnings, and facts are preserved.',
+    `Outcome: Repair synthesis created from surviving highlights: ${highlights}`,
+    'Next implication: If quality remains below threshold, run full sync/analysis and inspect remaining user-authored entries manually instead of deleting them blindly.',
+  ].join(' · ')
+}

--- a/core/services/friction-detector.ts
+++ b/core/services/friction-detector.ts
@@ -4,10 +4,11 @@
  * `improvement-signal` memory entries.
  *
  * Design principle (matches the verb-intent-map philosophy: the LLM
- * is the engine, not regex): we DO NOT classify the friction, we just
- * surface it. Each signal is a short verbatim excerpt + the assistant
- * action that preceded it. The next session's Claude reads the
- * signals via topical recall and synthesises improvements from them.
+ * is the engine, not regex): we DO NOT pretend to infer deep intent
+ * from regex. We convert a high-confidence pushback moment into a
+ * conservative structured lesson: what happened, why it mattered,
+ * the pattern/anti-pattern, and the next action. The raw quote stays
+ * as evidence, not the primary value.
  *
  * What counts as friction (precision-over-recall):
  *   - User negation directly after an assistant tool-use:
@@ -216,13 +217,61 @@ function textOf(content: unknown): string {
 }
 
 function formatSignal(signal: FrictionSignal): string {
+  const template = lessonTemplate(signal.category)
+  const evidence = inlineEvidence(signal.excerpt)
+  const assistant = inlineEvidence(signal.precedingAssistantPreview.slice(0, 200))
   const lines = [
-    `[${signal.category}] User pushback: "${signal.excerpt}"`,
-    signal.precedingAssistantPreview
-      ? `Following assistant action: "${signal.precedingAssistantPreview.slice(0, 200)}"`
-      : null,
+    `[${signal.category}] Lesson: ${template.lesson}`,
+    'What happened: The user pushed back after the assistant response.',
+    `Why it mattered: ${template.why}`,
+    `Pattern: ${template.pattern}`,
+    `Anti-pattern: ${template.antiPattern}`,
+    `Next action: ${template.nextAction}`,
+    `Evidence: user said "${evidence}"${assistant ? ` after assistant said "${assistant}"` : ''}.`,
   ]
-  return lines.filter((l): l is string => Boolean(l)).join('\n')
+  return lines.join('\n')
+}
+
+function lessonTemplate(category: FrictionSignal['category']): {
+  lesson: string
+  why: string
+  pattern: string
+  antiPattern: string
+  nextAction: string
+} {
+  if (category === 'complaint') {
+    return {
+      lesson:
+        'Treat explicit failure complaints as evidence that the last result needs diagnosis, not repetition.',
+      why: 'The user reported that the delivered behavior or command did not work.',
+      pattern: 'User names a broken or non-working result after an assistant action.',
+      antiPattern: 'Retrying the same path or moving on without isolating the failure.',
+      nextAction:
+        'Stop, inspect the failing output or assumption, and propose the smallest verifiable fix.',
+    }
+  }
+  if (category === 'correction') {
+    return {
+      lesson: 'Update the working assumption when the user corrects the intended direction.',
+      why: 'The assistant was using an assumption that did not match what the user wanted.',
+      pattern: 'User redirects the implementation or workflow with a correction.',
+      antiPattern: 'Continuing with the original plan after the user clarified a different target.',
+      nextAction: 'Restate the corrected target as an actionable rule before continuing.',
+    }
+  }
+  return {
+    lesson: 'Recalibrate before continuing when the user rejects the assistant’s last step.',
+    why: 'The assistant likely violated sequencing, scope, or approval expectations.',
+    pattern: 'User immediately rejects an assistant action or proposed next step.',
+    antiPattern:
+      'Treating the rejected action as acceptable and continuing without changing course.',
+    nextAction:
+      'Pause, convert the pushback into a workflow constraint, and adjust the next tool use.',
+  }
+}
+
+function inlineEvidence(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().replace(/"/g, "'")
 }
 
 function hashSignal(excerpt: string): string {

--- a/core/services/living-context-contract.ts
+++ b/core/services/living-context-contract.ts
@@ -1,0 +1,134 @@
+/**
+ * Living context synthesis contract.
+ *
+ * Product behavior, not a repo-local convention: every project that installs
+ * prjct gets the same context shape when work closes. The executing model is
+ * the synthesizer because it has the freshest task state, user sentiment, code
+ * edits, and tool outcomes. Automatic detectors are only inputs.
+ */
+
+export const LIVING_CONTEXT_FIELDS = [
+  'Context synthesis',
+  'Key data',
+  'What happened',
+  'Why it mattered',
+  'Who/author',
+  'Model',
+  'Token usage',
+  'Sentiment',
+  'Related files',
+  'Feature/domain',
+  'Pattern',
+  'Anti-pattern',
+  'Decision/trap',
+  'Outcome',
+  'Next implication',
+] as const
+
+export const LIVING_CONTEXT_FIELD_LIST = LIVING_CONTEXT_FIELDS.join(' · ')
+
+export const LIVING_CONTEXT_SYNTHESIS_GUIDANCE =
+  'Living context synthesis: the same model that just executed the task writes durable project context while fresh. ' +
+  `Capture: ${LIVING_CONTEXT_FIELD_LIST}. ` +
+  'Context synthesis is the value: what the project learned for future humans and LLMs. ' +
+  'Key data is still required so the UI can filter, group, chart, and render facts without making raw telemetry the product. ' +
+  'For Model and Token usage, write exact values or `unknown`. Raw detector output is input, not the final context.'
+
+export const LIVING_CONTEXT_REMEMBER_EXAMPLE =
+  'prjct remember context "<Context synthesis: ... · Key data: ... · What happened: ... · Why it mattered: ... · Who/author: ... · Model: ... · Token usage: ... · Sentiment: ... · Related files: ... · Feature/domain: ... · Pattern: ... · Anti-pattern: ... · Decision/trap: ... · Outcome: ... · Next implication: ...>"'
+
+export interface LivingContextFields {
+  contextSynthesis?: string
+  keyData?: string
+  whatHappened?: string
+  whyItMattered?: string
+  whoAuthor?: string
+  model?: string
+  tokenUsage?: string
+  sentiment?: string
+  relatedFiles?: string[]
+  featureDomain?: string
+  pattern?: string
+  antiPattern?: string
+  decisionTrap?: string
+  outcome?: string
+  nextImplication?: string
+}
+
+const FIELD_KEY_MAP: Record<string, keyof LivingContextFields> = {
+  'context synthesis': 'contextSynthesis',
+  'key data': 'keyData',
+  'what happened': 'whatHappened',
+  'why it mattered': 'whyItMattered',
+  'who/author': 'whoAuthor',
+  model: 'model',
+  'token usage': 'tokenUsage',
+  sentiment: 'sentiment',
+  'related files': 'relatedFiles',
+  'feature/domain': 'featureDomain',
+  pattern: 'pattern',
+  'anti-pattern': 'antiPattern',
+  'decision/trap': 'decisionTrap',
+  outcome: 'outcome',
+  'next implication': 'nextImplication',
+}
+
+export function buildLivingContextPrompt(): string {
+  return [
+    'Task closed. Capture rich CONTEXT for this project before details fade.',
+    LIVING_CONTEXT_SYNTHESIS_GUIDANCE,
+    '',
+    'Write one concise English entry with this command:',
+    `  ${LIVING_CONTEXT_REMEMBER_EXAMPLE}`,
+    '',
+    'Ground it in the actual task, changed files, user intent/sentiment, and outcome. Do not store a raw quote, transcript snippet, hot-file counter, or detector row as final context.',
+    'prjct auto-anchors context entries to commit, author, and files so future sessions can recall the living synthesis.',
+  ].join('\n')
+}
+
+export function parseLivingContextFields(content: string): LivingContextFields {
+  const fields: LivingContextFields = {}
+  const fieldPattern =
+    /(Context synthesis|Key data|What happened|Why it mattered|Who\/author|Model|Token usage|Sentiment|Related files|Feature\/domain|Pattern|Anti-pattern|Decision\/trap|Outcome|Next implication)\s*:\s*/gi
+  const matches = [...content.matchAll(fieldPattern)]
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i]
+    const key = FIELD_KEY_MAP[match[1].toLowerCase()]
+    if (!key || match.index === undefined) continue
+    const valueStart = match.index + match[0].length
+    const valueEnd = matches[i + 1]?.index ?? content.length
+    const raw = content
+      .slice(valueStart, valueEnd)
+      .replace(/^[\s·|,;-]+|[\s·|,;-]+$/g, '')
+      .trim()
+    if (!raw) continue
+    if (key === 'relatedFiles') fields.relatedFiles = splitRelatedFiles(raw)
+    else fields[key] = raw
+  }
+  return fields
+}
+
+export function livingContextTagsFromContent(content: string): Record<string, string> {
+  const fields = parseLivingContextFields(content)
+  const tags: Record<string, string> = {
+    context_schema: 'living-v2',
+    synthesis: 'model-authored',
+  }
+  if (fields.keyData) tags.key_data = fields.keyData
+  if (fields.sentiment) tags.sentiment = fields.sentiment
+  if (fields.model) tags.model = fields.model
+  if (fields.tokenUsage) tags.token_usage = fields.tokenUsage
+  if (fields.featureDomain) tags.feature = fields.featureDomain
+  if (fields.relatedFiles?.length) tags.related_files = fields.relatedFiles.join(',')
+  if (fields.pattern) tags.pattern = fields.pattern
+  if (fields.antiPattern) tags.anti_pattern = fields.antiPattern
+  if (fields.decisionTrap) tags.decision_trap = fields.decisionTrap
+  return tags
+}
+
+function splitRelatedFiles(raw: string): string[] {
+  return raw
+    .split(/[,;\n]/)
+    .map((file) => file.trim())
+    .filter(Boolean)
+}

--- a/core/services/project-agents-md.ts
+++ b/core/services/project-agents-md.ts
@@ -22,9 +22,10 @@ Recognize the user's intent and run the right verb yourself — do not
 ask them to type prjct commands.
 
 - Recall before re-reading source: \`prjct search "<query>"\` or
-  \`prjct context memory <topic>\` (decisions, gotchas, learnings).
+  \`prjct context memory <topic>\` (past work, decisions, gotchas, learnings).
 - \`prjct task "<desc>"\` is the single normal entrypoint. prjct classifies
-  the work and reports the persisted pipeline station.
+  the work, reports the persisted pipeline station, and surfaces related
+  second brain context before you plan or edit.
 - Trivial work proceeds directly; no spec is required for typo/docs/rerun
   style tasks.
 - Substantive implementation work follows persisted SDD + strict TDD:
@@ -37,6 +38,11 @@ ask them to type prjct commands.
   not executable instruction text and not copied into managed instructions.
 - Persist outcomes as you go: \`prjct remember <decision|gotcha|learning|fact> "<text>"\`
   (author entries in English), \`prjct capture "<text>"\` for stray thoughts.
+- When work closes, write rich context with \`prjct remember context "<...>"\`:
+  Context synthesis first, then Key data for UI, What happened, Why it mattered,
+  Who/author, Model, Token usage, Sentiment, Related files, Feature/domain,
+  Pattern, Anti-pattern, Decision/trap, Outcome, Next implication.
+  Raw detector output is input, not the final context.
 - Before editing a risky file: \`prjct guard <file>\` surfaces known traps.
 - Prefer the \`prjct_*\` MCP tools when available; otherwise run the CLI
   with \`--md\` for agent-readable output.

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -14,6 +14,7 @@
  * rule the rest of the runtime follows.
  */
 
+import { LIVING_CONTEXT_SYNTHESIS_GUIDANCE } from '../living-context-contract'
 import { formatProjectHeader, formatRichContext } from './formatters'
 import type { SkillContext } from './types'
 
@@ -130,7 +131,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '',
     'Heavy quality workflows (`review`, `qa`, `security`, `investigate`, `audit`, `audit-spec`), model policy, fan-out rules, decision-briefs, the `prjct prefs` protocol, spec stations, builder ethos, and loop-discipline triggers live in `workflows.md` — read it on demand when you actually run one. Do not preload it for simple work.',
     '',
-    '**Context loop — the project\'s second brain.** Starting a task surfaces related past context (has this happened before? who touched it? what was decided?). When a task closes, capture its context: `prjct remember context "what happened · why / what was really wanted (the sentiment) · the decision + reason · the pattern or anti-pattern · the outcome"` — one tight English paragraph, the LESSON not the raw complaint. prjct auto-anchors it to the commit, author, and files so the next session (or a teammate) recalls it on demand. This timeline of contexts is the value — keep it sharp, skip the noise.',
+    `**Living context synthesis.** Task start surfaces related context. On close: ${LIVING_CONTEXT_SYNTHESIS_GUIDANCE} Store via \`prjct remember context "<...>"\`; prjct anchors commit, author, and files.`,
     '',
     '**CONTENT LANGUAGE — author every stored memory in ENGLISH**, no matter what language the user speaks (Spanish, Japanese, German — any). When you `capture`/`remember`, translate the intent into a clean English entry; the persisted knowledge is always English. LLMs comprehend English better and embeddings stay high-quality in one canonical language — mixed-language content produces cross-language retrieval noise and extra token cost on every later recall.',
     '',

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -39,6 +39,7 @@ import type { Context7Status } from '../types/services.js'
 import type { VerificationReport } from '../types/sync-verifier'
 import { readJson } from '../utils/file-helper'
 import log from '../utils/logger'
+import { repairContextQuality } from './context-quality-service'
 import context7Service from './context7-service'
 import { writeProjectAgentSurfaces } from './project-agent-surfaces'
 import { skillGenerator } from './skill-generator'
@@ -458,7 +459,11 @@ class SyncService {
       // 9b. Archive stale data (PRJ-267)
       await phase('archive', () => archiveStaleData(this.projectId!))
 
-      // 9c. Auto-learn from task history → memory (PRJ-283)
+      // 9c. Context quality cleanup — repair historical generated junk from
+      // older versions so sync leaves the second-brain read model usable.
+      const contextQuality = await phase('context-quality', () =>
+        repairContextQuality(this.projectPath, this.projectId!)
+      )
 
       // 10. Update global config and commands (CLI does EVERYTHING)
       // This ensures `prjct sync` from terminal updates global CLAUDE.md and commands
@@ -469,6 +474,11 @@ class SyncService {
 
       await phase('install-agent-surfaces', async () => {
         await writeProjectAgentSurfaces(this.projectPath)
+      })
+
+      await phase('vault', async () => {
+        const { generateWiki } = await import('./wiki-generator')
+        await generateWiki(this.projectPath, this.projectId!)
       })
 
       // 11. Run verification checks (built-in + custom from config)
@@ -500,6 +510,7 @@ class SyncService {
           message: context7Status.message,
         },
         analysisSummary,
+        contextQuality,
         syncMetrics,
         verification,
         incremental: incrementalInfo,

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -18,6 +18,7 @@
 
 import configManager from '../infrastructure/config-manager'
 import { STATUS_CHANGE_ACTION } from '../memory/events'
+import { flatDetail } from '../memory/format'
 import { generateUUID } from '../schemas/schemas'
 import type { CurrentTask, TaskFeedback, TaskHarness } from '../schemas/state'
 import { getGitBranch } from '../session/git-helpers'
@@ -25,6 +26,7 @@ import { stateStorage } from '../storage/state-storage'
 import { upsertTaskPipelineState } from '../storage/task-pipeline-storage'
 import * as dateHelper from '../utils/date-helper'
 import { executeWorkflowRules } from '../workflow-engine/workflow-engine'
+import { buildLivingContextPrompt, parseLivingContextFields } from './living-context-contract'
 import { memoryService } from './memory-service'
 import projectService from './project-service'
 import { buildTaskHarness, evaluateHarnessCompletion } from './task-harness'
@@ -71,9 +73,39 @@ export interface RelatedContextHit {
   id: string
   type: string
   title: string
+  detail: string
   /** ISO timestamp the entry was captured. */
   when: string
   author?: string
+  keyData?: string
+  feature?: string
+  files?: string[]
+  why?: string
+  pattern?: string
+  antiPattern?: string
+  decisionTrap?: string
+  outcome?: string
+  nextImplication?: string
+}
+
+export function formatRelatedContextForAgent(hit: RelatedContextHit): string {
+  const when = hit.when ? hit.when.slice(0, 10) : ''
+  const who = hit.author ? ` by ${hit.author}` : ''
+  const meta = [when, who].filter(Boolean).join('')
+  const parts = [
+    `[${hit.type}] ${hit.title}${meta ? ` (${meta.trim()})` : ''}  \`${hit.id}\``,
+    hit.feature ? `Feature: ${hit.feature}` : null,
+    hit.keyData ? `Key data: ${hit.keyData}` : null,
+    hit.files?.length ? `Files: ${hit.files.map((file) => `\`${file}\``).join(', ')}` : null,
+    hit.why ? `Why: ${hit.why}` : null,
+    hit.pattern ? `Pattern: ${hit.pattern}` : null,
+    hit.antiPattern ? `Avoid: ${hit.antiPattern}` : null,
+    hit.decisionTrap ? `Decision/trap: ${hit.decisionTrap}` : null,
+    hit.outcome ? `Outcome: ${hit.outcome}` : null,
+    hit.nextImplication ? `Next: ${hit.nextImplication}` : null,
+    hit.detail ? `Detail: ${hit.detail}` : null,
+  ].filter((part): part is string => Boolean(part))
+  return parts.join(' — ')
 }
 
 /**
@@ -258,13 +290,30 @@ async function recallRelatedContext(
       projectPath,
       hits.map((h) => h.id)
     )
-    return hits.map((h) => ({
-      id: h.id,
-      type: h.type,
-      title: deriveTitle(h),
-      when: h.rememberedAt,
-      author: h.tags?.author,
-    }))
+    return hits.map((h) => {
+      const fields = parseLivingContextFields(h.content)
+      const files =
+        fields.relatedFiles ??
+        h.tags?.related_files?.split(',').filter(Boolean) ??
+        h.tags?.files?.split(',').filter(Boolean)
+      return {
+        id: h.id,
+        type: h.type,
+        title: deriveTitle(h),
+        detail: fields.contextSynthesis ?? flatDetail(h.content, 180),
+        when: h.rememberedAt,
+        author: fields.whoAuthor ?? h.tags?.author,
+        keyData: fields.keyData ?? h.tags?.key_data,
+        feature: fields.featureDomain ?? h.tags?.feature,
+        files,
+        why: fields.whyItMattered,
+        pattern: fields.pattern,
+        antiPattern: fields.antiPattern,
+        decisionTrap: fields.decisionTrap,
+        outcome: fields.outcome,
+        nextImplication: fields.nextImplication,
+      }
+    })
   } catch {
     return []
   }
@@ -275,13 +324,7 @@ async function recallRelatedContext(
  * work and understands the sentiment) writes the task's CONTEXT — the per-task
  * unit of the project's second-brain RAG. English, structured, not a raw quote.
  */
-export const TASK_CONTEXT_PROMPT =
-  'Task closed. Capture its CONTEXT for the project’s second brain so the next ' +
-  'session (or collaborator) can recall it:\n' +
-  '  prjct remember context "<what happened · why / what was really wanted (the ' +
-  'sentiment) · the decision + reason · the pattern or anti-pattern · the outcome>"\n' +
-  'Write it in English, one tight paragraph grounded in this task. Not the raw ' +
-  'complaint — the lesson. prjct auto-anchors it to the commit, author and files.'
+export const TASK_CONTEXT_PROMPT = buildLivingContextPrompt()
 
 export type SetStatusOutcome =
   | {
@@ -334,6 +377,7 @@ export async function setTaskStatus(
         harnessWarnings: verification.warnings,
       })
       await stateStorage.completeTaskInWorkspace(projectId, ws.workspaceId)
+      await regenerateVaultAfterTaskWrite(projectPath, projectId)
       return {
         ok: true,
         taskId: wsTask.id,
@@ -406,6 +450,10 @@ export async function setTaskStatus(
     // already-completed task). The audit log still captures intent.
   }
 
+  if (normalized === 'done' || normalized === 'completed') {
+    await regenerateVaultAfterTaskWrite(projectPath, projectId)
+  }
+
   return {
     ok: true,
     taskId: active.id,
@@ -413,6 +461,18 @@ export async function setTaskStatus(
     verificationWarnings: verification.warnings,
     contextPrompt:
       normalized === 'done' || normalized === 'completed' ? TASK_CONTEXT_PROMPT : undefined,
+  }
+}
+
+async function regenerateVaultAfterTaskWrite(
+  projectPath: string,
+  projectId: string
+): Promise<void> {
+  try {
+    const { requestVaultRegeneration } = await import('./vault-regeneration')
+    await requestVaultRegeneration(projectPath, projectId)
+  } catch {
+    // Best-effort: task state is source of truth; next write/hook can recover.
   }
 }
 

--- a/core/services/vault-regeneration.ts
+++ b/core/services/vault-regeneration.ts
@@ -1,0 +1,19 @@
+/**
+ * Post-write vault regeneration.
+ *
+ * The generated vault is a derived read model over SQLite. Any durable write
+ * that agents may read back must request a regen immediately after the DB
+ * mutation completes; otherwise `.prjct/wiki/_generated/` becomes stale.
+ */
+
+import configManager from '../infrastructure/config-manager'
+
+export async function requestVaultRegeneration(
+  projectPath: string,
+  projectId?: string
+): Promise<void> {
+  const pid = projectId ?? (await configManager.getProjectId(projectPath))
+  if (!pid) return
+  const { regenerateWikiDeferred } = await import('./wiki-generator')
+  await regenerateWikiDeferred(projectPath, pid)
+}

--- a/core/services/wiki/developer-profile-builder.ts
+++ b/core/services/wiki/developer-profile-builder.ts
@@ -15,6 +15,7 @@
 import type { MemoryEntry } from '../../memory/entries'
 import { deriveTitle } from '../../memory/format'
 import { truncate } from './_shared'
+import { summarizeFrictionLesson } from './friction-lessons'
 
 const MAX_PREFERENCES = 25
 const MAX_FRICTION = 15
@@ -23,10 +24,9 @@ function teaser(content: string): string {
   return truncate(content.replace(/\s+/g, ' ').trim(), 200)
 }
 
-/** First line of a friction signal is `[category] User pushback: "<quote>"`. */
+/** Structured lessons lead; legacy rows fall back to their first line. */
 function frictionLine(content: string): string {
-  const first = content.split('\n')[0] ?? content
-  return truncate(first.replace(/\s+/g, ' ').trim(), 200)
+  return summarizeFrictionLesson(content, 240)
 }
 
 export function buildDeveloperProfile(declared: MemoryEntry[]): string | null {

--- a/core/services/wiki/friction-lessons.ts
+++ b/core/services/wiki/friction-lessons.ts
@@ -1,0 +1,33 @@
+/**
+ * Display helpers for friction-detector lessons.
+ *
+ * New detector output is structured:
+ *   [category] Lesson: ...
+ *   Next action: ...
+ *
+ * Older rows started with:
+ *   [category] User pushback: "..."
+ *
+ * Keep both readable so existing SQLite rows do not need migration.
+ */
+
+import { truncate } from './_shared'
+
+function compact(line: string): string {
+  return line.replace(/\s+/g, ' ').trim()
+}
+
+export function summarizeFrictionLesson(content: string, max = 220): string {
+  const lines = content.split('\n').map(compact).filter(Boolean)
+
+  const first = lines[0] ?? compact(content)
+  const lesson = first.match(/^\[[^\]]+\]\s+Lesson:\s*(.+)$/i)?.[1]
+  if (!lesson) return truncate(first, max)
+
+  const nextAction = lines
+    .find((line) => /^Next action:\s*/i.test(line))
+    ?.replace(/^Next action:\s*/i, '')
+
+  const summary = nextAction ? `${lesson} Next: ${nextAction}` : lesson
+  return truncate(summary, max)
+}

--- a/core/services/wiki/memory-builder.ts
+++ b/core/services/wiki/memory-builder.ts
@@ -41,6 +41,7 @@ export const PER_ENTRY_TYPES: ReadonlySet<string> = new Set([
   'fact',
   'insight',
   'spec',
+  'context',
   'feedback',
   'improvement-idea',
   'question',

--- a/core/services/wiki/signals-builder.ts
+++ b/core/services/wiki/signals-builder.ts
@@ -17,6 +17,7 @@
 import type { MemoryEntry } from '../../memory/entries'
 import { type FormatMemoryMdOptions, linkifyMemRefs } from '../../memory/format'
 import { truncate } from './_shared'
+import { summarizeFrictionLesson } from './friction-lessons'
 
 /** `tags.source` values produced by automatic detectors, not by an agent/user. */
 export const MACHINE_SOURCES: ReadonlySet<string> = new Set([
@@ -132,8 +133,8 @@ export function buildSignalsFile(
   if (friction.length > 0) {
     sections.push({
       title: 'Friction',
-      intro: 'Moments the developer pushed back — do not repeat.',
-      rows: friction.map((e) => `- ${oneLine(e.content)}${stamp(e)} ${anchor(e)}`),
+      intro: 'Processed lessons from developer pushback — do not repeat.',
+      rows: friction.map((e) => `- ${summarizeFrictionLesson(e.content)}${stamp(e)} ${anchor(e)}`),
     })
   }
 

--- a/core/sync/entity-handlers/memories.ts
+++ b/core/sync/entity-handlers/memories.ts
@@ -101,9 +101,42 @@ export const memoriesHandler: EntityHandler = {
     }
   },
 
-  async delete(_projectId, _data) {
-    // No-op by design: sync NEVER deletes or modifies a local record. A memory
-    // removed on another machine stays in this machine's vault — local is the
-    // source of truth and is never destroyed by a pull.
+  async delete(projectId, data) {
+    const id = field(data, 'id', 'id')
+    const content = field(data, 'content', 'content')
+    const type = field(data, 'type', 'type')
+
+    const candidates: string[] = []
+    if (/^mem_\d+$/.test(id)) candidates.push(id)
+    if (content && type) {
+      const contentHash = memoryFingerprint(content)
+      const rows = prjctDb.query<{ id: string }>(
+        projectId,
+        'SELECT id FROM memories WHERE content_hash = ? AND type = ? AND deleted_at IS NULL',
+        contentHash,
+        type
+      )
+      candidates.push(...rows.map((row) => row.id))
+    }
+
+    const unique = [...new Set(candidates)]
+    for (const memId of unique) {
+      const numeric = memId.match(/^mem_(\d+)$/)?.[1]
+      if (numeric) {
+        prjctDb.run(
+          projectId,
+          'UPDATE events SET type = ? WHERE id = ?',
+          'memory.deleted.context-quality',
+          Number(numeric)
+        )
+      }
+      prjctDb.run(
+        projectId,
+        'UPDATE memories SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL',
+        new Date().toISOString(),
+        memId
+      )
+      prjctDb.run(projectId, 'DELETE FROM memory_embeddings WHERE memory_id = ?', memId)
+    }
   },
 }

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -96,6 +96,18 @@ export interface SyncAnalysisSummary {
   criticalAntiPatterns: number
 }
 
+export interface ContextQualitySummary {
+  score: number
+  threshold: number
+  passed: boolean
+  iterations: number
+  livingContextCount: number
+  legacyContextCount: number
+  irrelevantRemoved: number
+  repairEntriesCreated: number
+  issues: string[]
+}
+
 // Sync Result & Context Generator Config
 
 export interface IncrementalInfo {
@@ -121,6 +133,7 @@ export interface ProjectSyncResult {
   stack: StackDetection
   context7?: SyncContext7Status
   analysisSummary?: SyncAnalysisSummary
+  contextQuality?: ContextQualitySummary
   syncMetrics?: SyncMetrics
   verification?: VerificationReport
   incremental?: IncrementalInfo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "2.76.1",
+  "version": "2.77.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/codex/SKILL.md
+++ b/templates/codex/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: prjct
-description: Use when the user mentions p., prjct, tasks, specs, shipping, or project memory. Routes to the prjct CLI and MCP tools — run commands on demand, do not preload context.
+description: Use for prjct task/memory/workflow. Run prjct verbs yourself; do not preload context.
 ---
 
-# prjct — project memory & workflow
+# prjct
 
-Run `prjct <command> --md` and follow its output. Pull context on demand; never dump it all.
+Run `prjct <cmd> --md` and follow it.
 
-- Flow: `prjct task` → work → `prjct status done` → `prjct ship`
-- Memory (write in ENGLISH always): `prjct remember <decision|gotcha|learning|fact> "<text>"`, `prjct context memory <topic>` (recall), `prjct guard <file>` (preventive memory before editing)
-- Capture stray thoughts: `prjct capture "<text>"`
-- Worktrees: remove only AFTER the PR merges, from the main worktree; never with unpushed work.
-- `prjct --help` lists commands; prefer prjct MCP tools (`prjct_*`) when available.
+- Start work: `prjct task "<desc>" --md`; read the surfaced second-brain context before planning/editing.
+- Recall: `prjct context memory <topic>` / `prjct search "<query>"`; guard files with `prjct guard <file>`.
+- Save memory in English: `prjct remember <decision|learning|gotcha|context> "<text>"`.
+- On close: `prjct status done --md`, then write context: synthesis first; key data for UI; what happened/why/who/model/tokens/sentiment/files/feature/pattern/anti-pattern/decision/outcome/next. Raw detector output is input, not final context.
+- Ship only after user OK: `prjct ship --md`.
 
 Commit footer: `Generated with [p/](https://www.prjct.app/)`


### PR DESCRIPTION
## Summary
- add sync-time context quality scoring, cleanup, and repair for generated project context
- regenerate vault surfaces from sync and after memory/task mutations
- emit delete tombstones for removed generated context so cloud/realtime state does not keep stale garbage
- add living-v2 context contract with synthesis-first fields and structured key data for UI

## Verification
- bun run check
- bun run typecheck
- bun test (1775/1775 passing)
- git diff --check