### PR TITLE
fix(test): sandbox HOME so the suite can't overwrite the real ~/.claude/CLAUDE.md

### DIFF
--- a/core/__tests__/_setup/reset-singletons.ts
+++ b/core/__tests__/_setup/reset-singletons.ts
@@ -49,6 +49,37 @@ if (!process.env.PRJCT_VAULT_ROOT) {
   })
 }
 
+// Sandbox the interactive user's HOME for the ENTIRE test process.
+//
+// The global agent-config writer (`installGlobalConfig`) resolves its
+// destination via `resolveUserHome()` → `~/.claude/CLAUDE.md`, honoring
+// `process.env.HOME`. Many tests transitively trigger it (sync-service, setup,
+// self-heal, install-flow, …), so on a dev machine the suite OVERWRITES the
+// user's real `~/.claude/CLAUDE.md` — injecting the throwaway PRJCT_VAULT_ROOT
+// path into their global instructions. Redirecting HOME to a throwaway dir
+// keeps every home-relative write (agent config, `~/.prjct-cli` fallback) out
+// of the real home. Git-using tests set their identity locally per repo
+// (`git config user.email …`), so they don't depend on the real `~/.gitconfig`.
+// Set before any test imports the path manager so it's in effect process-wide.
+if (!process.env.PRJCT_TEST_HOME) {
+  const homeSandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-test-home-'))
+  process.env.PRJCT_TEST_HOME = homeSandbox
+  process.env.HOME = homeSandbox
+  process.env.USERPROFILE = homeSandbox
+  const cleanupHome = () => {
+    try {
+      fs.rmSync(homeSandbox, { recursive: true, force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+  process.on('exit', cleanupHome)
+  process.on('SIGINT', () => {
+    cleanupHome()
+    process.exit(130)
+  })
+}
+
 // Deterministic agent detection for the whole test process.
 //
 // `agentService` only accepts agent type `claude` (VALID_AGENT_TYPES), but


### PR DESCRIPTION
## Problem

Running the full `bun test` suite on a dev machine **overwrites the user's real `~/.claude/CLAUDE.md`** — injecting the throwaway test vault path (`/var/folders/.../prjct-test-vault-XXXX/<slug>/_generated/`) into their global agent instructions.

Root cause: the global agent-config writer `installGlobalConfig` (core/infrastructure/command-installer/global-config.ts) resolves its destination via `resolveUserHome()` → `~/.claude/CLAUDE.md`, honoring `process.env.HOME`. The preload already sandboxes the vault root (`PRJCT_VAULT_ROOT`), but **not** the write destination. Many tests transitively trigger the writer (sync-service, setup, self-heal, install-flow, wiki-incremental, codex-skill), so the real home file gets clobbered.

## Fix

Redirect `HOME` (and `USERPROFILE`) to a throwaway temp dir in the global test preload `core/__tests__/_setup/reset-singletons.ts`, mirroring the existing `PRJCT_VAULT_ROOT` sandbox block (created once, cleaned up on exit/SIGINT). Every home-relative write (agent config, `~/.prjct-cli` fallback) now lands in the sandbox instead of the real home.

Git-using tests set their identity **locally per repo** (`git config user.email …`), so they don't depend on the real `~/.gitconfig` — sandboxing HOME is safe.

Notably this does **not** fold the override into `resolveUserHome()`/`PRJCT_CLI_HOME`: `.claude` intentionally uses the real home in production, and reusing `PRJCT_CLI_HOME` would relocate `.claude` for real users who set it to move `~/.prjct-cli`.

## Verification
- Full suite **1829 pass / 0 fail**.
- `md5 ~/.claude/CLAUDE.md` is **identical before and after** running the writer-triggering tests and the full suite (previously it changed every run).

Relates to the leak family in mem_1988 (test-isolation in bun test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)