### PR TITLE
fix: statusline version check owned by daemon, not legacy files

### DIFF
--- a/core/__tests__/services/update-checker.test.ts
+++ b/core/__tests__/services/update-checker.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Update-checker unit tests.
+ *
+ * Covers the daemon-owned "is a newer prjct published?" logic:
+ *   - writes the global flag with updateAvailable computed from installed vs latest
+ *   - reuses the cached `latest` within the throttle window (no refetch)
+ *   - recomputes updateAvailable against the CURRENT installed version, so the
+ *     flag clears the instant the CLI is upgraded — even on a cached `latest`
+ *   - tolerates an offline registry (no flag flip, no throw)
+ *
+ * The npm fetch is stubbed via global.fetch; the CLI home is redirected to a
+ * temp dir through PRJCT_CLI_HOME so nothing touches the real state file.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { readUpdateStatus, refreshUpdateStatus } from '../../services/update-checker'
+
+let tmpHome: string
+let prevHome: string | undefined
+const realFetch = globalThis.fetch
+
+function stubFetch(version: string | null): void {
+  globalThis.fetch = (async () => {
+    if (version === null) throw new Error('offline')
+    return new Response(JSON.stringify({ version }), { status: 200 })
+  }) as unknown as typeof fetch
+}
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-update-'))
+  prevHome = process.env.PRJCT_CLI_HOME
+  process.env.PRJCT_CLI_HOME = tmpHome
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  if (prevHome === undefined) delete process.env.PRJCT_CLI_HOME
+  else process.env.PRJCT_CLI_HOME = prevHome
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+describe('update-checker — refreshUpdateStatus', () => {
+  test('flags an upgrade when latest is newer than installed', async () => {
+    stubFetch('3.13.0')
+    const status = await refreshUpdateStatus('3.12.0')
+    expect(status?.updateAvailable).toBe(true)
+    expect(status?.latest).toBe('3.13.0')
+    expect(readUpdateStatus()?.updateAvailable).toBe(true)
+  })
+
+  test('no upgrade when already on the latest', async () => {
+    stubFetch('3.12.0')
+    const status = await refreshUpdateStatus('3.12.0')
+    expect(status?.updateAvailable).toBe(false)
+  })
+
+  test('clears the flag after upgrade using cached latest (no refetch)', async () => {
+    stubFetch('3.13.0')
+    await refreshUpdateStatus('3.12.0') // upgrade available
+
+    // Simulate the CLI having been upgraded; registry is now unreachable so any
+    // refetch would fail. The cached `latest` (3.13.0) must be reused and the
+    // flag recomputed against the new installed version → no longer available.
+    stubFetch(null)
+    const status = await refreshUpdateStatus('3.13.0')
+    expect(status?.latest).toBe('3.13.0')
+    expect(status?.updateAvailable).toBe(false)
+  })
+
+  test('offline first run produces no false upgrade signal', async () => {
+    stubFetch(null)
+    const status = await refreshUpdateStatus('3.12.0')
+    expect(status?.latest).toBeNull()
+    expect(status?.updateAvailable).toBe(false)
+  })
+
+  test('empty installed version is a no-op', async () => {
+    stubFetch('3.13.0')
+    const status = await refreshUpdateStatus('')
+    expect(status).toBeNull()
+    expect(readUpdateStatus()).toBeNull()
+  })
+})

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -731,20 +731,12 @@ if [[ -f "$CONFIG" ]]; then
   PROJECT_ID=$(grep -o '"projectId"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG" | sed 's/.*"projectId"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/')
 
   if [[ -n "$PROJECT_ID" ]]; then
-    PROJECT_JSON="$HOME/.prjct-cli/projects/$PROJECT_ID/project.json"
-
-    # Check version mismatch
-    if [[ -f "$PROJECT_JSON" ]]; then
-      PROJECT_VERSION=$(grep -o '"cliVersion"[[:space:]]*:[[:space:]]*"[^"]*"' "$PROJECT_JSON" | sed 's/.*"cliVersion"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/')
-
-      # If no cliVersion or different version, show update notice
-      if [[ -z "$PROJECT_VERSION" ]] || [[ "$PROJECT_VERSION" != "$CLI_VERSION" ]]; then
-        echo "⚠️ prjct v$CLI_VERSION available! Run p. upgrade"
-        exit 0
-      fi
-    else
-      # No project.json means project needs sync
-      echo "⚠️ prjct v$CLI_VERSION available! Run p. upgrade"
+    # Upgrade notice — the daemon checks npm and writes this GLOBAL flag.
+    # The statusline only READS it; it does no version comparison itself.
+    UPDATE_STATUS="$HOME/.prjct-cli/state/update-status.json"
+    if [[ -f "$UPDATE_STATUS" ]] && grep -q '"updateAvailable"[[:space:]]*:[[:space:]]*true' "$UPDATE_STATUS"; then
+      LATEST=$(grep -o '"latest"[[:space:]]*:[[:space:]]*"[^"]*"' "$UPDATE_STATUS" | sed 's/.*"latest"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/')
+      echo "⚠️ prjct v$LATEST available! Run p. upgrade"
       exit 0
     fi
 

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -19,6 +19,7 @@ import { resetGroupLoaders } from '../commands/register'
 import { commandRegistry } from '../commands/registry'
 import type { HookIo } from '../hooks/_runner'
 import { getHookRunner } from '../hooks/registry'
+import { refreshUpdateStatus } from '../services/update-checker'
 import prjctDb from '../storage/database'
 import { realtimeManager } from '../sync/realtime-manager'
 import type { DaemonRequest, DaemonResponse, DaemonState } from '../types/daemon'
@@ -53,11 +54,15 @@ const WAL_CHECKPOINT_INTERVAL = 50
  */
 const VERSION_DRIFT_CHECK_MIN_MS = 1000
 
+/** How often the daemon re-checks npm for a newer published version. */
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
+
 let ipcServer: Server | null = null
 let commands: PrjctCommands | null = null
 let state: DaemonState | null = null
 let ownVersion: string | null = null
 let lastDriftCheckMs = 0
+let updateTimer: ReturnType<typeof setInterval> | null = null
 
 // Serializes command execution. handleRequestInner patches the GLOBAL
 // console.log/error to capture a command's output; with concurrent socket
@@ -130,6 +135,21 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
     } catch {
       // never block daemon startup
     }
+  }
+
+  // Own the "is a newer prjct published?" question. The daemon is the one
+  // process that reliably knows the installed version, so it refreshes the
+  // global update-status flag here (and hourly below). The statusline only
+  // READS that flag — it no longer does any version comparison itself.
+  // Best-effort + non-blocking: a slow/offline registry must never delay
+  // startup or serving.
+  if (ownVersion) {
+    const version = ownVersion
+    void refreshUpdateStatus(version).catch(() => undefined)
+    updateTimer = setInterval(() => {
+      void refreshUpdateStatus(version).catch(() => undefined)
+    }, UPDATE_CHECK_INTERVAL_MS)
+    updateTimer.unref?.()
   }
 
   // Pre-load modules (this is the whole point — do it once)
@@ -504,6 +524,10 @@ function shutdown(exitCode: number): void {
   }
 
   if (state?.idleTimer) clearTimeout(state.idleTimer)
+  if (updateTimer) {
+    clearInterval(updateTimer)
+    updateTimer = null
+  }
 
   if (ipcServer) {
     ipcServer.close()

--- a/core/infrastructure/statusline-installer.ts
+++ b/core/infrastructure/statusline-installer.ts
@@ -151,15 +151,12 @@ CONFIG="$CWD/.prjct/prjct.config.json"
 if [ -f "$CONFIG" ]; then
   PROJECT_ID=$(jq -r '.projectId // ""' "$CONFIG" 2>/dev/null)
   if [ -n "$PROJECT_ID" ]; then
-    PROJECT_JSON="$HOME/.prjct-cli/projects/$PROJECT_ID/project.json"
-    if [ -f "$PROJECT_JSON" ]; then
-      PROJECT_VERSION=$(jq -r '.cliVersion // ""' "$PROJECT_JSON" 2>/dev/null)
-      if [ -z "$PROJECT_VERSION" ] || [ "$PROJECT_VERSION" != "$CLI_VERSION" ]; then
-        echo "prjct v$CLI_VERSION - run p. upgrade"
-        exit 0
-      fi
-    else
-      echo "prjct v$CLI_VERSION - run p. upgrade"
+    # Upgrade notice — the daemon checks npm and writes this GLOBAL flag.
+    # The statusline only READS it; it does no version comparison itself.
+    UPDATE_STATUS="$HOME/.prjct-cli/state/update-status.json"
+    if [ -f "$UPDATE_STATUS" ] && [ "$(jq -r '.updateAvailable // false' "$UPDATE_STATUS" 2>/dev/null)" = "true" ]; then
+      LATEST=$(jq -r '.latest // ""' "$UPDATE_STATUS" 2>/dev/null)
+      echo "prjct v$LATEST - run p. upgrade"
       exit 0
     fi
     STATE="$HOME/.prjct-cli/projects/$PROJECT_ID/storage/state.json"

--- a/core/services/auto-updater.ts
+++ b/core/services/auto-updater.ts
@@ -16,6 +16,7 @@ import { promisify } from 'node:util'
 import { resolveCliHome } from '../infrastructure/cli-home'
 import { compareSemver } from '../schemas/model'
 import { getConfig, setConfig } from './global-config'
+import { fetchLatestVersion } from './update-checker'
 
 const execFileP = promisify(execFile)
 
@@ -23,7 +24,6 @@ const execFileP = promisify(execFile)
 const stateDir = (): string => path.join(resolveCliHome(), 'state')
 const logPath = (): string => path.join(stateDir(), 'auto-update.log')
 const THROTTLE_MS = 60 * 60 * 1000 // 1 hour
-const NPM_REGISTRY = 'https://registry.npmjs.org/prjct-cli/latest'
 
 type InstallSource = 'binary' | 'npm' | 'bun' | 'unknown'
 
@@ -76,21 +76,6 @@ export async function runBackgroundCheck(currentVersion: string): Promise<void> 
 }
 
 // Internals
-
-async function fetchLatestVersion(): Promise<string | null> {
-  try {
-    // 6s timeout — npm registry should answer fast or not at all
-    const ac = new AbortController()
-    const timer = setTimeout(() => ac.abort(), 6000)
-    const res = await fetch(NPM_REGISTRY, { signal: ac.signal })
-    clearTimeout(timer)
-    if (!res.ok) return null
-    const json = (await res.json()) as { version?: string }
-    return typeof json.version === 'string' ? json.version : null
-  } catch {
-    return null
-  }
-}
 
 function detectInstallSource(): InstallSource {
   // 1. Binary install lives at ~/.prjct-cli/bin/prjct

--- a/core/services/update-checker.ts
+++ b/core/services/update-checker.ts
@@ -1,0 +1,113 @@
+/**
+ * Update Checker — owns the "is a newer prjct published?" question.
+ *
+ * Single source of truth for the upgrade-available signal. The DAEMON calls
+ * `refreshUpdateStatus(installedVersion)` (on startup + hourly) because it is
+ * the one process that reliably knows the installed version; it writes a small
+ * global flag file that cheap readers (the Claude statusline, scripts) can
+ * consult WITHOUT doing any version comparison themselves.
+ *
+ * Design notes:
+ * - The npm-registry fetch is throttled to 1/hour (network is the expensive
+ *   part). `updateAvailable` is recomputed against the CURRENT installed
+ *   version on every call, so the moment the CLI is upgraded the flag clears
+ *   even if the cached `latest` is reused — no stale "upgrade available" nag.
+ * - The flag is GLOBAL (version is global), not project-scoped. It lives under
+ *   the CLI state dir alongside the auto-updater log.
+ * - Everything is best-effort: a missing file, offline registry, or parse
+ *   error simply means "no signal" (statusline shows branding), never a crash.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { resolveCliHome } from '../infrastructure/cli-home'
+import { compareSemver } from '../schemas/model'
+
+const NPM_REGISTRY = 'https://registry.npmjs.org/prjct-cli/latest'
+const FETCH_THROTTLE_MS = 60 * 60 * 1000 // 1 hour between registry hits
+
+const stateDir = (): string => path.join(resolveCliHome(), 'state')
+const statusPath = (): string => path.join(stateDir(), 'update-status.json')
+
+export interface UpdateStatus {
+  /** Version of the running CLI when last checked. */
+  installed: string
+  /** Latest version published to npm, or null if never successfully fetched. */
+  latest: string | null
+  /** True when `latest` is strictly newer than `installed`. */
+  updateAvailable: boolean
+  /** ISO timestamp of the last refresh. */
+  checkedAt: string
+}
+
+/** Read the persisted update status, or null if absent/unreadable. */
+export function readUpdateStatus(): UpdateStatus | null {
+  try {
+    const raw = fs.readFileSync(statusPath(), 'utf-8')
+    const parsed = JSON.parse(raw) as UpdateStatus
+    if (typeof parsed.installed !== 'string') return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Refresh and persist the update status for `installedVersion`.
+ *
+ * Reuses the cached `latest` when the registry was hit < 1h ago, but always
+ * recomputes `updateAvailable` against `installedVersion` so an upgrade is
+ * reflected immediately. Returns the written status (or a no-network fallback).
+ */
+export async function refreshUpdateStatus(installedVersion: string): Promise<UpdateStatus | null> {
+  if (!installedVersion) return null
+
+  const prev = readUpdateStatus()
+  let latest = prev?.latest ?? null
+
+  const fetchedRecently =
+    prev?.checkedAt && Date.now() - Date.parse(prev.checkedAt) < FETCH_THROTTLE_MS
+  if (!fetchedRecently) {
+    const fetched = await fetchLatestVersion()
+    if (fetched) latest = fetched
+  }
+
+  const updateAvailable = latest != null && compareSemver(latest, installedVersion) > 0
+  const status: UpdateStatus = {
+    installed: installedVersion,
+    latest,
+    updateAvailable,
+    checkedAt: new Date().toISOString(),
+  }
+
+  try {
+    fs.mkdirSync(stateDir(), { recursive: true })
+    fs.writeFileSync(statusPath(), `${JSON.stringify(status, null, 2)}\n`)
+  } catch {
+    /* best-effort: failing to persist must never break the caller */
+  }
+
+  return status
+}
+
+/** Fetch the latest published version from the npm registry, or null on failure. */
+export async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    // 6s timeout — the registry answers fast or not at all.
+    const ac = new AbortController()
+    const timer = setTimeout(() => ac.abort(), 6000)
+    const res = await fetch(NPM_REGISTRY, { signal: ac.signal })
+    clearTimeout(timer)
+    if (!res.ok) return null
+    const json = (await res.json()) as { version?: string }
+    return typeof json.version === 'string' ? json.version : null
+  } catch {
+    return null
+  }
+}
+
+export const _internal = {
+  statusPath,
+  FETCH_THROTTLE_MS,
+  NPM_REGISTRY,
+}


### PR DESCRIPTION
## Problem

The Claude statusline showed a **permanent false** `⚠️ prjct vX available! Run p. upgrade` banner — even when already on the latest version.

Root cause: the statusline bash compared a project's recorded `cliVersion` (legacy `~/.prjct-cli/projects/<id>/project.json`) against the embedded `CLI_VERSION`. That file — and `storage/state.json` — were **removed in the v1.24.1+ SQLite migration**. The script always hit the "needs sync" `else` branch and nagged forever, and it **never actually checked npm** for a newer version.

## Fix — the daemon owns the version check

Per the intended design: the daemon is the one process that reliably knows the installed version, so it owns the "is a newer prjct published?" question. The statusline only **reads** a flag.

- **New `core/services/update-checker.ts`** — owns the npm-registry fetch + `compareSemver`, writes a global `~/.prjct-cli/state/update-status.json` flag `{installed, latest, updateAvailable, checkedAt}`. The registry fetch is throttled to 1/hour, but `updateAvailable` is recomputed against the **current** installed version on every call, so the flag clears the instant the CLI is upgraded.
- **`core/daemon/daemon.ts`** — calls `refreshUpdateStatus(ownVersion)` on startup + hourly (unref'd timer, cleared on shutdown).
- **Both statusline generators** (`commands/setup.ts`, `infrastructure/statusline-installer.ts`) now only **read** `updateAvailable=true` and show the real `latest` version — no comparison, no dead `project.json`.
- **`auto-updater.ts`** reuses the shared `fetchLatestVersion` (DRY).

## Tests

New `update-checker.test.ts` (5 cases): upgrade detected, no-upgrade, post-upgrade flag clearing via cached `latest`, offline no-false-positive, empty installed no-op.

Full suite: **1967 pass, 0 fail** · typecheck ✅ · format ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)