### PR TITLE
feat(storage): metrics in typed tables + stamp tasks.shipped_at — two more dual-store bugs fixed

### DIFF
--- a/core/__tests__/storage/metrics-storage-typed.test.ts
+++ b/core/__tests__/storage/metrics-storage-typed.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Schema v2 — sync metrics in typed tables (metrics_daily + metrics_agent_usage).
+ * Covers the rewrite (upsert-per-sync, SQL-aggregate summary) and migration 52
+ * (backfill the kv_store blob incl. lifetime-totals remainder, retire the key).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { prjctDb } from '../../storage/database'
+import { migrations } from '../../storage/database/migrations'
+import { openDatabase } from '../../storage/database/sqlite-compat'
+import { metricsStorage } from '../../storage/metrics-storage'
+
+let tmpRoot: string
+const pid = 'test-metrics-typed'
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+describe('metrics-storage — typed tables', () => {
+  beforeEach(async () => {
+    prjctDb.close()
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-metrics-'))
+    pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+    pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+      path.join(tmpRoot, id, layer, filename)
+    await fs.mkdir(path.join(tmpRoot, pid, 'sync'), { recursive: true })
+    await fs.writeFile(path.join(tmpRoot, pid, 'sync', 'pending.json'), '[]', 'utf-8')
+    prjctDb.getDb(pid)
+  })
+
+  afterEach(async () => {
+    prjctDb.close()
+    pathManager.getGlobalProjectPath = origGlobal
+    pathManager.getFilePath = origFile
+    if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('recordSync upserts the metrics_daily row product.ts SUMs (the read-never-written bug)', async () => {
+    await metricsStorage.recordSync(pid, { originalSize: 1000, filteredSize: 400, duration: 120 })
+    await metricsStorage.recordSync(pid, { originalSize: 500, filteredSize: 250, duration: 80 })
+
+    // The exact aggregates `prjct product` runs — were permanently 0 before.
+    const syncs = prjctDb.get<{ v: number }>(
+      pid,
+      'SELECT COALESCE(SUM(syncs), 0) AS v FROM metrics_daily'
+    )?.v
+    const tokens = prjctDb.get<{ v: number }>(
+      pid,
+      'SELECT COALESCE(SUM(tokens_saved), 0) AS v FROM metrics_daily'
+    )?.v
+    expect(syncs).toBe(2)
+    expect(tokens).toBe(600 + 250)
+  })
+
+  it('getSummary aggregates via SQL (totals, weighted rate, top agents)', async () => {
+    await metricsStorage.recordSync(pid, {
+      originalSize: 1000,
+      filteredSize: 0,
+      duration: 100,
+      agents: ['scout', 'ranker'],
+    })
+    await metricsStorage.recordSync(pid, {
+      originalSize: 1000,
+      filteredSize: 500,
+      duration: 300,
+      agents: ['scout'],
+    })
+
+    const s = await metricsStorage.getSummary(pid)
+    expect(s.syncCount).toBe(2)
+    expect(s.totalTokensSaved).toBe(1500)
+    expect(s.avgSyncDuration).toBe(200)
+    expect(s.compressionRate).toBeCloseTo(0.75, 5) // (1.0 + 0.5) / 2
+    expect(s.topAgents[0].agentName).toBe('scout')
+    expect(s.topAgents[0].usageCount).toBe(2)
+    expect(s.last30DaysTokens).toBe(1500)
+  })
+
+  it('getDailyStats returns typed rows; getFirstSyncDate is MIN(date)', async () => {
+    await metricsStorage.recordSync(pid, { originalSize: 100, filteredSize: 50, duration: 10 })
+    const daily = await metricsStorage.getDailyStats(pid, 7)
+    expect(daily).toHaveLength(1)
+    expect(daily[0].tokensSaved).toBe(50)
+    expect(await metricsStorage.getFirstSyncDate(pid)).toBe(daily[0].date)
+  })
+})
+
+describe('migration 52 — kv metrics blob → typed tables', () => {
+  it('backfills daily rows + agent usage, preserves lifetime totals, retires the key', () => {
+    const db = openDatabase(':memory:')
+    db.run(
+      `CREATE TABLE metrics_daily (
+         date TEXT PRIMARY KEY, tokens_saved INTEGER NOT NULL DEFAULT 0,
+         syncs INTEGER NOT NULL DEFAULT 0, avg_compression_rate REAL NOT NULL DEFAULT 0,
+         total_duration INTEGER NOT NULL DEFAULT 0 )`
+    )
+    db.run(
+      'CREATE TABLE kv_store (key TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at TEXT NOT NULL)'
+    )
+    // Blob shape: lifetime totals EXCEED the (90-day-trimmed) daily sum — the
+    // pre-history remainder must be preserved via a synthetic row.
+    const blob = {
+      totalTokensSaved: 1000,
+      syncCount: 12,
+      totalSyncDuration: 5000,
+      avgCompressionRate: 0.4,
+      firstSync: '2026-01-15T10:00:00.000Z',
+      dailyStats: [
+        {
+          date: '2026-06-20',
+          tokensSaved: 300,
+          syncs: 4,
+          avgCompressionRate: 0.5,
+          totalDuration: 2000,
+        },
+      ],
+      agentUsage: [{ agentName: 'scout', usageCount: 7, tokensSaved: 420 }],
+    }
+    db.prepare('INSERT INTO kv_store (key, data, updated_at) VALUES (?, ?, ?)').run(
+      'metrics',
+      JSON.stringify(blob),
+      '2026-06-20'
+    )
+
+    const m52 = migrations.find((m) => m.version === 52)
+    expect(m52).toBeTruthy()
+    m52?.up(db)
+
+    // Lifetime totals reproduce exactly via SUM (daily + remainder rows).
+    const sums = db
+      .prepare(
+        'SELECT SUM(tokens_saved) AS t, SUM(syncs) AS s, SUM(total_duration) AS d FROM metrics_daily'
+      )
+      .get() as { t: number; s: number; d: number }
+    expect(sums.t).toBe(1000)
+    expect(sums.s).toBe(12)
+    expect(sums.d).toBe(5000)
+    // Remainder row landed on the firstSync date.
+    const pre = db
+      .prepare("SELECT tokens_saved, syncs FROM metrics_daily WHERE date = '2026-01-15'")
+      .get() as { tokens_saved: number; syncs: number }
+    expect(pre.tokens_saved).toBe(700)
+    expect(pre.syncs).toBe(8)
+    // Agent usage normalized.
+    const agent = db
+      .prepare(
+        "SELECT usage_count, tokens_saved FROM metrics_agent_usage WHERE agent_name = 'scout'"
+      )
+      .get() as { usage_count: number; tokens_saved: number }
+    expect(agent.usage_count).toBe(7)
+    expect(agent.tokens_saved).toBe(420)
+    // Blob retired.
+    const kv = db.prepare("SELECT COUNT(*) AS c FROM kv_store WHERE key = 'metrics'").get() as {
+      c: number
+    }
+    expect(kv.c).toBe(0)
+    db.close()
+  })
+})

--- a/core/commands/analysis/stats.ts
+++ b/core/commands/analysis/stats.ts
@@ -82,10 +82,10 @@ export async function stats(
       // Use fallback
     }
 
-    // Determine first sync date
-    const metricsData = await metricsStorage.read(projectId)
-    const firstSyncDate = metricsData.firstSync
-      ? new Date(metricsData.firstSync).toLocaleDateString('en-US', {
+    // Determine first sync date (MIN(date) over the typed metrics_daily rows)
+    const firstSync = await metricsStorage.getFirstSyncDate(projectId)
+    const firstSyncDate = firstSync
+      ? new Date(firstSync).toLocaleDateString('en-US', {
           month: 'short',
           day: 'numeric',
           year: 'numeric',

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -278,6 +278,23 @@ export class ShippingCommands extends PrjctCommandsBase {
         // (getByVersion finds the row we just wrote → skip)
       }
 
+      // Stamp the shipped work cycle in the typed `tasks` table. `prjct
+      // product` counts shipped cycles via `shipped_at IS NOT NULL` — nothing
+      // ever wrote that column, so the count sat at 0 forever. Best-effort:
+      // a ship without an active cycle simply has no row to stamp.
+      if (currentTask) {
+        try {
+          prjctDb.run(
+            projectId,
+            'UPDATE tasks SET shipped_at = ? WHERE id = ?',
+            dateHelper.getTimestamp(),
+            currentTask.id
+          )
+        } catch {
+          /* mirror column only — never block a ship */
+        }
+      }
+
       await this.logToMemory(projectPath, 'feature_shipped', {
         feature: featureName,
         version: newVersion,

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2143,6 +2143,94 @@ export const migrations: Migration[] = [
       db.run("DELETE FROM kv_store WHERE key = 'shipped'")
     },
   },
+  {
+    version: 52,
+    name: 'metrics-typed-store',
+    up: (db: SqliteDatabase) => {
+      // Schema v2: sync metrics lived in the `kv_store['metrics']` JSON blob
+      // while the typed `metrics_daily` table — already SUMmed by `prjct
+      // product` for the value score — was never written, so those stats read
+      // 0 forever. This makes the typed tables the single store:
+      //   - metrics_daily       daily rows (existing table; now the only store)
+      //   - metrics_agent_usage per-agent counters (agentUsage[] normalized)
+      // Derivable totals (totalTokensSaved/syncCount/averages/firstSync) become
+      // SQL aggregates; `watchTriggers` had zero readers and is dropped.
+      db.run(
+        `CREATE TABLE IF NOT EXISTS metrics_agent_usage (
+           agent_name   TEXT PRIMARY KEY,
+           usage_count  INTEGER NOT NULL DEFAULT 0,
+           tokens_saved INTEGER NOT NULL DEFAULT 0
+         )`
+      )
+      const blob = db.prepare("SELECT data FROM kv_store WHERE key = 'metrics'").get() as
+        | { data?: string }
+        | undefined
+      if (blob?.data) {
+        let parsed: {
+          dailyStats?: Array<Record<string, unknown>>
+          agentUsage?: Array<Record<string, unknown>>
+          totalTokensSaved?: number
+          syncCount?: number
+          totalSyncDuration?: number
+          avgCompressionRate?: number
+          firstSync?: string
+        } = {}
+        try {
+          parsed = JSON.parse(blob.data)
+        } catch {
+          parsed = {} // malformed blob must not brick startup
+        }
+        const daily = Array.isArray(parsed.dailyStats) ? parsed.dailyStats : []
+        const insertDay = db.prepare(
+          `INSERT OR IGNORE INTO metrics_daily
+             (date, tokens_saved, syncs, avg_compression_rate, total_duration)
+           VALUES (?, ?, ?, ?, ?)`
+        )
+        let dailyTokens = 0
+        let dailySyncs = 0
+        let dailyDuration = 0
+        for (const d of daily) {
+          const date = d.date as string | undefined
+          if (!date) continue
+          const tokens = Number(d.tokensSaved) || 0
+          const syncs = Number(d.syncs) || 0
+          const duration = Number(d.totalDuration) || 0
+          insertDay.run(date, tokens, syncs, Number(d.avgCompressionRate) || 0, duration)
+          dailyTokens += tokens
+          dailySyncs += syncs
+          dailyDuration += duration
+        }
+        // The blob kept RUNNING totals but trimmed dailyStats to 90 days, so
+        // lifetime totals can exceed the daily sum. Preserve the difference in
+        // one synthetic "pre-history" row dated at firstSync (or epoch) so SQL
+        // aggregates still reproduce the true lifetime numbers.
+        const remTokens = Math.max(0, (Number(parsed.totalTokensSaved) || 0) - dailyTokens)
+        const remSyncs = Math.max(0, (Number(parsed.syncCount) || 0) - dailySyncs)
+        const remDuration = Math.max(0, (Number(parsed.totalSyncDuration) || 0) - dailyDuration)
+        if (remTokens > 0 || remSyncs > 0) {
+          const preDate = (parsed.firstSync || '1970-01-01T00:00:00.000Z').split('T')[0]
+          insertDay.run(
+            preDate,
+            remTokens,
+            remSyncs,
+            Number(parsed.avgCompressionRate) || 0,
+            remDuration
+          )
+        }
+        const agents = Array.isArray(parsed.agentUsage) ? parsed.agentUsage : []
+        const insertAgent = db.prepare(
+          `INSERT OR IGNORE INTO metrics_agent_usage (agent_name, usage_count, tokens_saved)
+           VALUES (?, ?, ?)`
+        )
+        for (const a of agents) {
+          const name = a.agentName as string | undefined
+          if (!name) continue
+          insertAgent.run(name, Number(a.usageCount) || 0, Number(a.tokensSaved) || 0)
+        }
+      }
+      db.run("DELETE FROM kv_store WHERE key = 'metrics'")
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/storage/metrics-storage.ts
+++ b/core/storage/metrics-storage.ts
@@ -1,44 +1,52 @@
 /**
  * Metrics Storage
  *
- * Manages value dashboard metrics via storage/metrics.json
- * Generates context/metrics.md for Claude
+ * Schema v2: sync metrics live in typed tables —
+ *   - `metrics_daily`       one row per day (date PK): tokens saved, syncs,
+ *                           weighted compression rate, total duration
+ *   - `metrics_agent_usage` per-agent counters
  *
- * Tracks:
- * - Token savings (compression)
- * - Sync performance
- * - Agent usage
- * - Daily trends for visualization
+ * Totals are SQL aggregates over `metrics_daily` (lifetime numbers preserved
+ * by migration 52's synthetic pre-history row), so writers and readers can
+ * never drift the way the legacy `kv_store['metrics']` blob did — that blob
+ * kept running totals nothing else could see, while `prjct product` SUMmed
+ * the never-written typed table and reported 0 forever.
+ *
+ * Tracks: token savings (compression), sync performance, agent usage, daily
+ * trends for visualization.
  */
 
-import {
-  type AgentUsage,
-  type DailyStats,
-  DEFAULT_METRICS,
-  estimateCostSaved,
-  type MetricsJson,
-  MetricsJsonSchema,
-} from '../schemas/metrics'
-import { getTimestamp } from '../utils/date-helper'
-import { StorageManager } from './storage-manager'
+import { type AgentUsage, type DailyStats, estimateCostSaved } from '../schemas/metrics'
+import { prjctDb } from './database'
 
-class MetricsStorage extends StorageManager<MetricsJson> {
-  constructor() {
-    super('metrics.json', MetricsJsonSchema)
-  }
+interface DailyRow {
+  date: string
+  tokens_saved: number
+  syncs: number
+  avg_compression_rate: number
+  total_duration: number
+}
 
-  protected getDefault(): MetricsJson {
-    return { ...DEFAULT_METRICS }
-  }
+const rowToDaily = (r: DailyRow): DailyStats => ({
+  date: r.date,
+  tokensSaved: r.tokens_saved,
+  syncs: r.syncs,
+  avgCompressionRate: r.avg_compression_rate,
+  totalDuration: r.total_duration,
+})
 
-  protected getEventType(action: 'update' | 'create' | 'delete'): string {
-    return `metrics.${action}d`
-  }
+const dayCutoff = (daysAgo: number): string => {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString().split('T')[0]
+}
 
+class MetricsStorage {
   // =========== Domain Methods ===========
 
   /**
-   * Record a sync event with metrics
+   * Record a sync event: upsert today's `metrics_daily` row (weighted-average
+   * merge for the compression rate) and bump per-agent counters.
    */
   async recordSync(
     projectId: string,
@@ -46,96 +54,50 @@ class MetricsStorage extends StorageManager<MetricsJson> {
       originalSize: number // Tokens before compression
       filteredSize: number // Tokens after compression
       duration: number // Sync duration in ms
-      isWatch?: boolean // From watch mode?
+      isWatch?: boolean // Accepted for API compat; not stored — zero readers
       agents?: string[] // Agents used
     }
   ): Promise<void> {
     const tokensSaved = Math.max(0, metrics.originalSize - metrics.filteredSize)
     const compressionRate = metrics.originalSize > 0 ? tokensSaved / metrics.originalSize : 0
-
     const today = new Date().toISOString().split('T')[0]
 
-    await this.update(projectId, (data) => {
-      // Update totals
-      const newSyncCount = data.syncCount + 1
-      const newTotalTokensSaved = data.totalTokensSaved + tokensSaved
-      const newTotalDuration = data.totalSyncDuration + metrics.duration
+    prjctDb.run(
+      projectId,
+      `INSERT INTO metrics_daily (date, tokens_saved, syncs, avg_compression_rate, total_duration)
+       VALUES (?, ?, 1, ?, ?)
+       ON CONFLICT(date) DO UPDATE SET
+         tokens_saved = metrics_daily.tokens_saved + excluded.tokens_saved,
+         avg_compression_rate =
+           (metrics_daily.avg_compression_rate * metrics_daily.syncs + excluded.avg_compression_rate)
+             / (metrics_daily.syncs + 1),
+         syncs = metrics_daily.syncs + 1,
+         total_duration = metrics_daily.total_duration + excluded.total_duration`,
+      today,
+      tokensSaved,
+      compressionRate,
+      metrics.duration
+    )
 
-      // Running average for compression rate
-      const newAvgCompression =
-        data.syncCount === 0
-          ? compressionRate
-          : (data.avgCompressionRate * data.syncCount + compressionRate) / newSyncCount
-
-      // Update daily stats
-      const dailyStats = [...data.dailyStats]
-      const todayIndex = dailyStats.findIndex((d) => d.date === today)
-
-      if (todayIndex >= 0) {
-        const existing = dailyStats[todayIndex]
-        dailyStats[todayIndex] = {
-          ...existing,
-          tokensSaved: existing.tokensSaved + tokensSaved,
-          syncs: existing.syncs + 1,
-          avgCompressionRate:
-            (existing.avgCompressionRate * existing.syncs + compressionRate) / (existing.syncs + 1),
-          totalDuration: existing.totalDuration + metrics.duration,
-        }
-      } else {
-        dailyStats.push({
-          date: today,
-          tokensSaved,
-          syncs: 1,
-          avgCompressionRate: compressionRate,
-          totalDuration: metrics.duration,
-        })
+    if (metrics.agents?.length) {
+      const perAgent = Math.floor(tokensSaved / metrics.agents.length)
+      for (const agentName of metrics.agents) {
+        prjctDb.run(
+          projectId,
+          `INSERT INTO metrics_agent_usage (agent_name, usage_count, tokens_saved)
+           VALUES (?, 1, ?)
+           ON CONFLICT(agent_name) DO UPDATE SET
+             usage_count = metrics_agent_usage.usage_count + 1,
+             tokens_saved = metrics_agent_usage.tokens_saved + excluded.tokens_saved`,
+          agentName,
+          perAgent
+        )
       }
-
-      // Keep only last 90 days
-      const cutoff = new Date()
-      cutoff.setDate(cutoff.getDate() - 90)
-      const cutoffStr = cutoff.toISOString().split('T')[0]
-      const trimmedStats = dailyStats.filter((d) => d.date >= cutoffStr)
-
-      // Update agent usage
-      const agentUsage = [...data.agentUsage]
-      if (metrics.agents) {
-        for (const agentName of metrics.agents) {
-          const idx = agentUsage.findIndex((a) => a.agentName === agentName)
-          if (idx >= 0) {
-            agentUsage[idx] = {
-              ...agentUsage[idx],
-              usageCount: agentUsage[idx].usageCount + 1,
-              tokensSaved:
-                agentUsage[idx].tokensSaved + Math.floor(tokensSaved / metrics.agents.length),
-            }
-          } else {
-            agentUsage.push({
-              agentName,
-              usageCount: 1,
-              tokensSaved: Math.floor(tokensSaved / metrics.agents.length),
-            })
-          }
-        }
-      }
-
-      return {
-        totalTokensSaved: newTotalTokensSaved,
-        avgCompressionRate: newAvgCompression,
-        syncCount: newSyncCount,
-        watchTriggers: data.watchTriggers + (metrics.isWatch ? 1 : 0),
-        avgSyncDuration: newTotalDuration / newSyncCount,
-        totalSyncDuration: newTotalDuration,
-        agentUsage,
-        dailyStats: trimmedStats,
-        firstSync: data.firstSync || getTimestamp(),
-        lastUpdated: getTimestamp(),
-      }
-    })
+    }
   }
 
   /**
-   * Get metrics summary for dashboard
+   * Metrics summary for the dashboard — pure SQL aggregates.
    */
   async getSummary(projectId: string): Promise<{
     totalTokensSaved: number
@@ -147,59 +109,80 @@ class MetricsStorage extends StorageManager<MetricsJson> {
     last30DaysTokens: number
     trend: number // Percentage change vs previous 30 days
   }> {
-    const data = await this.read(projectId)
+    const totals = prjctDb.get<{
+      tokens: number
+      syncs: number
+      duration: number
+      weighted_rate: number
+    }>(
+      projectId,
+      `SELECT COALESCE(SUM(tokens_saved), 0) AS tokens,
+              COALESCE(SUM(syncs), 0) AS syncs,
+              COALESCE(SUM(total_duration), 0) AS duration,
+              COALESCE(SUM(avg_compression_rate * syncs), 0) AS weighted_rate
+       FROM metrics_daily`
+    )
+    const syncCount = totals?.syncs ?? 0
+    const totalTokensSaved = totals?.tokens ?? 0
 
-    const last30 = this.getLast30Days(data.dailyStats)
-    const prev30 = this.getPrev30Days(data.dailyStats)
+    const rangeTokens = (from: string, to?: string): number =>
+      prjctDb.get<{ t: number }>(
+        projectId,
+        to
+          ? 'SELECT COALESCE(SUM(tokens_saved), 0) AS t FROM metrics_daily WHERE date >= ? AND date < ?'
+          : 'SELECT COALESCE(SUM(tokens_saved), 0) AS t FROM metrics_daily WHERE date >= ?',
+        ...(to ? [from, to] : [from])
+      )?.t ?? 0
 
-    const last30Tokens = last30.reduce((sum, d) => sum + d.tokensSaved, 0)
-    const prev30Tokens = prev30.reduce((sum, d) => sum + d.tokensSaved, 0)
-
+    const last30Tokens = rangeTokens(dayCutoff(30))
+    const prev30Tokens = rangeTokens(dayCutoff(60), dayCutoff(30))
     const trend = prev30Tokens > 0 ? ((last30Tokens - prev30Tokens) / prev30Tokens) * 100 : 0
 
+    const topAgents = prjctDb
+      .query<{ agent_name: string; usage_count: number; tokens_saved: number }>(
+        projectId,
+        'SELECT * FROM metrics_agent_usage ORDER BY usage_count DESC LIMIT 5'
+      )
+      .map((a) => ({
+        agentName: a.agent_name,
+        usageCount: a.usage_count,
+        tokensSaved: a.tokens_saved,
+      }))
+
     return {
-      totalTokensSaved: data.totalTokensSaved,
-      estimatedCostSaved: estimateCostSaved(data.totalTokensSaved),
-      compressionRate: data.avgCompressionRate,
-      syncCount: data.syncCount,
-      avgSyncDuration: data.avgSyncDuration,
-      topAgents: [...data.agentUsage].sort((a, b) => b.usageCount - a.usageCount).slice(0, 5),
+      totalTokensSaved,
+      estimatedCostSaved: estimateCostSaved(totalTokensSaved),
+      compressionRate: syncCount > 0 ? (totals?.weighted_rate ?? 0) / syncCount : 0,
+      syncCount,
+      avgSyncDuration: syncCount > 0 ? (totals?.duration ?? 0) / syncCount : 0,
+      topAgents,
       last30DaysTokens: last30Tokens,
       trend,
     }
   }
 
   /**
-   * Get daily stats for a period
+   * Daily stats for a period, oldest → newest.
    */
   async getDailyStats(projectId: string, days: number = 30): Promise<DailyStats[]> {
-    const data = await this.read(projectId)
-    const cutoff = new Date()
-    cutoff.setDate(cutoff.getDate() - days)
-    const cutoffStr = cutoff.toISOString().split('T')[0]
-
-    return data.dailyStats
-      .filter((d) => d.date >= cutoffStr)
-      .sort((a, b) => a.date.localeCompare(b.date))
+    return prjctDb
+      .query<DailyRow>(
+        projectId,
+        'SELECT * FROM metrics_daily WHERE date >= ? ORDER BY date ASC',
+        dayCutoff(days)
+      )
+      .map(rowToDaily)
   }
 
-  private getLast30Days(dailyStats: DailyStats[]): DailyStats[] {
-    const cutoff = new Date()
-    cutoff.setDate(cutoff.getDate() - 30)
-    const cutoffStr = cutoff.toISOString().split('T')[0]
-    return dailyStats.filter((d) => d.date >= cutoffStr)
-  }
-
-  private getPrev30Days(dailyStats: DailyStats[]): DailyStats[] {
-    const end = new Date()
-    end.setDate(end.getDate() - 30)
-    const start = new Date()
-    start.setDate(start.getDate() - 60)
-
-    const startStr = start.toISOString().split('T')[0]
-    const endStr = end.toISOString().split('T')[0]
-
-    return dailyStats.filter((d) => d.date >= startStr && d.date < endStr)
+  /**
+   * First tracked day (was the blob's `firstSync`) — MIN(date) over the typed
+   * rows; empty string when nothing has been tracked yet.
+   */
+  async getFirstSyncDate(projectId: string): Promise<string> {
+    return (
+      prjctDb.get<{ d: string | null }>(projectId, 'SELECT MIN(date) AS d FROM metrics_daily')?.d ??
+      ''
+    )
   }
 }
 


### PR DESCRIPTION
Fixes live bugs #1 and #2 from the kv_store audit (both shipped-class dual-store bugs: typed table READ but never WRITTEN).

**metrics:** `prjct product` SUMs `metrics_daily` — never written, stats read 0 forever. MetricsStorage rewritten onto typed SQL (`metrics_daily` upsert per sync + new `metrics_agent_usage`; totals/trend/firstSync as SQL aggregates; `watchTriggers` dropped — zero readers). Migration 52 backfills the blob preserving lifetime totals exactly (synthetic pre-history row for the 90-day-trim remainder) and retires the key. **Verified on a copy of the real DB:** blob → 16 daily rows, summary reports the real 206 syncs / 8.8M tokens saved (was 0).

**tasks.shipped_at:** counted via `IS NOT NULL`, no writer. Ship flow now stamps the active cycle's row after the shipped record lands (best-effort).

typecheck + biome clean · 1909/1909 tests (+4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)