### PR TITLE
feat: synthesis context eval gate

### DIFF
--- a/.prjct/prjct.config.json
+++ b/.prjct/prjct.config.json
@@ -1,4 +1,9 @@
 {
   "projectId": "bc401c41-c8b9-436a-ac78-c91cac82ab4f",
-  "dataPath": "~/.prjct-cli/projects/bc401c41-c8b9-436a-ac78-c91cac82ab4f"
+  "dataPath": "~/.prjct-cli/projects/bc401c41-c8b9-436a-ac78-c91cac82ab4f",
+  "cloud": {
+    "enabled": true,
+    "paused": false,
+    "linkedAt": "2026-06-26T13:45:21.570Z"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-26
+
+### Added
+- synthesis context eval gate
+
 ## [3.1.0] - 2026-06-26
 
 ### Added

--- a/core/__tests__/eval/ledger-pairs.test.ts
+++ b/core/__tests__/eval/ledger-pairs.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  exportLedgerPairs,
+  type LabeledPair,
+  temporalSplit,
+  toQueryText,
+} from '../../eval/ledger-pairs'
+import prjctDb from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+function pair(anchorId: string, anchorDate: string): LabeledPair {
+  return {
+    anchorId,
+    queryText: `query ${anchorId}`,
+    positives: [`positive-${anchorId}`],
+    anchorDate,
+  }
+}
+
+let tmpRoot = ''
+let projectId = ''
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-ledger-pairs-'))
+  projectId = `ledger-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  patchPathManager(tmpRoot)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0') // force migrations
+})
+
+afterEach(async () => {
+  restorePathManager()
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => undefined)
+})
+
+describe('toQueryText', () => {
+  it('strips mem ids so eval queries cannot leak the target id', () => {
+    expect(toQueryText('Fix follows mem_123 and MEM-456 with context')).toBe(
+      'Fix follows and with context'
+    )
+  })
+
+  it('normalizes whitespace after stripping references', () => {
+    expect(toQueryText('  mem_1\n\nuseful   context\tmem-2  ')).toBe('useful context')
+  })
+})
+
+describe('temporalSplit', () => {
+  it('keeps the newest pairs in eval and older pairs in train', () => {
+    const split = temporalSplit(
+      [
+        pair('newest', '2026-01-05T00:00:00.000Z'),
+        pair('oldest', '2026-01-01T00:00:00.000Z'),
+        pair('middle', '2026-01-03T00:00:00.000Z'),
+      ],
+      1 / 3
+    )
+
+    expect(split.cutoff).toBe('2026-01-05T00:00:00.000Z')
+    expect(split.train.map((p) => p.anchorId)).toEqual(['oldest', 'middle'])
+    expect(split.evalSet.map((p) => p.anchorId)).toEqual(['newest'])
+  })
+
+  it('returns an empty split for no pairs', () => {
+    expect(temporalSplit([])).toEqual({ cutoff: '', train: [], evalSet: [] })
+  })
+})
+
+describe('exportLedgerPairs', () => {
+  it('includes durable ship-surfaced labels when the positive exists in the corpus', () => {
+    const id = prjctDb.appendEvent(projectId, 'memory.remember.decision', {
+      content: 'Use range predicates instead of LIKE for memory event scans.',
+      tags: {},
+      provenance: 'declared',
+    })
+    const positiveId = `mem_${id}`
+    prjctDb.run(
+      projectId,
+      `INSERT INTO retrieval_eval_labels
+         (query_text, positive_id, source, source_task_id, created_at, metadata)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      'memory event scan performance',
+      positiveId,
+      'ship-surfaced',
+      'task-1',
+      '2026-01-01T00:00:00.000Z',
+      '{}'
+    )
+
+    const corpus = exportLedgerPairs(projectId)
+    const label = corpus.pairs.find((p) => p.source === 'ship-surfaced')
+
+    expect(label).toMatchObject({
+      queryText: 'memory event scan performance',
+      positives: [positiveId],
+      source: 'ship-surfaced',
+    })
+  })
+})

--- a/core/__tests__/eval/retrieval-metrics.test.ts
+++ b/core/__tests__/eval/retrieval-metrics.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  type AggregateMetrics,
+  aggregate,
+  evaluateImprovementGate,
+  firstRelevantRank,
+  ndcgAtK,
+  recallAtK,
+  reciprocalRank,
+} from '../../eval/retrieval-metrics'
+
+const rel = (...ids: string[]) => new Set(ids)
+const metrics = (overrides: Partial<AggregateMetrics>): AggregateMetrics => ({
+  queries: 100,
+  recallAtK: 0.5,
+  mrr: 0.5,
+  ndcgAtK: 0.5,
+  k: 10,
+  ...overrides,
+})
+
+describe('firstRelevantRank', () => {
+  it('returns the 1-indexed rank of the first relevant id', () => {
+    expect(firstRelevantRank(['a', 'b', 'c'], rel('b'))).toBe(2)
+    expect(firstRelevantRank(['a', 'b', 'c'], rel('a'))).toBe(1)
+  })
+  it('returns 0 when no relevant id is present', () => {
+    expect(firstRelevantRank(['a', 'b'], rel('z'))).toBe(0)
+  })
+})
+
+describe('recallAtK', () => {
+  it('is 1 when the single relevant id is within k', () => {
+    expect(recallAtK(['a', 'b', 'c'], rel('c'), 3)).toBe(1)
+  })
+  it('is 0 when the relevant id is beyond k', () => {
+    expect(recallAtK(['a', 'b', 'c'], rel('c'), 2)).toBe(0)
+  })
+  it('fractions over a multi-id relevant set', () => {
+    expect(recallAtK(['a', 'b', 'c', 'd'], rel('a', 'd', 'z'), 4)).toBeCloseTo(2 / 3)
+  })
+  it('is 0 for an empty relevant set', () => {
+    expect(recallAtK(['a'], rel(), 5)).toBe(0)
+  })
+})
+
+describe('reciprocalRank', () => {
+  it('is 1/rank of the first hit', () => {
+    expect(reciprocalRank(['a', 'b', 'c'], rel('b'))).toBeCloseTo(1 / 2)
+  })
+  it('is 0 with no hit', () => {
+    expect(reciprocalRank(['a'], rel('z'))).toBe(0)
+  })
+})
+
+describe('ndcgAtK', () => {
+  it('is 1 when the only relevant id is ranked first', () => {
+    expect(ndcgAtK(['a', 'b', 'c'], rel('a'), 3)).toBeCloseTo(1)
+  })
+  it('discounts a relevant id ranked lower', () => {
+    // single relevant at rank 2 → DCG = 1/log2(3), IDCG = 1/log2(2) = 1
+    expect(ndcgAtK(['a', 'b'], rel('b'), 2)).toBeCloseTo(1 / Math.log2(3))
+  })
+  it('is 0 when nothing relevant is in the top-k', () => {
+    expect(ndcgAtK(['a', 'b', 'c'], rel('c'), 2)).toBe(0)
+  })
+})
+
+describe('aggregate', () => {
+  it('means each metric over the cases', () => {
+    const m = aggregate(
+      [
+        { ranked: ['x', 'a'], relevant: rel('x') }, // RR 1, recall 1, ndcg 1
+        { ranked: ['a', 'y'], relevant: rel('y') }, // RR 1/2, recall 1, ndcg 1/log2(3)
+      ],
+      5
+    )
+    expect(m.queries).toBe(2)
+    expect(m.recallAtK).toBeCloseTo(1)
+    expect(m.mrr).toBeCloseTo((1 + 0.5) / 2)
+    expect(m.ndcgAtK).toBeCloseTo((1 + 1 / Math.log2(3)) / 2)
+  })
+  it('handles the empty batch', () => {
+    expect(aggregate([], 5)).toEqual({ queries: 0, recallAtK: 0, mrr: 0, ndcgAtK: 0, k: 5 })
+  })
+})
+
+describe('evaluateImprovementGate', () => {
+  it('passes when sample is large enough, primary lift clears 20%, and guards do not regress', () => {
+    const gate = evaluateImprovementGate(
+      metrics({ ndcgAtK: 0.5 }),
+      metrics({ recallAtK: 0.5, mrr: 0.51, ndcgAtK: 0.61 })
+    )
+
+    expect(gate.passed).toBe(true)
+    expect(gate.sampleOk).toBe(true)
+    expect(gate.requiredPrimaryValue).toBeCloseTo(0.6)
+    expect(gate.blockers).toEqual([])
+  })
+
+  it('fails when the eval sample is too small even if metrics improve', () => {
+    const gate = evaluateImprovementGate(
+      metrics({ queries: 13, ndcgAtK: 0.5 }),
+      metrics({ queries: 13, ndcgAtK: 0.8 })
+    )
+
+    expect(gate.passed).toBe(false)
+    expect(gate.blockers).toContain('sample 13/100')
+  })
+
+  it('fails when the primary metric lift is below the required 20%', () => {
+    const gate = evaluateImprovementGate(metrics({ ndcgAtK: 0.5 }), metrics({ ndcgAtK: 0.59 }))
+
+    expect(gate.passed).toBe(false)
+    expect(gate.blockers).toContain('ndcgAtK lift below 20%')
+  })
+
+  it('fails when any guarded metric regresses', () => {
+    const gate = evaluateImprovementGate(
+      metrics({ recallAtK: 0.5, ndcgAtK: 0.5 }),
+      metrics({ recallAtK: 0.49, ndcgAtK: 0.7 })
+    )
+
+    expect(gate.passed).toBe(false)
+    expect(gate.blockers).toContain('recallAtK regressed')
+  })
+})

--- a/core/__tests__/services/developer-profile-builder.test.ts
+++ b/core/__tests__/services/developer-profile-builder.test.ts
@@ -40,7 +40,6 @@ describe('buildDeveloperProfile', () => {
           'Pattern: User rejects a workflow or implementation assumption.',
           'Anti-pattern: Treating a convenience dependency as acceptable without checking repo constraints.',
           'Next action: Check existing dependency policy and choose a no-native-deps path.',
-          'Evidence: user said "no native deps"',
         ].join('\n'),
         {
           source: 'friction-detector',

--- a/core/__tests__/services/friction-detector.test.ts
+++ b/core/__tests__/services/friction-detector.test.ts
@@ -101,7 +101,9 @@ describe('friction-detector parseJsonl + extractSignals', () => {
     expect(formatted).toContain('Pattern:')
     expect(formatted).toContain('Anti-pattern:')
     expect(formatted).toContain('Next action:')
-    expect(formatted).toContain('Evidence: user said "no, primero corramos los tests"')
+    expect(formatted).not.toContain('Evidence:')
+    expect(formatted).not.toContain('no, primero corramos los tests')
+    expect(formatted).not.toContain("I'll run prjct ship now.")
     expect(formatted).not.toStartWith('[negation] User pushback:')
   })
 

--- a/core/__tests__/services/signals-builder.test.ts
+++ b/core/__tests__/services/signals-builder.test.ts
@@ -74,7 +74,6 @@ describe('buildSignalsFile', () => {
         'Pattern: User rejects premature workflow execution.',
         'Anti-pattern: Running release commands before explicit green light.',
         'Next action: Pause and run the requested checks first.',
-        'Evidence: user said "no corras el ship manual"',
       ].join('\n'),
       tags: { source: 'friction-detector' },
     }),

--- a/core/__tests__/services/usefulness.test.ts
+++ b/core/__tests__/services/usefulness.test.ts
@@ -110,7 +110,10 @@ describe('usefulnessService.rerank', () => {
 
 describe('usefulnessService — ship-success attribution', () => {
   it('credits surfaced entries on ship and clears the log', () => {
-    usefulnessService.recordSurfaced(projectId, ['mem_10', 'mem_11'], 'task-1', T0_ISO)
+    usefulnessService.recordSurfaced(projectId, ['mem_10', 'mem_11'], 'task-1', T0_ISO, {
+      queryText: 'authentication migration gotcha',
+      surface: 'context-memory',
+    })
     const credited = usefulnessService.creditShippedTask(projectId, 'task-1', T0_ISO)
     expect(credited).toBe(2)
 
@@ -121,6 +124,32 @@ describe('usefulnessService — ship-success attribution', () => {
 
     // Log cleared → a second credit finds nothing.
     expect(usefulnessService.creditShippedTask(projectId, 'task-1', T0_ISO)).toBe(0)
+
+    const labels = prjctDb.query<{
+      query_text: string
+      positive_id: string
+      source: string
+      source_task_id: string
+    }>(
+      projectId,
+      `SELECT query_text, positive_id, source, source_task_id
+       FROM retrieval_eval_labels
+       ORDER BY positive_id`
+    )
+    expect(labels).toEqual([
+      {
+        query_text: 'authentication migration gotcha',
+        positive_id: 'mem_10',
+        source: 'ship-surfaced',
+        source_task_id: 'task-1',
+      },
+      {
+        query_text: 'authentication migration gotcha',
+        positive_id: 'mem_11',
+        source: 'ship-surfaced',
+        source_task_id: 'task-1',
+      },
+    ])
   })
 
   it('only credits the shipped task, leaving other tasks pending', () => {

--- a/core/__tests__/storage/sqlite-migration.test.ts
+++ b/core/__tests__/storage/sqlite-migration.test.ts
@@ -950,6 +950,64 @@ describe('SQLite Migration', () => {
       expect(migrations[0].name).toBe('initial-schema')
     })
 
+    it('scrubs literal friction transcript evidence from existing memory rows', async () => {
+      await fs.mkdir(path.join(tmpRoot!, testProjectId), { recursive: true })
+      const db = prjctDb.getDb(testProjectId)
+      const literal = [
+        '[negation] Lesson: Recalibrate before continuing.',
+        'What happened: The user pushed back after the assistant response.',
+        'Why it mattered: The assistant likely violated sequencing expectations.',
+        'Pattern: User immediately rejects an assistant action.',
+        'Anti-pattern: Continuing without changing course.',
+        'Next action: Pause and adjust the next tool use.',
+        'Evidence: user said "no literal quotes" after assistant said "I will continue".',
+      ].join('\n')
+
+      db.run('DELETE FROM _migrations WHERE version = 35')
+      prjctDb.appendEvent(testProjectId, 'memory.remember.improvement-signal', {
+        content: literal,
+        tags: { source: 'friction-detector' },
+        provenance: 'extracted',
+      })
+      prjctDb.run(
+        testProjectId,
+        `INSERT INTO memories
+           (id, project_id, title, content, tags, type, provenance, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        'mem_literal',
+        testProjectId,
+        'literal friction',
+        literal,
+        JSON.stringify({ source: 'friction-detector' }),
+        'improvement-signal',
+        'extracted',
+        '2026-01-01T00:00:00.000Z',
+        '2026-01-01T00:00:00.000Z'
+      )
+
+      prjctDb.close(testProjectId)
+      prjctDb.getDb(testProjectId)
+
+      const event = prjctDb.get<{ data: string }>(
+        testProjectId,
+        `SELECT data FROM events
+         WHERE type = 'memory.remember.improvement-signal'
+         ORDER BY id DESC LIMIT 1`
+      )
+      const eventContent = JSON.parse(event!.data).content as string
+      const memory = prjctDb.get<{ content: string }>(
+        testProjectId,
+        "SELECT content FROM memories WHERE id = 'mem_literal'"
+      )
+
+      expect(eventContent).toContain('Why it mattered:')
+      expect(eventContent).toContain('Next action:')
+      expect(eventContent).not.toContain('Evidence:')
+      expect(eventContent).not.toContain('no literal quotes')
+      expect(memory?.content).not.toContain('Evidence:')
+      expect(memory?.content).not.toContain('I will continue')
+    })
+
     it('should support document CRUD operations', async () => {
       await fs.mkdir(path.join(tmpRoot!, testProjectId), { recursive: true })
       // Create

--- a/core/eval/ledger-pairs.ts
+++ b/core/eval/ledger-pairs.ts
@@ -1,0 +1,152 @@
+/**
+ * Ledger → labeled retrieval pairs.
+ *
+ * The reinforcement ledger already encodes supervision for free: when a NEW
+ * entry references an OLDER one (`resolves:`/`relates:`/inline `mem_N`, the same
+ * extraction the usefulness loop credits), that older entry is, by the author's
+ * own hand, a RELEVANT result for the context the new entry describes. So each
+ * reference edge is a labeled pair: query = the citing entry's text, positive =
+ * the cited entry. No manual annotation, no LLM judge — author-declared signal.
+ *
+ * This is the honest benchmark substrate for every retrieval change. It is
+ * deliberately conservative (reference edges only, test-scaffolding filtered)
+ * so the held-out numbers mean something.
+ */
+
+import { isModelMemory, type MemoryEntry } from '../memory/entries'
+import { projectMemory } from '../memory/project-memory'
+import { extractRefIds } from '../services/usefulness'
+import prjctDb from '../storage/database'
+
+/** Inline/test-scaffolding anchors that are not real project knowledge. */
+const TEST_NOISE_RE = /REINFORCE-TEST|REINFORCE-FINAL|reinforce-test/i
+
+/** Strip the literal `mem_N` tokens so the query can't leak the target id. */
+export function toQueryText(content: string): string {
+  return content
+    .replace(/\bmem[_-]\d+\b/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export interface LabeledPair {
+  /** The citing (newer) entry — the query. */
+  anchorId: string
+  /** Anchor content with `mem_N` tokens stripped — what we actually search. */
+  queryText: string
+  /** Cited (older) entries that exist in the corpus — the relevant set. */
+  positives: string[]
+  /** Anchor capture time (ISO) — the axis for a leak-free temporal split. */
+  anchorDate: string
+  /** Where the supervision came from. Defaults to explicit author references. */
+  source?: 'reference-edge' | 'ship-surfaced'
+}
+
+export interface LedgerCorpus {
+  /** Every model-worthy entry, the candidate pool a retriever ranks over. */
+  entries: MemoryEntry[]
+  pairs: LabeledPair[]
+}
+
+/**
+ * Build the candidate corpus + labeled pairs from a project's memory. Only
+ * reference edges where BOTH ends are real, non-deleted, model-worthy entries
+ * become positives; anchors/targets that are test scaffolding are dropped.
+ */
+export function exportLedgerPairs(projectId: string, poolLimit = 100_000): LedgerCorpus {
+  const all = projectMemory
+    .recall(projectId, { limit: poolLimit })
+    .filter((e) => isModelMemory(e) && e.content.trim().length > 0)
+
+  const byId = new Map(all.map((e) => [e.id, e]))
+  const pairs: LabeledPair[] = []
+
+  for (const e of all) {
+    if (TEST_NOISE_RE.test(e.content)) continue
+    const refs = extractRefIds(e.content, e.tags ?? {})
+    const positives = refs.filter((id) => {
+      if (id === e.id) return false
+      const target = byId.get(id)
+      return !!target && !TEST_NOISE_RE.test(target.content)
+    })
+    if (positives.length === 0) continue
+    pairs.push({
+      anchorId: e.id,
+      queryText: toQueryText(e.content),
+      positives: [...new Set(positives)],
+      anchorDate: e.rememberedAt,
+      source: 'reference-edge',
+    })
+  }
+
+  for (const p of exportStoredEvalPairs(projectId, byId)) pairs.push(p)
+
+  return { entries: all, pairs }
+}
+
+interface EvalLabelRow {
+  id: number
+  query_text: string
+  positive_id: string
+  source: string
+  created_at: string
+}
+
+function exportStoredEvalPairs(
+  projectId: string,
+  byId: ReadonlyMap<string, MemoryEntry>
+): LabeledPair[] {
+  let rows: EvalLabelRow[]
+  try {
+    rows = prjctDb.query<EvalLabelRow>(
+      projectId,
+      `SELECT id, query_text, positive_id, source, created_at
+       FROM retrieval_eval_labels
+       ORDER BY created_at ASC, id ASC`
+    )
+  } catch {
+    return []
+  }
+
+  const pairs: LabeledPair[] = []
+  const seen = new Set<string>()
+  for (const row of rows) {
+    const queryText = toQueryText(row.query_text)
+    const target = byId.get(row.positive_id)
+    if (!queryText || !target || TEST_NOISE_RE.test(target.content)) continue
+    const key = `${queryText}\u0000${row.positive_id}\u0000${row.source}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    pairs.push({
+      anchorId: `label_${row.id}`,
+      queryText,
+      positives: [row.positive_id],
+      anchorDate: row.created_at,
+      source: row.source === 'ship-surfaced' ? 'ship-surfaced' : 'reference-edge',
+    })
+  }
+  return pairs
+}
+
+export interface TemporalSplit {
+  cutoff: string
+  train: LabeledPair[]
+  evalSet: LabeledPair[]
+}
+
+/**
+ * Split pairs by anchor date so eval anchors are strictly NEWER than train —
+ * the only honest split when the ledger is both the label source and the thing
+ * under test. `evalFraction` is the share of the newest pairs held out.
+ */
+export function temporalSplit(pairs: LabeledPair[], evalFraction = 0.2): TemporalSplit {
+  const sorted = [...pairs].sort((a, b) => a.anchorDate.localeCompare(b.anchorDate))
+  if (sorted.length === 0) return { cutoff: '', train: [], evalSet: [] }
+  const idx = Math.max(1, Math.floor(sorted.length * (1 - evalFraction)))
+  const cutoff = sorted[Math.min(idx, sorted.length - 1)].anchorDate
+  return {
+    cutoff,
+    train: sorted.filter((p) => p.anchorDate < cutoff),
+    evalSet: sorted.filter((p) => p.anchorDate >= cutoff),
+  }
+}

--- a/core/eval/retrieval-eval.ts
+++ b/core/eval/retrieval-eval.ts
@@ -1,0 +1,79 @@
+/**
+ * Retrieval eval runner — scores a retriever over the labeled ledger pairs.
+ *
+ * Provider-agnostic by construction: `evalProvider` takes any EmbeddingProvider
+ * (today's local hashing embedder, tomorrow's ONNX pretrained encoder) and the
+ * SAME corpus + pairs, so a swap is measured apples-to-apples. The BM25 leg uses
+ * the real FTS5 path so the lexical baseline is the one prjct actually serves.
+ */
+
+import type { MemoryEntry } from '../memory/entries'
+import { projectMemory } from '../memory/project-memory'
+import { cosineSimilarity, type EmbeddingProvider } from '../services/embeddings'
+import type { LabeledPair } from './ledger-pairs'
+import { type AggregateMetrics, aggregate } from './retrieval-metrics'
+
+/** Rank every corpus id (except `excludeId`) by cosine to a query vector. */
+function rankByVector(
+  queryVec: number[],
+  corpusVecs: Array<{ id: string; vec: number[] }>,
+  excludeId: string
+): string[] {
+  return corpusVecs
+    .filter((c) => c.id !== excludeId)
+    .map((c) => ({ id: c.id, score: cosineSimilarity(queryVec, c.vec) }))
+    .sort((a, b) => b.score - a.score)
+    .map((c) => c.id)
+}
+
+/**
+ * Embed the corpus once with `provider`, then for each pair rank the corpus by
+ * cosine to the query and score the cited positives. One forward pass over the
+ * corpus + one per query — trivial for a project's hundreds of entries.
+ */
+export async function evalProvider(
+  corpus: MemoryEntry[],
+  pairs: LabeledPair[],
+  provider: EmbeddingProvider,
+  k: number
+): Promise<AggregateMetrics> {
+  const corpusVecs = (await provider.embed(corpus.map((e) => e.content))).map((vec, i) => ({
+    id: corpus[i].id,
+    vec,
+  }))
+  const cases: Array<{ ranked: string[]; relevant: Set<string> }> = []
+  for (const p of pairs) {
+    const [qv] = await provider.embed([p.queryText])
+    if (!qv) continue
+    const ranked = rankByVector(qv, corpusVecs, p.anchorId)
+    cases.push({ ranked, relevant: new Set(p.positives) })
+  }
+  return aggregate(cases, k)
+}
+
+/**
+ * BM25 baseline over the real FTS5 index. Queries with the anchor's tokens and
+ * scores where the cited positives land. Anchors that the lexical leg can't
+ * tokenize (empty after stripping) contribute an empty ranking (a miss), which
+ * is the honest outcome.
+ */
+export function evalBm25(projectId: string, pairs: LabeledPair[], k: number): AggregateMetrics {
+  const cases: Array<{ ranked: string[]; relevant: Set<string> }> = []
+  for (const p of pairs) {
+    const keywords = p.queryText
+      .split(/\s+/)
+      .filter((w) => w.length > 2)
+      .slice(0, 32)
+    let ranked: string[] = []
+    try {
+      ranked = projectMemory
+        .searchFts(projectId, keywords, 100)
+        .map((e) => e.id)
+        .filter((id) => id !== p.anchorId)
+    } catch {
+      ranked = []
+    }
+    cases.push({ ranked, relevant: new Set(p.positives) })
+  }
+  return aggregate(cases, k)
+}

--- a/core/eval/retrieval-metrics.ts
+++ b/core/eval/retrieval-metrics.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure retrieval-quality metrics — the honest yardstick for any change to the
+ * recall pipeline (hashing embeddings → pretrained encoder, rerankers, etc.).
+ *
+ * Every function takes a RANKED list of candidate ids (best-first) and the SET
+ * of ids that are actually relevant for that query, and returns a scalar. No
+ * I/O, no DB, no provider — so they unit-test trivially and can score the
+ * output of any retriever (BM25, semantic, blended) identically.
+ */
+
+/** Rank (1-indexed) of the first relevant id in `ranked`, or 0 if none. */
+export function firstRelevantRank(ranked: string[], relevant: ReadonlySet<string>): number {
+  for (let i = 0; i < ranked.length; i++) {
+    if (relevant.has(ranked[i])) return i + 1
+  }
+  return 0
+}
+
+/** Fraction of relevant ids found within the top `k`. Single-relevant → 0/1. */
+export function recallAtK(ranked: string[], relevant: ReadonlySet<string>, k: number): number {
+  if (relevant.size === 0) return 0
+  const top = ranked.slice(0, k)
+  let hit = 0
+  for (const id of top) if (relevant.has(id)) hit++
+  return hit / relevant.size
+}
+
+/** Reciprocal rank of the first relevant hit (0 if none in the list). */
+export function reciprocalRank(ranked: string[], relevant: ReadonlySet<string>): number {
+  const r = firstRelevantRank(ranked, relevant)
+  return r === 0 ? 0 : 1 / r
+}
+
+/**
+ * Binary-relevance nDCG@k. DCG sums 1/log2(rank+1) over relevant hits in the
+ * top-k; IDCG is the same with all relevants packed at the front. Returns a
+ * value in [0,1] where 1 = every relevant id ranked above every irrelevant.
+ */
+export function ndcgAtK(ranked: string[], relevant: ReadonlySet<string>, k: number): number {
+  if (relevant.size === 0) return 0
+  let dcg = 0
+  const top = ranked.slice(0, k)
+  for (let i = 0; i < top.length; i++) {
+    if (relevant.has(top[i])) dcg += 1 / Math.log2(i + 2)
+  }
+  const ideal = Math.min(relevant.size, k)
+  let idcg = 0
+  for (let i = 0; i < ideal; i++) idcg += 1 / Math.log2(i + 2)
+  return idcg === 0 ? 0 : dcg / idcg
+}
+
+export interface AggregateMetrics {
+  /** Number of (query, relevant-set) cases scored. */
+  queries: number
+  recallAtK: number
+  mrr: number
+  ndcgAtK: number
+  k: number
+}
+
+export type RetrievalMetricKey = 'recallAtK' | 'mrr' | 'ndcgAtK'
+
+export interface MetricLift {
+  metric: RetrievalMetricKey
+  baseline: number
+  candidate: number
+  absoluteDelta: number
+  /** Relative lift over baseline; Infinity means baseline was zero and candidate improved. */
+  relativeLift: number
+}
+
+export interface ImprovementGateOptions {
+  /** Minimum labeled cases before the comparison is decision-grade. */
+  minCases?: number
+  /** Required relative lift on the primary metric. 0.2 = +20%. */
+  minRelativeLift?: number
+  /** The metric that must clear the configured lift threshold. */
+  primaryMetric?: RetrievalMetricKey
+  /** Metrics that must not regress. Defaults to every aggregate metric. */
+  guardMetrics?: RetrievalMetricKey[]
+}
+
+export interface ImprovementGateResult {
+  passed: boolean
+  sampleOk: boolean
+  sampleCount: number
+  minCases: number
+  minRelativeLift: number
+  primaryMetric: RetrievalMetricKey
+  requiredPrimaryValue: number
+  lifts: MetricLift[]
+  blockers: string[]
+}
+
+/**
+ * Mean Recall@k, MRR and nDCG@k over a batch of ranked results. Each case is a
+ * ranked id list plus its relevant set — typically one per labeled ledger pair.
+ */
+export function aggregate(
+  cases: Array<{ ranked: string[]; relevant: ReadonlySet<string> }>,
+  k: number
+): AggregateMetrics {
+  if (cases.length === 0) return { queries: 0, recallAtK: 0, mrr: 0, ndcgAtK: 0, k }
+  let recall = 0
+  let mrr = 0
+  let ndcg = 0
+  for (const c of cases) {
+    recall += recallAtK(c.ranked, c.relevant, k)
+    mrr += reciprocalRank(c.ranked, c.relevant)
+    ndcg += ndcgAtK(c.ranked, c.relevant, k)
+  }
+  const n = cases.length
+  return { queries: n, recallAtK: recall / n, mrr: mrr / n, ndcgAtK: ndcg / n, k }
+}
+
+function metricLift(
+  metric: RetrievalMetricKey,
+  baseline: AggregateMetrics,
+  candidate: AggregateMetrics
+): MetricLift {
+  const base = baseline[metric]
+  const next = candidate[metric]
+  const absoluteDelta = next - base
+  return {
+    metric,
+    baseline: base,
+    candidate: next,
+    absoluteDelta,
+    relativeLift: base === 0 ? (next > 0 ? Number.POSITIVE_INFINITY : 0) : absoluteDelta / base,
+  }
+}
+
+/**
+ * Decision gate for retrieval changes. A candidate is only accepted when the
+ * eval set is large enough, the primary metric clears the required relative
+ * lift, and no guarded metric regresses against current behavior.
+ */
+export function evaluateImprovementGate(
+  baseline: AggregateMetrics,
+  candidate: AggregateMetrics,
+  options: ImprovementGateOptions = {}
+): ImprovementGateResult {
+  const minCases = options.minCases ?? 100
+  const minRelativeLift = options.minRelativeLift ?? 0.2
+  const primaryMetric = options.primaryMetric ?? 'ndcgAtK'
+  const guardMetrics = options.guardMetrics ?? ['recallAtK', 'mrr', 'ndcgAtK']
+  const sampleCount = Math.min(baseline.queries, candidate.queries)
+  const sampleOk = sampleCount >= minCases
+  const metrics = Array.from(new Set<RetrievalMetricKey>([primaryMetric, ...guardMetrics]))
+  const lifts = metrics.map((m) => metricLift(m, baseline, candidate))
+  const blockers: string[] = []
+
+  if (!sampleOk) blockers.push(`sample ${sampleCount}/${minCases}`)
+
+  const primary = lifts.find((l) => l.metric === primaryMetric)
+  const requiredPrimaryValue = baseline[primaryMetric] * (1 + minRelativeLift)
+  if (!primary || primary.absoluteDelta <= 0 || primary.relativeLift < minRelativeLift) {
+    blockers.push(`${primaryMetric} lift below ${(minRelativeLift * 100).toFixed(0)}%`)
+  }
+
+  for (const lift of lifts) {
+    if (guardMetrics.includes(lift.metric) && lift.absoluteDelta < 0) {
+      blockers.push(`${lift.metric} regressed`)
+    }
+  }
+
+  return {
+    passed: blockers.length === 0,
+    sampleOk,
+    sampleCount,
+    minCases,
+    minRelativeLift,
+    primaryMetric,
+    requiredPrimaryValue,
+    lifts,
+    blockers,
+  }
+}

--- a/core/eval/run.ts
+++ b/core/eval/run.ts
@@ -1,0 +1,110 @@
+/**
+ * Retrieval eval CLI — prints the baseline Recall@k / MRR / nDCG@k for a
+ * project's recall pipeline over its own ledger pairs, with a leak-free
+ * temporal split. This is the yardstick: run it before and after any retrieval
+ * change (encoder swap, reranker) to prove the change with a number.
+ *
+ *   bun run scripts/eval-retrieval.mjs <projectId> [k]
+ *
+ * Pass a provider in code (evalProvider) to compare a candidate encoder against
+ * the LocalSubwordEmbeddingProvider baseline on the SAME pairs.
+ */
+
+import { LocalSubwordEmbeddingProvider } from '../services/embeddings'
+import { exportLedgerPairs, temporalSplit } from './ledger-pairs'
+import { evalBm25, evalProvider } from './retrieval-eval'
+import {
+  type AggregateMetrics,
+  evaluateImprovementGate,
+  type ImprovementGateResult,
+} from './retrieval-metrics'
+
+interface TimedMetrics {
+  metrics: AggregateMetrics
+  ms: number
+}
+
+function elapsedMs(start: bigint): number {
+  return Number(process.hrtime.bigint() - start) / 1_000_000
+}
+
+function fmt(m: TimedMetrics): string {
+  const p = (x: number) => (x * 100).toFixed(1).padStart(5)
+  return (
+    `n=${String(m.metrics.queries).padStart(3)}  ` +
+    `Recall@${m.metrics.k}=${p(m.metrics.recallAtK)}%  ` +
+    `MRR=${p(m.metrics.mrr)}%  ` +
+    `nDCG@${m.metrics.k}=${p(m.metrics.ndcgAtK)}%  ` +
+    `wall=${m.ms.toFixed(1)}ms`
+  )
+}
+
+function fmtLift(value: number): string {
+  if (value === Number.POSITIVE_INFINITY) return '+∞'
+  return `${value >= 0 ? '+' : ''}${(value * 100).toFixed(1)}%`
+}
+
+function fmtGate(gate: ImprovementGateResult): string {
+  const primary = gate.lifts.find((l) => l.metric === gate.primaryMetric)
+  const lift = primary ? fmtLift(primary.relativeLift) : 'n/a'
+  const status = gate.passed ? 'PASS' : 'FAIL'
+  const blockers = gate.blockers.length > 0 ? ` — ${gate.blockers.join('; ')}` : ''
+  const remaining = Math.max(0, gate.minCases - gate.sampleCount)
+  const target = `${(gate.requiredPrimaryValue * 100).toFixed(1)}%`
+  const next =
+    remaining > 0
+      ? `; need ${remaining} more labeled pairs`
+      : `; candidate ${gate.primaryMetric} target ${target}`
+  return `${status} (${gate.primaryMetric} lift ${lift}, required +${(gate.minRelativeLift * 100).toFixed(0)}%, sample ${gate.sampleCount}/${gate.minCases}${next})${blockers}`
+}
+
+export async function runEval(projectId: string, k = 10): Promise<void> {
+  const { entries, pairs } = exportLedgerPairs(projectId)
+  const split = temporalSplit(pairs, 0.2)
+  const bySource = pairs.reduce<Record<string, number>>((acc, pair) => {
+    const source = pair.source ?? 'reference-edge'
+    acc[source] = (acc[source] ?? 0) + 1
+    return acc
+  }, {})
+
+  console.log(`\n=== Retrieval baseline · project ${projectId} ===`)
+  console.log(`corpus entries (model-worthy): ${entries.length}`)
+  console.log(`labeled ledger pairs:          ${pairs.length}`)
+  console.log(
+    `label sources:                 ${Object.entries(bySource)
+      .map(([source, n]) => `${source}=${n}`)
+      .join(', ')}`
+  )
+  console.log('cost profile:                  local CPU + SQLite; no LLM/API tokens by default')
+  console.log(`temporal split @ ${split.cutoff || 'n/a'}`)
+  console.log(`  train: ${split.train.length}   eval(held-out): ${split.evalSet.length}\n`)
+
+  const local = new LocalSubwordEmbeddingProvider()
+
+  // Score the FULL pair set (more signal at this small volume) and the held-out
+  // eval set (the honest, leak-free number) side by side.
+  for (const [label, set] of [
+    ['ALL pairs', pairs],
+    ['EVAL (held-out)', split.evalSet],
+  ] as const) {
+    if (set.length === 0) {
+      console.log(`${label.padEnd(18)} — empty, skipped`)
+      continue
+    }
+    const bm25Start = process.hrtime.bigint()
+    const bm25 = { metrics: evalBm25(projectId, set, k), ms: elapsedMs(bm25Start) }
+    const hashingStart = process.hrtime.bigint()
+    const hashing = {
+      metrics: await evalProvider(entries, set, local, k),
+      ms: elapsedMs(hashingStart),
+    }
+    console.log(`${label}`)
+    console.log(`  BM25 (FTS5)      ${fmt(bm25)}`)
+    console.log(`  hashing (local)  ${fmt(hashing)}`)
+    console.log(
+      `  gate             ${fmtGate(evaluateImprovementGate(bm25.metrics, hashing.metrics))}`
+    )
+    console.log('')
+  }
+  console.log('Drop a pretrained ONNX provider into evalProvider() to compare on the same pairs.\n')
+}

--- a/core/infrastructure/setup.ts
+++ b/core/infrastructure/setup.ts
@@ -26,6 +26,7 @@ import { getTemplateContent } from '../agentic/template-loader'
 import context7Service from '../services/context7-service'
 import { dependencyValidator } from '../services/dependency-validator'
 import { prjctDb } from '../storage/database'
+import { LATEST_SCHEMA_VERSION } from '../storage/database/migrations'
 import { getErrorMessage, isNotFoundError } from '../types/fs'
 import type { AIProviderConfig, AIProviderName } from '../types/provider'
 import { getTimeout } from '../utils/constants'
@@ -387,10 +388,11 @@ async function installAntigravitySkill(): Promise<{
  * test-created entries. Opening SQLite per dir (`getDoc` runs the
  * migration check + a kv query, ~3ms each) made upgrades take up to a
  * minute. A `.cli-version` marker file per dir records "reconciled with
- * VERSION": the steady state is one tiny fs read per dir (~µs), and the
- * DB is only opened for dirs whose marker is missing or stale.
+ * VERSION + schema": the steady state is one tiny fs read per dir (~µs),
+ * and the DB is only opened for dirs whose marker is missing or stale.
  */
 const CLI_VERSION_MARKER = '.cli-version'
+const CLI_PROJECT_RECONCILIATION_MARKER = `${VERSION}\nschema=${LATEST_SCHEMA_VERSION}`
 
 async function migrateProjectsCliVersion(): Promise<void> {
   try {
@@ -410,7 +412,7 @@ async function migrateProjectsCliVersion(): Promise<void> {
       try {
         const markerPath = path.join(projectsDir, projectId, CLI_VERSION_MARKER)
         const marker = await fs.readFile(markerPath, 'utf-8').catch(() => '')
-        if (marker.trim() === VERSION) {
+        if (marker.trim() === CLI_PROJECT_RECONCILIATION_MARKER) {
           continue
         }
 
@@ -423,7 +425,7 @@ async function migrateProjectsCliVersion(): Promise<void> {
 
         // Mark even doc-less dirs (test artifacts) so the next upgrade
         // skips them with a single read instead of a DB open.
-        await fs.writeFile(markerPath, VERSION, 'utf-8').catch(() => {})
+        await fs.writeFile(markerPath, CLI_PROJECT_RECONCILIATION_MARKER, 'utf-8').catch(() => {})
       } catch {
         // Skip projects with database issues
       }

--- a/core/memory/enriched-recall.ts
+++ b/core/memory/enriched-recall.ts
@@ -114,7 +114,9 @@ export async function enrichedRecall(
       usefulnessService.recordSurfaced(
         projectId,
         entries.map((e) => e.id),
-        task.id
+        task.id,
+        new Date().toISOString(),
+        { queryText: topic, surface: 'context-memory' }
       )
     }
   } catch {

--- a/core/services/auto-updater.ts
+++ b/core/services/auto-updater.ts
@@ -4,10 +4,12 @@
  * OPT-IN (default off, user enables via `prjct config set auto-update on`),
  * throttled to 1/hour, runs as a detached child so the Claude session
  * never waits. Any error is swallowed + logged to update.log. Upgrade
- * path is picked by detecting how prjct was installed (binary, npm, bun).
+ * path is picked by detecting how prjct was installed (npm, bun). Binary
+ * installs are never self-updated here because that would require running a
+ * remote installer script in the background.
  */
 
-import { execFile, spawn } from 'node:child_process'
+import { execFile, execFileSync, spawn } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -107,13 +109,19 @@ function detectInstallSource(): InstallSource {
   // We don't need certainty — if both fail, default to npm which is
   // most common.
   try {
-    const npmGlobal = String(require('node:child_process').execSync('npm root -g')).trim()
+    const npmGlobal = execFileSync('npm', ['root', '-g'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
     if (npmGlobal && fs.existsSync(path.join(npmGlobal, 'prjct-cli'))) return 'npm'
   } catch {
     /* ignore */
   }
   try {
-    const bunBin = String(require('node:child_process').execSync('bun pm bin -g')).trim()
+    const bunBin = execFileSync('bun', ['pm', 'bin', '-g'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
     if (bunBin && fs.existsSync(path.join(bunBin, 'prjct'))) return 'bun'
   } catch {
     /* ignore */
@@ -123,15 +131,9 @@ function detectInstallSource(): InstallSource {
 
 async function applyUpgrade(source: InstallSource, _targetVersion: string): Promise<void> {
   if (source === 'binary') {
-    // Re-run install-via-claude.sh — it handles platform detection,
-    // checksum, atomic swap. Fetch over curl since we know git might
-    // not be present on the user's box.
-    const url =
-      'https://raw.githubusercontent.com/jlopezlira/prjct-cli/main/scripts/install-via-claude.sh'
-    await execFileP('bash', ['-c', `curl -sSL '${url}' | bash`], {
-      timeout: 120_000,
-      maxBuffer: 4 * 1024 * 1024,
-    })
+    log(
+      `binary install auto-update skipped for ${_targetVersion}; run the installer manually to upgrade`
+    )
     return
   }
   if (source === 'bun') {

--- a/core/services/doctor-service.ts
+++ b/core/services/doctor-service.ts
@@ -9,7 +9,7 @@
  * - Provides actionable recommendations
  */
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 import chalk from 'chalk'
 import { verifyCodexPRouterReady } from '../infrastructure/codex-skill'
@@ -83,24 +83,30 @@ class DoctorService {
     const checks: CheckResult[] = []
 
     // Git (required)
-    checks.push(this.checkCommand('git', 'git --version', /git version ([\d.]+)/, false))
+    checks.push(this.checkCommand('git', ['git', '--version'], /git version ([\d.]+)/, false))
 
     // Node (required)
-    checks.push(this.checkCommand('node', 'node --version', /v([\d.]+)/, false))
+    checks.push(this.checkCommand('node', ['node', '--version'], /v([\d.]+)/, false))
 
     // Bun (optional)
-    checks.push(this.checkCommand('bun', 'bun --version', /([\d.]+)/, true))
+    checks.push(this.checkCommand('bun', ['bun', '--version'], /([\d.]+)/, true))
 
     // GitHub CLI (optional)
     checks.push(
-      this.checkCommand('gh', 'gh --version', /gh version ([\d.]+)/, true, 'needed for PR commands')
+      this.checkCommand(
+        'gh',
+        ['gh', '--version'],
+        /gh version ([\d.]+)/,
+        true,
+        'needed for PR commands'
+      )
     )
 
     // Claude Code (optional)
     checks.push(
       this.checkCommand(
         'claude',
-        'claude --version',
+        ['claude', '--version'],
         /claude ([\d.]+)/,
         true,
         'Anthropic Claude Code CLI'
@@ -109,24 +115,36 @@ class DoctorService {
 
     // Gemini CLI (optional)
     checks.push(
-      this.checkCommand('gemini', 'gemini --version', /gemini ([\d.]+)/, true, 'Google Gemini CLI')
+      this.checkCommand(
+        'gemini',
+        ['gemini', '--version'],
+        /gemini ([\d.]+)/,
+        true,
+        'Google Gemini CLI'
+      )
     )
 
     // OpenAI Codex CLI (optional)
-    checks.push(this.checkCommand('codex', 'codex --version', /([\d.]+)/, true, 'OpenAI Codex CLI'))
+    checks.push(
+      this.checkCommand('codex', ['codex', '--version'], /([\d.]+)/, true, 'OpenAI Codex CLI')
+    )
 
     return checks
   }
 
   private checkCommand(
     name: string,
-    command: string,
+    command: [string, ...string[]],
     versionRegex: RegExp,
     optional: boolean,
     description?: string
   ): CheckResult {
     try {
-      const output = execSync(command, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+      const [bin, ...args] = command
+      const output = execFileSync(bin, args, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
       const match = output.match(versionRegex)
       const version = match ? match[1] : 'unknown'
 
@@ -217,15 +235,16 @@ class DoctorService {
 
   private async checkGitRepo(): Promise<CheckResult> {
     try {
-      execSync('git rev-parse --git-dir', {
+      execFileSync('git', ['rev-parse', '--git-dir'], {
         cwd: this.projectPath,
         stdio: ['pipe', 'pipe', 'pipe'],
       })
 
       // Check for uncommitted changes
-      const status = execSync('git status --porcelain', {
+      const status = execFileSync('git', ['status', '--porcelain'], {
         cwd: this.projectPath,
         encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
       })
       const hasChanges = status.trim().length > 0
 

--- a/core/services/friction-detector.ts
+++ b/core/services/friction-detector.ts
@@ -7,8 +7,9 @@
  * is the engine, not regex): we DO NOT pretend to infer deep intent
  * from regex. We convert a high-confidence pushback moment into a
  * conservative structured lesson: what happened, why it mattered,
- * the pattern/anti-pattern, and the next action. The raw quote stays
- * as evidence, not the primary value.
+ * the pattern/anti-pattern, and the next action. Raw transcript quotes
+ * are used only transiently for classification/dedup and are NOT stored
+ * in durable memory — context value is the reusable lesson, not the literal.
  *
  * What counts as friction (precision-over-recall):
  *   - User negation directly after an assistant tool-use:
@@ -218,8 +219,6 @@ function textOf(content: unknown): string {
 
 function formatSignal(signal: FrictionSignal): string {
   const template = lessonTemplate(signal.category)
-  const evidence = inlineEvidence(signal.excerpt)
-  const assistant = inlineEvidence(signal.precedingAssistantPreview.slice(0, 200))
   const lines = [
     `[${signal.category}] Lesson: ${template.lesson}`,
     'What happened: The user pushed back after the assistant response.',
@@ -227,7 +226,6 @@ function formatSignal(signal: FrictionSignal): string {
     `Pattern: ${template.pattern}`,
     `Anti-pattern: ${template.antiPattern}`,
     `Next action: ${template.nextAction}`,
-    `Evidence: user said "${evidence}"${assistant ? ` after assistant said "${assistant}"` : ''}.`,
   ]
   return lines.join('\n')
 }
@@ -268,10 +266,6 @@ function lessonTemplate(category: FrictionSignal['category']): {
     nextAction:
       'Pause, convert the pushback into a workflow constraint, and adjust the next tool use.',
   }
-}
-
-function inlineEvidence(text: string): string {
-  return text.replace(/\s+/g, ' ').trim().replace(/"/g, "'")
 }
 
 function hashSignal(excerpt: string): string {

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -94,6 +94,19 @@ interface UsefulnessRow {
   last_used_at: string
 }
 
+interface SurfaceRow {
+  memory_id: string
+  query_text: string | null
+  surface: string | null
+}
+
+export interface SurfaceOptions {
+  /** User/search query that caused this memory to surface. Stored as data, not instructions. */
+  queryText?: string
+  /** Retrieval surface, e.g. context-memory, guard, prompt-cue. */
+  surface?: string
+}
+
 function bump(
   projectId: string,
   memoryId: string,
@@ -187,18 +200,26 @@ export const usefulnessService = {
     projectId: string,
     memoryIds: string[],
     taskId: string,
-    nowIso: string = new Date().toISOString()
+    nowIso: string = new Date().toISOString(),
+    opts: SurfaceOptions = {}
   ): void {
     if (!taskId || memoryIds.length === 0) return
     try {
+      const queryText = opts.queryText?.trim() || null
+      const surface = opts.surface?.trim() || null
       for (const id of memoryIds) {
         prjctDb.run(
           projectId,
-          `INSERT OR IGNORE INTO memory_surface_log (memory_id, task_id, created_at)
-           VALUES (?, ?, ?)`,
+          `INSERT INTO memory_surface_log (memory_id, task_id, created_at, query_text, surface)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(memory_id, task_id) DO UPDATE SET
+             query_text = COALESCE(memory_surface_log.query_text, excluded.query_text),
+             surface = COALESCE(memory_surface_log.surface, excluded.surface)`,
           id,
           taskId,
-          nowIso
+          nowIso,
+          queryText,
+          surface
         )
       }
     } catch {
@@ -263,13 +284,28 @@ export const usefulnessService = {
   ): number {
     if (!taskId) return 0
     try {
-      const rows = prjctDb.query<{ memory_id: string }>(
+      const rows = prjctDb.query<SurfaceRow>(
         projectId,
-        'SELECT memory_id FROM memory_surface_log WHERE task_id = ?',
+        'SELECT memory_id, query_text, surface FROM memory_surface_log WHERE task_id = ?',
         taskId
       )
       for (const r of rows) {
         addScore(projectId, r.memory_id, SHIP_WEIGHT, nowIso)
+        const queryText = r.query_text?.trim()
+        if (queryText) {
+          prjctDb.run(
+            projectId,
+            `INSERT OR IGNORE INTO retrieval_eval_labels
+               (query_text, positive_id, source, source_task_id, created_at, metadata)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+            queryText,
+            r.memory_id,
+            'ship-surfaced',
+            taskId,
+            nowIso,
+            JSON.stringify({ surface: r.surface ?? 'unknown' })
+          )
+        }
       }
       prjctDb.run(projectId, 'DELETE FROM memory_surface_log WHERE task_id = ?', taskId)
       return rows.length

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -11,6 +11,28 @@ import type { Migration } from '../../types/storage/extended'
 import { INITIAL_SCHEMA_SQL } from './initial-schema.sql'
 import type { SqliteDatabase } from './sqlite-compat'
 
+function stripLiteralFrictionEvidence(content: string): string {
+  const lines = content.split('\n')
+  if (!/^\[[^\]]+\]\s+Lesson:/i.test(lines[0] ?? '')) return content
+  const cleaned = lines
+    .filter((line) => !/^Evidence:\s*/i.test(line.trim()))
+    .join('\n')
+    .trim()
+  return cleaned || content
+}
+
+function scrubFrictionEventData(raw: string): string | null {
+  try {
+    const data = JSON.parse(raw) as { content?: unknown }
+    if (typeof data.content !== 'string') return null
+    const cleaned = stripLiteralFrictionEvidence(data.content)
+    if (cleaned === data.content) return null
+    return JSON.stringify({ ...data, content: cleaned })
+  } catch {
+    return null
+  }
+}
+
 export const migrations: Migration[] = [
   {
     version: 1,
@@ -1049,4 +1071,79 @@ export const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 34,
+    name: 'retrieval-eval-labels',
+    up: (db: SqliteDatabase) => {
+      try {
+        db.run('ALTER TABLE memory_surface_log ADD COLUMN query_text TEXT')
+      } catch {
+        // Column may already exist.
+      }
+      try {
+        db.run('ALTER TABLE memory_surface_log ADD COLUMN surface TEXT')
+      } catch {
+        // Column may already exist.
+      }
+      db.run(`
+        CREATE TABLE IF NOT EXISTS retrieval_eval_labels (
+          id             INTEGER PRIMARY KEY AUTOINCREMENT,
+          query_text     TEXT NOT NULL,
+          positive_id    TEXT NOT NULL,
+          source         TEXT NOT NULL,
+          source_task_id TEXT NOT NULL DEFAULT '',
+          created_at     TEXT NOT NULL,
+          metadata       TEXT NOT NULL DEFAULT '{}'
+        )
+      `)
+      db.run(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_retrieval_eval_labels_unique
+          ON retrieval_eval_labels(source, source_task_id, positive_id, query_text)
+      `)
+      db.run(`
+        CREATE INDEX IF NOT EXISTS idx_retrieval_eval_labels_created
+          ON retrieval_eval_labels(created_at)
+      `)
+    },
+  },
+  {
+    version: 35,
+    name: 'scrub-literal-friction-evidence',
+    up: (db: SqliteDatabase) => {
+      const eventRows = db
+        .prepare(
+          `SELECT id, data FROM events
+           WHERE type = 'memory.remember.improvement-signal'
+             AND json_valid(data)
+             AND json_extract(data, '$.tags.source') = 'friction-detector'
+             AND json_extract(data, '$.content') LIKE '%Evidence:%'`
+        )
+        .all() as Array<{ id: number; data: string }>
+      const updateEvent = db.prepare('UPDATE events SET data = ? WHERE id = ?')
+      for (const row of eventRows) {
+        const cleaned = scrubFrictionEventData(row.data)
+        if (cleaned) updateEvent.run(cleaned, row.id)
+      }
+
+      const memoryRows = db
+        .prepare(
+          `SELECT id, content FROM memories
+           WHERE type = 'improvement-signal'
+             AND json_extract(tags, '$.source') = 'friction-detector'
+             AND content LIKE '%Evidence:%'`
+        )
+        .all() as Array<{ id: string; content: string }>
+      const updateMemory = db.prepare(
+        'UPDATE memories SET content = ?, content_hash = ?, updated_at = ? WHERE id = ?'
+      )
+      const now = new Date().toISOString()
+      for (const row of memoryRows) {
+        const cleaned = stripLiteralFrictionEvidence(row.content)
+        if (cleaned !== row.content)
+          updateMemory.run(cleaned, memoryFingerprint(cleaned), now, row.id)
+      }
+    },
+  },
 ]
+
+export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/sync/secure-auth-token.ts
+++ b/core/sync/secure-auth-token.ts
@@ -339,10 +339,6 @@ export async function clearAuthToken(): Promise<void> {
   await activeStore().clear()
 }
 
-export async function getAuthTokenLocation(): Promise<AuthTokenLocation> {
-  return activeStore().location()
-}
-
 export function _setAuthTokenStoreForTests(store: AuthTokenStore | null): void {
   testStore = store
   cached = undefined

--- a/knip.json
+++ b/knip.json
@@ -6,10 +6,10 @@
     "core/daemon/entry.ts",
     "core/mcp/entry.ts",
     "core/hooks/cold-entry.ts",
-    "scripts/*.{js,ts}",
+    "scripts/*.{js,ts,mjs}",
     "core/__tests__/**/*.test.ts"
   ],
-  "project": ["core/**/*.ts", "bin/**/*.ts", "scripts/**/*.{js,ts}"],
+  "project": ["core/**/*.ts", "bin/**/*.ts", "scripts/**/*.{js,ts,mjs}"],
   "ignore": ["core/types/**"],
   "ignoreExportsUsedInFile": true,
   "rules": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/eval-retrieval.mjs
+++ b/scripts/eval-retrieval.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+/**
+ * Retrieval eval entrypoint. Bun resolves the TS module directly.
+ *   bun run scripts/eval-retrieval.mjs <projectId> [k]
+ */
+import { runEval } from '../core/eval/run.ts'
+
+const projectId = process.argv[2]
+const k = process.argv[3] ? Number(process.argv[3]) : 10
+if (!projectId) {
+  console.error('usage: bun run scripts/eval-retrieval.mjs <projectId> [k]')
+  process.exit(1)
+}
+runEval(projectId, k).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add retrieval eval harness and enforce a 20% improvement gate with minimum label coverage
- persist deterministic retrieval labels from surfaced context credited on ship
- scrub literal friction transcript evidence from existing customer project DBs via schema migration
- remove risky shell-based auto-update path and clean dead exports

## Verification
- bun run check
- bun run typecheck
- bun run knip
- bun test