### PR TITLE
fix: ships now sync to cloud via canonical shipped_items event

### DIFF
--- a/core/storage/shipped-storage.ts
+++ b/core/storage/shipped-storage.ts
@@ -69,8 +69,14 @@ class ShippedStorage extends StorageManager<ShippedJson> {
       lastUpdated: getTimestamp(),
     }))
 
-    // Publish event
-    await this.publishEvent(projectId, 'feature.shipped', {
+    // Publish a canonical `shipped_item` event: `shipped_item.created` derives
+    // to entityType `shipped_items` (the table the cloud reads for ships) and a
+    // top-level `id` so the event carries a stable entity id. The legacy
+    // `feature.shipped` shape pluralized to `features` (off-contract → dropped)
+    // and exposed only `shipId` (unrecognized → null entity id), so ships never
+    // reached the cloud.
+    await this.publishEvent(projectId, 'shipped_item.created', {
+      id: shipped.id,
       shipId: shipped.id,
       name: shipped.name,
       version: shipped.version,


### PR DESCRIPTION
Part of the projects/dashboard overhaul. Pairs with prjct-cli-api `fix/web-projects-overhaul-api` and prjct-cli-app `fix/projects-ui-overhaul`.

## Problem
`shippedStorage.addShipped` published a legacy `feature.shipped` event, which `deriveEntityShape` pluralizes to entity_type `features` — off the sync contract (the server reads `shipped_items`/`shipped_features`), so every ship was dropped at ingest. The payload also only carried `shipId`, unrecognized by `entityIdOf`, so the entity id was null.

## Fix
Emit `shipped_item.created` (derives to `shipped_items`, the table the cloud reads for ships) with a top-level `id`. Ships now reach the cloud and appear in the web app's project + dashboard ship lists.

Sync + shipping tests pass; biome check clean (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)