### PR TITLE
fix: surface indexed file cues for all agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-06-26
+
+### Added
+- Investigate why Claude spent 55k tokens exploring existing repo context instead of prjct surfacing files context and repo state
+
 ## [3.2.0] - 2026-06-26
 
 ### Added

--- a/core/__tests__/hooks/prompt.test.ts
+++ b/core/__tests__/hooks/prompt.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { indexProject } from '../../domain/bm25'
 import {
   _resetGitSnapshotCacheForTests,
   buildProjectState,
@@ -22,6 +23,7 @@ import {
 } from '../../hooks/prompt'
 import configManager from '../../infrastructure/config-manager'
 import pathManager from '../../infrastructure/path-manager'
+import { buildIndexedFileCue } from '../../services/file-cue'
 import prjctDb from '../../storage/database'
 import { stateStorage } from '../../storage/state-storage'
 import { execFileAsync } from '../../utils/exec'
@@ -183,5 +185,35 @@ describe('UserPromptSubmit — topical trap cue', () => {
     seedMirror('mem_4', 'gotcha', 'biome resolves zero files inside a git worktree')
     const cue = buildTopicalCue(projectId, 'completely unrelated cooking recipe question')
     expect(cue).toBeNull()
+  })
+})
+
+describe('UserPromptSubmit — indexed file cue', () => {
+  it('returns null before the project has a file index', async () => {
+    await freshProject()
+    const cue = buildIndexedFileCue(projectId, 'map headless API endpoints')
+    expect(cue).toBeNull()
+  })
+
+  it('surfaces likely files from the sync-built BM25 index', async () => {
+    await freshProject()
+    await fs.mkdir(path.join(projectPath, 'core', 'server'), { recursive: true })
+    await fs.mkdir(path.join(projectPath, 'core', 'hooks'), { recursive: true })
+    await fs.writeFile(
+      path.join(projectPath, 'core', 'server', 'headless-api.ts'),
+      'export function mapHeadlessApiEndpoints() { return [] }'
+    )
+    await fs.writeFile(
+      path.join(projectPath, 'core', 'hooks', 'prompt.ts'),
+      'export function promptHook() { return null }'
+    )
+
+    await indexProject(projectPath, projectId)
+
+    const cue = buildIndexedFileCue(projectId, 'map headless API endpoints')
+    expect(cue).not.toBeNull()
+    expect(cue).toContain('Likely files from prjct index')
+    expect(cue).toContain('core/server/headless-api.ts')
+    expect(cue).toContain('bm25')
   })
 })

--- a/core/__tests__/services/task-service-pipeline.test.ts
+++ b/core/__tests__/services/task-service-pipeline.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { indexProject } from '../../domain/bm25'
 import pathManager from '../../infrastructure/path-manager'
 import { startTask } from '../../services/task-service'
 import { MAIN_WORKSPACE_ID } from '../../services/workspace-id'
@@ -60,5 +61,26 @@ describe('task service pipeline orchestration', () => {
     expect(
       getTaskPipelineState(projectId, outcome.taskId ?? '', MAIN_WORKSPACE_ID)?.requiresTestsFirst
     ).toBe(true)
+  })
+
+  it('surfaces likely files from the project index when work starts', async () => {
+    await fs.mkdir(path.join(projectPath, 'core', 'server'), { recursive: true })
+    await fs.writeFile(
+      path.join(projectPath, 'core', 'server', 'headless-api.ts'),
+      'export function mapHeadlessApiEndpoints() { return [] }'
+    )
+    await fs.writeFile(
+      path.join(projectPath, 'core', 'server', 'billing.ts'),
+      'export function updateBilling() { return null }'
+    )
+    await indexProject(projectPath, projectId)
+
+    const outcome = await startTask(projectId, projectPath, 'map headless API endpoints', {
+      skipHooks: true,
+    })
+
+    expect(outcome.ok).toBe(true)
+    expect(outcome.likelyFiles?.[0]?.path).toBe('core/server/headless-api.ts')
+    expect(outcome.likelyFiles?.[0]?.signals).toContain('bm25')
   })
 })

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -15,6 +15,7 @@
  *   - md-helpers.ts    — buildFlowDiagram for `--md` output
  */
 
+import { formatLikelyFileForAgent } from '../services/file-cue'
 import { collectActiveTasks } from '../services/task-overview'
 import { formatRelatedContextForAgent, startTask } from '../services/task-service'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
@@ -94,6 +95,8 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const harness = outcome.harness
       const related = outcome.relatedContext ?? []
       const relatedLines = related.map(formatRelatedContextForAgent)
+      const likelyFiles = outcome.likelyFiles ?? []
+      const likelyFileLines = likelyFiles.map(formatLikelyFileForAgent)
 
       if (options.md) {
         console.log(
@@ -134,6 +137,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
             relatedLines.length > 0
               ? mdSection('Related context — has this come up before?', mdList(relatedLines))
               : null,
+            likelyFileLines.length > 0
+              ? mdSection('Likely files — from prjct index', mdList(likelyFileLines))
+              : null,
             mdNextSteps([
               { label: 'Pull project memory', command: 'prjct context memory <topic>' },
               { label: 'Synthesize context', command: 'prjct remember context "..."' },
@@ -153,6 +159,10 @@ export class WorkflowCommands extends PrjctCommandsBase {
         if (relatedLines.length > 0) {
           out.info('Related context — has this come up before?')
           for (const line of relatedLines) out.info(`  ${line}`)
+        }
+        if (likelyFileLines.length > 0) {
+          out.info('Likely files — from prjct index')
+          for (const line of likelyFileLines) out.info(`  ${line}`)
         }
         showStateInfo('working')
         showNextSteps('task')

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -25,6 +25,7 @@ import path from 'node:path'
 import configManager from '../infrastructure/config-manager'
 import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import { buildIndexedFileCue } from '../services/file-cue'
 import { collectActiveTasks } from '../services/task-overview'
 import { recordSurfacedForActiveTask } from '../services/usefulness/surface-attribution'
 import { queueStorage } from '../storage/queue-storage'
@@ -35,7 +36,7 @@ import { fileExists } from '../utils/file-helper'
 import { type HookIo, runHook } from './_runner'
 import { extractKeywords, safeTruncate } from './_shared'
 
-const STATE_BUDGET = 900
+const STATE_BUDGET = 1500
 /** FTS candidates fetched before the preventive-type filter picks ONE. */
 const CUE_CANDIDATES = 8
 
@@ -283,7 +284,8 @@ export function runPromptHook(projectPath: string = process.cwd(), io?: HookIo):
         // keywords hit a gotcha/anti-pattern (see header). State leads;
         // the cue is appended and shares the same hard budget.
         const cue = config?.projectId ? buildTopicalCue(config.projectId, prompt, p) : null
-        return safeTruncate(cue ? `${state}\n\n${cue}` : state, STATE_BUDGET)
+        const files = config?.projectId ? buildIndexedFileCue(config.projectId, prompt) : null
+        return safeTruncate([state, cue, files].filter(Boolean).join('\n\n'), STATE_BUDGET)
       },
     },
     io

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -11,6 +11,7 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
+import { formatLikelyFileForAgent } from '../../services/file-cue'
 import { collectActiveTasks } from '../../services/task-overview'
 import { formatRelatedContextForAgent, setTaskStatus, startTask } from '../../services/task-service'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
@@ -115,6 +116,12 @@ export function registerProjectTools(server: McpServer) {
           lines.push('', 'Related second-brain context:')
           for (const hit of outcome.relatedContext) {
             lines.push(`- ${formatRelatedContextForAgent(hit)}`)
+          }
+        }
+        if (outcome.likelyFiles && outcome.likelyFiles.length > 0) {
+          lines.push('', 'Likely files from prjct index:')
+          for (const file of outcome.likelyFiles) {
+            lines.push(`- ${formatLikelyFileForAgent(file)}`)
           }
         }
         return { content: [{ type: 'text', text: lines.join('\n') }] }

--- a/core/services/agent-rag-protocol.ts
+++ b/core/services/agent-rag-protocol.ts
@@ -8,7 +8,7 @@
 
 export const AGENT_RAG_PROTOCOL_LINES = [
   '- prjct is a RAG-backed project memory harness. Do not preload project history into agent instructions.',
-  '- Start work with `prjct work "<intent>" --md`; use only the surfaced related context before planning/editing.',
+  '- Start work with `prjct work "<intent>" --md`; use the surfaced related context and likely files before planning/editing.',
   '- Pull more context on demand with `prjct search`, `prjct context memory`, `prjct guard`, or MCP `prjct_*` tools.',
   '- The vault `_generated/` is a regenerated SQLite snapshot for Read/Glob fallback, not the source of truth and not something to load wholesale.',
   '- On close, save synthesized context via `prjct remember context "<...>"`: what changed, why it matters, key UI data, model/tokens if known, files, pattern/anti-pattern, outcome, next implication.',

--- a/core/services/file-cue.ts
+++ b/core/services/file-cue.ts
@@ -1,0 +1,43 @@
+import { hasIndexes, rankFiles } from '../domain/file-ranker'
+
+export interface LikelyFileHit {
+  path: string
+  signals: string[]
+}
+
+const DEFAULT_FILE_CUE_COUNT = 5
+
+export function rankLikelyFiles(
+  projectId: string,
+  query: string,
+  limit: number = DEFAULT_FILE_CUE_COUNT
+): LikelyFileHit[] {
+  const trimmed = query.trim()
+  if (!trimmed) return []
+
+  const indexes = hasIndexes(projectId)
+  if (!indexes.bm25) return []
+
+  return rankFiles(projectId, trimmed, { topN: limit }).map((file) => ({
+    path: file.path,
+    signals: [
+      file.signals.bm25 > 0 ? 'bm25' : null,
+      file.signals.imports > 0 ? 'imports' : null,
+      file.signals.cochange > 0 ? 'cochange' : null,
+    ].filter((signal): signal is string => signal !== null),
+  }))
+}
+
+export function formatLikelyFileForAgent(file: LikelyFileHit): string {
+  const suffix = file.signals.length > 0 ? ` (${file.signals.join('+')})` : ''
+  return `\`${file.path}\`${suffix}`
+}
+
+export function buildIndexedFileCue(projectId: string, query: string): string | null {
+  const files = rankLikelyFiles(projectId, query)
+  if (files.length === 0) return null
+  return [
+    '**Likely files from prjct index:**',
+    ...files.map((file) => `- ${formatLikelyFileForAgent(file)}`),
+  ].join('\n')
+}

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -26,6 +26,7 @@ import { stateStorage } from '../storage/state-storage'
 import { upsertTaskPipelineState } from '../storage/task-pipeline-storage'
 import * as dateHelper from '../utils/date-helper'
 import { executeWorkflowRules } from '../workflow-engine/workflow-engine'
+import { type LikelyFileHit, rankLikelyFiles } from './file-cue'
 import { buildLivingContextPrompt, parseLivingContextFields } from './living-context-contract'
 import { memoryService } from './memory-service'
 import projectService from './project-service'
@@ -67,6 +68,12 @@ export interface StartTaskOutcome {
    * on-demand at task start (PULL, not a session-start dump).
    */
   relatedContext?: RelatedContextHit[]
+  /**
+   * File targets ranked from the sync-built code indexes for THIS work
+   * description. This is the cheap repo map that prevents agents from
+   * spending the first minutes rediscovering where existing code lives.
+   */
+  likelyFiles?: LikelyFileHit[]
 }
 
 export interface RelatedContextHit {
@@ -247,6 +254,7 @@ export async function startTask(
   // on demand. Reuses the one RAG pipeline (enrichedRecall) so it works over
   // the user's EXISTING memory from day one. Best-effort; never blocks a start.
   const relatedContext = await recallRelatedContext(projectPath, projectId, description)
+  const likelyFiles = recallLikelyFiles(projectId, description)
 
   return {
     ok: true,
@@ -265,6 +273,16 @@ export async function startTask(
     },
     instructions: beforeResult.instructions,
     relatedContext,
+    likelyFiles,
+  }
+}
+
+/** Pull likely file targets from prebuilt indexes (best-effort, no live scan). */
+function recallLikelyFiles(projectId: string, description: string): LikelyFileHit[] {
+  try {
+    return rankLikelyFiles(projectId, description)
+  } catch {
+    return []
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- surface likely file targets from sync-built BM25/import/co-change indexes at work-cycle start
- share the file-cue service across CLI, MCP, and Claude prompt hook
- update the agent RAG protocol so all generated agent surfaces point agents at related context plus likely files before planning

## Verification
- bun run check
- bun run typecheck
- bun run knip
- bun test core/__tests__/hooks/prompt.test.ts core/__tests__/services/task-service-pipeline.test.ts core/__tests__/domain/file-ranker.test.ts
- bun test core/__tests__/services/project-agent-surfaces.test.ts core/__tests__/services/project-agents-md.test.ts core/__tests__/services/project-claude-md.test.ts core/__tests__/services/skill-generator.test.ts
- bun test