### PR TITLE
fix: backfill historical ships to cloud on sync

### DIFF
--- a/core/__tests__/storage/shipped-storage-backfill.test.ts
+++ b/core/__tests__/storage/shipped-storage-backfill.test.ts
@@ -1,0 +1,63 @@
+/**
+ * ShippedStorage.republishShips — one-time historical-ship backfill.
+ *
+ * Ships shipped before the canonical-event fix were emitted off-contract
+ * (`feature.shipped` → `features`) and dropped at /sync/batch. republishShips
+ * re-emits every locally-stored ship as `shipped_item.created` (entity_type
+ * `shipped_items`, top-level `id`) so they finally reach the cloud — guarded by
+ * a per-project kv flag so it runs exactly once.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { syncEventBus } from '../../events/sync-events'
+import prjctDb from '../../storage/database'
+import { shippedStorage } from '../../storage/shipped-storage'
+
+let tempProjectsDir: string
+let originalProjectsDir: string | undefined
+let projectId: string
+
+describe('ShippedStorage.republishShips backfill', () => {
+  beforeEach(async () => {
+    tempProjectsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-ship-backfill-'))
+    originalProjectsDir = process.env.PRJCT_PROJECTS_DIR
+    process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+    projectId = `ship-bf-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+  })
+
+  afterEach(async () => {
+    if (originalProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+    else process.env.PRJCT_PROJECTS_DIR = originalProjectsDir
+    await fs.rm(tempProjectsDir, { recursive: true, force: true })
+  })
+
+  test('re-publishes each local ship as a canonical shipped_items event, exactly once', async () => {
+    await shippedStorage.addShipped(projectId, { name: 'Auth', version: '1.0.0' })
+    await shippedStorage.addShipped(projectId, { name: 'Billing', version: '1.1.0' })
+    // Isolate the backfill from the addShipped publishes above.
+    await syncEventBus.clearPending(projectId)
+
+    const count = await shippedStorage.republishShips(projectId)
+    expect(count).toBe(2)
+
+    const pending = await syncEventBus.getPending(projectId)
+    const ships = pending.filter((e) => e.entityType === 'shipped_items')
+    expect(ships.length).toBe(2)
+    for (const e of ships) {
+      expect(e.eventType).toBe('upsert')
+      expect(e.entityId).toBeTruthy() // recognized via top-level `id`
+      expect((e.data as Record<string, unknown>).id).toBe(e.entityId)
+    }
+
+    // Second run is a no-op — the per-project flag is set.
+    await syncEventBus.clearPending(projectId)
+    const again = await shippedStorage.republishShips(projectId)
+    expect(again).toBe(0)
+    const pendingAfter = await syncEventBus.getPending(projectId)
+    expect(pendingAfter.filter((e) => e.entityType === 'shipped_items').length).toBe(0)
+  })
+})

--- a/core/storage/shipped-storage.ts
+++ b/core/storage/shipped-storage.ts
@@ -10,7 +10,12 @@ import { ShippedJsonSchema } from '../schemas/shipped'
 import type { ShippedFeature, ShippedJson } from '../types/storage'
 import { getDaysAgo, getTimestamp } from '../utils/date-helper'
 import { ARCHIVE_POLICIES, archiveStorage } from './archive-storage'
+import { prjctDb } from './database'
 import { StorageManager } from './storage-manager'
+
+// Per-project guard so the historical-ship backfill runs once. Bump the suffix
+// to force a re-backfill in a future release.
+const SHIP_BACKFILL_FLAG = 'shipped:backfilled:v1'
 
 class ShippedStorage extends StorageManager<ShippedJson> {
   constructor() {
@@ -36,6 +41,31 @@ class ShippedStorage extends StorageManager<ShippedJson> {
   async getAll(projectId: string): Promise<ShippedFeature[]> {
     const data = await this.read(projectId)
     return data.shipped
+  }
+
+  /**
+   * One-time backfill: re-publish every locally-stored ship as a canonical
+   * `shipped_item.created` event so ships shipped BEFORE the canonical-event fix
+   * (which previously emitted off-contract `feature.shipped` and were dropped at
+   * /sync/batch) finally reach the cloud. Guarded by a per-project kv flag so it
+   * runs once; idempotent server-side via (project_id, entity_id, content_hash)
+   * dedup. Returns the number of ships re-published (0 if already backfilled).
+   */
+  async republishShips(projectId: string): Promise<number> {
+    if (prjctDb.getDoc<{ at: string }>(projectId, SHIP_BACKFILL_FLAG)) return 0
+    const data = await this.read(projectId)
+    const ships = Array.isArray(data.shipped) ? data.shipped : []
+    for (const ship of ships) {
+      await this.publishEvent(projectId, 'shipped_item.created', {
+        id: ship.id,
+        shipId: ship.id,
+        name: ship.name,
+        version: ship.version,
+        shippedAt: ship.shippedAt,
+      })
+    }
+    prjctDb.setDoc(projectId, SHIP_BACKFILL_FLAG, { at: getTimestamp(), count: ships.length })
+    return ships.length
   }
 
   /**

--- a/core/sync/sync-manager.ts
+++ b/core/sync/sync-manager.ts
@@ -7,6 +7,7 @@
 
 import { syncEventBus } from '../events/sync-events'
 import { buildProjectMeta } from '../services/sync/project-meta'
+import { shippedStorage } from '../storage/shipped-storage'
 import type { SyncEvent } from '../types/events'
 import type {
   PullResult,
@@ -192,6 +193,15 @@ class SyncManager {
     }
 
     const result: SyncResult = { success: true, skipped: false }
+
+    // One-time per project: re-publish historical ships as canonical events so
+    // ships shipped before the canonical-event fix reach the cloud. Best-effort
+    // — the enqueued events ride the push below; the normal queue owns delivery.
+    try {
+      await shippedStorage.republishShips(projectId)
+    } catch {
+      // never block sync on the backfill
+    }
 
     // Push first
     const pushResult = await this.push(projectId, opts)


### PR DESCRIPTION
## Problem
Ships shipped **before** the canonical-event fix (v3.8.0) were emitted off-contract (`feature.shipped` → `features`, payload had only `shipId`) and silently dropped at `/sync/batch`. They never reached the cloud, so the web project-detail page shows no ships even though multiple exist locally. The v3.8.0 fix only corrected *new* ships.

## Fix
- `ShippedStorage.republishShips(projectId)` — re-emits every locally-stored ship as a canonical `shipped_item.created` event (top-level `id` → `entity_type` `shipped_items`).
- Guarded by a per-project kv flag `shipped:backfilled:v1` → runs **once per project**. Idempotent via `content_hash` + server-side `(project_id, entity_id, content_hash)` dedup, so re-runs/duplicate ships don't create duplicates.
- Hooked best-effort at the start of `SyncManager.sync()` (before push) so the republished events ride the same batch; never blocks sync on failure.

## Test
`core/__tests__/storage/shipped-storage-backfill.test.ts` — verifies N local ships re-publish as canonical events with recognized entity ids, and the second run is a no-op (flag set).

Typecheck + full suite green (164 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)