### PR TITLE
feat(storage): ships in typed shipped_features table — retire the 5.4MB kv_store blob (Schema v2 C5)

### DIFF
--- a/core/__tests__/commands/shipping.test.ts
+++ b/core/__tests__/commands/shipping.test.ts
@@ -123,8 +123,8 @@ describe('ship() — workflow-first', () => {
     // …the marker was cleared…
     expect(prjctDb.getDoc(projectId, SHIP_MARKER_KEY)).toBeNull()
     // …and the current ship still recorded its own row.
-    const all = await shippedStorage.read(projectId)
-    expect(all.shipped.some((s: { name: string }) => s.name === 'next thing')).toBe(true)
+    const all = await shippedStorage.getAll(projectId)
+    expect(all.some((s) => s.name === 'next thing')).toBe(true)
   })
 
   test('reconcile is a no-op when the marker version is already recorded', async () => {
@@ -137,9 +137,9 @@ describe('ship() — workflow-first', () => {
 
     await cmd.ship('another', projectPath, { md: true, intent: 'register-only' })
 
-    const all = await shippedStorage.read(projectId)
+    const all = await shippedStorage.getAll(projectId)
     // No duplicate 5.0.0 row, and the stale marker is cleared.
-    expect(all.shipped.filter((s: { version: string }) => s.version === '5.0.0')).toHaveLength(1)
+    expect(all.filter((s) => s.version === '5.0.0')).toHaveLength(1)
     expect(prjctDb.getDoc(projectId, SHIP_MARKER_KEY)).toBeNull()
   })
 

--- a/core/__tests__/storage/archive-storage.test.ts
+++ b/core/__tests__/storage/archive-storage.test.ts
@@ -160,44 +160,50 @@ describe('Archive Storage', () => {
 
   describe('shipped archival', () => {
     it('should archive shipped features older than 90 days', async () => {
-      // Write shipped data with old and recent items
-      await shippedStorage.write(testProjectId, {
-        shipped: [
-          { id: 'recent', name: 'Recent', version: '2.0.0', shippedAt: daysAgoISO(10) },
-          { id: 'old', name: 'Old', version: '1.0.0', shippedAt: daysAgoISO(100) },
-        ],
-        lastUpdated: getTimestamp(),
-      })
+      // Seed shipped rows (typed store) with old and recent items.
+      const recent = await shippedStorage.addShipped(
+        testProjectId,
+        { name: 'Recent', version: '2.0.0' },
+        daysAgoISO(10)
+      )
+      const old = await shippedStorage.addShipped(
+        testProjectId,
+        { name: 'Old', version: '1.0.0' },
+        daysAgoISO(100)
+      )
 
       const archived = await shippedStorage.archiveOldShipped(testProjectId)
       expect(archived).toBe(1)
 
       // Verify active storage only has recent
-      const data = await shippedStorage.read(testProjectId)
-      expect(data.shipped).toHaveLength(1)
-      expect(data.shipped[0].id).toBe('recent')
+      const data = await shippedStorage.getAll(testProjectId)
+      expect(data).toHaveLength(1)
+      expect(data[0].id).toBe(recent.id)
 
       // Verify archive table has old item
       const records = archiveStorage.getArchived(testProjectId, 'shipped')
       expect(records).toHaveLength(1)
-      expect(records[0].entity_id).toBe('old')
+      expect(records[0].entity_id).toBe(old.id)
       expect(records[0].summary).toBe('Old v1.0.0')
     })
 
     it('should not archive recent shipped features', async () => {
-      await shippedStorage.write(testProjectId, {
-        shipped: [
-          { id: 'r1', name: 'R1', version: '1.0.0', shippedAt: daysAgoISO(5) },
-          { id: 'r2', name: 'R2', version: '1.1.0', shippedAt: daysAgoISO(30) },
-        ],
-        lastUpdated: getTimestamp(),
-      })
+      await shippedStorage.addShipped(
+        testProjectId,
+        { name: 'R1', version: '1.0.0' },
+        daysAgoISO(5)
+      )
+      await shippedStorage.addShipped(
+        testProjectId,
+        { name: 'R2', version: '1.1.0' },
+        daysAgoISO(30)
+      )
 
       const archived = await shippedStorage.archiveOldShipped(testProjectId)
       expect(archived).toBe(0)
 
-      const data = await shippedStorage.read(testProjectId)
-      expect(data.shipped).toHaveLength(2)
+      const data = await shippedStorage.getAll(testProjectId)
+      expect(data).toHaveLength(2)
     })
   })
 

--- a/core/__tests__/storage/shipped-storage-typed.test.ts
+++ b/core/__tests__/storage/shipped-storage-typed.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Schema v2 C5 — ships in the typed `shipped_features` table.
+ * Covers the rewrite (idempotent writes + indexed reads) and the migration
+ * (dedupe the legacy kv_store blob, retire it).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { prjctDb } from '../../storage/database'
+import { migrations } from '../../storage/database/migrations'
+import { openDatabase } from '../../storage/database/sqlite-compat'
+import { shippedStorage } from '../../storage/shipped-storage'
+
+let tmpRoot: string
+const pid = 'test-shipped-typed'
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+const iso = (daysAgo: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString()
+}
+
+describe('shipped-storage — typed table (Schema v2 C5)', () => {
+  beforeEach(async () => {
+    prjctDb.close()
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-shipped-'))
+    pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+    pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+      path.join(tmpRoot, id, layer, filename)
+    await fs.mkdir(path.join(tmpRoot, pid, 'sync'), { recursive: true })
+    await fs.writeFile(path.join(tmpRoot, pid, 'sync', 'pending.json'), '[]', 'utf-8')
+    prjctDb.getDb(pid)
+  })
+
+  afterEach(async () => {
+    prjctDb.close()
+    pathManager.getGlobalProjectPath = origGlobal
+    pathManager.getFilePath = origFile
+    if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('addShipped is idempotent on the natural key (root-cause of the 33k blob)', async () => {
+    const at = iso(1)
+    await shippedStorage.addShipped(pid, { name: 'rate limiter', version: '1.0.0' }, at)
+    // Re-apply the SAME (name, version, shippedAt) — as a sync pull would.
+    await shippedStorage.addShipped(pid, { name: 'rate limiter', version: '1.0.0' }, at)
+    await shippedStorage.addShipped(pid, { name: 'rate limiter', version: '1.0.0' }, at)
+    expect(await shippedStorage.getCount(pid)).toBe(1)
+  })
+
+  it('distinct ships (same name, different version/time) are kept', async () => {
+    await shippedStorage.addShipped(pid, { name: 'auth', version: '1.0.0' }, iso(3))
+    await shippedStorage.addShipped(pid, { name: 'auth', version: '2.0.0' }, iso(2))
+    expect(await shippedStorage.getCount(pid)).toBe(2)
+  })
+
+  it('reads are typed + bounded (getRecent limit, getByVersion, getByDateRange)', async () => {
+    await shippedStorage.addShipped(pid, { name: 'a', version: '1.0.0' }, iso(30))
+    await shippedStorage.addShipped(pid, { name: 'b', version: '2.0.0' }, iso(2))
+    await shippedStorage.addShipped(pid, { name: 'c', version: '3.0.0' }, iso(1))
+
+    const recent = await shippedStorage.getRecent(pid, 2)
+    expect(recent.map((r) => r.name)).toEqual(['c', 'b']) // newest-first, limited
+
+    const byVer = await shippedStorage.getByVersion(pid, '2.0.0')
+    expect(byVer?.name).toBe('b')
+
+    const range = await shippedStorage.getByDateRange(pid, new Date(iso(5)), new Date())
+    expect(range.map((r) => r.name).sort()).toEqual(['b', 'c']) // excludes the 30-day-old 'a'
+  })
+
+  it('round-trips extra fields (tasks/type) through the cold data column', async () => {
+    await shippedStorage.addShipped(pid, {
+      name: 'export',
+      version: '1.0.0',
+      type: 'feature',
+      tasks: ['t1', 't2'],
+    })
+    const [row] = await shippedStorage.getRecent(pid, 1)
+    expect(row.type).toBe('feature')
+    expect(row.tasks).toEqual(['t1', 't2'])
+  })
+})
+
+describe('migration 51 — backfill kv_store blob → typed table, deduped', () => {
+  it('dedupes the blob by natural key and retires the kv_store key', () => {
+    const db = openDatabase(':memory:')
+    // Minimal schema the migration touches.
+    db.run(
+      `CREATE TABLE shipped_features (
+         id TEXT PRIMARY KEY, name TEXT NOT NULL, shipped_at TEXT NOT NULL, version TEXT NOT NULL,
+         description TEXT, type TEXT, duration TEXT, data TEXT )`
+    )
+    db.run(
+      'CREATE TABLE kv_store (key TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at TEXT NOT NULL)'
+    )
+    // A blob with the real duplication shape: same ship re-added with new ids.
+    const at = '2026-06-01T00:00:00.000Z'
+    const ships = [
+      { id: 'a1', name: 'ship one', version: '1.0.0', shippedAt: at },
+      { id: 'a2', name: 'ship one', version: '1.0.0', shippedAt: at }, // dup (new id)
+      { id: 'a3', name: 'ship one', version: '1.0.0', shippedAt: at }, // dup (new id)
+      { id: 'b1', name: 'ship two', version: '2.0.0', shippedAt: at }, // distinct
+    ]
+    db.prepare('INSERT INTO kv_store (key, data, updated_at) VALUES (?, ?, ?)').run(
+      'shipped',
+      JSON.stringify({ shipped: ships, lastUpdated: at }),
+      at
+    )
+
+    const m51 = migrations.find((m) => m.version === 51)
+    expect(m51).toBeTruthy()
+    m51?.up(db)
+
+    const count = db.prepare('SELECT COUNT(*) AS c FROM shipped_features').get() as { c: number }
+    expect(count.c).toBe(2) // 4 blob rows → 2 distinct natural keys
+    const blob = db.prepare("SELECT COUNT(*) AS c FROM kv_store WHERE key = 'shipped'").get() as {
+      c: number
+    }
+    expect(blob.c).toBe(0) // legacy blob retired
+    db.close()
+  })
+})

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2087,6 +2087,62 @@ export const migrations: Migration[] = [
       db.run('DROP TABLE IF EXISTS analysis')
     },
   },
+  {
+    version: 51,
+    name: 'shipped-features-typed-store',
+    up: (db: SqliteDatabase) => {
+      // Schema v2 C5: ships lived in the `kv_store['shipped']` JSON blob (read
+      // + rewritten whole on every ship), while the typed `shipped_features`
+      // table — already READ by recall (project-memory) and reporting
+      // (product) — was never written, so those surfaces silently returned
+      // empty. This migration makes the typed table the single store.
+      //
+      // Root-cause for the observed 33k-row / 41-real-ship blob: `addShipped`
+      // minted a fresh id every call and the sync pull re-applied each ship, so
+      // the same ship accreted ~800×. A UNIQUE natural-key index makes the
+      // write idempotent (INSERT OR IGNORE) and dedups the backfill.
+      db.run(
+        'CREATE UNIQUE INDEX IF NOT EXISTS ux_shipped_natural ON shipped_features(name, version, shipped_at)'
+      )
+      const blob = db.prepare("SELECT data FROM kv_store WHERE key = 'shipped'").get() as
+        | { data?: string }
+        | undefined
+      if (blob?.data) {
+        let ships: Array<Record<string, unknown>> = []
+        try {
+          const parsed = JSON.parse(blob.data) as { shipped?: unknown }
+          if (Array.isArray(parsed?.shipped))
+            ships = parsed.shipped as Array<Record<string, unknown>>
+        } catch {
+          // Malformed blob must not brick startup — leave it, migrate nothing.
+          ships = []
+        }
+        const insert = db.prepare(
+          `INSERT OR IGNORE INTO shipped_features
+             (id, name, shipped_at, version, description, type, duration, data)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        for (const s of ships) {
+          const id = s.id as string | undefined
+          const name = s.name as string | undefined
+          const shippedAt = s.shippedAt as string | undefined
+          if (!id || !name || !shippedAt) continue
+          insert.run(
+            id,
+            name,
+            shippedAt,
+            (s.version as string) ?? '',
+            (s.description as string) ?? null,
+            (s.type as string) ?? null,
+            (s.duration as string) ?? null,
+            JSON.stringify(s)
+          )
+        }
+      }
+      // Retire the legacy blob — the typed table is now the source of truth.
+      db.run("DELETE FROM kv_store WHERE key = 'shipped'")
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/storage/shipped-storage.ts
+++ b/core/storage/shipped-storage.ts
@@ -1,8 +1,17 @@
 /**
  * Shipped Storage
  *
- * Manages shipped features via storage/shipped.json
- * Generates context/shipped.md for Claude
+ * Schema v2 (C5): ships are stored in the typed `shipped_features` table —
+ * indexed columns for the hot fields (name, version, shipped_at) and a cold
+ * `data` JSON column for the rare extras (tasks, agent, changes). Reads are
+ * bounded indexed queries, NOT a parse of the whole history: `getRecent` is a
+ * `LIMIT`, `getCount` is a `COUNT(*)`. The legacy `kv_store['shipped']` blob
+ * (read + rewritten whole on every ship) is retired by migration 51, which
+ * also backfills it into this table.
+ *
+ * `addShipped` is idempotent via the natural-key UNIQUE index
+ * (name, version, shipped_at) — re-applying a pulled ship is a no-op, closing
+ * the duplication that had grown the blob to 33k rows for 41 real ships.
  */
 
 import { generateUUID } from '../schemas/schemas'
@@ -17,16 +26,51 @@ import { StorageManager } from './storage-manager'
 // to force a re-backfill in a future release.
 const SHIP_BACKFILL_FLAG = 'shipped:backfilled:v1'
 
+/** A row of the typed `shipped_features` table. */
+interface ShippedFeatureRow {
+  id: string
+  name: string
+  shipped_at: string
+  version: string
+  description: string | null
+  type: string | null
+  duration: string | null
+  data: string | null
+}
+
+/** Reconstruct a full `ShippedFeature` from a typed row + its cold `data` JSON. */
+function rowToFeature(row: ShippedFeatureRow): ShippedFeature {
+  let extra: Partial<ShippedFeature> = {}
+  if (row.data) {
+    try {
+      extra = JSON.parse(row.data) as Partial<ShippedFeature>
+    } catch {
+      extra = {}
+    }
+  }
+  const feature: ShippedFeature = {
+    ...extra,
+    id: row.id,
+    name: row.name,
+    shippedAt: row.shipped_at,
+    version: row.version,
+  }
+  if (row.description != null) feature.description = row.description
+  if (row.type != null) feature.type = row.type as ShippedFeature['type']
+  if (row.duration != null) feature.duration = row.duration
+  return feature
+}
+
 class ShippedStorage extends StorageManager<ShippedJson> {
   constructor() {
     super('shipped.json', ShippedJsonSchema)
   }
 
+  // Vestigial abstract-method implementations — the base blob read/write path
+  // is no longer used (all methods below query the typed table). Kept only so
+  // `publishEvent` (the sync surface) stays available on this class.
   protected getDefault(): ShippedJson {
-    return {
-      shipped: [],
-      lastUpdated: '',
-    }
+    return { shipped: [], lastUpdated: '' }
   }
 
   protected getEventType(action: 'update' | 'create' | 'delete'): string {
@@ -35,26 +79,25 @@ class ShippedStorage extends StorageManager<ShippedJson> {
 
   // =========== Domain Methods ===========
 
-  /**
-   * Get all shipped features
-   */
+  /** All ships, newest first. */
   async getAll(projectId: string): Promise<ShippedFeature[]> {
-    const data = await this.read(projectId)
-    return data.shipped
+    return prjctDb
+      .query<ShippedFeatureRow>(
+        projectId,
+        'SELECT * FROM shipped_features ORDER BY shipped_at DESC'
+      )
+      .map(rowToFeature)
   }
 
   /**
    * One-time backfill: re-publish every locally-stored ship as a canonical
    * `shipped_item.created` event so ships shipped BEFORE the canonical-event fix
-   * (which previously emitted off-contract `feature.shipped` and were dropped at
-   * /sync/batch) finally reach the cloud. Guarded by a per-project kv flag so it
-   * runs once; idempotent server-side via (project_id, entity_id, content_hash)
-   * dedup. Returns the number of ships re-published (0 if already backfilled).
+   * finally reach the cloud. Guarded by a per-project kv flag so it runs once;
+   * idempotent server-side via (project_id, entity_id, content_hash) dedup.
    */
   async republishShips(projectId: string): Promise<number> {
     if (prjctDb.getDoc<{ at: string }>(projectId, SHIP_BACKFILL_FLAG)) return 0
-    const data = await this.read(projectId)
-    const ships = Array.isArray(data.shipped) ? data.shipped : []
+    const ships = await this.getAll(projectId)
     for (const ship of ships) {
       await this.publishEvent(projectId, 'shipped_item.created', {
         id: ship.id,
@@ -68,18 +111,21 @@ class ShippedStorage extends StorageManager<ShippedJson> {
     return ships.length
   }
 
-  /**
-   * Get recent shipped features
-   */
+  /** Recent ships — a bounded indexed query, not a full-history read. */
   async getRecent(projectId: string, limit: number = 5): Promise<ShippedFeature[]> {
-    const data = await this.read(projectId)
-    return data.shipped
-      .sort((a, b) => new Date(b.shippedAt).getTime() - new Date(a.shippedAt).getTime())
-      .slice(0, limit)
+    return prjctDb
+      .query<ShippedFeatureRow>(
+        projectId,
+        'SELECT * FROM shipped_features ORDER BY shipped_at DESC LIMIT ?',
+        limit
+      )
+      .map(rowToFeature)
   }
 
   /**
-   * Add a shipped feature
+   * Record a shipped feature. Idempotent: the natural-key UNIQUE index means
+   * re-applying the same (name, version, shipped_at) is a no-op — pulled ships
+   * from other machines never accrete duplicates.
    */
   async addShipped(
     projectId: string,
@@ -94,17 +140,22 @@ class ShippedStorage extends StorageManager<ShippedJson> {
       shippedAt: shippedAt || getTimestamp(),
     }
 
-    await this.update(projectId, (data) => ({
-      shipped: [shipped, ...(Array.isArray(data.shipped) ? data.shipped : [])],
-      lastUpdated: getTimestamp(),
-    }))
+    prjctDb.run(
+      projectId,
+      `INSERT OR IGNORE INTO shipped_features
+         (id, name, shipped_at, version, description, type, duration, data)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      shipped.id,
+      shipped.name,
+      shipped.shippedAt,
+      shipped.version ?? '',
+      shipped.description ?? null,
+      shipped.type ?? null,
+      shipped.duration ?? null,
+      JSON.stringify(shipped)
+    )
 
-    // Publish a canonical `shipped_item` event: `shipped_item.created` derives
-    // to entityType `shipped_items` (the table the cloud reads for ships) and a
-    // top-level `id` so the event carries a stable entity id. The legacy
-    // `feature.shipped` shape pluralized to `features` (off-contract → dropped)
-    // and exposed only `shipId` (unrecognized → null entity id), so ships never
-    // reached the cloud.
+    // Publish a canonical `shipped_item` event for cloud sync (unchanged wire).
     await this.publishEvent(projectId, 'shipped_item.created', {
       id: shipped.id,
       shipId: shipped.id,
@@ -116,40 +167,43 @@ class ShippedStorage extends StorageManager<ShippedJson> {
     return shipped
   }
 
-  /**
-   * Get shipped by version
-   */
+  /** Most recent ship for a version. */
   async getByVersion(projectId: string, version: string): Promise<ShippedFeature | undefined> {
-    const data = await this.read(projectId)
-    return data.shipped.find((s) => s.version === version)
+    const row = prjctDb.get<ShippedFeatureRow>(
+      projectId,
+      'SELECT * FROM shipped_features WHERE version = ? ORDER BY shipped_at DESC LIMIT 1',
+      version
+    )
+    return row ? rowToFeature(row) : undefined
   }
 
-  /**
-   * Get count
-   */
+  /** Total ships — a COUNT, not a length of a parsed array. */
   async getCount(projectId: string): Promise<number> {
-    const data = await this.read(projectId)
-    return data.shipped.length
+    return (
+      prjctDb.get<{ c: number }>(projectId, 'SELECT COUNT(*) AS c FROM shipped_features')?.c ?? 0
+    )
   }
 
   /**
-   * Get shipped in date range
+   * Ships in a date range. `shipped_at` is ISO-8601 UTC text, so lexicographic
+   * comparison is chronological.
    */
   async getByDateRange(
     projectId: string,
     startDate: Date,
     endDate: Date
   ): Promise<ShippedFeature[]> {
-    const data = await this.read(projectId)
-    return data.shipped.filter((s) => {
-      const date = new Date(s.shippedAt)
-      return date >= startDate && date <= endDate
-    })
+    return prjctDb
+      .query<ShippedFeatureRow>(
+        projectId,
+        'SELECT * FROM shipped_features WHERE shipped_at >= ? AND shipped_at <= ? ORDER BY shipped_at DESC',
+        startDate.toISOString(),
+        endDate.toISOString()
+      )
+      .map(rowToFeature)
   }
 
-  /**
-   * Get stats for a period
-   */
+  /** Ship count for a period. */
   async getStats(
     projectId: string,
     period: 'week' | 'month' | 'year' = 'month'
@@ -170,27 +224,26 @@ class ShippedStorage extends StorageManager<ShippedJson> {
     }
 
     const shipped = await this.getByDateRange(projectId, startDate, now)
-
-    return {
-      count: shipped.length,
-      period,
-    }
+    return { count: shipped.length, period }
   }
 
   /**
-   * Archive shipped features older than retention period (PRJ-267).
-   * Moves old items to archive table, keeps 1-line summary in active storage.
-   * Returns count of archived items.
+   * Archive shipped features older than retention period (PRJ-267). Moves old
+   * rows to the archive table and deletes them from the active table.
    */
   async archiveOldShipped(projectId: string): Promise<number> {
-    const data = await this.read(projectId)
-    const threshold = getDaysAgo(ARCHIVE_POLICIES.SHIPPED_RETENTION_DAYS)
+    const thresholdIso = getDaysAgo(ARCHIVE_POLICIES.SHIPPED_RETENTION_DAYS).toISOString()
 
-    const stale = data.shipped.filter((s) => new Date(s.shippedAt) < threshold)
+    const stale = prjctDb
+      .query<ShippedFeatureRow>(
+        projectId,
+        'SELECT * FROM shipped_features WHERE shipped_at < ? ORDER BY shipped_at DESC',
+        thresholdIso
+      )
+      .map(rowToFeature)
 
     if (stale.length === 0) return 0
 
-    // Persist to archive table
     archiveStorage.archiveMany(
       projectId,
       stale.map((s) => ({
@@ -202,15 +255,7 @@ class ShippedStorage extends StorageManager<ShippedJson> {
       }))
     )
 
-    // Remove from active storage
-    const freshIds = new Set(
-      data.shipped.filter((s) => new Date(s.shippedAt) >= threshold).map((s) => s.id)
-    )
-
-    await this.update(projectId, (d) => ({
-      shipped: d.shipped.filter((s) => freshIds.has(s.id)),
-      lastUpdated: getTimestamp(),
-    }))
+    prjctDb.run(projectId, 'DELETE FROM shipped_features WHERE shipped_at < ?', thresholdIso)
 
     await this.publishEvent(projectId, 'shipped.archived', {
       count: stale.length,


### PR DESCRIPTION
## The problem — a broken dual store

Ships lived in the `kv_store['shipped']` JSON blob (read **and rewritten whole** on every ship), while the typed `shipped_features` table — already **read** by recall (`project-memory`) and reporting (`product`) — was **never written**. So:
- Recall/reporting of ships silently returned **empty** despite thousands of ships.
- The blob grew to **5.46 MB / 33,639 rows** for **41 real feature names**.

**Root cause of the ~800×-per-ship duplication:** `addShipped` minted a fresh id every call and the sync pull re-applied each ship, so the same `(name, version, shipped_at)` accreted endlessly under distinct ids.

## The fix — typed table as the single store

- **`ShippedStorage` rewritten** to query `shipped_features` directly: `getRecent` is a `LIMIT`, `getCount` a `COUNT(*)`, `getByVersion`/`getByDateRange` indexed lookups — no full-history parse. Hot fields are typed columns; rare extras (tasks/agent/changes) round-trip through a cold `data` column. `publishEvent` (cloud-sync wire) unchanged.
- **Idempotency at the root:** a UNIQUE natural-key index `(name, version, shipped_at)` + `INSERT OR IGNORE` — re-applying a pulled ship is a no-op.
- **Migration 51** backfills the legacy blob into the table (deduped by the natural key) and retires the `kv_store['shipped']` key.

## Verified on the real project DB
```
BEFORE: schema 50, shipped_features = 0 rows, kv_store['shipped'] = 33,639 entries (5.46 MB)
AFTER:  schema 51, shipped_features = 108 rows, kv_store['shipped'] = deleted
getRecent(3) → real ships (was empty); recall of ships now works
```
108 = genuinely distinct `(name, version, shipped_at)` ships recovered from the 33,639-row duplicated blob.

## Tests
- Migrated `shipping`/`archive` tests off the removed blob API onto the typed API.
- New `shipped-storage-typed` suite: idempotency (the 33k root cause), distinct-ship retention, bounded typed reads, cold-column round-trip, migration dedup + blob retirement.
- typecheck clean · biome clean · **1900/1900 green**

This closes Schema v2 **C5 (shipped)** — one of the three remaining `kv_store` JSON-blob domains. `state` (C4) and `queue` are next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
