### PR TITLE
feat: triage drives orchestration — trivial→direct, complex→SDD+TDD+crew, per-subagent model

### DIFF
--- a/core/__tests__/services/task-orchestration.test.ts
+++ b/core/__tests__/services/task-orchestration.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test'
+import type { HarnessKind, HarnessLevel, HarnessRisk } from '../../schemas/state'
+import { orchestrationFor } from '../../services/task-orchestration'
+
+const h = (level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk = 'medium') => ({
+  level,
+  kind,
+  risk,
+})
+
+describe('orchestrationFor — triage drives model/effort routing', () => {
+  test('H0 trivial → cheap model, low effort, DIRECT, no ceremony', () => {
+    const p = orchestrationFor(h('H0', 'chore', 'low'))
+    expect(p.model).toBe('fast')
+    expect(p.effort).toBe('low')
+    expect(p.spec).toBe('none')
+    expect(p.tests).toBe('none')
+    expect(p.fanout).toBe('direct')
+    expect(p.directive).toContain('no subagents')
+    expect(p.directive).toContain('Don’t burn frontier tokens')
+    // No duplicated effort phrase.
+    expect(p.directive).not.toContain('low effort, low effort')
+  })
+
+  test('H1 bug → balanced model, direct, regression test behind', () => {
+    const p = orchestrationFor(h('H1', 'bug'))
+    expect(p.model).toBe('balanced')
+    expect(p.fanout).toBe('direct')
+    expect(p.spec).toBe('none')
+    expect(p.tests).toBe('after')
+  })
+
+  test('H2 feature → frontier, frame spec, tests-first, parallel fan-out', () => {
+    const p = orchestrationFor(h('H2', 'feature'))
+    expect(p.model).toBe('frontier')
+    expect(p.spec).toBe('frame')
+    expect(p.tests).toBe('first')
+    expect(p.fanout).toBe('parallel')
+    expect(p.directive).toContain('mem_3432') // subagents inherit the model
+  })
+
+  test('H3 high-risk → frontier, HIGH effort, reviewed spec, tests-first, CREW', () => {
+    const p = orchestrationFor(h('H3', 'security', 'high'))
+    expect(p.model).toBe('frontier')
+    expect(p.effort).toBe('high')
+    expect(p.spec).toBe('reviewed')
+    expect(p.tests).toBe('first')
+    expect(p.fanout).toBe('crew')
+    expect(p.directive).toContain('crew')
+    expect(p.directive).toContain('Set EACH subagent')
+  })
+})
+
+describe('orchestrationFor — SDD/TDD modes are a FLOOR (only ADD ceremony)', () => {
+  test('SDD strict forces a reviewed spec even on a simple bug', () => {
+    const off = orchestrationFor(h('H1', 'bug'), 'off')
+    expect(off.spec).toBe('none')
+    const strict = orchestrationFor(h('H1', 'bug'), 'strict')
+    expect(strict.spec).toBe('reviewed')
+  })
+
+  test('SDD advisory raises none → frame but never lowers reviewed', () => {
+    expect(orchestrationFor(h('H1', 'bug'), 'advisory').spec).toBe('frame')
+    // H3 already reviewed — advisory must not downgrade it.
+    expect(orchestrationFor(h('H3', 'security', 'high'), 'advisory').spec).toBe('reviewed')
+  })
+
+  test('TDD strict forces tests-first; assist raises none → after', () => {
+    expect(orchestrationFor(h('H1', 'bug'), 'off', 'strict').tests).toBe('first')
+    expect(orchestrationFor(h('H0', 'chore', 'low'), 'off', 'assist').tests).toBe('none') // chore: no code
+    expect(orchestrationFor(h('H1', 'bug'), 'off', 'assist').tests).toBe('after')
+  })
+
+  test('docs/chore NEVER get spec or tests, even under strict modes', () => {
+    const docs = orchestrationFor(h('H0', 'docs', 'low'), 'strict', 'strict')
+    expect(docs.spec).toBe('none')
+    expect(docs.tests).toBe('none')
+    expect(docs.fanout).toBe('direct')
+  })
+})
+
+describe('orchestrationFor — determinism', () => {
+  test('same inputs → identical plan (no LLM, no randomness)', () => {
+    const a = orchestrationFor(h('H2', 'refactor'), 'advisory', 'assist')
+    const b = orchestrationFor(h('H2', 'refactor'), 'advisory', 'assist')
+    expect(a).toEqual(b)
+  })
+})

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -107,6 +107,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const beforeInstructions = outcome.instructions ?? []
       const pipeline = outcome.pipeline
       const harness = outcome.harness
+      const orchestration = outcome.orchestration
       // Cap the passive surface: 3–4 reranked hits are enough as a "has this
       // come up before?" cue. The agent pulls full bodies on demand via
       // `prjct search <id>` / `prjct context memory`. Keeps work --md lean.
@@ -139,6 +140,9 @@ export class WorkflowCommands extends PrjctCommandsBase {
               ].filter((s): s is string => s !== null)
             )
           ),
+          orchestration
+            ? mdSection('How to run this (orchestration)', orchestration.directive)
+            : null,
           pipeline
             ? mdSection(
                 'Task Pipeline',
@@ -189,6 +193,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
             out.info(`Evidence: ${harness.expectedEvidence.join(', ')}`)
           }
         }
+        if (orchestration) out.info(orchestration.directive)
         if (riskLines.length > 0) {
           out.info('⚠ Risk — what bit us in this area before (read before you edit)')
           for (const line of riskLines) out.info(`  ${line}`)

--- a/core/services/task-orchestration.ts
+++ b/core/services/task-orchestration.ts
@@ -1,0 +1,167 @@
+/**
+ * Triage → orchestration. The harness (`buildTaskHarness`) classifies each
+ * task into a level (H0-H3), kind, and risk. That classification gated
+ * EVIDENCE, but nothing routed the *LLM resource* — so a trivial docs edit and
+ * a security migration both ran on whatever (often frontier) model the parent
+ * agent happened to be on, and any subagents INHERITED that expensive model
+ * (mem_3432). That is burning tokens.
+ *
+ * This module turns the triage into a concrete, correct orchestration plan:
+ * which model tier + effort THIS task deserves, whether it needs a spec (SDD),
+ * tests-first (TDD), and whether to do it directly or fan out to a group of
+ * subagents — and it always reminds the agent to SET each subagent's model
+ * (they inherit the parent's otherwise). The project's `sdd`/`tdd` modes are
+ * reconciled as a FLOOR over the risk-based default (strict forces the
+ * ceremony even on a low-risk task; the triage can only ADD ceremony, never
+ * remove what a mode requires).
+ *
+ * Deterministic + free (no LLM call to decide how to spend the LLM).
+ */
+
+import type { HarnessKind, HarnessLevel, HarnessRisk, TaskHarness } from '../schemas/state'
+
+/** Rig-agnostic capability tier (see core/schemas/model.ts MODEL_TIERS). */
+export type ModelTier = 'fast' | 'balanced' | 'frontier'
+export type Effort = 'low' | 'medium' | 'high'
+/** none = skip; frame = lightweight `prjct spec`; reviewed = spec + audit panel. */
+export type SpecCeremony = 'none' | 'frame' | 'reviewed'
+/** none = skip; after = test the change; first = tests before implementation. */
+export type TestCeremony = 'none' | 'after' | 'first'
+/** direct = do it yourself; parallel = independent subagents; crew = leader + review crew. */
+export type FanOut = 'direct' | 'parallel' | 'crew'
+
+export type SddMode = 'off' | 'advisory' | 'strict'
+export type TddMode = 'off' | 'assist' | 'strict'
+
+export interface OrchestrationPlan {
+  model: ModelTier
+  effort: Effort
+  spec: SpecCeremony
+  tests: TestCeremony
+  fanout: FanOut
+  /** Agent-facing one-block directive — how to run THIS task efficiently. */
+  directive: string
+}
+
+const SPEC_RANK: Record<SpecCeremony, number> = { none: 0, frame: 1, reviewed: 2 }
+const TEST_RANK: Record<TestCeremony, number> = { none: 0, after: 1, first: 2 }
+const maxSpec = (a: SpecCeremony, b: SpecCeremony): SpecCeremony =>
+  SPEC_RANK[a] >= SPEC_RANK[b] ? a : b
+const maxTest = (a: TestCeremony, b: TestCeremony): TestCeremony =>
+  TEST_RANK[a] >= TEST_RANK[b] ? a : b
+
+/** Is this a code-touching task (docs/chore never need spec/tests)? */
+function isCodeKind(kind: HarnessKind): boolean {
+  return kind !== 'docs' && kind !== 'chore'
+}
+
+/** Risk-based defaults per harness level (before SDD/TDD mode floors). */
+function baseline(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): OrchestrationPlan {
+  const code = isCodeKind(kind)
+  switch (level) {
+    case 'H0':
+      // Trivial (docs/chore). Do NOT spend a frontier model on this.
+      return {
+        model: 'fast',
+        effort: 'low',
+        spec: 'none',
+        tests: 'none',
+        fanout: 'direct',
+        directive: '',
+      }
+    case 'H1':
+      // Simple bug/change. Fix directly on a balanced model; leave a test behind.
+      return {
+        model: 'balanced',
+        effort: 'medium',
+        spec: 'none',
+        tests: code ? 'after' : 'none',
+        fanout: 'direct',
+        directive: '',
+      }
+    case 'H2':
+      // Substantial feature/refactor. Frame a lightweight spec, tests first,
+      // frontier for the implementation; fan out only if scope is separable.
+      return {
+        model: 'frontier',
+        effort: 'medium',
+        spec: code ? 'frame' : 'none',
+        tests: code ? 'first' : 'none',
+        fanout: 'parallel',
+        directive: '',
+      }
+    default:
+      // H3 — high-risk (security / architecture / migration). Full ceremony.
+      return {
+        model: 'frontier',
+        effort: risk === 'high' ? 'high' : 'medium',
+        spec: code ? 'reviewed' : 'none',
+        tests: code ? 'first' : 'none',
+        fanout: 'crew',
+        directive: '',
+      }
+  }
+}
+
+/** SDD/TDD project modes are a FLOOR: they can only ADD ceremony. */
+function applyModeFloors(
+  plan: OrchestrationPlan,
+  kind: HarnessKind,
+  sdd: SddMode,
+  tdd: TddMode
+): OrchestrationPlan {
+  if (!isCodeKind(kind)) return plan
+  let spec = plan.spec
+  if (sdd === 'advisory') spec = maxSpec(spec, 'frame')
+  if (sdd === 'strict') spec = maxSpec(spec, 'reviewed')
+  let tests = plan.tests
+  if (tdd === 'assist') tests = maxTest(tests, 'after')
+  if (tdd === 'strict') tests = maxTest(tests, 'first')
+  return { ...plan, spec, tests }
+}
+
+const SPEC_TEXT: Record<SpecCeremony, string> = {
+  none: 'no spec',
+  frame: 'frame a lightweight spec (`prjct spec "<title>"`)',
+  reviewed: 'reviewed spec + audit panel (`prjct spec "<title>"` → `prjct spec audit <id>`)',
+}
+const TEST_TEXT: Record<TestCeremony, string> = {
+  none: 'no test ceremony',
+  after: 'leave a regression test behind',
+  first: 'tests BEFORE implementation',
+}
+const FANOUT_TEXT: Record<FanOut, string> = {
+  direct: 'do it yourself — no subagents',
+  parallel:
+    'fan out to parallel subagents ONLY if scope splits into independent pieces — set EACH subagent’s model explicitly (they inherit yours otherwise: mem_3432)',
+  crew: 'run a crew (`prjct crew`): leader + implementer + review lenses. Set EACH subagent’s model (Explore→fast, implementer→frontier, reviewers→balanced) — they inherit your expensive model unless you fix it',
+}
+const MODEL_HINT: Record<ModelTier, string> = {
+  fast: 'fast/cheap model (e.g. haiku)',
+  balanced: 'balanced model (e.g. sonnet)',
+  frontier: 'frontier model (e.g. opus)',
+}
+
+/** Compose the agent-facing directive block from the resolved plan. */
+function renderDirective(level: HarnessLevel, kind: HarnessKind, plan: OrchestrationPlan): string {
+  const effortNote =
+    plan.effort === 'high' ? ', HIGH effort' : plan.effort === 'low' ? ', low effort' : ''
+  if (level === 'H0') {
+    return `Orchestrate (${level} ${kind}): trivial — do it directly on a ${MODEL_HINT[plan.model]}${effortNote}. ${SPEC_TEXT[plan.spec]}, ${TEST_TEXT[plan.tests]}, ${FANOUT_TEXT[plan.fanout]}. Don’t burn frontier tokens on this.`
+  }
+  return `Orchestrate (${level} ${kind}/${plan.model}${effortNote}): ${SPEC_TEXT[plan.spec]}; ${TEST_TEXT[plan.tests]}; ${FANOUT_TEXT[plan.fanout]}.`
+}
+
+/**
+ * The public entrypoint: given the triage harness and the project's SDD/TDD
+ * modes, produce the orchestration plan + its agent-facing directive.
+ */
+export function orchestrationFor(
+  harness: Pick<TaskHarness, 'level' | 'kind' | 'risk'>,
+  sdd: SddMode = 'off',
+  tdd: TddMode = 'off'
+): OrchestrationPlan {
+  const base = baseline(harness.level, harness.kind, harness.risk)
+  const withFloors = applyModeFloors(base, harness.kind, sdd, tdd)
+  return { ...withFloors, directive: renderDirective(harness.level, harness.kind, withFloors) }
+}

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -33,6 +33,7 @@ import { buildLivingContextPrompt, parseLivingContextFields } from './living-con
 import { memoryService } from './memory-service'
 import projectService from './project-service'
 import { buildTaskHarness, evaluateHarnessCompletion } from './task-harness'
+import { type OrchestrationPlan, orchestrationFor } from './task-orchestration'
 import {
   decideTaskPipeline,
   formatTaskPipelineNextAction,
@@ -54,6 +55,8 @@ export interface StartTaskOutcome {
   linearId?: string
   linkedSpecId?: string
   harness?: TaskHarness
+  /** Triage → orchestration plan: model/effort + spec/tests + fan-out directive. */
+  orchestration?: OrchestrationPlan
   pipeline?: {
     classification: TaskPipelineClassification
     station: TaskPipelineStation
@@ -216,6 +219,25 @@ export async function startTask(
   const linkedSpecId = options.spec
   const harness = buildTaskHarness(description)
 
+  // Triage → orchestration: turn the harness + the project's SDD/TDD modes
+  // into a concrete plan (model tier, effort, spec/tests ceremony, fan-out) so
+  // a trivial task runs cheap and DIRECT while a complex one gets spec + TDD +
+  // a subagent crew — and the agent is told to set each subagent's model (they
+  // inherit the parent's expensive model otherwise). This is what makes the
+  // classification actually SAVE tokens instead of only gating evidence.
+  const orchestration = await (async () => {
+    try {
+      const cfg = await configManager.readConfig(projectPath).catch(() => null)
+      const [{ effectiveSddMode }, { effectiveTddMode }] = await Promise.all([
+        import('../commands/sdd'),
+        import('../commands/tdd'),
+      ])
+      return orchestrationFor(harness, effectiveSddMode(cfg), effectiveTddMode(cfg))
+    } catch {
+      return orchestrationFor(harness)
+    }
+  })()
+
   // Multi-agent: a task in a child worktree lands in activeTasks[] keyed by
   // its workspaceId, so parallel agents don't clobber a shared currentTask.
   // The main worktree keeps the singular currentTask path (transparent for
@@ -305,6 +327,7 @@ export async function startTask(
     linearId,
     linkedSpecId,
     harness,
+    orchestration,
     pipeline: {
       classification: pipelineState.classification,
       station: pipelineState.station,


### PR DESCRIPTION
## The problem — classification without routing = burning tokens

prjct triaged every task (`buildTaskHarness` → H0-H3 / kind / risk) but the classification only gated **evidence**. Nothing routed the **LLM resource**: a trivial docs edit and a security migration both ran on whatever (often frontier) model the parent agent was on, and any subagents **inherited that expensive model** (mem_3432). Triage that doesn't route is just burning tokens — the exact gap called out.

## The fix — triage DRIVES orchestration

New `core/services/task-orchestration.ts` turns the triage into a concrete, **deterministic** (no LLM, no cost) plan, surfaced at `prjct work` start:

| Level | Model / effort | SDD | TDD | Fan-out |
|---|---|---|---|---|
| **H0** trivial (docs/chore) | fast/cheap, low | none | none | **direct — no subagents** ("don't burn frontier tokens") |
| **H1** bug | balanced, medium | none | regression test | direct |
| **H2** feature/refactor | frontier, medium | frame a spec | tests-first | parallel **if** scope splits |
| **H3** security/arch/migration | frontier, **HIGH** | reviewed spec + audit | strict tests-first | **crew** (leader + implementer + review lenses) |

Every fan-out directive tells the agent to **set each subagent's model explicitly** (Explore→fast, implementer→frontier, reviewers→balanced) — closing the inherit-the-expensive-parent leak. The project's `sdd`/`tdd` modes are a **FLOOR**: strict forces the ceremony even on a low-risk task; triage can only ADD, never remove what a mode requires. docs/chore never get spec/tests regardless of mode.

## Verified end-to-end (real `prjct work`)

```
work "fix typo in README"        → Orchestrate (H1): no spec; regression test; do it yourself — no subagents.
work "add export feature"        → Orchestrate (H2/frontier): frame a spec; tests BEFORE impl; fan out if separable; set each subagent's model.
work "auth token security migration" → Orchestrate (H3/frontier, HIGH): reviewed spec + audit; tests BEFORE impl; run a CREW; set EACH subagent's model.
work "bump dependency chore"     → Orchestrate (H0): trivial — fast/cheap model, do it yourself — no subagents. Don't burn frontier tokens.
```

Wired into `StartTaskOutcome.orchestration` and rendered as a "How to run this (orchestration)" block in `prjct work --md` (+ a one-liner in plain output).

## Checks
- typecheck clean · biome clean · **1891/1891 tests** (+9 orchestration unit tests: per-level routing, SDD/TDD mode floors, docs/chore exemption, determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
