### PR TITLE
fix: regenerate statusline body on upgrade so the version-check fix ships

### DIFF
--- a/core/__tests__/commands/statusline-install.test.ts
+++ b/core/__tests__/commands/statusline-install.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Statusline install guard tests.
+ *
+ * The monolithic (bash-3.2-safe) statusline generator must:
+ *   - REPLACE an old/legacy body (e.g. the project.json-based one that caused
+ *     the permanent false "upgrade available" banner) with the flag-reading
+ *     body that consults ~/.prjct-cli/state/update-status.json
+ *   - NEVER clobber a modern modular ("v2") statusline (detected by the
+ *     `build_statusline` marker), which lives in statusline-installer.ts and
+ *     requires bash 4+ — downgrading those users would break their statusline.
+ *
+ * HOME is redirected to a temp dir (resolveUserHome reads process.env.HOME
+ * live) so nothing touches the real ~/.claude.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { SetupCommands } from '../../commands/setup'
+
+let tmpHome: string
+let prevHome: string | undefined
+let statusLinePath: string
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-statusline-'))
+  fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true })
+  statusLinePath = path.join(tmpHome, '.claude', 'prjct-statusline.sh')
+  prevHome = process.env.HOME
+  process.env.HOME = tmpHome
+})
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME
+  else process.env.HOME = prevHome
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+describe('installStatusLine — guard', () => {
+  test('replaces a legacy project.json body with the flag-reading body', async () => {
+    fs.writeFileSync(
+      statusLinePath,
+      '#!/bin/bash\nCLI_VERSION="3.0.0"\n# legacy: checks project.json\n'
+    )
+
+    const result = await new SetupCommands().installStatusLine()
+    expect(result.success).toBe(true)
+
+    const body = fs.readFileSync(statusLinePath, 'utf-8')
+    expect(body).toContain('update-status.json')
+    expect(body).not.toContain('project.json')
+  })
+
+  test('does not clobber a modern modular (v2) statusline', async () => {
+    const modular = '#!/usr/bin/env bash\n# prjct statusline v2\nbuild_statusline() { :; }\n'
+    fs.writeFileSync(statusLinePath, modular)
+
+    const result = await new SetupCommands().installStatusLine()
+    expect(result.success).toBe(true)
+
+    // Untouched — still the modular script.
+    expect(fs.readFileSync(statusLinePath, 'utf-8')).toBe(modular)
+  })
+
+  test('installs the flag-reading body on a fresh machine', async () => {
+    const result = await new SetupCommands().installStatusLine()
+    expect(result.success).toBe(true)
+
+    const body = fs.readFileSync(statusLinePath, 'utf-8')
+    expect(body).toContain('update-status.json')
+    expect(body).not.toContain('project.json')
+  })
+})

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -710,6 +710,19 @@ margin:1.25rem 0;font-size:.875rem;color:#f87171}
       const settingsPath = pathManager.getClaudeSettingsPath()
       const statusLinePath = path.join(claudeDir, 'prjct-statusline.sh')
 
+      // Don't clobber the modern modular ("v2") statusline if it's already
+      // installed — that system (statusline-installer.ts) requires bash 4+.
+      // This monolithic generator is the bash-3.2-safe variant; only (re)write
+      // it when the installed statusline is absent or this same kind. Refreshing
+      // it here is what lets self-heal repair the legacy false-upgrade-banner
+      // body on upgrade without downgrading modular users.
+      if (await fileExists(statusLinePath)) {
+        const existing = await fs.readFile(statusLinePath, 'utf-8')
+        if (existing.includes('build_statusline')) {
+          return { success: true }
+        }
+      }
+
       // Version is embedded at install time
       const scriptContent = `#!/bin/bash
 # prjct Status Line for Claude Code

--- a/core/infrastructure/self-heal.ts
+++ b/core/infrastructure/self-heal.ts
@@ -85,5 +85,17 @@ export async function runSelfHeal(currentVersion: string): Promise<void> {
     // best-effort
   }
 
+  // Regenerate the Claude statusline so an upgrade actually delivers body
+  // changes (e.g. the version-check rewrite). Without this, an old statusline
+  // body persisted across upgrades — the source of the permanent false
+  // "upgrade available" banner. installStatusLine is guarded to never clobber
+  // a modern modular ("v2") statusline.
+  try {
+    const { SetupCommands } = await import('../commands/setup')
+    await new SetupCommands().installStatusLine()
+  } catch {
+    // best-effort
+  }
+
   writeStamp(currentVersion)
 }


### PR DESCRIPTION
## Why

v3.12.1 fixed the statusline's version-check logic, but **the fixed body never reached existing installs** — which is why the false `⚠️ prjct vX available! Run p. upgrade` banner persisted ("no funciona").

The deployment gap:
- `update.ts` (the upgrade flow) doesn't reinstall the statusline
- `self-heal` didn't either
- `statusline-installer.ts` only sed-bumps `CLI_VERSION` while keeping the old body

So machines kept the legacy `project.json`-based body (and its permanent false banner) even after upgrading. The body only regenerated on an explicit `prjct setup`.

## Fix

- **`self-heal.ts`** now reinstalls the statusline on version drift (best-effort), so an upgrade actually delivers statusline body changes.
- **`setup.ts` `installStatusLine`** is guarded to **never clobber a modern modular ("v2") statusline** (detected via the `build_statusline` marker). That system requires bash 4+, so downgrading those users to the monolithic body would be a regression. It only (re)writes the bash-3.2-safe monolithic body when the installed statusline is absent or the same kind.

## Compat note

The monolithic statusline is bash-3.2-safe (macOS default). The modular "v2" statusline requires bash 4+ and degrades to bare `prjct` text without it — hence the guard, so this fix never migrates monolithic users onto a statusline their shell can't run.

## Tests

New `statusline-install.test.ts`: legacy `project.json` body is replaced with the flag-reading body, modular v2 is left untouched, fresh install works. Full suite: **1970 pass, 0 fail** · typecheck ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)