### PR TITLE
feat: token-efficient, agent-agnostic work surface (v3.8.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ ask them to type prjct commands.
   related second brain context before you plan or edit.
 - Lookup is pull-first and bounded:
 - prjct is a RAG-backed project memory harness. Do not preload project history into agent instructions.
-- Start work with `prjct work "<intent>" --md`; use the surfaced related context and likely files before planning/editing.
+- Start work with `prjct work "<intent>" --md`; read the surfaced likely files FIRST and use related context before planning/editing — do not grep-walk the repo to rediscover where code lives.
 - Pull more context on demand with `prjct search`, `prjct context memory`, `prjct guard`, or MCP `prjct_*` tools.
 - The vault `_generated/` is a regenerated SQLite snapshot for Read/Glob fallback, not the source of truth and not something to load wholesale.
 - On close, save synthesized context via `prjct remember context "<...>"`: what changed, why it matters, key UI data, model/tokens if known, files, pattern/anti-pattern, outcome, next implication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-06-27
+
+### Added
+- work token savings
+
 ## [3.7.0] - 2026-06-26
 
 ### Added

--- a/core/__tests__/services/file-cue.test.ts
+++ b/core/__tests__/services/file-cue.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test'
+import { formatLikelyFileForAgent, type LikelyFileHit } from '../../services/file-cue'
+
+describe('file-cue agent surface', () => {
+  it('renders a path with a one-line reason and signals so the agent reads it instead of grep-walking', () => {
+    const hit: LikelyFileHit = {
+      path: 'core/commands/workflow.ts',
+      signals: ['bm25', 'imports'],
+      reason: 'matches your task terms',
+    }
+    const line = formatLikelyFileForAgent(hit)
+    expect(line).toBe('`core/commands/workflow.ts` — matches your task terms (bm25+imports)')
+  })
+
+  it('still renders the reason when no signals are present', () => {
+    const hit: LikelyFileHit = {
+      path: 'core/x.ts',
+      signals: [],
+      reason: 'related by prjct index',
+    }
+    expect(formatLikelyFileForAgent(hit)).toBe('`core/x.ts` — related by prjct index')
+  })
+})

--- a/core/__tests__/services/living-context-contract.test.ts
+++ b/core/__tests__/services/living-context-contract.test.ts
@@ -82,7 +82,7 @@ describe('living context contract', () => {
     expect(tags.feature).toBe('memory')
   })
 
-  it('formats retrieved context with UI key data and synthesized detail', () => {
+  it('formats retrieved context as a compact, self-sufficient one-liner', () => {
     const line = formatRelatedContextForAgent({
       id: 'mem_1',
       type: 'context',
@@ -92,7 +92,29 @@ describe('living context contract', () => {
       when: '2026-06-26T00:00:00Z',
     } satisfies RelatedContextHit)
 
-    expect(line).toContain('Key data: feature=memory; surface=dashboard')
-    expect(line).toContain('Detail: Durable synthesis for the next LLM.')
+    // Compact surface: head (type, title, date, id) + the single most salient
+    // field. Full body stays one `prjct search <id>` away — no verbose
+    // "Key data:"/"Detail:" prefixes that bloated the passive work surface.
+    expect(line).toContain('[context] Living context')
+    expect(line).toContain('`mem_1`')
+    expect(line).toContain('feature=memory; surface=dashboard')
+    expect(line).not.toContain('Key data:')
+    expect(line).not.toContain('Detail:')
+  })
+
+  it('prioritizes a trap/decision over generic fields in the compact line', () => {
+    const line = formatRelatedContextForAgent({
+      id: 'mem_2',
+      type: 'gotcha',
+      title: 'Worktree ship trap',
+      detail: 'long body about worktree ship behavior',
+      when: '2026-06-26T00:00:00Z',
+      why: 'generic reason',
+      decisionTrap: 'ship inside a worktree double-bumps the version',
+      keyData: 'k=v',
+    } satisfies RelatedContextHit)
+
+    expect(line).toContain('ship inside a worktree double-bumps the version')
+    expect(line).not.toContain('generic reason')
   })
 })

--- a/core/__tests__/services/transcript-jsonl.test.ts
+++ b/core/__tests__/services/transcript-jsonl.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import { parseTranscriptJsonl, sumTranscriptUsage } from '../../services/transcript-jsonl'
+
+describe('sumTranscriptUsage', () => {
+  it('sums input/output across assistant turns, counting cache reads/creations as input', () => {
+    const lines = parseTranscriptJsonl(
+      [
+        JSON.stringify({ type: 'user', message: { role: 'user' } }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            usage: {
+              input_tokens: 100,
+              output_tokens: 40,
+              cache_creation_input_tokens: 10,
+              cache_read_input_tokens: 5,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', usage: { input_tokens: 200, output_tokens: 60 } },
+        }),
+      ].join('\n')
+    )
+
+    const usage = sumTranscriptUsage(lines)
+    expect(usage.tokensIn).toBe(100 + 10 + 5 + 200)
+    expect(usage.tokensOut).toBe(40 + 60)
+  })
+
+  it('returns zero usage when no usage blocks are present', () => {
+    const lines = parseTranscriptJsonl(JSON.stringify({ type: 'user', message: { role: 'user' } }))
+    expect(sumTranscriptUsage(lines)).toEqual({ tokensIn: 0, tokensOut: 0 })
+  })
+
+  it('is agent-agnostic: reads OpenAI and Gemini usage shapes too', () => {
+    const lines = parseTranscriptJsonl(
+      [
+        // OpenAI Chat Completions shape (top-level usage)
+        JSON.stringify({ usage: { prompt_tokens: 300, completion_tokens: 120 } }),
+        // Gemini shape (usageMetadata)
+        JSON.stringify({ usageMetadata: { promptTokenCount: 50, candidatesTokenCount: 25 } }),
+      ].join('\n')
+    )
+    const usage = sumTranscriptUsage(lines)
+    expect(usage.tokensIn).toBe(300 + 50)
+    expect(usage.tokensOut).toBe(120 + 25)
+  })
+})

--- a/core/__tests__/services/work-cost-tokens.test.ts
+++ b/core/__tests__/services/work-cost-tokens.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { buildWorkCostSnapshot, recordTaskTokenUsage } from '../../services/work-cost-service'
+import { prjctDb } from '../../storage/database'
+
+let projectPath: string
+let tmpRoot: string
+let projectId: string
+const originalGetGlobalProjectPath = pathManager.getGlobalProjectPath.bind(pathManager)
+
+describe('agent-agnostic token measurement', () => {
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-tok-root-'))
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-tok-project-'))
+    projectId = `tok-${Math.random().toString(36).slice(2, 10)}`
+    pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+    await configManager.writeConfig(projectPath, {
+      projectId,
+      dataPath: path.join(tmpRoot, 'data'),
+    })
+    prjctDb.getDb(projectId)
+  })
+
+  afterEach(async () => {
+    prjctDb.close()
+    pathManager.getGlobalProjectPath = originalGetGlobalProjectPath
+    await fs.rm(projectPath, { recursive: true, force: true })
+    await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('records token usage as an event and surfaces it as a measured cycle (no tasks-table row needed)', () => {
+    // The live work flow never writes the legacy `tasks` table, so this is the
+    // path that actually proves net savings for any agent.
+    recordTaskTokenUsage(projectId, 'task-x', 18000, 4000, {
+      description: 'measured via CLI/MCP',
+      agent: 'codex',
+    })
+
+    const snapshot = buildWorkCostSnapshot(projectId, 30)
+    expect(snapshot.knownTokenCycles).toBe(1)
+    expect(snapshot.tokensTotal).toBe(22000)
+    expect(snapshot.mostExpensive[0]?.description).toBe('measured via CLI/MCP')
+  })
+
+  it('uses the latest report per task (SET semantics, not increment)', () => {
+    recordTaskTokenUsage(projectId, 'task-y', 1000, 100)
+    recordTaskTokenUsage(projectId, 'task-y', 5000, 900)
+
+    const snapshot = buildWorkCostSnapshot(projectId, 30)
+    expect(snapshot.knownTokenCycles).toBe(1)
+    expect(snapshot.tokensTotal).toBe(5900)
+  })
+})

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -195,7 +195,7 @@ export const COMMANDS: CommandMeta[] = [
     group: 'legacy',
     surface: 'legacy',
     routing: { group: 'primitives', method: 'status' },
-    optionSchema: {},
+    optionSchema: { strings: ['tokensIn', 'tokensOut'] },
     description: 'Compatibility lifecycle escape hatch; prefer `work` outcomes',
     usage: { claude: null, terminal: 'prjct status <value>' },
     params: '[value]',

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -14,6 +14,7 @@ import { projectMemory } from '../memory/project-memory'
 import type { TaskType } from '../schemas/state'
 import { memoryService } from '../services/memory-service'
 import { readLastStatus, resolveActiveTask, setTaskStatus } from '../services/task-service'
+import { recordTaskTokenUsage } from '../services/work-cost-service'
 import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
@@ -37,7 +38,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
   async status(
     value: string | null = null,
     projectPath: string = process.cwd(),
-    options: MdOption = {}
+    options: MdOption & { tokensIn?: string; tokensOut?: string } = {}
   ): Promise<CommandResult> {
     try {
       const pid = await requireProject(projectPath)
@@ -58,6 +59,19 @@ export class PrimitiveCommands extends PrjctCommandsBase {
           const task = await requireActiveTask(pid.value, options, projectPath)
           if (!task.ok) return task.result
           return { success: false, error: 'No active work cycle' }
+        }
+        // Agent-agnostic token attribution: any CLI-driven agent (Codex,
+        // Gemini, …) can report this cycle's usage with `--tokens-in/--tokens-out`
+        // so prjct measures net savings without a Claude-style transcript.
+        const tokensIn = Number.parseInt(options.tokensIn ?? '', 10)
+        const tokensOut = Number.parseInt(options.tokensOut ?? '', 10)
+        if (outcome.taskId && (Number.isFinite(tokensIn) || Number.isFinite(tokensOut))) {
+          recordTaskTokenUsage(
+            pid.value,
+            outcome.taskId,
+            Number.isFinite(tokensIn) ? tokensIn : 0,
+            Number.isFinite(tokensOut) ? tokensOut : 0
+          )
         }
         const msg = `status → ${value}`
         if (options.md) console.log(`✓ ${msg}`)

--- a/core/commands/product.ts
+++ b/core/commands/product.ts
@@ -803,6 +803,38 @@ function formatPerformanceText(days: number, cycles: PerformanceCycle[]): string
   return `AI work performance (${days}d): ${cycles.length} cycle(s), ${knownTime.length} with duration, ${minutes} known minute(s).`
 }
 
+/**
+ * Net-savings view: measured tokens/cycle now vs. the declared historical
+ * baseline (e.g. a captured "90k tokens" mention from before this optimization).
+ * This is the line that answers prjct's north star — "does using prjct cost
+ * fewer tokens than not?" Renders an honest "insufficient data" note until both
+ * sides have signal, rather than a fake number.
+ */
+function formatNetSavingsMd(snapshot: WorkCostSnapshot): string[] {
+  const lines = ['## Net Savings vs. Baseline', '']
+  const avgMeasured =
+    snapshot.knownTokenCycles > 0 ? snapshot.tokensTotal / snapshot.knownTokenCycles : null
+  const mentions = snapshot.historicalRescue.declaredTokenMentions
+  const avgDeclared = mentions > 0 ? snapshot.historicalRescue.declaredTokensTotal / mentions : null
+
+  if (avgMeasured === null || avgDeclared === null || avgDeclared === 0) {
+    lines.push(
+      '- Insufficient data yet: need at least one token-measured cycle and one declared baseline mention.',
+      ''
+    )
+    return lines
+  }
+
+  const deltaPct = Math.round(((avgDeclared - avgMeasured) / avgDeclared) * 100)
+  const verdict = deltaPct > 0 ? `${deltaPct}% fewer` : `${Math.abs(deltaPct)}% more`
+  lines.push('| Metric | Value |', '|---|---:|')
+  lines.push(`| Avg measured tokens/cycle | ${Math.round(avgMeasured).toLocaleString()} |`)
+  lines.push(`| Avg declared baseline tokens | ${Math.round(avgDeclared).toLocaleString()} |`)
+  lines.push(`| Net | **${verdict} tokens/cycle** |`)
+  lines.push('')
+  return lines
+}
+
 function formatCostMd(snapshot: WorkCostSnapshot): string {
   const lines = ['# AI Work Cost', '', `Window: last ${snapshot.windowDays} day(s)`, '']
   lines.push('## Subscription Burn', '', '| Metric | Value |', '|---|---:|')
@@ -814,6 +846,7 @@ function formatCostMd(snapshot: WorkCostSnapshot): string {
   lines.push(`| Total tokens | ${snapshot.tokensTotal.toLocaleString()} |`)
   lines.push(`| Agent sessions | ${snapshot.measuredSessions} |`)
   lines.push('')
+  lines.push(...formatNetSavingsMd(snapshot))
   lines.push('## Historical Rescue', '', '| Signal | Value |', '|---|---:|')
   lines.push(`| Inferred work cycles | ${snapshot.historicalRescue.inferredWorkCycles} |`)
   lines.push(`| Normalized task rows | ${snapshot.historicalRescue.taskTableCycles} |`)

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -15,6 +15,7 @@
  *   - md-helpers.ts    — buildFlowDiagram for `--md` output
  */
 
+import { safeTruncate } from '../hooks/_shared'
 import { formatLikelyFileForAgent } from '../services/file-cue'
 import { collectActiveTasks } from '../services/task-overview'
 import { formatRelatedContextForAgent, startTask } from '../services/task-service'
@@ -93,61 +94,70 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const beforeInstructions = outcome.instructions ?? []
       const pipeline = outcome.pipeline
       const harness = outcome.harness
-      const related = outcome.relatedContext ?? []
+      // Cap the passive surface: 3–4 reranked hits are enough as a "has this
+      // come up before?" cue. The agent pulls full bodies on demand via
+      // `prjct search <id>` / `prjct context memory`. Keeps work --md lean.
+      const related = (outcome.relatedContext ?? []).slice(0, 4)
       const relatedLines = related.map(formatRelatedContextForAgent)
       const likelyFiles = outcome.likelyFiles ?? []
       const likelyFileLines = likelyFiles.map(formatLikelyFileForAgent)
 
       if (options.md) {
-        console.log(
-          mdOutput(
-            mdTaskHeader({ description: taskDescription, status: 'active' }),
-            mdSection(
-              'State',
-              mdList(
-                [
-                  `Work cycle: \`${taskId}\``,
-                  branch ? `Branch: \`${branch}\`` : null,
-                  linearId ? `Linear: \`${linearId}\`` : null,
-                  harness ? `Harness: ${harness.level} ${harness.kind}/${harness.risk}` : null,
-                  harness?.expectedEvidence.length
-                    ? `Evidence: ${harness.expectedEvidence.join(', ')}`
-                    : null,
-                  beforeInstructions.length > 0
-                    ? `Agent instructions: ${beforeInstructions.length}`
-                    : null,
-                ].filter((s): s is string => s !== null)
+        const md = mdOutput(
+          mdTaskHeader({ description: taskDescription, status: 'active' }),
+          mdSection(
+            'State',
+            mdList(
+              [
+                `Work cycle: \`${taskId}\``,
+                branch ? `Branch: \`${branch}\`` : null,
+                linearId ? `Linear: \`${linearId}\`` : null,
+                harness ? `Harness: ${harness.level} ${harness.kind}/${harness.risk}` : null,
+                harness?.expectedEvidence.length
+                  ? `Evidence: ${harness.expectedEvidence.join(', ')}`
+                  : null,
+                beforeInstructions.length > 0
+                  ? `Agent instructions: ${beforeInstructions.length}`
+                  : null,
+              ].filter((s): s is string => s !== null)
+            )
+          ),
+          pipeline
+            ? mdSection(
+                'Task Pipeline',
+                mdList([
+                  `Classification: \`${pipeline.classification}\``,
+                  `Station: \`${pipeline.station}\``,
+                  `Requires spec: ${pipeline.requiresSpec ? 'yes' : 'no'}`,
+                  `Tests first: ${pipeline.requiresTestsFirst ? 'yes' : 'no'}`,
+                  `Next action: ${pipeline.nextAction}`,
+                ])
               )
-            ),
-            pipeline
-              ? mdSection(
-                  'Task Pipeline',
-                  mdList([
-                    `Classification: \`${pipeline.classification}\``,
-                    `Station: \`${pipeline.station}\``,
-                    `Requires spec: ${pipeline.requiresSpec ? 'yes' : 'no'}`,
-                    `Tests first: ${pipeline.requiresTestsFirst ? 'yes' : 'no'}`,
-                    `Next action: ${pipeline.nextAction}`,
-                  ])
-                )
-              : null,
-            beforeInstructions.length > 0
-              ? mdSection('Agent Instructions', mdList(beforeInstructions))
-              : null,
-            relatedLines.length > 0
-              ? mdSection('Related context — has this come up before?', mdList(relatedLines))
-              : null,
-            likelyFileLines.length > 0
-              ? mdSection('Likely files — from prjct index', mdList(likelyFileLines))
-              : null,
-            mdNextSteps([
-              { label: 'Pull project memory', command: 'prjct context memory <topic>' },
-              { label: 'Synthesize context', command: 'prjct remember context "..."' },
-              { label: 'Measure performance', command: 'prjct performance --md' },
-              { label: 'Ship when done', command: 'prjct ship --md' },
-            ])
-          )
+            : null,
+          beforeInstructions.length > 0
+            ? mdSection('Agent Instructions', mdList(beforeInstructions))
+            : null,
+          relatedLines.length > 0
+            ? mdSection('Related context — has this come up before?', mdList(relatedLines))
+            : null,
+          likelyFileLines.length > 0
+            ? mdSection(
+                'Likely files — from prjct index',
+                [
+                  '> Read these first. Pull more with `prjct search`/`prjct context memory` before grep-walking the repo.',
+                  mdList(likelyFileLines),
+                ].join('\n')
+              )
+            : null,
+          mdNextSteps([
+            { label: 'Synthesize context on close', command: 'prjct remember context "..."' },
+            { label: 'Ship when done', command: 'prjct ship --md' },
+          ])
         )
+        // Hard budget on the passive surface — no single work start should blow
+        // up the agent's context. Per-entry caps already bound the parts; this
+        // is the belt-and-suspenders ceiling.
+        console.log(safeTruncate(md, 2000))
       } else {
         out.done(`Work: ${taskDescription}`)
         if (harness) {

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -25,11 +25,16 @@ import { detectAndPersistLeanDebt } from '../services/lean-detector'
 import { detectAndPersistPatterns } from '../services/pattern-detector'
 import { recordCleanupReport, runSessionCleanup } from '../services/session-cleanup'
 import { detectSkillMisses } from '../services/skill-miss-detector'
-import { parseTranscriptJsonl, type TranscriptJsonlLine } from '../services/transcript-jsonl'
+import {
+  parseTranscriptJsonl,
+  sumTranscriptUsage,
+  type TranscriptJsonlLine,
+} from '../services/transcript-jsonl'
 import { ingestTranscript } from '../services/transcript-learner'
 import { usefulnessService } from '../services/usefulness'
 import { regenerateWikiDeferred } from '../services/wiki-generator'
 import { ingestCapturedNotes, ingestWorkflowEdits } from '../services/wiki-ingest'
+import { recordTaskTokenUsage } from '../services/work-cost-service'
 import { type HookIo, runHook } from './_runner'
 
 interface HookInput {
@@ -53,6 +58,28 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         if (input.transcript_path) {
           const raw = await fs.readFile(input.transcript_path, 'utf-8').catch(() => null)
           if (raw !== null) transcriptLines = parseTranscriptJsonl(raw)
+        }
+
+        // Measure the work cycle's token cost: sum the transcript usage and
+        // write it onto the active task. Closes the work-cost coverage gap so
+        // `prjct performance` can prove prjct's net token savings. Best-effort.
+        if (transcriptLines && transcriptLines.length > 0) {
+          try {
+            const usage = sumTranscriptUsage(transcriptLines)
+            if (usage.tokensIn + usage.tokensOut > 0) {
+              const { collectActiveTasks } = await import('../services/task-overview')
+              const overview = await collectActiveTasks(config.projectId, p)
+              const taskId = overview.current?.id
+              if (taskId) {
+                recordTaskTokenUsage(config.projectId, taskId, usage.tokensIn, usage.tokensOut, {
+                  description: overview.current?.description,
+                  agent: 'claude',
+                })
+              }
+            }
+          } catch {
+            /* measurement must never block session end */
+          }
         }
 
         // Captured notes → memory entries (existing behavior).

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -14,6 +14,7 @@ import { z } from 'zod'
 import { formatLikelyFileForAgent } from '../../services/file-cue'
 import { collectActiveTasks } from '../../services/task-overview'
 import { formatRelatedContextForAgent, setTaskStatus, startTask } from '../../services/task-service'
+import { recordTaskTokenUsage } from '../../services/work-cost-service'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
 import { queueStorage } from '../../storage/queue-storage'
 import { resolveProjectId } from '../resolve'
@@ -113,13 +114,16 @@ export function registerProjectTools(server: McpServer) {
           for (const i of outcome.instructions) lines.push(`- ${i}`)
         }
         if (outcome.relatedContext && outcome.relatedContext.length > 0) {
-          lines.push('', 'Related second-brain context:')
-          for (const hit of outcome.relatedContext) {
+          lines.push('', 'Related second-brain context (pull full bodies with prjct_search):')
+          for (const hit of outcome.relatedContext.slice(0, 4)) {
             lines.push(`- ${formatRelatedContextForAgent(hit)}`)
           }
         }
         if (outcome.likelyFiles && outcome.likelyFiles.length > 0) {
-          lines.push('', 'Likely files from prjct index:')
+          lines.push(
+            '',
+            'Likely files from prjct index — read these first, do not grep-walk the repo:'
+          )
           for (const file of outcome.likelyFiles) {
             lines.push(`- ${formatLikelyFileForAgent(file)}`)
           }
@@ -131,34 +135,56 @@ export function registerProjectTools(server: McpServer) {
 
   s.tool(
     'prjct_task_set_status',
-    'Change the active work cycle status (e.g. "done", "paused", "active"). Records the transition and drives the workflow state machine through the compatibility status backend. "active"/"resume" promotes paused work back to focus.',
+    'Change the active work cycle status (e.g. "done", "paused", "active"). Records the transition and drives the workflow state machine through the compatibility status backend. "active"/"resume" promotes paused work back to focus. Optionally report this cycle\'s token usage (tokensIn/tokensOut) so prjct can measure net savings — any agent (Claude, Codex, Gemini, …) should pass its own counts when closing work.',
     {
       projectPath: z.string().describe('Project directory path'),
       status: z
         .string()
         .describe('New status: done | completed | paused | active | resume | in_progress'),
+      tokensIn: z
+        .number()
+        .optional()
+        .describe('Optional: total input tokens this work cycle consumed (any provider).'),
+      tokensOut: z
+        .number()
+        .optional()
+        .describe('Optional: total output tokens this work cycle produced (any provider).'),
     },
-    safeMcpCall('prjct_task_set_status', async (args: { projectPath: string; status: string }) => {
-      const projectId = await resolveProjectId(args.projectPath)
-      const outcome = await setTaskStatus(projectId, args.projectPath, args.status)
-      if (!outcome.ok) {
-        const text =
-          outcome.reason === 'unsupported'
-            ? outcome.message
-            : 'No active work cycle to update. Start one with prjct_task_start.'
-        return { content: [{ type: 'text', text }] }
+    safeMcpCall(
+      'prjct_task_set_status',
+      async (args: {
+        projectPath: string
+        status: string
+        tokensIn?: number
+        tokensOut?: number
+      }) => {
+        const projectId = await resolveProjectId(args.projectPath)
+        const outcome = await setTaskStatus(projectId, args.projectPath, args.status)
+        if (!outcome.ok) {
+          const text =
+            outcome.reason === 'unsupported'
+              ? outcome.message
+              : 'No active work cycle to update. Start one with prjct_task_start.'
+          return { content: [{ type: 'text', text }] }
+        }
+        // Agent-agnostic token attribution: any agent reports its own usage here
+        // (Claude also auto-records via the Stop hook transcript; both write the
+        // same column, last write wins with the authoritative total).
+        if (outcome.taskId && (args.tokensIn != null || args.tokensOut != null)) {
+          recordTaskTokenUsage(projectId, outcome.taskId, args.tokensIn ?? 0, args.tokensOut ?? 0)
+        }
+        const warnings = outcome.verificationWarnings ?? []
+        const text = [`✓ status → ${outcome.status} (task ${outcome.taskId})`]
+        if (warnings.length > 0) {
+          text.push('', 'Harness warnings:')
+          for (const warning of warnings) text.push(`- ${warning}`)
+        }
+        if (outcome.contextPrompt) text.push('', outcome.contextPrompt)
+        return {
+          content: [{ type: 'text', text: text.join('\n') }],
+        }
       }
-      const warnings = outcome.verificationWarnings ?? []
-      const text = [`✓ status → ${outcome.status} (task ${outcome.taskId})`]
-      if (warnings.length > 0) {
-        text.push('', 'Harness warnings:')
-        for (const warning of warnings) text.push(`- ${warning}`)
-      }
-      if (outcome.contextPrompt) text.push('', outcome.contextPrompt)
-      return {
-        content: [{ type: 'text', text: text.join('\n') }],
-      }
-    })
+    )
   )
 
   s.tool(

--- a/core/services/agent-rag-protocol.ts
+++ b/core/services/agent-rag-protocol.ts
@@ -8,7 +8,7 @@
 
 export const AGENT_RAG_PROTOCOL_LINES = [
   '- prjct is a RAG-backed project memory harness. Do not preload project history into agent instructions.',
-  '- Start work with `prjct work "<intent>" --md`; use the surfaced related context and likely files before planning/editing.',
+  '- Start work with `prjct work "<intent>" --md`; read the surfaced likely files FIRST and use related context before planning/editing — do not grep-walk the repo to rediscover where code lives.',
   '- Pull more context on demand with `prjct search`, `prjct context memory`, `prjct guard`, or MCP `prjct_*` tools.',
   '- The vault `_generated/` is a regenerated SQLite snapshot for Read/Glob fallback, not the source of truth and not something to load wholesale.',
   '- On close, save synthesized context via `prjct remember context "<...>"`: what changed, why it matters, key UI data, model/tokens if known, files, pattern/anti-pattern, outcome, next implication.',

--- a/core/services/file-cue.ts
+++ b/core/services/file-cue.ts
@@ -3,9 +3,34 @@ import { hasIndexes, rankFiles } from '../domain/file-ranker'
 export interface LikelyFileHit {
   path: string
   signals: string[]
+  /** One-line, honest reason this file surfaced — lets the agent trust the cue
+   *  and read it directly instead of grep-walking the repo. */
+  reason: string
 }
 
 const DEFAULT_FILE_CUE_COUNT = 5
+
+/**
+ * Translate the dominant ranking signal into a short, honest reason. The agent
+ * uses this to decide whether to open the file — a `path` alone reads as a guess,
+ * a `path — why` reads as a lead. Derived purely from signals already computed
+ * by `rankFiles` (zero extra DB work).
+ */
+function reasonFromSignals(signals: { bm25: number; imports: number; cochange: number }): string {
+  const ranked = [
+    { name: 'bm25', score: signals.bm25, label: 'matches your task terms' },
+    { name: 'imports', score: signals.imports, label: 'in the import graph of matched files' },
+    {
+      name: 'cochange',
+      score: signals.cochange,
+      label: 'historically co-changes with matched files',
+    },
+  ]
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+  if (ranked.length === 0) return 'related by prjct index'
+  return ranked[0]!.label
+}
 
 export function rankLikelyFiles(
   projectId: string,
@@ -25,12 +50,13 @@ export function rankLikelyFiles(
       file.signals.imports > 0 ? 'imports' : null,
       file.signals.cochange > 0 ? 'cochange' : null,
     ].filter((signal): signal is string => signal !== null),
+    reason: reasonFromSignals(file.signals),
   }))
 }
 
 export function formatLikelyFileForAgent(file: LikelyFileHit): string {
   const suffix = file.signals.length > 0 ? ` (${file.signals.join('+')})` : ''
-  return `\`${file.path}\`${suffix}`
+  return `\`${file.path}\` — ${file.reason}${suffix}`
 }
 
 export function buildIndexedFileCue(projectId: string, query: string): string | null {

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -95,24 +95,31 @@ export interface RelatedContextHit {
   nextImplication?: string
 }
 
+const RELATED_SALIENT_MAX = 120
+
+/**
+ * Compact but self-sufficient one-liner for the passive `work` surface:
+ * `[type] title (date) \`id\` — <single most salient field>`.
+ *
+ * The full body stays one `prjct search <id>` away. We surface only the field
+ * most likely to change what the agent does — a trap/decision/anti-pattern
+ * outranks generic "why/outcome/key data" — instead of joining every field
+ * (which ran ~500 chars/entry). Drops the passive surface to ~100 chars/entry
+ * while still carrying the actionable signal.
+ */
 export function formatRelatedContextForAgent(hit: RelatedContextHit): string {
   const when = hit.when ? hit.when.slice(0, 10) : ''
   const who = hit.author ? ` by ${hit.author}` : ''
   const meta = [when, who].filter(Boolean).join('')
-  const parts = [
-    `[${hit.type}] ${hit.title}${meta ? ` (${meta.trim()})` : ''}  \`${hit.id}\``,
-    hit.feature ? `Feature: ${hit.feature}` : null,
-    hit.keyData ? `Key data: ${hit.keyData}` : null,
-    hit.files?.length ? `Files: ${hit.files.map((file) => `\`${file}\``).join(', ')}` : null,
-    hit.why ? `Why: ${hit.why}` : null,
-    hit.pattern ? `Pattern: ${hit.pattern}` : null,
-    hit.antiPattern ? `Avoid: ${hit.antiPattern}` : null,
-    hit.decisionTrap ? `Decision/trap: ${hit.decisionTrap}` : null,
-    hit.outcome ? `Outcome: ${hit.outcome}` : null,
-    hit.nextImplication ? `Next: ${hit.nextImplication}` : null,
-    hit.detail ? `Detail: ${hit.detail}` : null,
-  ].filter((part): part is string => Boolean(part))
-  return parts.join(' — ')
+  const head = `[${hit.type}] ${hit.title}${meta ? ` (${meta.trim()})` : ''}  \`${hit.id}\``
+
+  // Priority: what would make me act differently first.
+  const salient =
+    hit.decisionTrap ?? hit.antiPattern ?? hit.why ?? hit.outcome ?? hit.keyData ?? hit.detail
+  if (!salient) return head
+  const trimmed =
+    salient.length > RELATED_SALIENT_MAX ? `${salient.slice(0, RELATED_SALIENT_MAX - 1)}…` : salient
+  return `${head} — ${trimmed}`
 }
 
 /**

--- a/core/services/transcript-jsonl.ts
+++ b/core/services/transcript-jsonl.ts
@@ -27,3 +27,63 @@ export function parseTranscriptJsonl(raw: string): TranscriptJsonlLine[] {
   }
   return out
 }
+
+export interface TranscriptUsage {
+  tokensIn: number
+  tokensOut: number
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+/**
+ * Pull an {in,out} usage pair from a single usage object, tolerant of every
+ * major provider's field naming so prjct's token accounting is agent-agnostic
+ * (Claude, OpenAI/Codex, Gemini), not Claude-only:
+ *   - Claude   : input_tokens / output_tokens (+ cache_creation/read as input)
+ *   - OpenAI   : prompt_tokens / completion_tokens (Chat); input_tokens/output_tokens (Responses)
+ *   - Gemini   : promptTokenCount / candidatesTokenCount
+ * Cache reads/creations count as input — real billed input the cycle incurred.
+ */
+function usagePairFrom(usage: Record<string, unknown>): TranscriptUsage {
+  const tokensIn =
+    num(usage.input_tokens) +
+    num(usage.cache_creation_input_tokens) +
+    num(usage.cache_read_input_tokens) +
+    num(usage.prompt_tokens) +
+    num(usage.promptTokenCount)
+  const tokensOut =
+    num(usage.output_tokens) + num(usage.completion_tokens) + num(usage.candidatesTokenCount)
+  return { tokensIn, tokensOut }
+}
+
+/**
+ * Sum input/output token usage across the assistant turns in a transcript.
+ *
+ * Looks for a usage object in the shapes the supported agents emit
+ * (`message.usage`, top-level `usage`, or Gemini's `usageMetadata`) and sums
+ * via {@link usagePairFrom}. This feeds `tasks.tokens_in/out`, which closes the
+ * work-cost coverage gap (the whole point: prove prjct's net token savings).
+ * Non-Claude agents that don't write a readable transcript report tokens
+ * instead via the `prjct_task_set_status` MCP tool / `prjct status` CLI.
+ */
+export function sumTranscriptUsage(lines: TranscriptJsonlLine[]): TranscriptUsage {
+  let tokensIn = 0
+  let tokensOut = 0
+  for (const line of lines) {
+    const usage =
+      asRecord(asRecord(line.message)?.usage) ??
+      asRecord(line.usage) ??
+      asRecord(line.usageMetadata)
+    if (!usage) continue
+    const pair = usagePairFrom(usage)
+    tokensIn += pair.tokensIn
+    tokensOut += pair.tokensOut
+  }
+  return { tokensIn, tokensOut }
+}

--- a/core/services/work-cost-service.ts
+++ b/core/services/work-cost-service.ts
@@ -83,6 +83,108 @@ export interface WorkCostSnapshot {
   gaps: string[]
 }
 
+export const TASK_TOKENS_EVENT = 'memory.task_tokens'
+
+/**
+ * Persist measured token usage for a work cycle. Agent-agnostic: any agent
+ * (Claude via the Stop-hook transcript, or Codex/Gemini/… via the
+ * `prjct_task_set_status` MCP tool / `prjct status --tokens-*` CLI) records the
+ * same way, so `tokenCoveragePercent` becomes real — the prerequisite for
+ * proving prjct's net token savings.
+ *
+ * Primary write is an EVENT (prjct's north star: inputs are events to process,
+ * not rows to dump), keyed by task so the snapshot can aggregate it even though
+ * the live work flow keeps state in state-storage, not the legacy `tasks`
+ * table. We also mirror onto `tasks` best-effort for migrated installs. SET
+ * semantics: the latest report is the authoritative cumulative total.
+ * Never throws.
+ */
+export function recordTaskTokenUsage(
+  projectId: string,
+  taskId: string,
+  tokensIn: number,
+  tokensOut: number,
+  meta?: { description?: string; agent?: string }
+): void {
+  if (!taskId || tokensIn + tokensOut <= 0) return
+  const ti = Math.round(tokensIn)
+  const to = Math.round(tokensOut)
+  try {
+    prjctDb.appendEvent(
+      projectId,
+      TASK_TOKENS_EVENT,
+      {
+        taskId,
+        tokensIn: ti,
+        tokensOut: to,
+        ...(meta?.description ? { description: meta.description } : {}),
+        ...(meta?.agent ? { agent: meta.agent } : {}),
+      },
+      taskId
+    )
+  } catch {
+    /* measurement must never block the caller */
+  }
+  try {
+    prjctDb.run(
+      projectId,
+      'UPDATE tasks SET tokens_in = ?, tokens_out = ? WHERE id = ?',
+      ti,
+      to,
+      taskId
+    )
+  } catch {
+    /* best-effort mirror — the event is the source of truth */
+  }
+}
+
+interface TokenEventRow {
+  task_id: string | null
+  data: string
+}
+
+/**
+ * Aggregate measured token usage from `memory.task_tokens` events in the
+ * window, one cycle per task (latest event wins — SET semantics). This is what
+ * makes measurement work for the live flow, where work cycles never land in the
+ * `tasks` table.
+ */
+function measuredCyclesFromEvents(projectId: string, since: string): Map<string, WorkCostTask> {
+  const rows = query<TokenEventRow>(
+    projectId,
+    `SELECT task_id, data
+     FROM events
+     WHERE type = ? AND timestamp >= ? AND json_valid(data)
+     ORDER BY id DESC`,
+    TASK_TOKENS_EVENT,
+    since
+  )
+  const byTask = new Map<string, WorkCostTask>()
+  for (const row of rows) {
+    let parsed: { taskId?: string; tokensIn?: number; tokensOut?: number; description?: string }
+    try {
+      parsed = JSON.parse(row.data)
+    } catch {
+      continue
+    }
+    const id = row.task_id ?? parsed.taskId
+    if (!id || byTask.has(id)) continue // first seen = latest (DESC) = authoritative
+    const tokensIn = nullableNumber(parsed.tokensIn ?? null) ?? 0
+    const tokensOut = nullableNumber(parsed.tokensOut ?? null) ?? 0
+    if (tokensIn + tokensOut <= 0) continue
+    byTask.set(id, {
+      id,
+      description: parsed.description ?? id,
+      status: 'measured',
+      tokensIn,
+      tokensOut,
+      tokensTotal: tokensIn + tokensOut,
+      minutes: null,
+    })
+  }
+  return byTask
+}
+
 export function buildWorkCostSnapshot(projectId: string, days: number): WorkCostSnapshot {
   const since = sinceIso(days)
   const now = new Date().toISOString()
@@ -94,10 +196,17 @@ export function buildWorkCostSnapshot(projectId: string, days: number): WorkCost
      ORDER BY COALESCE(completed_at, shipped_at, started_at) DESC`,
     since
   )
-  const measuredTasks = taskRows
-    .map(toCostTask)
-    .filter((task): task is WorkCostTask => task !== null)
-    .sort((a, b) => b.tokensTotal - a.tokensTotal)
+  // Merge two measurement sources, event wins (it's the authoritative latest
+  // SET and the only one the live flow actually populates): the legacy `tasks`
+  // table (migrated installs) and `memory.task_tokens` events (every agent).
+  const merged = new Map<string, WorkCostTask>()
+  for (const task of taskRows.map(toCostTask)) {
+    if (task) merged.set(task.id, task)
+  }
+  for (const [id, cycle] of measuredCyclesFromEvents(projectId, since)) {
+    merged.set(id, cycle)
+  }
+  const measuredTasks = [...merged.values()].sort((a, b) => b.tokensTotal - a.tokensTotal)
 
   const eventWorkStarts = eventCount(projectId, 'memory.task_started', since)
   const eventStatusChanges = eventCount(projectId, 'memory.status.changed', since)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Context

A recent `prjct work` cycle burned ~90k tokens. The goal: prjct must net out **cheaper** than working without it. Diagnosis showed the cost wasn't prjct's own injection (~2-5k/turn, hooks already budgeted) — it was the agent grep-walking the repo to rediscover code (the same "55k-token exploration" issue from mem_3926/mem_3923). All changes are **agent-agnostic** (Claude, Codex, Gemini, Cursor, …), not Claude-only.

## What changed

**1 · Anti-exploration file surfacing (biggest net win)**
- `file-cue.ts`: each likely file now carries an honest one-line reason derived from its dominant ranking signal (`matches your task terms` / `in the import graph` / `co-changes`).
- Explicit "read these first, don't grep-walk the repo" directive in `work --md`, MCP `prjct_task_start`, and `agent-rag-protocol.ts` (propagated to AGENTS.md/CLAUDE.md).

**2 · Compact, self-sufficient emission**
- `formatRelatedContextForAgent`: ~500 chars (all fields joined) → ~100-char one-liner (`[type] title (date) id — most-salient field`); full body on demand via `prjct search`.
- Related context capped to 4 on the work surface; `work --md` wrapped in `safeTruncate(2000)`; Next Steps trimmed 4→2.

**3 · Net-savings measurement (agent-agnostic)**
- `sumTranscriptUsage` parses Claude / OpenAI / Gemini usage shapes.
- Root-cause fix: the legacy `tasks` SQL table is empty in live installs, so the old `UPDATE tasks` no-op'd. `recordTaskTokenUsage` now emits a durable `memory.task_tokens` event (prjct's event north-star) that `buildWorkCostSnapshot` aggregates (latest-per-task SET semantics).
- Entry points per agent: Claude → Stop-hook transcript; others → `prjct_task_set_status` MCP token params **or** `prjct status done --tokens-in N --tokens-out N` CLI.
- `insights cost --md` gains a **Net Savings vs. Baseline** block.

## Verification
- typecheck clean, biome clean, full suite **1837 pass / 0 fail** (3 new test files).
- E2E on local v3.8.0: `work` → `status done --tokens-in 18000 --tokens-out 4000` → `insights cost --md` shows 1 measured cycle, 22k total, Net Savings block renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)