### PR TITLE
fix: make prjct harness-agnostic across LLMs (Codex/Gemini) + sandbox-safe

### DIFF
--- a/core/__tests__/infrastructure/agent-detector.test.ts
+++ b/core/__tests__/infrastructure/agent-detector.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Sandbox detection — `sandboxed` was historically hardcoded false; it now
+ * derives from CODEX_SANDBOX / PRJCT_SANDBOX so write-error messaging and any
+ * future degraded-mode branching can react to a restricted harness (Codex).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { isSandboxed } from '../../infrastructure/agent-detector'
+
+let prevCodex: string | undefined
+let prevPrjct: string | undefined
+
+beforeEach(() => {
+  prevCodex = process.env.CODEX_SANDBOX
+  prevPrjct = process.env.PRJCT_SANDBOX
+  delete process.env.CODEX_SANDBOX
+  delete process.env.PRJCT_SANDBOX
+})
+
+afterEach(() => {
+  if (prevCodex === undefined) delete process.env.CODEX_SANDBOX
+  else process.env.CODEX_SANDBOX = prevCodex
+  if (prevPrjct === undefined) delete process.env.PRJCT_SANDBOX
+  else process.env.PRJCT_SANDBOX = prevPrjct
+})
+
+describe('isSandboxed', () => {
+  it('is false with no sandbox signal', () => {
+    expect(isSandboxed()).toBe(false)
+  })
+
+  it('is true under CODEX_SANDBOX', () => {
+    process.env.CODEX_SANDBOX = 'seatbelt'
+    expect(isSandboxed()).toBe(true)
+  })
+
+  it('is true under PRJCT_SANDBOX=1', () => {
+    process.env.PRJCT_SANDBOX = '1'
+    expect(isSandboxed()).toBe(true)
+  })
+})

--- a/core/__tests__/services/context7-service-provider.test.ts
+++ b/core/__tests__/services/context7-service-provider.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Context7 is provider-aware: it configures into the ACTIVE harness's MCP
+ * config (Claude → mcp.json, Codex → config.toml) and treats unmanaged
+ * providers as a non-error skip. This is what unblocks `prjct sync` for
+ * non-Claude harnesses — the smoke check is stubbed out here via
+ * PRJCT_SKIP_CONTEXT7_SMOKE so we exercise config wiring, not the network.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import context7Service from '../../services/context7-service'
+import { codexHasContext7Server, getCodexConfigTomlPath } from '../../utils/codex-mcp'
+
+let home: string
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-c7-provider-'))
+  for (const k of ['HOME', 'PRJCT_TEST_MODE', 'NODE_ENV', 'PRJCT_SKIP_CONTEXT7_SMOKE']) {
+    saved[k] = process.env[k]
+  }
+  process.env.HOME = home
+  process.env.PRJCT_TEST_MODE = '1' // route Codex config.toml under the temp home
+  process.env.NODE_ENV = 'test' // route the verify cache to a temp path
+  process.env.PRJCT_SKIP_CONTEXT7_SMOKE = '1' // skip the npx network smoke check
+})
+
+afterEach(async () => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+  await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('context7Service provider-awareness', () => {
+  it('install("codex") registers context7 in config.toml', async () => {
+    const status = await context7Service.install('codex')
+    expect(status.installed).toBe(true)
+    expect(status.configPath).toBe(getCodexConfigTomlPath())
+    expect(await codexHasContext7Server()).toBe(true)
+  })
+
+  it('ensureReady("codex") succeeds once configured (smoke skipped)', async () => {
+    const status = await context7Service.ensureReady('codex')
+    expect(status.verified).toBe(true)
+    expect(await codexHasContext7Server()).toBe(true)
+  })
+
+  it('install() for an unmanaged provider is a non-error skip', async () => {
+    const status = await context7Service.install('gemini')
+    expect(status.installed).toBe(false)
+    expect(status.message).toMatch(/not supported|skipping/i)
+  })
+
+  it('ensureReady() rejects for an unmanaged provider', async () => {
+    await expect(context7Service.ensureReady('gemini')).rejects.toThrow()
+  })
+})

--- a/core/__tests__/services/task-service-verb-guard.test.ts
+++ b/core/__tests__/services/task-service-verb-guard.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Verb-collision guard — agents on non-Claude harnesses (Codex) wrap a bare
+ * CLI verb as a work intent (`prjct work "sync"`). startTask must reject a lone
+ * registered verb BEFORE any state mutation and point at the real command.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { startTask } from '../../services/task-service'
+
+describe('startTask verb-collision guard', () => {
+  it('rejects a bare registered verb and suggests the real command', async () => {
+    const r = await startTask('proj', '/nope', 'sync')
+    expect(r.ok).toBe(false)
+    expect(r.blocked).toContain('prjct sync')
+  })
+
+  it('rejects regardless of casing/whitespace', async () => {
+    const r = await startTask('proj', '/nope', '  Ship  ')
+    expect(r.ok).toBe(false)
+    expect(r.blocked).toContain('prjct ship')
+  })
+
+  it('does not block a real multi-word task description', async () => {
+    // Reaches past the guard; fails later on the missing project, NOT on the
+    // collision guard — so the message must not be the verb-collision one.
+    const r = await startTask('proj', '/nope', 'fix the sync flow').catch((e) => ({
+      ok: false as const,
+      blocked: String(e),
+    }))
+    if (r.ok === false && r.blocked) {
+      expect(r.blocked).not.toContain('is a prjct command')
+    }
+  })
+})

--- a/core/__tests__/types/fs-error.test.ts
+++ b/core/__tests__/types/fs-error.test.ts
@@ -1,0 +1,51 @@
+/**
+ * fs write-error translation — the sandboxed-agent (Codex read-only home) path.
+ * Pins that read-only / permission failures become one actionable line and
+ * that unrelated errors are reported verbatim.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { describeFsWriteError, isReadonlyError } from '../../types/fs'
+
+function nodeError(code: string, message = code): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException
+  err.code = code
+  return err
+}
+
+describe('isReadonlyError', () => {
+  it('detects EROFS and SQLITE_READONLY codes', () => {
+    expect(isReadonlyError(nodeError('EROFS'))).toBe(true)
+    expect(isReadonlyError(nodeError('SQLITE_READONLY'))).toBe(true)
+  })
+
+  it('detects the SQLite readonly message without a code', () => {
+    expect(isReadonlyError(new Error('attempt to write a readonly database'))).toBe(true)
+  })
+
+  it('is false for unrelated errors', () => {
+    expect(isReadonlyError(nodeError('ENOSPC'))).toBe(false)
+    expect(isReadonlyError(new Error('boom'))).toBe(false)
+  })
+})
+
+describe('describeFsWriteError', () => {
+  it('gives an actionable sandbox hint for read-only failures', () => {
+    const msg = describeFsWriteError(nodeError('EROFS'), '/home/x/.prjct-cli/db', 'database')
+    expect(msg).toContain('/home/x/.prjct-cli/db')
+    expect(msg).toContain('database')
+    expect(msg).toMatch(/sandbox|read-only/i)
+    expect(msg).toContain('approve')
+  })
+
+  it('treats EPERM/EACCES as sandbox-class failures', () => {
+    expect(describeFsWriteError(nodeError('EPERM'), '/p', 'config')).toMatch(/sandbox|read-only/i)
+    expect(describeFsWriteError(nodeError('EACCES'), '/p', 'config')).toMatch(/sandbox|read-only/i)
+  })
+
+  it('reports unrelated errors verbatim', () => {
+    const msg = describeFsWriteError(nodeError('ENOSPC', 'no space left'), '/p', 'file')
+    expect(msg).toContain('no space left')
+    expect(msg).not.toMatch(/approve/)
+  })
+})

--- a/core/__tests__/utils/codex-mcp.test.ts
+++ b/core/__tests__/utils/codex-mcp.test.ts
@@ -17,7 +17,10 @@ import os from 'node:os'
 import path from 'node:path'
 import {
   buildCodexStatusLineToml,
+  buildContext7McpTomlBlock,
   buildPrjctMcpTomlBlock,
+  codexHasContext7Server,
+  ensureCodexContext7Server,
   ensureCodexMcpServer,
 } from '../../utils/codex-mcp'
 
@@ -119,6 +122,59 @@ describe('ensureCodexMcpServer', () => {
     expect(body).toContain(
       '[tui]\nstatus_line = ["model-with-reasoning", "current-dir", "git-branch", "context-remaining", "five-hour-limit", "weekly-limit", "task-progress"]\nraw_output_mode = true'
     )
+  })
+})
+
+describe('ensureCodexContext7Server', () => {
+  it('creates config.toml with the context7 server when missing', async () => {
+    const r = await ensureCodexContext7Server(configPath)
+    expect(r.changed).toBe(true)
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('[mcp_servers.context7]')
+    expect(body).toContain('# prjct:mcp:context7:start')
+    expect(body).toContain('# prjct:mcp:context7:end')
+    expect(await codexHasContext7Server(configPath)).toBe(true)
+  })
+
+  it('co-exists with the prjct MCP block (both managed independently)', async () => {
+    await ensureCodexMcpServer(configPath)
+    await ensureCodexContext7Server(configPath)
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('[mcp_servers.prjct]')
+    expect(body).toContain('[mcp_servers.context7]')
+    // Exactly one of each — no accumulation.
+    expect(body.split('[mcp_servers.prjct]').length - 1).toBe(1)
+    expect(body.split('[mcp_servers.context7]').length - 1).toBe(1)
+  })
+
+  it('is idempotent — second run reports unchanged', async () => {
+    await ensureCodexContext7Server(configPath)
+    const first = await fs.readFile(configPath, 'utf-8')
+    const r = await ensureCodexContext7Server(configPath)
+    expect(r.changed).toBe(false)
+    expect(await fs.readFile(configPath, 'utf-8')).toBe(first)
+  })
+
+  it('preserves a user-managed [mcp_servers.context7] entry', async () => {
+    const user = '[mcp_servers.context7]\ncommand = "my-context7"\nargs = []\n'
+    await fs.writeFile(configPath, user, 'utf-8')
+    const r = await ensureCodexContext7Server(configPath)
+    expect(r.skipped).toBe('user-managed')
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('command = "my-context7"')
+  })
+
+  it('codexHasContext7Server is false for a missing file', async () => {
+    expect(await codexHasContext7Server(path.join(dir, 'nope.toml'))).toBe(false)
+  })
+})
+
+describe('buildContext7McpTomlBlock', () => {
+  it('emits a context7 table with its own markers', () => {
+    const block = buildContext7McpTomlBlock()
+    expect(block).toContain('[mcp_servers.context7]')
+    expect(block).toContain('# prjct:mcp:context7:start')
+    expect(block).not.toContain('description')
   })
 })
 

--- a/core/commands/setup/mcp.ts
+++ b/core/commands/setup/mcp.ts
@@ -10,7 +10,7 @@
 import { detectCodex, detectKimi } from '../../infrastructure/ai-provider'
 import context7Service from '../../services/context7-service'
 import { getErrorMessage } from '../../types/fs'
-import { ensureCodexMcpServer } from '../../utils/codex-mcp'
+import { ensureCodexContext7Server, ensureCodexMcpServer } from '../../utils/codex-mcp'
 import { ensureKimiMcpServer } from '../../utils/kimi-mcp'
 import {
   getClaudeMcpConfigPath,
@@ -77,10 +77,12 @@ export async function setupMcpServers(
     const codex = await detectCodex()
     if (codex.installed) {
       const result = await ensureCodexMcpServer()
+      // Give Codex the same Context7 capability Claude gets via mcp.json.
+      const context7 = await ensureCodexContext7Server()
       if (!options.silent) {
         if (result.skipped === 'user-managed') {
           console.log('✅ prjct Codex config ready (MCP user-managed)')
-        } else if (result.changed) {
+        } else if (result.changed || context7.changed) {
           console.log('✅ prjct Codex config updated in ~/.codex/config.toml')
         } else {
           console.log('✅ prjct Codex config already ready')

--- a/core/infrastructure/agent-detector.ts
+++ b/core/infrastructure/agent-detector.ts
@@ -106,9 +106,24 @@ function getTerminalAgent(): DetectedAgent {
   return { ...TERMINAL_AGENT }
 }
 
+/**
+ * Whether prjct is running inside a restricted sandbox (e.g. OpenAI Codex
+ * executes shell commands in one). `CODEX_SANDBOX` is the documented signal;
+ * `PRJCT_SANDBOX=1` lets any harness or test opt in. Used to tune error
+ * messaging — a write failure in a sandbox needs an "approve access" hint, not
+ * a "your disk is broken" one.
+ */
+export function isSandboxed(): boolean {
+  return Boolean(process.env.CODEX_SANDBOX || process.env.PRJCT_SANDBOX === '1')
+}
+
 export async function detect(): Promise<DetectedAgent> {
   if (cachedAgent) return cachedAgent
 
-  cachedAgent = (await isClaudeEnvironment()) ? getClaudeAgent() : getTerminalAgent()
+  const agent = (await isClaudeEnvironment()) ? getClaudeAgent() : getTerminalAgent()
+  // The `sandboxed` flag was historically hardcoded false; derive it at runtime
+  // so downstream consumers can branch on it.
+  agent.environment = { ...agent.environment, sandboxed: isSandboxed() }
+  cachedAgent = agent
   return cachedAgent
 }

--- a/core/services/context7-service.ts
+++ b/core/services/context7-service.ts
@@ -7,6 +7,11 @@ import { CONTEXT7_VERIFY_TTL_MS } from '../constants/timings'
 import { resolveCliHome } from '../infrastructure/cli-home'
 import { getErrorMessage, isNotFoundError } from '../types/fs'
 import type { Context7Status } from '../types/services.js'
+import {
+  codexHasContext7Server,
+  ensureCodexContext7Server,
+  getCodexConfigTomlPath,
+} from '../utils/codex-mcp'
 import { execFileAsync } from '../utils/exec'
 import { writeJson } from '../utils/file-helper'
 import { MCP_SERVER_PRESETS } from '../utils/mcp-config'
@@ -23,22 +28,31 @@ export function getVerifyCachePath(): string {
   return path.join(resolveCliHome(), 'state', 'context7-verify.json')
 }
 
-async function readPersistedVerify(): Promise<{ at: number; status: Context7Status } | null> {
+type PersistedVerify = { at: number; provider: string; status: Context7Status }
+
+async function readPersistedVerify(): Promise<PersistedVerify | null> {
   try {
     const raw = await fs.readFile(getVerifyCachePath(), 'utf-8')
-    const parsed = JSON.parse(raw) as { at: number; status: Context7Status }
-    if (typeof parsed?.at === 'number' && parsed.status) return parsed
+    const parsed = JSON.parse(raw) as PersistedVerify
+    // `provider` defaults to 'claude' for caches written before provider-awareness.
+    if (typeof parsed?.at === 'number' && parsed.status) {
+      return { ...parsed, provider: parsed.provider ?? 'claude' }
+    }
   } catch {
     // missing / corrupt — fall through to fresh verify
   }
   return null
 }
 
-async function writePersistedVerify(at: number, status: Context7Status): Promise<void> {
+async function writePersistedVerify(
+  at: number,
+  provider: string,
+  status: Context7Status
+): Promise<void> {
   const file = getVerifyCachePath()
   try {
     await fs.mkdir(path.dirname(file), { recursive: true })
-    await fs.writeFile(file, JSON.stringify({ at, status }), 'utf-8')
+    await fs.writeFile(file, JSON.stringify({ at, provider, status }), 'utf-8')
   } catch {
     // best-effort; cache miss is acceptable
   }
@@ -55,7 +69,7 @@ interface Context7TemplateConfig {
 }
 
 const CONTEXT7_DEFAULT = MCP_SERVER_PRESETS.context7
-let cachedVerify: { at: number; status: Context7Status } | null = null
+let cachedVerify: { at: number; provider: string; status: Context7Status } | null = null
 
 const CONTEXT7_SMOKE_SYSTEM_PATH_DIRS = [
   path.dirname(process.execPath),
@@ -201,7 +215,23 @@ async function runSmokeCheck(): Promise<void> {
 }
 
 class Context7Service {
-  async install(): Promise<Context7Status> {
+  /**
+   * Configure the Context7 MCP server for the given harness. Claude uses
+   * `~/.claude/mcp.json`; Codex uses `[mcp_servers.context7]` in its TOML.
+   * Providers without a managed path return a non-error "unsupported" status
+   * so callers can skip rather than fail.
+   */
+  async install(provider: string = 'claude'): Promise<Context7Status> {
+    if (provider === 'codex') return this.installCodex()
+    if (provider !== 'claude') {
+      return {
+        installed: false,
+        verified: false,
+        configPath: '',
+        message: `Context7 auto-config not supported for ${provider}; skipping`,
+      }
+    }
+
     const configPath = getConfigPath()
     const claudeDir = path.dirname(configPath)
     await fs.mkdir(claudeDir, { recursive: true })
@@ -239,65 +269,99 @@ class Context7Service {
     }
   }
 
-  async verify(): Promise<Context7Status> {
+  private async installCodex(): Promise<Context7Status> {
+    const result = await ensureCodexContext7Server()
+    if (result.changed) cachedVerify = null
+    return {
+      installed: true,
+      verified: false,
+      configPath: result.path,
+      message:
+        result.skipped === 'user-managed'
+          ? 'Context7 MCP user-managed in config.toml'
+          : 'Context7 MCP configured in config.toml',
+    }
+  }
+
+  /** Whether Context7 is registered for `provider`, and where. */
+  private async resolveConfigured(
+    provider: string
+  ): Promise<{ ok: boolean; configPath: string; message?: string }> {
+    if (provider === 'codex') {
+      const configPath = getCodexConfigTomlPath()
+      const has = await codexHasContext7Server(configPath)
+      return has
+        ? { ok: true, configPath }
+        : { ok: false, configPath, message: 'Context7 MCP not configured in ~/.codex/config.toml' }
+    }
+    if (provider !== 'claude') {
+      return { ok: false, configPath: '', message: `Context7 not managed for ${provider}` }
+    }
+    const configPath = getConfigPath()
+    const config = await readConfig(configPath)
+    const mcpServers = (config.mcpServers as Record<string, unknown>) || {}
+    const context7 = mcpServers.context7 as { command?: string; args?: string[] } | undefined
+    if (!context7?.command || !Array.isArray(context7.args) || context7.args.length === 0) {
+      return { ok: false, configPath, message: 'Context7 MCP not configured in ~/.claude/mcp.json' }
+    }
+    return { ok: true, configPath }
+  }
+
+  async verify(provider: string = 'claude'): Promise<Context7Status> {
     const now = Date.now()
-    if (cachedVerify && now - cachedVerify.at < CONTEXT7_VERIFY_TTL_MS) {
+    if (
+      cachedVerify &&
+      cachedVerify.provider === provider &&
+      now - cachedVerify.at < CONTEXT7_VERIFY_TTL_MS
+    ) {
       return cachedVerify.status
     }
 
-    // Persistent cache — skip the ~1.1s `npx ... --help` smoke check when
-    // a recent successful verify exists for the same configPath.
+    // Persistent cache — skip the ~1.1s `npx ... --help` smoke check when a
+    // recent successful verify exists for the same provider.
     const persisted = await readPersistedVerify()
     if (
       persisted?.status.verified &&
-      now - persisted.at < CONTEXT7_VERIFY_TTL_MS &&
-      persisted.status.configPath === getConfigPath()
+      persisted.provider === provider &&
+      now - persisted.at < CONTEXT7_VERIFY_TTL_MS
     ) {
       cachedVerify = persisted
       return persisted.status
     }
 
-    const configPath = getConfigPath()
-    const config = await readConfig(configPath)
-    const mcpServers = (config.mcpServers as Record<string, unknown>) || {}
-    const context7 = mcpServers.context7 as { command?: string; args?: string[] } | undefined
-
-    if (!context7?.command || !Array.isArray(context7.args) || context7.args.length === 0) {
+    const configured = await this.resolveConfigured(provider)
+    if (!configured.ok) {
       return {
         installed: false,
         verified: false,
-        configPath,
-        message: 'Context7 MCP not configured in ~/.claude/mcp.json',
+        configPath: configured.configPath,
+        message: configured.message,
       }
     }
 
     try {
       await runSmokeCheck()
-      const status = {
-        installed: true,
-        verified: true,
-        configPath,
-      }
-      cachedVerify = { at: now, status }
+      const status = { installed: true, verified: true, configPath: configured.configPath }
+      cachedVerify = { at: now, provider, status }
       // Persist successful verify so subsequent CLI invocations skip the smoke check.
-      await writePersistedVerify(now, status)
+      await writePersistedVerify(now, provider, status)
       return status
     } catch (error) {
       const status = {
         installed: true,
         verified: false,
-        configPath,
+        configPath: configured.configPath,
         message: `Context7 smoke check failed: ${getErrorMessage(error)}`,
       }
-      cachedVerify = { at: now, status }
+      cachedVerify = { at: now, provider, status }
       // Don't persist failures — next invocation should retry.
       return status
     }
   }
 
-  async ensureReady(): Promise<Context7Status> {
-    await this.install()
-    const status = await this.verify()
+  async ensureReady(provider: string = 'claude'): Promise<Context7Status> {
+    await this.install(provider)
+    const status = await this.verify(provider)
     if (!status.verified) {
       const msg =
         status.message ||

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -21,7 +21,7 @@ import { indexProject as indexBm25, updateProjectIndex as updateBm25 } from '../
 import { indexCoChanges } from '../domain/git-cochange'
 import { indexImports, updateImportGraph } from '../domain/import-graph'
 import { getErrorMessage } from '../errors'
-import { detectCodex } from '../infrastructure/ai-provider'
+import { detectCodex, getActiveProvider } from '../infrastructure/ai-provider'
 import { verifyCodexPRouterReady } from '../infrastructure/codex-skill'
 import commandInstaller from '../infrastructure/command-installer'
 import configManager from '../infrastructure/config-manager'
@@ -123,24 +123,27 @@ class SyncService {
       // Keep prjct-managed MCP defaults self-healing from sync as well as setup.
       await phase('mcp-defaults', () => setupMcpServers({ silent: true, verifyContext7: false }))
 
-      // Context7 is mandatory for deterministic coding workflows
+      // Context7 is best-effort, never a hard gate, and provider-aware: it
+      // configures into the ACTIVE harness's MCP config (Claude → mcp.json,
+      // Codex → config.toml). Its smoke check needs network, so a hard failure
+      // here used to abort sync entirely for Codex/Gemini and any sandboxed/
+      // offline run — even though indexing, memory and vault regen don't depend
+      // on it. Mirror the Codex-router check above: try, warn on failure, keep
+      // going. `verified:false` still surfaces so `prjct start`/setup can repair.
+      const activeProvider = await getActiveProvider().catch(() => null)
+      const context7Provider = activeProvider?.name ?? 'claude'
       try {
-        context7Status = await phase('context7', () => context7Service.ensureReady())
+        context7Status = await phase('context7', () =>
+          context7Service.ensureReady(context7Provider)
+        )
       } catch (error) {
-        return {
-          success: false,
-          projectId: this.projectId,
-          cliVersion: this.cliVersion,
-          git: emptyGitData(),
-          stats: emptyStats(),
-          commands: emptyCommands(),
-          stack: emptyStack(),
-          context7: {
-            installed: context7Status.installed,
-            verified: false,
-            message: getErrorMessage(error),
-          },
-          error: `Context7 MCP is required but not ready: ${getErrorMessage(error)}. Run 'prjct start' to repair.`,
+        const message = getErrorMessage(error)
+        log.warn(`Context7 MCP not ready (continuing sync): ${message}`)
+        context7Status = {
+          installed: context7Status.installed,
+          verified: false,
+          configPath: context7Status.configPath,
+          message,
         }
       }
 

--- a/core/services/sync/state-update.ts
+++ b/core/services/sync/state-update.ts
@@ -9,7 +9,7 @@ import path from 'node:path'
 import type { StateJson } from '../../schemas/state'
 import { prjctDb } from '../../storage/database'
 import { stateStorage } from '../../storage/state-storage'
-import { getErrorMessage } from '../../types/fs'
+import { describeFsWriteError, getErrorMessage } from '../../types/fs'
 import type { GitData, ProjectStats } from '../../types/project-sync'
 import type { StackDetection } from '../../types/stack'
 import * as dateHelper from '../../utils/date-helper'
@@ -23,9 +23,13 @@ const PROJECT_DIRS = ['storage', 'context', 'memory', 'analysis', 'config', 'syn
  * `globalPath` exists before any writer touches it.
  */
 export async function ensureProjectDirectories(globalPath: string): Promise<void> {
-  await Promise.all(
-    PROJECT_DIRS.map((dir) => fs.mkdir(path.join(globalPath, dir), { recursive: true }))
-  )
+  try {
+    await Promise.all(
+      PROJECT_DIRS.map((dir) => fs.mkdir(path.join(globalPath, dir), { recursive: true }))
+    )
+  } catch (error) {
+    throw new Error(describeFsWriteError(error, globalPath, 'project directories'))
+  }
 }
 
 export async function updateProjectDoc(args: {

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -16,6 +16,7 @@
  *    so it is safe under MCP stdio.
  */
 
+import { REGISTERED_VERBS_SET } from '../commands/verb-names'
 import configManager from '../infrastructure/config-manager'
 import { STATUS_CHANGE_ACTION } from '../memory/events'
 import { deriveTitle as deriveMemTitle, flatDetail, preventiveLabel } from '../memory/format'
@@ -149,6 +150,20 @@ export async function startTask(
   description: string,
   options: { skipHooks?: boolean; spec?: string } = {}
 ): Promise<StartTaskOutcome> {
+  // Verb-collision guard. Agents on non-Claude harnesses (e.g. Codex) that
+  // don't have the verb-intent map memorized tend to wrap a bare CLI verb as
+  // a work description — `prjct work "sync"` instead of `prjct sync`. A lone
+  // registered verb is never a real work intent, so reject it and point at the
+  // command they meant. Multi-word descriptions ("ship the onboarding flow")
+  // pass untouched.
+  const lone = description.trim().toLowerCase()
+  if (REGISTERED_VERBS_SET.has(lone)) {
+    return {
+      ok: false,
+      blocked: `'${lone}' is a prjct command, not a work intent. Did you mean \`prjct ${lone}\`? To start a work cycle, describe the task (e.g. \`prjct work "fix the ${lone} flow"\`).`,
+    }
+  }
+
   // before_task workflow rules (gates may block, hooks may nudge).
   const beforeResult = await executeWorkflowRules(projectId, 'task', 'before', {
     projectPath,

--- a/core/storage/database.ts
+++ b/core/storage/database.ts
@@ -7,6 +7,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import pathManager from '../infrastructure/path-manager'
+import { describeFsWriteError } from '../types/fs'
 import type { MigrationRecord } from '../types/storage/extended'
 import { migrations } from './database/migrations'
 import {
@@ -86,15 +87,24 @@ class PrjctDatabase {
 
     const dbPath = this.getDbPath(projectId)
     const dbDir = path.dirname(dbPath)
-    if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true })
-    // openDatabase bakes in WAL + busy_timeout=5000 — daemon-safety pragmas
-    // every connection needs. Performance tuning stays here.
-    const db = openDatabase(dbPath)
+    let db: SqliteDatabase
+    try {
+      if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true })
+      // openDatabase bakes in WAL + busy_timeout=5000 — daemon-safety pragmas
+      // every connection needs. Performance tuning stays here.
+      db = openDatabase(dbPath)
 
-    db.run('PRAGMA synchronous = NORMAL')
-    db.run('PRAGMA cache_size = -2000') // 2MB cache
-    db.run('PRAGMA temp_store = MEMORY')
-    db.run('PRAGMA mmap_size = 33554432') // 32MB mmap
+      db.run('PRAGMA synchronous = NORMAL')
+      db.run('PRAGMA cache_size = -2000') // 2MB cache
+      db.run('PRAGMA temp_store = MEMORY')
+      db.run('PRAGMA mmap_size = 33554432') // 32MB mmap
+    } catch (error) {
+      // A sandboxed/offline harness (e.g. Codex running with a read-only home)
+      // surfaces this as a cryptic "attempt to write a readonly database" or
+      // EPERM/EACCES on the mkdir/open. Translate it into one actionable line
+      // instead of a raw driver stack trace.
+      throw new Error(describeFsWriteError(error, dbPath, 'database'))
+    }
 
     this.runMigrations(db, dbPath)
 

--- a/core/types/fs.ts
+++ b/core/types/fs.ts
@@ -48,6 +48,34 @@ export function isDirNotEmptyError(error: unknown): boolean {
 }
 
 /**
+ * Check if error is a read-only filesystem / read-only DB error. Covers the
+ * POSIX `EROFS`, the SQLite `SQLITE_READONLY` code, and the driver message
+ * variants ("attempt to write a readonly database") that surface when a
+ * sandboxed agent (e.g. OpenAI Codex) runs prjct against a read-only home.
+ */
+export function isReadonlyError(error: unknown): boolean {
+  const code = isNodeError(error) ? error.code : undefined
+  if (code === 'EROFS' || code === 'SQLITE_READONLY') return true
+  return /readonly|read-only/i.test(getErrorMessage(error))
+}
+
+/**
+ * Turn a raw fs/SQLite write failure into one actionable line. Read-only homes
+ * and permission denials are the common sandbox causes and the native message
+ * ("EPERM", "attempt to write a readonly database") gives the user nothing to
+ * act on. Non-permission errors are reported verbatim. `subject` lets callers
+ * name what failed to open/write (e.g. "database", "config").
+ */
+export function describeFsWriteError(error: unknown, targetPath: string, subject = 'file'): string {
+  const raw = getErrorMessage(error)
+  if (isReadonlyError(error) || isPermissionError(error)) {
+    const code = (isNodeError(error) && error.code) || 'read-only'
+    return `prjct can't write its ${subject} at ${targetPath} (${code}). This usually means a sandboxed or read-only environment. Re-run with write access to that path — some agents (e.g. Codex) run commands in a restricted sandbox, so approve filesystem/write access for prjct.`
+  }
+  return `Failed to write ${subject} at ${targetPath}: ${raw}`
+}
+
+/**
  * Check if error is a file exists error
  */
 export function isFileExistsError(error: unknown): boolean {

--- a/core/utils/codex-mcp.ts
+++ b/core/utils/codex-mcp.ts
@@ -18,6 +18,12 @@ import { MCP_SERVER_PRESETS } from './mcp-config'
 
 const START_MARKER = '# prjct:mcp:start - managed by prjct, do not edit between markers'
 const END_MARKER = '# prjct:mcp:end'
+// Context7 gets its own marker pair so it co-exists with the prjct block and
+// either can be re-managed independently. Keeping the prjct markers unnamed
+// preserves backward compatibility with configs written by older versions.
+const CONTEXT7_START_MARKER =
+  '# prjct:mcp:context7:start - managed by prjct, do not edit between markers'
+const CONTEXT7_END_MARKER = '# prjct:mcp:context7:end'
 const CODEX_STATUS_LINE_ITEMS = [
   'model-with-reasoning',
   'current-dir',
@@ -39,16 +45,61 @@ function tomlString(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
 }
 
-export function buildPrjctMcpTomlBlock(server: MCPServerConfig = MCP_SERVER_PRESETS.prjct): string {
+function buildMcpTomlBlock(
+  name: string,
+  server: MCPServerConfig,
+  startMarker: string,
+  endMarker: string
+): string {
   const args = (server.args ?? []).map(tomlString).join(', ')
   return [
-    START_MARKER,
-    '[mcp_servers.prjct]',
+    startMarker,
+    `[mcp_servers.${name}]`,
     `command = ${tomlString(server.command)}`,
     `args = [${args}]`,
-    END_MARKER,
+    endMarker,
     '',
   ].join('\n')
+}
+
+export function buildPrjctMcpTomlBlock(server: MCPServerConfig = MCP_SERVER_PRESETS.prjct): string {
+  return buildMcpTomlBlock('prjct', server, START_MARKER, END_MARKER)
+}
+
+export function buildContext7McpTomlBlock(
+  server: MCPServerConfig = MCP_SERVER_PRESETS.context7
+): string {
+  return buildMcpTomlBlock('context7', server, CONTEXT7_START_MARKER, CONTEXT7_END_MARKER)
+}
+
+/**
+ * Upsert a marker-delimited block into `existing`. Returns the new text plus
+ * whether a user-managed (marker-less) table of the same name was found — in
+ * which case we leave their config untouched.
+ */
+function upsertMarkedBlock(
+  existing: string,
+  block: string,
+  startMarker: string,
+  endMarker: string,
+  tableName: string
+): { next: string; skipped?: 'user-managed' } {
+  const startIdx = existing.indexOf(startMarker)
+  const endIdx = existing.indexOf(endMarker)
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx)
+    let after = existing.slice(endIdx + endMarker.length)
+    if (after.startsWith('\n')) after = after.slice(1)
+    return { next: before + block + after }
+  }
+  if (new RegExp(`^\\s*\\[mcp_servers\\.${tableName}\\]`, 'm').test(existing)) {
+    return { next: existing, skipped: 'user-managed' }
+  }
+  if (existing.trim().length > 0) {
+    return { next: `${existing.trimEnd()}\n\n${block}` }
+  }
+  return { next: block }
 }
 
 export function buildCodexStatusLineToml(): string {
@@ -107,29 +158,11 @@ export async function ensureCodexMcpServer(configPath = getCodexConfigTomlPath()
   }
 
   const block = buildPrjctMcpTomlBlock()
+  const upserted = upsertMarkedBlock(existing, block, START_MARKER, END_MARKER, 'prjct')
+  const skipped = upserted.skipped
 
-  let next: string
-  const startIdx = existing.indexOf(START_MARKER)
-  const endIdx = existing.indexOf(END_MARKER)
-
-  let skipped: 'user-managed' | undefined
-
-  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-    const before = existing.slice(0, startIdx)
-    let after = existing.slice(endIdx + END_MARKER.length)
-    if (after.startsWith('\n')) after = after.slice(1)
-    next = before + block + after
-  } else if (/^\s*\[mcp_servers\.prjct\]/m.test(existing)) {
-    next = existing
-    skipped = 'user-managed'
-  } else if (existing.trim().length > 0) {
-    next = `${existing.trimEnd()}\n\n${block}`
-  } else {
-    next = block
-  }
-
-  const withStatusLine = ensureCodexStatusLineToml(next)
-  next = withStatusLine.toml
+  const withStatusLine = ensureCodexStatusLineToml(upserted.next)
+  const next = withStatusLine.toml
 
   if (next === existing) {
     return { path: configPath, changed: false, skipped }
@@ -142,5 +175,53 @@ export async function ensureCodexMcpServer(configPath = getCodexConfigTomlPath()
     changed: true,
     skipped,
     statusLineChanged: withStatusLine.changed,
+  }
+}
+
+/**
+ * Idempotently register the Context7 MCP server in Codex's config.toml so
+ * Codex gets the same deterministic-docs capability Claude has via
+ * `~/.claude/mcp.json`. Managed between its own marker pair; a user-defined
+ * `[mcp_servers.context7]` (no markers) is preserved.
+ */
+export async function ensureCodexContext7Server(configPath = getCodexConfigTomlPath()): Promise<{
+  path: string
+  changed: boolean
+  skipped?: 'user-managed'
+}> {
+  let existing = ''
+  try {
+    existing = await fs.readFile(configPath, 'utf-8')
+  } catch {
+    // Missing file — we'll create it.
+  }
+
+  const block = buildContext7McpTomlBlock()
+  const { next, skipped } = upsertMarkedBlock(
+    existing,
+    block,
+    CONTEXT7_START_MARKER,
+    CONTEXT7_END_MARKER,
+    'context7'
+  )
+
+  if (next === existing) {
+    return { path: configPath, changed: false, skipped }
+  }
+
+  await fs.mkdir(path.dirname(configPath), { recursive: true })
+  await fs.writeFile(configPath, next, 'utf-8')
+  return { path: configPath, changed: true, skipped }
+}
+
+/** True iff config.toml carries a `[mcp_servers.context7]` table (managed or user). */
+export async function codexHasContext7Server(
+  configPath = getCodexConfigTomlPath()
+): Promise<boolean> {
+  try {
+    const existing = await fs.readFile(configPath, 'utf-8')
+    return /^\s*\[mcp_servers\.context7\]/m.test(existing)
+  } catch {
+    return false
   }
 }

--- a/core/utils/file-helper.ts
+++ b/core/utils/file-helper.ts
@@ -2,8 +2,34 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { SKIP_DIRS } from '../constants/file-patterns'
 import { safeRead } from '../storage/safe-reader'
-import { isNotFoundError } from '../types/fs'
+import {
+  describeFsWriteError,
+  isNotFoundError,
+  isPermissionError,
+  isReadonlyError,
+} from '../types/fs'
 import type { ValidationSchema } from '../types/storage/extended'
+
+/**
+ * Run a write and, if it fails because the target is read-only / permission
+ * denied (the sandboxed-agent case), rethrow with an actionable message.
+ * Transient or other errors (ENOSPC, EBUSY, …) pass through untouched so
+ * callers that inspect `error.code` keep working.
+ */
+async function withWriteErrorContext<T>(
+  targetPath: string,
+  subject: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  try {
+    return await fn()
+  } catch (error) {
+    if (isReadonlyError(error) || isPermissionError(error)) {
+      throw new Error(describeFsWriteError(error, targetPath, subject))
+    }
+    throw error
+  }
+}
 
 /**
  * File Helper - Centralized file operations with error handling
@@ -118,10 +144,12 @@ export async function readJson<T = unknown>(
  * Write object to JSON file (pretty-printed)
  */
 export async function writeJson(filePath: string, data: unknown, indent = 2): Promise<void> {
-  const dir = path.dirname(filePath)
-  await fs.mkdir(dir, { recursive: true })
-  const content = `${JSON.stringify(data, null, indent)}\n`
-  await fs.writeFile(filePath, content, 'utf-8')
+  await withWriteErrorContext(filePath, 'config', async () => {
+    const dir = path.dirname(filePath)
+    await fs.mkdir(dir, { recursive: true })
+    const content = `${JSON.stringify(data, null, indent)}\n`
+    await fs.writeFile(filePath, content, 'utf-8')
+  })
 }
 
 /**
@@ -142,9 +170,11 @@ export async function readFile(filePath: string, defaultValue = ''): Promise<str
  * Write text file
  */
 export async function writeFile(filePath: string, content: string): Promise<void> {
-  const dir = path.dirname(filePath)
-  await fs.mkdir(dir, { recursive: true })
-  await fs.writeFile(filePath, content, 'utf-8')
+  await withWriteErrorContext(filePath, 'file', async () => {
+    const dir = path.dirname(filePath)
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(filePath, content, 'utf-8')
+  })
 }
 
 /**
@@ -156,11 +186,13 @@ export async function writeFile(filePath: string, content: string): Promise<void
  * row is the source of truth; this is the mirror writer.
  */
 export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
-  const dir = path.dirname(filePath)
-  await fs.mkdir(dir, { recursive: true })
-  const tmpPath = `${filePath}.tmp`
-  await fs.writeFile(tmpPath, content, 'utf-8')
-  await fs.rename(tmpPath, filePath)
+  await withWriteErrorContext(filePath, 'file', async () => {
+    const dir = path.dirname(filePath)
+    await fs.mkdir(dir, { recursive: true })
+    const tmpPath = `${filePath}.tmp`
+    await fs.writeFile(tmpPath, content, 'utf-8')
+    await fs.rename(tmpPath, filePath)
+  })
 }
 
 /**

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -76,6 +76,14 @@ function stripShebangPlugin() {
 async function buildJs() {
   const esbuild = require('esbuild')
 
+  // Bake the package version into every bundle. getVersion() (core/utils/
+  // version.ts) reads process.env.PRJCT_VERSION FIRST, so this static
+  // replacement makes the built CLI always report its own version — no
+  // walking up __dirname into a stale duplicate install's package.json.
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'))
+  const versionDefine = { 'process.env.PRJCT_VERSION': JSON.stringify(pkg.version) }
+  console.log(`  → baking version ${pkg.version}`)
+
   // 1a. CLI core bundle (heavy, only loaded when daemon unavailable)
   console.log('  → dist/bin/prjct-core.mjs')
   const mainResult = await esbuild.build({
@@ -89,6 +97,7 @@ async function buildJs() {
     keepNames: true,
     packages: 'external',
     metafile: true,
+    define: versionDefine,
     banner: {
       js: `import { createRequire as __createRequire } from 'module';
 import { fileURLToPath as __fileURLToPath } from 'url';
@@ -115,6 +124,7 @@ var __dirname = __pathDirname(__filename);`,
     minify: true,
     keepNames: true,
     packages: 'external',
+    define: versionDefine,
     plugins: [stripShebangPlugin()],
     banner: {
       js: `#!/usr/bin/env node
@@ -145,6 +155,7 @@ var __dirname = __pathDirname(__filename);`,
     minify: true,
     keepNames: true,
     packages: 'external',
+    define: versionDefine,
     plugins: [stripShebangPlugin()],
     banner: {
       js: `#!/usr/bin/env node
@@ -170,6 +181,7 @@ var __dirname = __pathDirname(__filename);`,
     minify: true,
     keepNames: true,
     packages: 'external',
+    define: versionDefine,
     plugins: [stripShebangPlugin()],
     banner: {
       js: `#!/usr/bin/env node

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -213,16 +213,10 @@ function bumpVersion(type) {
   pkg.version = newVersion
   fs.writeFileSync(PACKAGE_JSON, `${JSON.stringify(pkg, null, 2)}\n`)
 
-  // Also update version.ts
-  const versionTsPath = path.join(ROOT, 'core/utils/version.ts')
-  if (fs.existsSync(versionTsPath)) {
-    let versionTs = fs.readFileSync(versionTsPath, 'utf8')
-    versionTs = versionTs.replace(
-      /export const VERSION = ['"][^'"]+['"]/,
-      `export const VERSION = '${newVersion}'`
-    )
-    fs.writeFileSync(versionTsPath, versionTs)
-  }
+  // version.ts resolves the version at runtime (PRJCT_VERSION → package.json);
+  // the build bakes pkg.version in via esbuild `define`. Nothing to rewrite
+  // here — bumping package.json before build() is what makes the binary carry
+  // the right version.
 
   info(`${currentVersion} → ${newVersion}`)
   success(`Version bumped to ${newVersion}`)
@@ -301,11 +295,13 @@ async function main() {
   log(`  prjct-cli Release (${type})`)
   log(`${'='.repeat(50)}`)
 
-  // Run all steps
+  // Run all steps. Order matters: bump the version BEFORE build so esbuild
+  // bakes the NEW version into the bundles (previously build ran first and the
+  // published binary reported the OLD version).
   const { branch } = validate()
-  await build()
   test()
   const { newVersion } = bumpVersion(type)
+  await build()
   commitAndTag(newVersion)
   publish()
   push(branch)


### PR DESCRIPTION
## Why

`prjct sync` (and the broader flow) **hard-failed for every non-Claude harness** (OpenAI Codex, Gemini) and any sandboxed/offline run. Reported via a Codex session that couldn't sync, plus a recurring client report that "prjct sync hangs/timeouts while other commands work".

## Root causes & fixes

**1. Context7 was an unconditional hard gate — now provider-aware + best-effort**
`sync-service.ts` returned `success:false` if `context7Service.ensureReady()` failed. But Context7 only ever configured under Claude (`~/.claude/mcp.json`) and its smoke check needs network → guaranteed failure on Codex/Gemini/sandbox. Now:
- `context7Service` is **provider-aware**: Claude → `mcp.json` (JSON), **Codex → `[mcp_servers.context7]` in `~/.codex/config.toml`** (TOML, own markers). Unmanaged providers are a non-error skip.
- sync resolves the active provider via `getActiveProvider()` and **never blocks** — try, warn, continue. `verified:false` still surfaces so `start`/setup repairs it.
- Codex gets **real Context7 parity**, not just "doesn't abort".

**2. Read-only/permission writes crashed cryptically — now actionable & non-fatal to sync**
Centralized `describeFsWriteError()`/`isReadonlyError()` in `types/fs` (EROFS/SQLITE_READONLY/EPERM/EACCES + message match). Applied at the `file-helper` write chokepoint, DB open, and `ensureProjectDirectories`. One "approve write access" line; transient errors pass through with their `code` intact.

**3. `prjct work "sync"` misroute — verb-collision guard**
Agents lacking the verb-intent map wrapped a bare verb as a work intent. `startTask` now rejects a lone registered verb before any state mutation and points at the real command.

**4. Version mismatch (v3.9.0 vs v3.11.0)**
`release.js` ran `build()` **before** `bumpVersion()`, so the published binary carried the old version. Reordered (bump → build) + bake version via esbuild `define` so `getVersion()` never walks `__dirname` into a stale pnpm duplicate.

**5. Sandbox detection** — `AgentEnvironment.sandboxed` was hardcoded `false`; now derived from `CODEX_SANDBOX`/`PRJCT_SANDBOX` via `isSandboxed()`.

## Verification

- `tsc` clean · `biome check .` clean · **full suite 1955→ green** (+ new tests below)
- New tests: Codex Context7 TOML wiring, provider-aware Context7, fs-error translation, sandbox detection, verb-collision guard
- E2E: built binary reports baked `v3.11.0`; `prjct work "status"` → rejected with suggestion; **forced Context7 EACCES → actionable message + sync still completes** (631 files indexed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)