### PR TITLE
perf: dedicated cold-hook bundle cuts hook cold-start 24–70% (v3.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-26
+
+### Added
+- cold hook bundle
+
 ## [3.0.0] - 2026-06-26
 
 ### Added

--- a/core/hooks/cold-entry.ts
+++ b/core/hooks/cold-entry.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Dedicated COLD hook entry — the in-process path a freshly-spawned `prjct
+ * hook <event>` takes when the daemon is unreachable or disabled
+ * (PRJCT_NO_DAEMON=1).
+ *
+ * WHY THIS FILE EXISTS (perf):
+ *   The daemon shim (scripts/build.js `generateDaemonShim`) used to fall back
+ *   to `import("./prjct-core.mjs")` for cold hooks — the FULL ~936KB CLI
+ *   bundle (every command, the MCP server, sync, wiki, analysis…), just to run
+ *   one hook whose real dependency closure is ~136KB. Parsing the extra ~800KB
+ *   on every cold hook is the dominant cost the hot-path benchmark measures
+ *   (scripts/bench-hooks.mjs; see mem_360 — spawn + module-load dominated, not
+ *   hook logic). esbuild bundles THIS entry on its own into
+ *   `dist/bin/prjct-hooks.mjs`, so the cold path parses only the hook closure.
+ *
+ * CONTRACT (must stay byte-identical to the old cold path in bin/prjct.ts):
+ *   - emit the hook's JSON line to stdout, then AWAIT every `afterEmit`
+ *     side-effect (vault regen, transcript ingest) before exit — cold mode has
+ *     no daemon to detach them onto, and skipping them is what made the vault
+ *     go stale. afterEmit is awaited here exactly as bin/prjct.ts did.
+ *   - fail-soft: any throw degrades to `{}` + exit 0; a hook must never disturb
+ *     the host session.
+ *
+ * The warm daemon path (core/daemon/daemon.ts handleHookRequest) and the
+ * dev/source path (`bun bin/prjct.ts hook`) are unchanged.
+ */
+
+import { getHookRunner } from './registry'
+
+/** Read all of stdin (the hook event JSON) with a timeout safety net.
+ *  Mirrors bin/prjct.ts `readAllStdin`. */
+async function readAllStdin(timeoutMs: number): Promise<string> {
+  if (process.stdin.isTTY) return ''
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = []
+    let done = false
+    const finish = () => {
+      if (done) return
+      done = true
+      resolve(Buffer.concat(chunks).toString('utf-8'))
+    }
+    process.stdin.on('data', (c: Buffer) => chunks.push(Buffer.from(c)))
+    process.stdin.on('end', finish)
+    process.stdin.on('error', finish)
+    setTimeout(finish, timeoutMs)
+  })
+}
+
+async function main(): Promise<void> {
+  // argv after the runtime + script: ["hook", "<subcommand>", ...].
+  const args = process.argv.slice(2)
+  const subcommand = args[1]
+  try {
+    const runner = getHookRunner(subcommand)
+    if (!runner) {
+      process.stdout.write('{}\n')
+      process.exit(0)
+    }
+    const stdinPayload = await readAllStdin(1000)
+    let input: unknown = {}
+    try {
+      input = stdinPayload ? JSON.parse(stdinPayload) : {}
+    } catch {
+      input = {}
+    }
+    const pending: Array<() => Promise<void>> = []
+    await runner(process.cwd(), {
+      input,
+      sink: (chunk: string) => {
+        process.stdout.write(chunk)
+      },
+      detachAfterEmit: (fn: () => Promise<void>) => {
+        pending.push(fn)
+      },
+    })
+    for (const fn of pending) await fn().catch(() => undefined)
+    process.exit(0)
+  } catch {
+    process.stdout.write('{}\n')
+    process.exit(0)
+  }
+}
+
+void main()

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "core/index.ts",
     "core/daemon/entry.ts",
     "core/mcp/entry.ts",
+    "core/hooks/cold-entry.ts",
     "scripts/*.{js,ts}",
     "core/__tests__/**/*.test.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -99,6 +99,34 @@ var __dirname = __pathDirname(__filename);`,
     },
   })
 
+  // 1a-hooks. Dedicated COLD-hook bundle (~136KB vs the ~936KB core).
+  // The shim's cold-hook fallback imports THIS instead of prjct-core.mjs, so a
+  // freshly-spawned hook parses only its real dependency closure (the 10 hook
+  // runners share almost all their deps) instead of the whole CLI. This is the
+  // dominant cost the hot-path benchmark measures (scripts/bench-hooks.mjs).
+  console.log('  → dist/bin/prjct-hooks.mjs (cold-hook bundle)')
+  await esbuild.build({
+    entryPoints: [path.join(ROOT, 'core/hooks/cold-entry.ts')],
+    outfile: path.join(DIST, 'bin', 'prjct-hooks.mjs'),
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    format: 'esm',
+    minify: true,
+    keepNames: true,
+    packages: 'external',
+    plugins: [stripShebangPlugin()],
+    banner: {
+      js: `#!/usr/bin/env node
+import { createRequire as __createRequire } from 'module';
+import { fileURLToPath as __fileURLToPath } from 'url';
+import { dirname as __pathDirname } from 'path';
+var require = __createRequire(import.meta.url);
+var __filename = __fileURLToPath(import.meta.url);
+var __dirname = __pathDirname(__filename);`,
+    },
+  })
+
   // 1b. Thin shim entry point (tries daemon first, ~3KB, <15ms parse)
   console.log('  → dist/bin/prjct.mjs (daemon shim)')
   const shimSource = generateDaemonShim()
@@ -257,9 +285,16 @@ function sendHook(sub,data){
   sock.on("error",soft);
   sock.on("close",soft);
 }
-if(cmd==="hook"&&process.env.PRJCT_NO_DAEMON!=="1"&&hasEndpoint()){
-  const sub=args[1];
-  if(process.stdin.isTTY){sendHook(sub,"")}else{let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>sendHook(sub,d));process.stdin.on("error",()=>sendHook(sub,d));setTimeout(()=>sendHook(sub,d),1000)}
+if(cmd==="hook"){
+  if(process.env.PRJCT_NO_DAEMON!=="1"&&hasEndpoint()){
+    const sub=args[1];
+    if(process.stdin.isTTY){sendHook(sub,"")}else{let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>sendHook(sub,d));process.stdin.on("error",()=>sendHook(sub,d));setTimeout(()=>sendHook(sub,d),1000)}
+  }else{
+    // Cold path (daemon disabled/unreachable): run the hook from the dedicated
+    // ~136KB hooks bundle, NOT the ~936KB core. cold-entry reads argv+stdin and
+    // exits, awaiting afterEmit (byte-identical output to the old core path).
+    import("./prjct-hooks.mjs").catch(()=>{process.stdout.write("{}\\n");process.exit(0)})
+  }
 }else if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&hasEndpoint()){
   const cArgs=[],cOpts={};
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}


### PR DESCRIPTION
## What

Hooks running without the daemon (`PRJCT_NO_DAEMON=1` or socket down) fell back to importing the full **~936KB** `prjct-core.mjs` bundle (every command + MCP + sync + wiki) just to run ONE hook.

This adds a dedicated minimal cold-hook bundle `dist/bin/prjct-hooks.mjs` built from a new self-contained entry `core/hooks/cold-entry.ts`. The daemon shim's cold-hook branch now imports it instead of `prjct-core.mjs`, skipping both the extra bundle bytes **and** all of `bin/prjct.ts` startup ceremony (verb-names, removed-verbs, update-notice, auto-route).

`cold-entry.ts` reads argv + stdin, runs the registry runner, **awaits `afterEmit`** (vault regen preserved), and is fail-soft (`{}` on any throw) — byte-identical output to the old path.

## Results — A/B (25 iters, p50, same machine, back-to-back)

| | Node | Bun |
|---|---|---|
| session-start | 304→98ms (**−68%**) | 281→85ms (**−70%**) |
| prompt | 299→128ms (**−57%**) | 281→84ms (**−70%**) |
| stop | 285→210ms (**−26%**) | 263→199ms (**−24%**) |

## Safety

- Warm daemon path **unchanged** (stays eager; `mem_332` trap avoided — `afterEmit` never enters the daemon request chain).
- Verified: **1782/1782 tests**, typecheck, biome, byte-identical hook output, `daemon-shim-sync` + `hook-routing` green, live warm path + generic daemon command OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)