### PR TITLE
feat: bidirectional sync + per-record created_at vs synced_at (v3.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-06-26
+
+### Added
+- make all sync entities bidirectional (pull+push) and preserve per-record created_at (origin creation time) distinct from synced_at (ingestion time on receiving machine)
+
 ## [3.4.0] - 2026-06-26
 
 ### Added

--- a/core/__tests__/sync/archives-handler.test.ts
+++ b/core/__tests__/sync/archives-handler.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Archives handler — pulled `archives` events reconstruct the full local
+ * archive row (entity_data included) and dedupe by the archived pair.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+import { archivesHandler } from '../../sync/entity-handlers/archives'
+
+let projectId: string
+let originalProjectsDir: string | undefined
+
+beforeEach(async () => {
+  prjctDb.close()
+  const tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-archives-h-'))
+  originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+  process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+  projectId = `arch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  await pathManager.ensureProjectStructure(projectId)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+})
+
+afterEach(() => {
+  if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+  else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+  prjctDb.close()
+})
+
+function getArchive(entityType: string, entityId: string) {
+  return prjctDb.get<{
+    id: string
+    entity_data: string
+    archived_at: string
+    reason: string
+  }>(
+    projectId,
+    'SELECT id, entity_data, archived_at, reason FROM archives WHERE entity_type = ? AND entity_id = ?',
+    entityType,
+    entityId
+  )
+}
+
+describe('archivesHandler', () => {
+  test('reconstructs the full archived row from a pulled event', async () => {
+    await archivesHandler.upsert(projectId, {
+      id: 'archive-row-1',
+      entity_type: 'shipped',
+      entity_id: 'ship-9',
+      entity_data: JSON.stringify({ name: 'feature X', version: '1.2.3' }),
+      summary: 'feature X v1.2.3',
+      reason: 'age',
+      archived_at: '2020-06-01T00:00:00.000Z',
+      created_at: '2020-06-01T00:00:00.000Z',
+    })
+
+    const row = getArchive('shipped', 'ship-9')
+    expect(row).not.toBeNull()
+    expect(row?.archived_at).toBe('2020-06-01T00:00:00.000Z')
+    expect(row?.reason).toBe('age')
+    // entity_data survived as the full payload, not a lossy stub.
+    expect(JSON.parse(row?.entity_data ?? '{}')).toEqual({ name: 'feature X', version: '1.2.3' })
+  })
+
+  test('dedupes by archived (entity_type, entity_id), not the per-machine id', async () => {
+    await archivesHandler.upsert(projectId, {
+      id: 'id-from-machine-A',
+      entity_type: 'idea',
+      entity_id: 'idea-1',
+      entity_data: JSON.stringify({ title: 'original' }),
+      reason: 'dormant',
+      archived_at: '2021-01-01T00:00:00.000Z',
+    })
+    // Same archived entity, different per-machine archive id — must not dup.
+    await archivesHandler.upsert(projectId, {
+      id: 'id-from-machine-B',
+      entity_type: 'idea',
+      entity_id: 'idea-1',
+      entity_data: JSON.stringify({ title: 'should be ignored' }),
+      reason: 'dormant',
+      archived_at: '2021-02-02T00:00:00.000Z',
+    })
+
+    const rows = prjctDb.query<{ id: string }>(
+      projectId,
+      'SELECT id FROM archives WHERE entity_type = ? AND entity_id = ?',
+      'idea',
+      'idea-1'
+    )
+    expect(rows.length).toBe(1)
+    expect(rows[0]?.id).toBe('id-from-machine-A')
+  })
+
+  test('delete is a no-op (sync never removes a local archive)', async () => {
+    await archivesHandler.upsert(projectId, {
+      id: 'a1',
+      entity_type: 'queue_task',
+      entity_id: 'q-1',
+      entity_data: '{}',
+      reason: 'age',
+      archived_at: '2022-01-01T00:00:00.000Z',
+    })
+    await archivesHandler.delete(projectId, { entity_type: 'queue_task', entity_id: 'q-1' })
+    expect(getArchive('queue_task', 'q-1')).not.toBeNull()
+  })
+})

--- a/core/__tests__/sync/entity-handlers.test.ts
+++ b/core/__tests__/sync/entity-handlers.test.ts
@@ -38,6 +38,7 @@ describe('entity-handlers registry', () => {
   test('exposes the canonical entity_types as keys', () => {
     expect(SUPPORTED_ENTITY_TYPES.sort()).toEqual(
       [
+        'archives',
         'custom_workflows',
         'ideas',
         'memories',

--- a/core/__tests__/sync/entity-map.test.ts
+++ b/core/__tests__/sync/entity-map.test.ts
@@ -63,7 +63,8 @@ describe('isTableIncluded', () => {
     // sync by default while raw prompts/sessions remain opt-out.
     expect(isTableIncluded('metrics_daily')).toBe(true)
     expect(isTableIncluded('work_cost_snapshots')).toBe(true)
-    expect(isTableIncluded('archives')).toBe(false)
+    // Archives are bidirectional now (handler + full entity_data) → default-on.
+    expect(isTableIncluded('archives')).toBe(true)
     expect(DEFAULT_INCLUDE.user_prompts).toBe(false)
     expect(DEFAULT_INCLUDE.agent_sessions).toBe(false)
     // Analysis + specs are project-understanding knowledge → on by default so

--- a/core/__tests__/sync/record-meta-timestamps.test.ts
+++ b/core/__tests__/sync/record-meta-timestamps.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-record origin vs ingestion timestamps (migration 36).
+ *
+ * Two contracts to pin for the cross-machine data model:
+ *   1. created_at = ORIGIN authored time. When an inbound event carries
+ *      created_at, applyEvent persists it verbatim into the side table —
+ *      it is NEVER replaced with the receiver's local clock.
+ *   2. synced_at = INGESTION time on THIS machine (the locally stamped
+ *      applied_at), distinct from created_at.
+ *   3. A producer that omits created_at forces the receiver to lose
+ *      origin chronology — applyEvent warns once per entity_type so the
+ *      gap surfaces instead of silently corrupting the timeline.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+import { getRecordMeta } from '../../sync/sync-applied-hashes'
+import { _resetWarnDedupeForTest, syncManager } from '../../sync/sync-manager'
+
+let projectId: string
+let originalProjectsDir: string | undefined
+let warnCalls: string[]
+let originalWarn: typeof console.warn
+
+beforeEach(async () => {
+  prjctDb.close()
+  const tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-record-meta-'))
+  originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+  process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+  projectId = `meta-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  await pathManager.ensureProjectStructure(projectId)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+
+  warnCalls = []
+  originalWarn = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnCalls.push(args.map((a) => String(a)).join(' '))
+  }
+  _resetWarnDedupeForTest()
+})
+
+afterEach(() => {
+  console.warn = originalWarn
+  _resetWarnDedupeForTest()
+  if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+  else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+  prjctDb.close()
+})
+
+async function applyEvent(event: Record<string, unknown>): Promise<void> {
+  await (
+    syncManager as unknown as {
+      applyEvent: (pid: string, ev: Record<string, unknown>) => Promise<void>
+    }
+  ).applyEvent(projectId, event)
+}
+
+describe('per-record origin vs ingestion timestamps', () => {
+  test('preserves origin created_at and stamps a distinct local synced_at', async () => {
+    const origin = '2020-01-01T00:00:00.000Z'
+    await applyEvent({
+      entity_type: 'tasks',
+      event_type: 'upsert',
+      content_hash: 'hash-task-1',
+      data: { id: 'task-1', description: 'from machine A', created_at: origin },
+    })
+
+    const meta = getRecordMeta(projectId, 'tasks', 'task-1')
+    expect(meta).not.toBeNull()
+    // Origin time survives the round trip verbatim — not overwritten.
+    expect(meta?.createdAt).toBe(origin)
+    // Ingestion time is the local apply time, clearly NOT the 2020 origin.
+    expect(meta?.syncedAt).not.toBe(origin)
+    expect(new Date(meta?.syncedAt ?? '').getFullYear()).toBeGreaterThan(2020)
+  })
+
+  test('accepts camelCase createdAt from the wire too', async () => {
+    const origin = '2021-05-05T12:00:00.000Z'
+    await applyEvent({
+      entity_type: 'tasks',
+      event_type: 'upsert',
+      content_hash: 'hash-task-2',
+      data: { id: 'task-2', description: 'camel', createdAt: origin },
+    })
+
+    expect(getRecordMeta(projectId, 'tasks', 'task-2')?.createdAt).toBe(origin)
+  })
+
+  test('warns once per entity_type when the producer omits created_at', async () => {
+    await applyEvent({
+      entity_type: 'tasks',
+      event_type: 'upsert',
+      content_hash: 'hash-task-3',
+      data: { id: 'task-3', description: 'no origin' },
+    })
+    await applyEvent({
+      entity_type: 'tasks',
+      event_type: 'upsert',
+      content_hash: 'hash-task-4',
+      data: { id: 'task-4', description: 'still no origin' },
+    })
+
+    const missing = warnCalls.filter((w) => w.includes('missing_origin_created_at'))
+    expect(missing.length).toBe(1)
+    // No origin recorded — created_at stays null rather than a faked local now().
+    expect(getRecordMeta(projectId, 'tasks', 'task-3')?.createdAt).toBeNull()
+  })
+
+  test('a later origin-less update does not blank an already-recorded created_at', async () => {
+    const origin = '2019-09-09T09:09:09.000Z'
+    await applyEvent({
+      entity_type: 'tasks',
+      event_type: 'upsert',
+      content_hash: 'hash-task-5a',
+      data: { id: 'task-5', description: 'v1', created_at: origin },
+    })
+    // Same entity, new content_hash, but the payload omits created_at.
+    await applyEvent({
+      entity_type: 'tasks',
+      event_type: 'upsert',
+      content_hash: 'hash-task-5b',
+      data: { id: 'task-5', description: 'v2 edited elsewhere' },
+    })
+
+    expect(getRecordMeta(projectId, 'tasks', 'task-5')?.createdAt).toBe(origin)
+  })
+})

--- a/core/__tests__/sync/sync-manager-unknown-entity.test.ts
+++ b/core/__tests__/sync/sync-manager-unknown-entity.test.ts
@@ -138,7 +138,9 @@ describe('applyEvent — unhandled entity_type warn (Phase 1.6 / B3)', () => {
       await applyEvent({
         entity_type: 'fake_handled',
         event_type: 'upsert',
-        data: { id: 'x' },
+        // created_at present so this stays focused on the no_local_handler
+        // warn — a missing origin would (correctly) trigger a separate warn.
+        data: { id: 'x', created_at: '2020-01-01T00:00:00.000Z' },
       })
       expect(warnCalls).toHaveLength(0)
     } finally {

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -252,6 +252,10 @@ export const projectMemory = {
           tags: args.tags ?? {},
           source: args.source ?? null,
           provenance: args.provenance ?? 'declared',
+          // Origin authored time. We're creating the memory right now on
+          // THIS machine, so now() IS the origin — receivers preserve it
+          // verbatim instead of stamping their own ingestion clock.
+          created_at: new Date().toISOString(),
           rememberedAt: new Date().toISOString(),
         },
       })

--- a/core/storage/archive-storage.ts
+++ b/core/storage/archive-storage.ts
@@ -19,6 +19,30 @@ import type {
 import { getTimestamp } from '../utils/date-helper'
 import { prjctDb } from './database'
 
+/**
+ * Build the sync payload for an archived item. Includes `entity_data`
+ * (the full archived row, JSON-encoded like the local column) so a
+ * receiving machine can reconstruct the archive instead of holding a
+ * lossy id-only stub, and `created_at` = the archive time so origin
+ * chronology survives the round trip (== `archived_at`).
+ */
+function archiveSyncPayload(
+  id: string,
+  item: ArchiveItem,
+  archivedAt: string
+): Record<string, unknown> {
+  return {
+    id,
+    entity_type: item.entityType,
+    entity_id: item.entityId,
+    entity_data: JSON.stringify(item.entityData),
+    summary: item.summary ?? null,
+    reason: item.reason,
+    archived_at: archivedAt,
+    created_at: archivedAt,
+  }
+}
+
 // Archival Policy Constants
 
 export const ARCHIVE_POLICIES = {
@@ -56,14 +80,7 @@ class ArchiveStorage {
       entityType: 'archives',
       entityId: id,
       eventType: 'upsert',
-      data: {
-        id,
-        entity_type: item.entityType,
-        entity_id: item.entityId,
-        summary: item.summary ?? null,
-        reason: item.reason,
-        archived_at: now,
-      },
+      data: archiveSyncPayload(id, item, now),
     })
 
     return id
@@ -76,6 +93,7 @@ class ArchiveStorage {
     if (items.length === 0) return 0
 
     const now = getTimestamp()
+    const published: Array<{ id: string; item: ArchiveItem }> = []
 
     prjctDb.transaction(projectId, (db) => {
       const stmt = db.prepare(
@@ -83,8 +101,9 @@ class ArchiveStorage {
       )
 
       for (const item of items) {
+        const id = generateUUID()
         stmt.run(
-          generateUUID(),
+          id,
           item.entityType,
           item.entityId,
           JSON.stringify(item.entityData),
@@ -92,8 +111,23 @@ class ArchiveStorage {
           now,
           item.reason
         )
+        published.push({ id, item })
       }
     })
+
+    // Sync AFTER the transaction commits. Bulk archives previously emitted
+    // no sync event at all — archives never reached other machines. Each
+    // archived item rides as a full upsert (entity_data included) so the
+    // receiver can reconstruct the row, not just know an id was archived.
+    for (const { id, item } of published) {
+      publishCRUDSync({
+        projectId,
+        entityType: 'archives',
+        entityId: id,
+        eventType: 'upsert',
+        data: archiveSyncPayload(id, item, now),
+      })
+    }
 
     return items.length
   }

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -1144,6 +1144,32 @@ export const migrations: Migration[] = [
       }
     },
   },
+  {
+    version: 36,
+    name: 'sync-applied-hashes-created-at',
+    up: (db: SqliteDatabase) => {
+      // Per-record origin timestamp on the generic sync side table.
+      //
+      // `applied_at` already records when THIS machine ingested the event
+      // (== synced_at). What was missing is `created_at`: the ORIGIN
+      // creation time, authored on whichever machine first produced the
+      // entity. Storing both here — instead of a column on every entity
+      // table — keeps the created_at/synced_at distinction in one place,
+      // applies uniformly to all synced entity types, and avoids churning
+      // each business schema.
+      //
+      // Nullable + backfilled to applied_at: rows that predate this
+      // migration have no recorded origin, so their best available
+      // approximation is the time we applied them. New rows get the real
+      // origin from the wire payload (sync-manager.applyEvent).
+      try {
+        db.run('ALTER TABLE sync_applied_hashes ADD COLUMN created_at TEXT')
+        db.run('UPDATE sync_applied_hashes SET created_at = applied_at WHERE created_at IS NULL')
+      } catch {
+        // Column may already exist (re-run safety).
+      }
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/storage/queue-storage.ts
+++ b/core/storage/queue-storage.ts
@@ -88,6 +88,7 @@ class QueueStorage extends StorageManager<QueueJson> {
       description: newTask.description,
       priority: newTask.priority,
       section: newTask.section,
+      created_at: newTask.createdAt,
     })
 
     return newTask
@@ -116,7 +117,11 @@ class QueueStorage extends StorageManager<QueueJson> {
     // Publish event for batch add
     await this.publishEvent(projectId, 'queue.tasks_added', {
       count: newTasks.length,
-      tasks: newTasks.map((t) => ({ id: t.id, description: t.description })),
+      tasks: newTasks.map((t) => ({
+        id: t.id,
+        description: t.description,
+        created_at: t.createdAt,
+      })),
     })
 
     return newTasks

--- a/core/sync/entity-handlers/archives.ts
+++ b/core/sync/entity-handlers/archives.ts
@@ -1,0 +1,83 @@
+/**
+ * Archives entity handler — applies a pulled `archives` event to local
+ * storage so archived records (stale shipped/ideas/queue/memories moved
+ * out of active storage) round-trip across machines.
+ *
+ * Cross-machine identity is the ARCHIVED pair `(entity_type, entity_id)`,
+ * not the archive row's own `id` (generated per machine, so it differs
+ * everywhere). An entity is archived once — if this machine already has
+ * an archive for that pair, applying again is a no-op.
+ *
+ * Apply is ADDITIVE and writes WITHOUT re-publishing (no echo): the
+ * `archives` table has no sync producer on insert here, mirroring how the
+ * other pulled handlers avoid re-enqueuing.
+ *
+ * `entity_data` arrives as the JSON-encoded archived row (same shape the
+ * local column stores), so a receiver reconstructs the full record rather
+ * than a lossy id-only stub. `delete` is a NO-OP — sync never removes a
+ * local archive.
+ */
+
+import prjctDb from '../../storage/database'
+import type { ApplyData, EntityHandler } from './types'
+
+function str(data: ApplyData, snake: string, camel: string): string {
+  return (data[snake] as string) ?? (data[camel] as string) ?? ''
+}
+
+export const archivesHandler: EntityHandler = {
+  async upsert(projectId, data) {
+    const id = str(data, 'id', 'id')
+    const entityType = str(data, 'entity_type', 'entityType')
+    const entityId = str(data, 'entity_id', 'entityId')
+    if (!id || !entityType || !entityId) return
+
+    // An entity is archived once — dedupe by the archived pair so a
+    // re-pull (or a different per-machine archive id) doesn't duplicate.
+    const dup = prjctDb.get<{ id: string }>(
+      projectId,
+      'SELECT id FROM archives WHERE entity_type = ? AND entity_id = ? LIMIT 1',
+      entityType,
+      entityId
+    )
+    if (dup) return
+
+    // entity_data rides as a JSON string (matches the local column). Fall
+    // back to '{}' rather than NULL — the column is NOT NULL.
+    const entityData =
+      typeof data.entity_data === 'string'
+        ? data.entity_data
+        : data.entity_data != null
+          ? JSON.stringify(data.entity_data)
+          : '{}'
+    // Origin time: prefer the explicit created_at, else archived_at.
+    const archivedAt =
+      str(data, 'archived_at', 'archivedAt') ||
+      str(data, 'created_at', 'createdAt') ||
+      new Date().toISOString()
+    const summary = (data.summary as string) ?? null
+    const reason = str(data, 'reason', 'reason') || 'sync'
+
+    try {
+      prjctDb.run(
+        projectId,
+        `INSERT OR IGNORE INTO archives
+           (id, entity_type, entity_id, entity_data, summary, archived_at, reason)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        id,
+        entityType,
+        entityId,
+        entityData,
+        summary,
+        archivedAt,
+        reason
+      )
+    } catch {
+      // Best-effort — a malformed archive row must not break the batch.
+    }
+  },
+
+  async delete(_projectId, _data) {
+    // No-op by design: sync never removes a local archive.
+  },
+}

--- a/core/sync/entity-handlers/index.ts
+++ b/core/sync/entity-handlers/index.ts
@@ -11,6 +11,7 @@
  * is generic over the registry.
  */
 
+import { archivesHandler } from './archives'
 import { customWorkflowsHandler } from './custom-workflows'
 import { ideasHandler } from './ideas'
 import { memoriesHandler } from './memories'
@@ -35,6 +36,7 @@ export const entityHandlers: Record<string, EntityHandler> = {
   custom_workflows: customWorkflowsHandler,
   workflow_rules: workflowRulesHandler,
   specs: specsHandler,
+  archives: archivesHandler,
 }
 
 /** Read-only list of supported entity types — useful for telemetry. */
@@ -59,11 +61,9 @@ export const UNKNOWN_ENTITY_TYPES: ReadonlySet<string> = new Set([
   'sessions',
   'agents',
   // Pushed by a producer but intentionally not applied locally yet:
-  //  - archives: the wire payload omits `entity_data` (lossy); default-off.
   //  - subtasks / metrics_daily / velocity_sprints: no producer emits them
   //    today, but they're in the canonical table map — list them so the
   //    exhaustiveness test treats them as known-skipped, not a missed handler.
-  'archives',
   'subtasks',
   'metrics_daily',
   'work_cost_snapshots',

--- a/core/sync/entity-map.ts
+++ b/core/sync/entity-map.ts
@@ -118,7 +118,11 @@ export const DEFAULT_INCLUDE: Record<IncludeGroup, boolean> = {
   // `metrics` now includes aggregated cost/context snapshots. It is default-on
   // because it contains rolled-up analytics, not raw prompts or transcripts.
   metrics: true,
-  archives: false,
+  // Archives are now bidirectional (handler + full entity_data payload), so
+  // they round-trip like any other authored record. Default-on to honor the
+  // "every entity syncs to every machine" directive — flip to false per
+  // project via cloud.include if archived volume becomes noise.
+  archives: true,
   // Raw prompts + agent sessions stay opt-out by default (privacy-sensitive,
   // heavy). Analysis + specs are project-understanding knowledge — on by
   // default so the cloud vault is a complete picture of the project.

--- a/core/sync/publish-helper.ts
+++ b/core/sync/publish-helper.ts
@@ -58,7 +58,7 @@ const LEGACY_TYPE_OF: Record<CrudEventType, string> = {
  * we sort top-level keys before stringifying so two equivalent
  * payloads produce the same hash.
  */
-function hashPayload(data: unknown): string {
+export function hashPayload(data: unknown): string {
   const canonical =
     data && typeof data === 'object' && !Array.isArray(data)
       ? JSON.stringify(sortKeys(data as Record<string, unknown>))

--- a/core/sync/sync-applied-hashes.ts
+++ b/core/sync/sync-applied-hashes.ts
@@ -20,6 +20,41 @@ interface AppliedHashRow {
 }
 
 /**
+ * Origin (`createdAt`) vs ingestion (`syncedAt`) timestamps for a synced
+ * entity. `createdAt` is the authored time from the producing machine;
+ * `syncedAt` is when THIS machine applied the event (== `applied_at`).
+ */
+export interface SyncRecordMeta {
+  createdAt: string | null
+  syncedAt: string
+}
+
+/**
+ * Read the origin/ingestion timestamps recorded for an entity. Returns
+ * null when no event has been applied yet. Best-effort — DB errors return
+ * null so callers can fall back gracefully.
+ */
+export function getRecordMeta(
+  projectId: string,
+  entityType: string,
+  entityId: string
+): SyncRecordMeta | null {
+  if (!entityType || !entityId) return null
+  try {
+    const row = prjctDb.get<{ created_at: string | null; applied_at: string }>(
+      projectId,
+      'SELECT created_at, applied_at FROM sync_applied_hashes WHERE entity_type = ? AND entity_id = ?',
+      entityType,
+      entityId
+    )
+    if (!row) return null
+    return { createdAt: row.created_at ?? null, syncedAt: row.applied_at }
+  } catch {
+    return null
+  }
+}
+
+/**
  * Look up the last-applied content_hash for an entity. Returns null
  * when no event has been applied yet. Best-effort — DB errors return
  * null so apply proceeds rather than blocking.
@@ -54,21 +89,28 @@ export function recordApplied(
   projectId: string,
   entityType: string,
   entityId: string,
-  contentHash: string
+  contentHash: string,
+  createdAt?: string | null
 ): void {
   if (!entityType || !entityId || !contentHash) return
   try {
+    // applied_at is stamped locally = ingestion time (synced_at).
+    // created_at is the ORIGIN time threaded from the wire payload; we
+    // COALESCE so a later event without origin info doesn't blank out a
+    // created_at we already recorded.
     prjctDb.run(
       projectId,
-      `INSERT INTO sync_applied_hashes (entity_type, entity_id, content_hash, applied_at)
-       VALUES (?, ?, ?, ?)
+      `INSERT INTO sync_applied_hashes (entity_type, entity_id, content_hash, applied_at, created_at)
+       VALUES (?, ?, ?, ?, ?)
        ON CONFLICT(entity_type, entity_id) DO UPDATE SET
          content_hash = excluded.content_hash,
-         applied_at   = excluded.applied_at`,
+         applied_at   = excluded.applied_at,
+         created_at   = COALESCE(excluded.created_at, sync_applied_hashes.created_at)`,
       entityType,
       entityId,
       contentHash,
-      getTimestamp()
+      getTimestamp(),
+      createdAt ?? null
     )
   } catch {
     // Best-effort — see header. Caller is applyEvent which already

--- a/core/sync/sync-manager.ts
+++ b/core/sync/sync-manager.ts
@@ -20,6 +20,7 @@ import type {
 import authConfig from './auth-config'
 import { entityHandlers, UNKNOWN_ENTITY_TYPES } from './entity-handlers'
 import { isTableIncluded, toCloudTable } from './entity-map'
+import { hashPayload } from './publish-helper'
 import { clearApplied, getApplied, recordApplied } from './sync-applied-hashes'
 import { syncClient } from './sync-client'
 
@@ -41,12 +42,29 @@ function warnNoLocalHandler(entityType: string): void {
   )
 }
 
+// Per-process dedupe for the "inbound event has no origin created_at"
+// warn. A producer that omits created_at from its payload forces the
+// receiver to lose origin chronology; this surfaces it once per
+// entity_type instead of per-event.
+const WARN_CREATED_AT: Set<string> = new Set()
+
+function warnMissingCreatedAt(entityType: string): void {
+  if (WARN_CREATED_AT.has(entityType)) return
+  WARN_CREATED_AT.add(entityType)
+  console.warn(
+    `[sync] inbound '${entityType}' event has no created_at — origin chronology ` +
+      `cannot be preserved. The producer should include created_at in its payload. ` +
+      `code=missing_origin_created_at`
+  )
+}
+
 /**
  * @internal — exposed for tests so a fresh process state can be
  * simulated without spawning a child. Do not call from prod code.
  */
 export function _resetWarnDedupeForTest(): void {
   WARN_LOGGED.clear()
+  WARN_CREATED_AT.clear()
 }
 
 // Event normalization (Phase 1.5 / B2)
@@ -474,8 +492,22 @@ class SyncManager {
     await handler.upsert(projectId, data)
     // Record AFTER handler success — handler durability is the source
     // of truth, this just trails what we last applied.
-    if (contentHash && entityId) {
-      recordApplied(projectId, entityType, entityId, contentHash)
+    //
+    // Meta recording is decoupled from contentHash: legacy producers
+    // (publishEvent, e.g. queue/shipped) don't carry a hash, but we
+    // still need their per-record created_at/synced_at. Fall back to a
+    // hash of the payload so every applied upsert gets a side-table row.
+    if (entityId) {
+      // Origin creation time from the wire payload. NEVER substitute
+      // local now() here: created_at must reflect when the entity was
+      // authored on its origin machine, not when we ingested it
+      // (that's applied_at / synced_at, stamped inside recordApplied).
+      // Missing origin is a producer bug — warn once so it surfaces.
+      const originCreatedAt =
+        (data.created_at as string | undefined) ?? (data.createdAt as string | undefined) ?? null
+      if (!originCreatedAt) warnMissingCreatedAt(entityType)
+      const effectiveHash = contentHash ?? hashPayload(data)
+      recordApplied(projectId, entityType, entityId, effectiveHash, originCreatedAt)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
Makes synced entities bidirectional and preserves per-record origin time distinct from ingestion time.

- **Migration 36** — `created_at` on `sync_applied_hashes` (generic side table). `applied_at` is the de-facto `synced_at` (local ingestion time).
- **`applyEvent`** — universal per-record meta recording (decoupled from `contentHash`, so legacy `publishEvent` producers are covered); threads origin `created_at` from the wire and **never** overwrites it with local `now()`; warns `missing_origin_created_at` when a producer omits it.
- **Producers** — `memories` and `queue` now include `created_at`.
- **`archives` bidirectional** — full `entity_data` payload (was lossy), `archiveMany` now publishes (previously emitted nothing), new `archivesHandler` (dedupes by archived `(entity_type, entity_id)`), default-on in `cloud.include`.

## Context
- API + UI already handle `created_at`/`synced_at` correctly (landed with the work-cost merge): server stores `data` verbatim, `origin_created_at()` resolves origin with fallback, UI orders by `created_at` and shows `synced_at` separately.
- work_cost_snapshots/analysis stay push-only by design (per-machine derived telemetry / regenerable) — recompute-local model.

## Test
- New: `record-meta-timestamps.test.ts`, `archives-handler.test.ts`
- 414/414 sync + storage tests pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)