### PR TITLE
fix: harden session ships — sync ping-pong, node 22.5–22.12 fallback, classifier false positives

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"18468b54-d843-406c-9867-3500042d2db3","pid":78358,"procStart":"Sun May  3 06:01:31 2026","acquiredAt":1777927056119}
+{"sessionId":"9cc6435d-9e7f-41d8-9bde-f4740675a1b5","pid":84409,"procStart":"Wed Jul  1 06:10:28 2026","acquiredAt":1782956202731}

--- a/bin/prjct.cjs
+++ b/bin/prjct.cjs
@@ -285,30 +285,46 @@ function runWithNode(args) {
  * Fastest path: run the bundled entry IN-PROCESS under the node that already
  * booted to run this launcher — NO second runtime boot. The historical design
  * spawned a fresh bun/node process solely to inject `--experimental-sqlite`;
- * but node:sqlite is available WITHOUT that flag on node >=22.5 (the supported
- * minimum), so the second process is pure overhead (~40ms). The bundled
- * `dist/bin/prjct.mjs` is a thin cold-entry (daemon client) that reads
- * process.argv directly — identical argv in-process vs spawned — and calls
- * process.exit() itself, so once imported it OWNS the process.
+ * when node:sqlite loads WITHOUT that flag (node >=22.13 / >=23.4), the second
+ * process is pure overhead (~40ms). The bundled `dist/bin/prjct.mjs` is a thin
+ * cold-entry (daemon client) that reads process.argv directly — identical argv
+ * in-process vs spawned — and calls process.exit() itself, so once imported it
+ * OWNS the process.
  *
  * Returns true once the entry has started (caller must NOT fall through to a
  * spawn, or the command would run twice). Returns false only when in-process
- * load is not viable (old node, missing bundle, Windows) or the module fails
- * to load — then the caller falls back to the spawn path.
+ * load is not viable (old node, missing bundle, Windows, flagged sqlite) or
+ * the module fails to load — then the caller falls back to the spawn path.
  */
 async function runInProcess() {
   // Windows keeps the well-tested spawn path (shim/pathext nuances).
   if (process.platform === 'win32') return false
   const distBin = path.join(ROOT_DIR, 'dist', 'bin', 'prjct.mjs')
   if (!fs.existsSync(distBin) || !nodeVersionOk()) return false
-  // node:sqlite is experimental on node 22.x → suppress the cosmetic
-  // ExperimentalWarning so stderr stays clean for `--md` consumers (the
-  // module is functionally available without the flag).
+  // node:sqlite still emits a one-time ExperimentalWarning on some versions →
+  // suppress ONLY that warning class so stderr stays clean for `--md`
+  // consumers without muting genuine sqlite-related warnings. Installed BEFORE
+  // the probe below, which would otherwise trip the warning itself.
   const origEmit = process.emitWarning.bind(process)
   process.emitWarning = (warning, ...rest) => {
     const msg = typeof warning === 'string' ? warning : warning?.message || ''
-    if (typeof msg === 'string' && /sqlite/i.test(msg)) return
+    const name =
+      (typeof warning === 'object' && warning?.name) ||
+      (typeof rest[0] === 'string' ? rest[0] : rest[0]?.type) ||
+      ''
+    if (name === 'ExperimentalWarning' && typeof msg === 'string' && /sqlite/i.test(msg)) return
     return origEmit(warning, ...rest)
+  }
+  // In-process cannot inject NODE_OPTIONS, so node:sqlite must be loadable
+  // WITHOUT --experimental-sqlite. That's node >=22.13 / >=23.4; on 22.5–22.12
+  // the flag is still required. Probe instead of hardcoding version ranges —
+  // if the un-flagged require throws, fall back to the spawn path (which
+  // injects the flag) so those versions keep working.
+  try {
+    require('node:sqlite')
+  } catch {
+    process.emitWarning = origEmit
+    return false
   }
   try {
     // Resolves when the entry's top-level finishes; the entry keeps the event

--- a/core/__tests__/infrastructure/cjs-launcher-setup-stamp.test.ts
+++ b/core/__tests__/infrastructure/cjs-launcher-setup-stamp.test.ts
@@ -51,16 +51,22 @@ describe('portable CJS launcher — in-process fast start', () => {
     expect(src).toContain('async function main()')
   })
 
-  test('suppresses the cosmetic node:sqlite ExperimentalWarning (clean stderr)', () => {
+  test('suppresses ONLY the node:sqlite ExperimentalWarning (not all sqlite warnings)', () => {
     const src = source()
     expect(src).toContain('process.emitWarning =')
+    expect(src).toContain("name === 'ExperimentalWarning'")
     expect(src).toContain('/sqlite/i')
   })
 
-  test('gates in-process on node >=22.5 and a present bundle; Windows keeps spawn', () => {
+  test('gates in-process on an UNFLAGGED node:sqlite probe (22.5–22.12 needs the flag → spawn)', () => {
     const src = source()
     expect(src).toContain('if (!fs.existsSync(distBin) || !nodeVersionOk()) return false')
     expect(src).toContain("if (process.platform === 'win32') return false")
+    // In-process cannot inject --experimental-sqlite; the probe must decide.
+    const probeIdx = src.indexOf("require('node:sqlite')")
+    const importIdx = src.indexOf('await import(url.pathToFileURL(distBin).href)')
+    expect(probeIdx).toBeGreaterThan(0)
+    expect(probeIdx).toBeLessThan(importIdx) // probe BEFORE committing in-process
   })
 
   // Runtime proof — only when a build exists (skipped in unbuilt checkouts so

--- a/core/__tests__/services/task-harness.test.ts
+++ b/core/__tests__/services/task-harness.test.ts
@@ -95,3 +95,27 @@ describe('evaluateHarnessCompletion', () => {
     expect(evaluation.warnings.join('\n')).not.toContain('expects a regression test')
   })
 })
+
+describe('detectKind — word-aware matching (no mid-word false positives)', () => {
+  test('"docker" no longer classifies as docs/H0 (was: substring "doc")', () => {
+    const h = buildTaskHarness('add docker healthcheck to the daemon')
+    expect(h.kind).not.toBe('docs')
+    expect(h.level).not.toBe('H0')
+  })
+
+  test('"author" no longer classifies as security/H3 (was: substring "auth")', () => {
+    const h = buildTaskHarness('update author field in package metadata')
+    expect(h.kind).not.toBe('security')
+    expect(h.level).not.toBe('H3')
+  })
+
+  test('"debug" no longer classifies as bug (was: substring "bug")', () => {
+    expect(buildTaskHarness('debug output improvements for the daemon').kind).not.toBe('bug')
+  })
+
+  test('legit families still match: documentation→docs, authentication→security, implementation→feature', () => {
+    expect(buildTaskHarness('update the documentation site').kind).toBe('docs')
+    expect(buildTaskHarness('harden the authentication flow').kind).toBe('security')
+    expect(buildTaskHarness('improve the implement flow for exports').kind).toBe('feature')
+  })
+})

--- a/core/__tests__/storage/shipped-storage-typed.test.ts
+++ b/core/__tests__/storage/shipped-storage-typed.test.ts
@@ -52,6 +52,28 @@ describe('shipped-storage — typed table (Schema v2 C5)', () => {
     expect(await shippedStorage.getCount(pid)).toBe(1)
   })
 
+  it('re-applying a pulled ship publishes NO new sync event (kills the ping-pong loop)', async () => {
+    const at = iso(2)
+    const pending = () =>
+      prjctDb.get<{ c: number }>(pid, 'SELECT COUNT(*) AS c FROM sync_pending')?.c ?? 0
+
+    const first = await shippedStorage.addShipped(pid, { name: 'sync echo', version: '1.0.0' }, at)
+    const afterFirst = pending()
+    expect(afterFirst).toBeGreaterThan(0) // genuine new ship → event published
+
+    // A sync pull re-applies the same ship (same natural key, as the
+    // entity-handler does). It must return the EXISTING row and publish
+    // nothing — publishing a fresh id per re-apply is the feedback loop that
+    // grew the legacy blob to 33k rows.
+    const reapplied = await shippedStorage.addShipped(
+      pid,
+      { name: 'sync echo', version: '1.0.0' },
+      at
+    )
+    expect(reapplied.id).toBe(first.id) // existing row, not a fresh UUID
+    expect(pending()).toBe(afterFirst) // zero new events
+  })
+
   it('distinct ships (same name, different version/time) are kept', async () => {
     await shippedStorage.addShipped(pid, { name: 'auth', version: '1.0.0' }, iso(3))
     await shippedStorage.addShipped(pid, { name: 'auth', version: '2.0.0' }, iso(2))

--- a/core/__tests__/storage/sqlite-factory-guard.test.ts
+++ b/core/__tests__/storage/sqlite-factory-guard.test.ts
@@ -30,6 +30,9 @@ const ALLOWLIST = new Set(
   [
     'core/storage/database/sqlite-compat.ts',
     'core/__tests__/storage/sqlite-factory-guard.test.ts',
+    // Source-inspection test: asserts the LAUNCHER's node:sqlite availability
+    // probe exists (as a string expectation) — it never acquires a driver.
+    'core/__tests__/infrastructure/cjs-launcher-setup-stamp.test.ts',
   ].map((p) => path.normalize(p))
 )
 

--- a/core/services/task-harness.ts
+++ b/core/services/task-harness.ts
@@ -127,13 +127,36 @@ export async function evaluateHarnessCompletion(
 }
 
 function detectKind(text: string): HarnessKind {
-  if (hasAny(text, ['security', 'seguridad', 'auth', 'permission', 'secret'])) return 'security'
-  if (hasAny(text, ['bug', 'fix', 'falla', 'fallo', 'error', 'broken', 'regression', 'no se'])) {
+  // Short ambiguous stems appear with their word families spelled out because
+  // hasAny only prefix-matches terms >=5 chars: bare `doc` used to substring-
+  // match "docker" (→ docs → H0 → cheap-model directive on a real code task),
+  // `auth` matched "author" (→ security → H3), `bug` matched "debug".
+  if (
+    hasAny(text, ['security', 'seguridad', 'auth', 'authent', 'authoriz', 'permission', 'secret'])
+  ) {
+    return 'security'
+  }
+  if (
+    hasAny(text, [
+      'bug',
+      'bugs',
+      'fix',
+      'fixes',
+      'fixed',
+      'fixing',
+      'falla',
+      'fallo',
+      'error',
+      'broken',
+      'regression',
+      'no se',
+    ])
+  ) {
     return 'bug'
   }
   if (hasAny(text, ['refactor', 'cleanup', 'split', 'restructure'])) return 'refactor'
-  if (hasAny(text, ['doc', 'readme', 'changelog', 'typo'])) return 'docs'
-  if (hasAny(text, ['chore', 'format', 'lint'])) return 'chore'
+  if (hasAny(text, ['doc', 'docs', 'document', 'readme', 'changelog', 'typo'])) return 'docs'
+  if (hasAny(text, ['chore', 'format', 'lint', 'linting', 'linter'])) return 'chore'
   if (hasAny(text, ['add', 'agrega', 'crear', 'implement', 'implementa', 'feature', 'mejora'])) {
     return 'feature'
   }
@@ -203,8 +226,22 @@ function extractScopeHints(description: string): string[] {
   return [...new Set(terms)].slice(0, 8)
 }
 
+/**
+ * Word-aware term matching. Bare `includes` classified "docker" as docs (via
+ * `doc`) and "author" as security (via `auth`) — and the resulting H0/H3
+ * levels now DRIVE the orchestration directive (model tier, ceremony), so a
+ * mid-word false positive strips tests off a real code task. Rules:
+ *  - terms >=5 chars match at a word START (`implement` → "implementation")
+ *  - shorter terms must match a WHOLE word (`doc` ≠ "docker", `fix` ≠ "fixture")
+ *  - multi-word terms (e.g. 'no se') keep plain substring semantics
+ */
 function hasAny(text: string, terms: string[]): boolean {
-  return terms.some((term) => text.includes(term))
+  return terms.some((term) => {
+    if (term.includes(' ')) return text.includes(term)
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const pattern = term.length >= 5 ? `\\b${escaped}` : `\\b${escaped}\\b`
+    return new RegExp(pattern).test(text)
+  })
 }
 
 function observedEvidenceFromFiles(files: string[]): string[] {

--- a/core/storage/shipped-storage.ts
+++ b/core/storage/shipped-storage.ts
@@ -140,7 +140,7 @@ class ShippedStorage extends StorageManager<ShippedJson> {
       shippedAt: shippedAt || getTimestamp(),
     }
 
-    prjctDb.run(
+    const result = prjctDb.run(
       projectId,
       `INSERT OR IGNORE INTO shipped_features
          (id, name, shipped_at, version, description, type, duration, data)
@@ -154,6 +154,23 @@ class ShippedStorage extends StorageManager<ShippedJson> {
       shipped.duration ?? null,
       JSON.stringify(shipped)
     )
+
+    // Natural-key collision (the row already exists — typically a sync pull
+    // re-applying a ship we already have): return the EXISTING row and publish
+    // NOTHING. Publishing here minted a fresh event id per re-apply, so every
+    // pull echoed a "new" ship back to the cloud and other devices re-pulled
+    // it — the unbounded ping-pong that grew the legacy blob to 33k rows.
+    if (result.changes === 0) {
+      const existing = prjctDb.get<ShippedFeatureRow>(
+        projectId,
+        'SELECT * FROM shipped_features WHERE name = ? AND version = ? AND shipped_at = ?',
+        shipped.name,
+        shipped.version ?? '',
+        shipped.shippedAt
+      )
+      if (existing) return rowToFeature(existing)
+      return shipped
+    }
 
     // Publish a canonical `shipped_item` event for cloud sync (unchanged wire).
     await this.publishEvent(projectId, 'shipped_item.created', {


### PR DESCRIPTION
## Adversarial review pass over this session's three ships → 3 real bugs, all fixed

Parallel finder agents + manual source verification over #498/#499/#500. Every finding below was **confirmed in source** before fixing.

### 1. shipped sync ping-pong (HIGH) — `core/storage/shipped-storage.ts`
`addShipped` published `shipped_item.created` with a **freshly minted id even when the INSERT OR IGNORE no-op'd**. Sync pull → re-apply known ship → "new" event echoed to cloud → other device pulls → echoes again: the same unbounded feedback loop that grew the legacy blob to 33k rows, relocated to the event stream. **Fix:** on natural-key collision (`run().changes === 0`) return the EXISTING row and publish nothing. Test asserts `sync_pending` count doesn't grow on re-apply.

### 2. node 22.5–22.12 hard-fail (HIGH) — `bin/prjct.cjs`
`node:sqlite` loads without `--experimental-sqlite` only from **22.13 / 23.4** — the in-process fast path (which can't inject NODE_OPTIONS) gated on ≥22.5, so on 22.5–22.12 every DB command failed. **Fix:** probe `require('node:sqlite')`; if the un-flagged load throws, fall back to the flag-injecting spawn path. Also narrowed the warning suppression to the ExperimentalWarning class only (was: any `/sqlite/i` warning, forever).

### 3. classifier mid-word false positives (HIGH) — `core/services/task-harness.ts`
`hasAny` used bare `includes()`: **"docker"→docs/H0** (cheap-model, no-tests directive on real code), **"author"→security/H3** (full crew for a metadata edit), "debug"→bug. Doubly important now that H-levels drive the orchestration directive. **Fix:** word-aware matching (≥5 chars = word-start prefix, shorter = whole word) + spelled-out word families. Verified: docker→feature/H2, author→no-security, documentation→docs, authentication→security still work.

## Also surfaced (next-phase backlog, NOT in this PR)
The audit of remaining `kv_store` blobs found live bugs in pre-existing code: `metrics_daily` read-but-never-written (product stats permanently 0), `tasks.shipped_at` never stamped, velocity write-path amputated, and the 1.08MB `queue` blob parsed per prompt. Documented for the C4/queue migration phase.

## Checks
typecheck clean · biome clean · **1905/1905 tests** (+6 regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
