### PR TITLE
fix(ci): unblock npm publish — make pre-commit biome check tolerate an all-ignored staged set

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,9 +17,16 @@ pre-commit:
       # bare `biome check .` reports "No files were processed" and exits 1,
       # blocking every commit. Explicit file args are force-checked regardless
       # of the ignore list, and only linting staged files is faster anyway.
+      #
+      # `--no-errors-on-unmatched`: when EVERY staged file is biome-ignored
+      # (e.g. a lone regenerated package-lock.json, or AGENTS.md), biome would
+      # otherwise exit 1 with "No files were processed" and block the commit —
+      # a false positive that was failing the release CI commit and ad-hoc
+      # docs-only commits. Real files are still fully linted; we only stop
+      # treating "nothing to lint" as an error.
       run: |
-        if command -v bun >/dev/null 2>&1; then bunx biome check {staged_files}
-        elif command -v npm >/dev/null 2>&1; then npx biome check {staged_files}
+        if command -v bun >/dev/null 2>&1; then bunx biome check --no-errors-on-unmatched {staged_files}
+        elif command -v npm >/dev/null 2>&1; then npx biome check --no-errors-on-unmatched {staged_files}
         else echo "Neither bun nor npm found in PATH" >&2; exit 1
         fi
       stage_fixed: true


### PR DESCRIPTION
## Problem

`v3.7.0` and `v3.8.0` were bumped on `main` but **never published to npm** (still `3.6.0`). The Release workflow's `Commit and tag` step fails:

```
× No files were processed in the specified paths.
  - package-lock.json
exit code 1
```

Root cause: the step runs `git add -A` then `git commit`. When `npm install` regenerates `package-lock.json` as the only staged change, the **lefthook pre-commit hook** runs `biome check {staged_files}` on a biome-ignored file, exits 1 ("No files were processed"), and fails the whole Release job before `npm publish`. The same false positive also blocks ad-hoc docs-only commits (e.g. a lone `AGENTS.md`).

## Fix

Fix the **hook**, not the symptom — no `--no-verify` bypass, so quality gating stays fully in force. Add `--no-errors-on-unmatched` to the lefthook `biome check`: when every staged file is biome-ignored, biome exits 0 instead of erroring; real files are still fully linted.

Verified locally:
- staged set = only an ignored file (`package-lock.json`) → exit **0**
- an in-project file with a real lint/format error → still exit **1**

## After merge
This push re-triggers Release, which will publish the pending **3.8.0** to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)