### PR TITLE
fix: login/logout auto-restart daemon so cloud auth isn't stale (v3.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-06-26
+
+### Added
+- investigate and fix multiple cloud sync problems users are reporting after recent v3.4.0/v3.5.0 sync ships
+
 ## [3.5.0] - 2026-06-26
 
 ### Added

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -49,6 +49,10 @@ export class SetupCommands extends PrjctCommandsBase {
 
       case 'logout': {
         await authConfig.clearAuth()
+        // Refresh the long-lived daemon so it drops the cleared session
+        // instead of reporting stale "authenticated" until a manual restart
+        // (mem_2880).
+        await this.refreshDaemonAuth()
         if (!options.md) out.done('Logged out. Auth credentials cleared')
         return {
           success: true,
@@ -151,6 +155,13 @@ export class SetupCommands extends PrjctCommandsBase {
                 `Email:  ${email}\nToken:  stored securely\nStatus: Connected`
               )
             }
+
+            // Refresh the long-lived daemon FIRST so it picks up the new
+            // token before anything routes through it. Without this the
+            // daemon keeps its boot-time (unauthenticated) state and
+            // cloud status/link report "not authenticated" until a manual
+            // `daemon restart` (mem_2880).
+            await this.refreshDaemonAuth()
 
             // Auto-sync if inside a prjct project
             await this.autoSync()
@@ -258,6 +269,21 @@ export class SetupCommands extends PrjctCommandsBase {
   /**
    * Auto-sync pending events if inside a prjct project
    */
+  /**
+   * Bounce the long-lived daemon after an auth change (login/logout) so it
+   * re-reads the secure token and reopens realtime with fresh credentials.
+   * Best-effort: a no-op when no daemon runs, and never throws — the auth
+   * change already succeeded regardless of the daemon's state (mem_2880).
+   */
+  private async refreshDaemonAuth(): Promise<void> {
+    try {
+      const { restartDaemon } = await import('../daemon/client')
+      await restartDaemon()
+    } catch {
+      // Best-effort: worst case the user runs `prjct daemon restart`.
+    }
+  }
+
   private async autoSync(): Promise<void> {
     try {
       const config = await configManager.readConfig(process.cwd()).catch(() => null)

--- a/core/daemon/client.ts
+++ b/core/daemon/client.ts
@@ -320,3 +320,37 @@ export async function spawnDaemon(): Promise<boolean> {
 
   return false
 }
+
+/**
+ * Restart the daemon so it re-reads auth/session state and reopens realtime
+ * connections with fresh credentials.
+ *
+ * The daemon is long-lived: `prjct login`/`logout` run in a separate cold
+ * process and update the secure token + auth.json, but the daemon keeps its
+ * realtime clients (and any sync state) bound to the credentials it booted
+ * with. Without a restart, `cloud status`/`link` keep reporting the OLD
+ * authenticated/unauthenticated state until a manual `daemon restart`
+ * (mem_2880). Login/logout call this so the new state takes effect at once.
+ *
+ * Best-effort and a no-op when no daemon is running (ephemeral / pull-based
+ * mode covers that). Graceful stop falls back to force-kill, then respawn.
+ * Returns whether a daemon is live afterward.
+ */
+export async function restartDaemon(): Promise<boolean> {
+  try {
+    if (!(await isDaemonRunning())) {
+      // Nothing to refresh — the next command spawns a daemon that reads
+      // the new auth on boot.
+      return false
+    }
+    const stopped = await stopDaemon()
+    if (!stopped) forceKillDaemon()
+    // Give the OS a beat to release the socket before respawning.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    return await spawnDaemon()
+  } catch {
+    // Never let a daemon refresh failure break login/logout — the user is
+    // still authenticated; worst case they run `daemon restart` manually.
+    return false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Problem
Customers report `cloud status`/`link` showing stale **not authenticated** after `prjct login` (and stale authenticated after `logout`) until a **manual `daemon restart`**. Root cause (mem_2880): the long-lived daemon boots realtime clients + auth state bound to its boot-time credentials; login/logout run in a separate cold process and update the secure token, but the daemon never picks it up.

## Fix
- New `restartDaemon()` in `core/daemon/client.ts` — reuses the exact stop(graceful→force)→spawn pattern already shipped in `update.ts`.
- `setup.ts` calls it via `refreshDaemonAuth()`: on login (after token verify, before autoSync) and on logout (after clearAuth).
- Best-effort: no-op when no daemon runs; never throws so the auth change always completes.
- Since `prjct upgrade` already restarts the daemon, customers upgrading to this version also get an immediate daemon bounce → fresh auth + pending flush.

## Test
- typecheck + lint clean; 39/39 daemon + auth tests pass.

> ⚠️ HOLD — do not merge until customer error signal confirms this is the right fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)