### PR TITLE
feat(storage): queue in typed queue_tasks — retire the 1.08MB per-prompt blob (Schema v2)

### DIFF
--- a/core/__tests__/storage/archive-storage.test.ts
+++ b/core/__tests__/storage/archive-storage.test.ts
@@ -300,47 +300,43 @@ describe('Archive Storage', () => {
 
   describe('queue cleanup', () => {
     it('should remove completed tasks older than 7 days', async () => {
-      await queueStorage.write(testProjectId, {
-        tasks: [
-          {
-            id: 'active',
-            description: 'Active',
-            type: 'feature',
-            priority: 'medium',
-            section: 'active',
-            createdAt: daysAgoISO(1),
-            completed: false,
-          },
-          {
-            id: 'recent-done',
-            description: 'Recent done',
-            type: 'feature',
-            priority: 'medium',
-            section: 'active',
-            createdAt: daysAgoISO(5),
-            completed: true,
-            completedAt: daysAgoISO(2),
-          },
-          {
-            id: 'old-done',
-            description: 'Old done',
-            type: 'feature',
-            priority: 'low',
-            section: 'active',
-            createdAt: daysAgoISO(30),
-            completed: true,
-            completedAt: daysAgoISO(10),
-          },
-        ],
-        lastUpdated: getTimestamp(),
+      // Seed typed queue rows: one active, one recently-completed, one stale.
+      await queueStorage.upsertTask(testProjectId, {
+        id: 'active',
+        description: 'Active',
+        type: 'feature',
+        priority: 'medium',
+        section: 'active',
+        createdAt: daysAgoISO(1),
+        completed: false,
+      })
+      await queueStorage.upsertTask(testProjectId, {
+        id: 'recent-done',
+        description: 'Recent done',
+        type: 'feature',
+        priority: 'medium',
+        section: 'active',
+        createdAt: daysAgoISO(5),
+        completed: true,
+        completedAt: daysAgoISO(2),
+      })
+      await queueStorage.upsertTask(testProjectId, {
+        id: 'old-done',
+        description: 'Old done',
+        type: 'feature',
+        priority: 'low',
+        section: 'active',
+        createdAt: daysAgoISO(30),
+        completed: true,
+        completedAt: daysAgoISO(10),
       })
 
       const removed = await queueStorage.removeStaleCompleted(testProjectId)
       expect(removed).toBe(1)
 
-      const data = await queueStorage.read(testProjectId)
-      expect(data.tasks).toHaveLength(2)
-      expect(data.tasks.map((t) => t.id).sort()).toEqual(['active', 'recent-done'])
+      const remaining = await queueStorage.getTasks(testProjectId)
+      expect(remaining).toHaveLength(2)
+      expect(remaining.map((t) => t.id).sort()).toEqual(['active', 'recent-done'])
 
       // Archive should have the old completed task
       const records = archiveStorage.getArchived(testProjectId, 'queue_task')

--- a/core/__tests__/storage/queue-storage-typed.test.ts
+++ b/core/__tests__/storage/queue-storage-typed.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Schema v2 — GTD queue in the typed `queue_tasks` table.
+ * Covers the rewrite (row-level CRUD, indexed per-prompt reads, sync upsert)
+ * and migration 53 (backfill the kv_store blob incl. extended fields, retire
+ * the key).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import { prjctDb } from '../../storage/database'
+import { migrations } from '../../storage/database/migrations'
+import { openDatabase } from '../../storage/database/sqlite-compat'
+import { queueStorage } from '../../storage/queue-storage'
+
+let tmpRoot: string
+const pid = 'test-queue-typed'
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+
+describe('queue-storage — typed table (Schema v2)', () => {
+  beforeEach(async () => {
+    prjctDb.close()
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-queue-'))
+    pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+    pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+      path.join(tmpRoot, id, layer, filename)
+    await fs.mkdir(path.join(tmpRoot, pid, 'sync'), { recursive: true })
+    await fs.writeFile(path.join(tmpRoot, pid, 'sync', 'pending.json'), '[]', 'utf-8')
+    prjctDb.getDb(pid)
+  })
+
+  afterEach(async () => {
+    prjctDb.close()
+    pathManager.getGlobalProjectPath = origGlobal
+    pathManager.getFilePath = origFile
+    if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('add → getActiveTasks/getBacklog are indexed row reads (the per-prompt hot path)', async () => {
+    await queueStorage.addTask(pid, {
+      description: 'active one',
+      priority: 'high',
+      type: 'feature',
+      section: 'active',
+    })
+    await queueStorage.addTask(pid, {
+      description: 'backlog one',
+      priority: 'low',
+      type: 'bug',
+      section: 'backlog',
+    })
+
+    const active = await queueStorage.getActiveTasks(pid)
+    expect(active).toHaveLength(1)
+    expect(active[0].description).toBe('active one')
+    const backlog = await queueStorage.getBacklog(pid)
+    expect(backlog).toHaveLength(1)
+    expect((await queueStorage.getNextTask(pid))?.description).toBe('active one')
+  })
+
+  it('completeTask flips the row once and excludes it from active', async () => {
+    const t = await queueStorage.addTask(pid, {
+      description: 'do it',
+      priority: 'medium',
+      type: 'feature',
+      section: 'active',
+    })
+    const done = await queueStorage.completeTask(pid, t.id)
+    expect(done?.completed).toBe(true)
+    expect(done?.completedAt).toBeTruthy()
+    expect(await queueStorage.completeTask(pid, t.id)).toBeNull() // already completed → no-op
+    expect(await queueStorage.getActiveTasks(pid)).toHaveLength(0)
+  })
+
+  it('updateTask/moveToSection/setPriority mutate single rows; extended fields round-trip', async () => {
+    const t = await queueStorage.addTask(pid, {
+      description: 'refine',
+      priority: 'low',
+      type: 'feature',
+      section: 'backlog',
+      body: '## details',
+      agent: 'fe',
+      groupName: 'Reports',
+    })
+    await queueStorage.moveToSection(pid, t.id, 'active')
+    await queueStorage.setPriority(pid, t.id, 'high')
+    const updated = await queueStorage.updateTask(pid, t.id, { description: 'refined' })
+    expect(updated?.description).toBe('refined')
+
+    const row = await queueStorage.getTask(pid, t.id)
+    expect(row?.section).toBe('active')
+    expect(row?.priority).toBe('high')
+    expect(row?.body).toBe('## details')
+    expect(row?.agent).toBe('fe')
+    expect(row?.groupName).toBe('Reports')
+  })
+
+  it('upsertTask (sync pull) inserts once and merges on re-apply — no duplicates', async () => {
+    await queueStorage.upsertTask(pid, { id: 'q1', description: 'from cloud', priority: 'high' })
+    await queueStorage.upsertTask(pid, { id: 'q1', description: 'from cloud v2' })
+    const all = await queueStorage.getTasks(pid)
+    expect(all).toHaveLength(1)
+    expect(all[0].description).toBe('from cloud v2')
+    expect(all[0].priority).toBe('high') // local field survived the merge
+  })
+
+  it('deleteByFeatureId removes only matching rows and reports the count', async () => {
+    await queueStorage.addTasks(pid, [
+      {
+        description: 'a',
+        priority: 'medium',
+        type: 'feature',
+        section: 'backlog',
+        featureId: 'f1',
+      },
+      {
+        description: 'b',
+        priority: 'medium',
+        type: 'feature',
+        section: 'backlog',
+        featureId: 'f1',
+      },
+      {
+        description: 'c',
+        priority: 'medium',
+        type: 'feature',
+        section: 'backlog',
+        featureId: 'f2',
+      },
+    ])
+    expect(await queueStorage.deleteByFeatureId(pid, 'f1')).toBe(2)
+    expect(await queueStorage.getTasks(pid)).toHaveLength(1)
+  })
+})
+
+describe('migration 53 — kv queue blob → typed table', () => {
+  it('backfills tasks (incl. extended fields) and retires the key', () => {
+    const db = openDatabase(':memory:')
+    db.run(
+      `CREATE TABLE queue_tasks (
+         id TEXT PRIMARY KEY, description TEXT NOT NULL, type TEXT, priority TEXT, section TEXT,
+         created_at TEXT NOT NULL, completed INTEGER DEFAULT 0, completed_at TEXT,
+         feature_id TEXT, feature_name TEXT )`
+    )
+    db.run(
+      'CREATE TABLE kv_store (key TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at TEXT NOT NULL)'
+    )
+    const blob = {
+      tasks: [
+        {
+          id: 'q1',
+          description: 'carry body',
+          type: 'bug',
+          priority: 'high',
+          section: 'active',
+          createdAt: '2026-06-01T00:00:00.000Z',
+          completed: false,
+          body: '## md body',
+          agent: 'be',
+          groupName: 'Audits',
+          groupId: 'g9',
+          featureId: 'f1',
+          originFeature: 'Stock',
+        },
+        {
+          id: 'q2',
+          description: 'done one',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          completed: true,
+          completedAt: '2026-05-02T00:00:00.000Z',
+        },
+        { description: 'no id — skipped' },
+        // The junk class that made up 6,046 of 6,105 real-blob entries:
+        { id: 'q3', description: '', createdAt: '2026-06-02T00:00:00.000Z', completed: false },
+      ],
+      lastUpdated: '2026-06-01',
+    }
+    db.prepare('INSERT INTO kv_store (key, data, updated_at) VALUES (?, ?, ?)').run(
+      'queue',
+      JSON.stringify(blob),
+      '2026-06-01'
+    )
+
+    const m53 = migrations.find((m) => m.version === 53)
+    expect(m53).toBeTruthy()
+    m53?.up(db)
+
+    const rows = db.prepare('SELECT * FROM queue_tasks ORDER BY id').all() as Array<
+      Record<string, unknown>
+    >
+    expect(rows).toHaveLength(2) // id-less AND empty-description entries skipped
+    expect(rows[0].body).toBe('## md body')
+    expect(rows[0].agent).toBe('be')
+    expect(rows[0].group_name).toBe('Audits')
+    expect(rows[0].feature_name).toBe('Stock')
+    expect(rows[1].completed).toBe(1)
+    const kv = db.prepare("SELECT COUNT(*) AS c FROM kv_store WHERE key = 'queue'").get() as {
+      c: number
+    }
+    expect(kv.c).toBe(0)
+    db.close()
+  })
+})

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2231,6 +2231,72 @@ export const migrations: Migration[] = [
       db.run("DELETE FROM kv_store WHERE key = 'metrics'")
     },
   },
+  {
+    version: 53,
+    name: 'queue-typed-store',
+    up: (db: SqliteDatabase) => {
+      // Schema v2: the GTD queue lived in the `kv_store['queue']` JSON blob —
+      // parsed WHOLE on every prompt (hooks/prompt.ts reads active tasks per
+      // UserPromptSubmit; the blob measured 1.08MB on the reference project)
+      // and rewritten whole on every mutation — while the typed `queue_tasks`
+      // table sat empty. This makes the typed table the single store.
+      // Columns for QueueTask fields the original table lacked:
+      for (const col of ['body TEXT', 'agent TEXT', 'group_name TEXT', 'group_id TEXT']) {
+        try {
+          db.run(`ALTER TABLE queue_tasks ADD COLUMN ${col}`)
+        } catch {
+          /* column already exists */
+        }
+      }
+      db.run(
+        'CREATE INDEX IF NOT EXISTS ix_queue_section ON queue_tasks(section, completed, created_at)'
+      )
+      const blob = db.prepare("SELECT data FROM kv_store WHERE key = 'queue'").get() as
+        | { data?: string }
+        | undefined
+      if (blob?.data) {
+        let tasks: Array<Record<string, unknown>> = []
+        try {
+          const parsed = JSON.parse(blob.data) as { tasks?: unknown }
+          if (Array.isArray(parsed?.tasks)) tasks = parsed.tasks as Array<Record<string, unknown>>
+        } catch {
+          tasks = [] // malformed blob must not brick startup
+        }
+        const insert = db.prepare(
+          `INSERT OR IGNORE INTO queue_tasks
+             (id, description, type, priority, section, created_at, completed, completed_at,
+              feature_id, feature_name, body, agent, group_name, group_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        for (const t of tasks) {
+          const id = t.id as string | undefined
+          const description = t.description as string | undefined
+          // Deliberate: skip empty-description rows. On the reference project
+          // 6,046 of 6,105 blob entries were EMPTY tasks accreted by the sync
+          // handler's `description || ''` (now guarded at the handler) — junk
+          // no consumer can use; only the real tasks migrate.
+          if (!id || !description) continue
+          insert.run(
+            id,
+            description,
+            (t.type as string) ?? null,
+            (t.priority as string) ?? null,
+            (t.section as string) ?? 'backlog',
+            (t.createdAt as string) ?? '1970-01-01T00:00:00.000Z',
+            t.completed ? 1 : 0,
+            (t.completedAt as string) ?? null,
+            (t.featureId as string) ?? null,
+            (t.originFeature as string) ?? null,
+            (t.body as string) ?? null,
+            (t.agent as string) ?? null,
+            (t.groupName as string) ?? null,
+            (t.groupId as string) ?? null
+          )
+        }
+      }
+      db.run("DELETE FROM kv_store WHERE key = 'queue'")
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/storage/queue-storage.ts
+++ b/core/storage/queue-storage.ts
@@ -1,8 +1,14 @@
 /**
  * Queue Storage
  *
- * Manages task queue via storage/queue.json
- * Generates context/next.md for Claude
+ * Schema v2: the GTD queue lives in the typed `queue_tasks` table — indexed
+ * reads (`getActiveTasks` runs on EVERY prompt via hooks/prompt.ts) and
+ * row-level writes. The legacy `kv_store['queue']` blob was parsed whole per
+ * prompt (1.08MB on the reference project) and rewritten whole per mutation;
+ * migration 53 backfilled it into this table and retired the key.
+ *
+ * Still extends StorageManager solely for `publishEvent` (the cloud-sync
+ * wire) — the blob read/write path is unused.
  */
 
 import { generateUUID } from '../schemas/schemas'
@@ -11,18 +17,80 @@ import { QueueJsonSchema } from '../schemas/state'
 import { sortBySectionAndPriority } from '../utils/collection-filters'
 import { getDaysAgo, getTimestamp } from '../utils/date-helper'
 import { ARCHIVE_POLICIES, archiveStorage } from './archive-storage'
+import { prjctDb } from './database'
 import { StorageManager } from './storage-manager'
+
+/** A row of the typed `queue_tasks` table. */
+interface QueueTaskRow {
+  id: string
+  description: string
+  type: string | null
+  priority: string | null
+  section: string | null
+  created_at: string
+  completed: number
+  completed_at: string | null
+  feature_id: string | null
+  feature_name: string | null
+  body: string | null
+  agent: string | null
+  group_name: string | null
+  group_id: string | null
+}
+
+function rowToTask(r: QueueTaskRow): QueueTask {
+  const task: QueueTask = {
+    id: r.id,
+    description: r.description,
+    priority: (r.priority ?? 'medium') as QueueTask['priority'],
+    type: (r.type ?? 'feature') as QueueTask['type'],
+    section: (r.section ?? 'backlog') as QueueTask['section'],
+    completed: r.completed === 1,
+    createdAt: r.created_at,
+  }
+  if (r.completed_at != null) task.completedAt = r.completed_at
+  if (r.feature_id != null) task.featureId = r.feature_id
+  if (r.feature_name != null) task.originFeature = r.feature_name
+  if (r.body != null) task.body = r.body
+  if (r.agent != null) task.agent = r.agent
+  if (r.group_name != null) task.groupName = r.group_name
+  if (r.group_id != null) task.groupId = r.group_id
+  return task
+}
+
+const INSERT_SQL = `INSERT INTO queue_tasks
+   (id, description, type, priority, section, created_at, completed, completed_at,
+    feature_id, feature_name, body, agent, group_name, group_id)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+function insertParams(t: QueueTask): (string | number | null)[] {
+  return [
+    t.id,
+    t.description,
+    t.type ?? null,
+    t.priority ?? null,
+    t.section ?? 'backlog',
+    t.createdAt,
+    t.completed ? 1 : 0,
+    t.completedAt ?? null,
+    t.featureId ?? null,
+    t.originFeature ?? null,
+    t.body ?? null,
+    t.agent ?? null,
+    t.groupName ?? null,
+    t.groupId ?? null,
+  ]
+}
 
 class QueueStorage extends StorageManager<QueueJson> {
   constructor() {
     super('queue.json', QueueJsonSchema)
   }
 
+  // Vestigial abstract-method implementations — the base blob path is unused;
+  // kept only so `publishEvent` (the sync surface) stays available.
   protected getDefault(): QueueJson {
-    return {
-      tasks: [],
-      lastUpdated: '',
-    }
+    return { tasks: [], lastUpdated: '' }
   }
 
   protected getEventType(action: 'update' | 'create' | 'delete'): string {
@@ -31,41 +99,40 @@ class QueueStorage extends StorageManager<QueueJson> {
 
   // =========== Domain Methods ===========
 
-  /**
-   * Get all tasks
-   */
+  /** All tasks, insertion order. */
   async getTasks(projectId: string): Promise<QueueTask[]> {
-    const queue = await this.read(projectId)
-    return queue.tasks
+    return prjctDb
+      .query<QueueTaskRow>(projectId, 'SELECT * FROM queue_tasks ORDER BY created_at ASC')
+      .map(rowToTask)
   }
 
-  /**
-   * Get active (non-backlog) tasks
-   */
+  /** Active (non-backlog, incomplete) tasks — the per-prompt hot read. */
   async getActiveTasks(projectId: string): Promise<QueueTask[]> {
-    const queue = await this.read(projectId)
-    return queue.tasks.filter((t) => t.section === 'active' && !t.completed)
+    return prjctDb
+      .query<QueueTaskRow>(
+        projectId,
+        "SELECT * FROM queue_tasks WHERE section = 'active' AND completed = 0 ORDER BY created_at ASC"
+      )
+      .map(rowToTask)
   }
 
-  /**
-   * Get backlog tasks
-   */
+  /** Backlog (incomplete) tasks. */
   async getBacklog(projectId: string): Promise<QueueTask[]> {
-    const queue = await this.read(projectId)
-    return queue.tasks.filter((t) => t.section === 'backlog' && !t.completed)
+    return prjctDb
+      .query<QueueTaskRow>(
+        projectId,
+        "SELECT * FROM queue_tasks WHERE section = 'backlog' AND completed = 0 ORDER BY created_at ASC"
+      )
+      .map(rowToTask)
   }
 
-  /**
-   * Get next task (highest priority incomplete)
-   */
+  /** Next task (highest-priority incomplete active). */
   async getNextTask(projectId: string): Promise<QueueTask | null> {
     const tasks = await this.getActiveTasks(projectId)
     return sortBySectionAndPriority(tasks)[0] || null
   }
 
-  /**
-   * Add a task to the queue
-   */
+  /** Add a task to the queue. */
   async addTask(
     projectId: string,
     task: Omit<QueueTask, 'id' | 'createdAt' | 'completed' | 'completedAt'>
@@ -76,13 +143,8 @@ class QueueStorage extends StorageManager<QueueJson> {
       createdAt: getTimestamp(),
       completed: false,
     }
+    prjctDb.run(projectId, INSERT_SQL, ...insertParams(newTask))
 
-    await this.update(projectId, (queue) => ({
-      tasks: [...queue.tasks, newTask],
-      lastUpdated: getTimestamp(),
-    }))
-
-    // Publish incremental event
     await this.publishEvent(projectId, 'queue.task_added', {
       taskId: newTask.id,
       description: newTask.description,
@@ -94,9 +156,7 @@ class QueueStorage extends StorageManager<QueueJson> {
     return newTask
   }
 
-  /**
-   * Add multiple tasks
-   */
+  /** Add multiple tasks. */
   async addTasks(
     projectId: string,
     tasks: Omit<QueueTask, 'id' | 'createdAt' | 'completed' | 'completedAt'>[]
@@ -108,13 +168,8 @@ class QueueStorage extends StorageManager<QueueJson> {
       createdAt: now,
       completed: false,
     }))
+    for (const t of newTasks) prjctDb.run(projectId, INSERT_SQL, ...insertParams(t))
 
-    await this.update(projectId, (queue) => ({
-      tasks: [...queue.tasks, ...newTasks],
-      lastUpdated: now,
-    }))
-
-    // Publish event for batch add
     await this.publishEvent(projectId, 'queue.tasks_added', {
       count: newTasks.length,
       tasks: newTasks.map((t) => ({
@@ -128,14 +183,44 @@ class QueueStorage extends StorageManager<QueueJson> {
   }
 
   /**
-   * Remove a task
+   * Upsert a task by id — the sync-pull apply path. Field merge matches the
+   * legacy handler: incoming values win, locally-only fields survive.
    */
-  async removeTask(projectId: string, taskId: string): Promise<void> {
-    await this.update(projectId, (queue) => ({
-      tasks: queue.tasks.filter((t) => t.id !== taskId),
-      lastUpdated: getTimestamp(),
-    }))
+  async upsertTask(
+    projectId: string,
+    task: Pick<QueueTask, 'id' | 'description'> & Partial<QueueTask>
+  ): Promise<void> {
+    const existing = await this.getTask(projectId, task.id)
+    if (existing) {
+      const merged = { ...existing, ...task }
+      prjctDb.run(
+        projectId,
+        `UPDATE queue_tasks SET description = ?, type = ?, priority = ?, section = ?
+         WHERE id = ?`,
+        merged.description,
+        merged.type ?? null,
+        merged.priority ?? null,
+        merged.section ?? 'backlog',
+        task.id
+      )
+      return
+    }
+    const row: QueueTask = {
+      ...task,
+      id: task.id,
+      description: task.description,
+      priority: task.priority ?? 'medium',
+      type: task.type ?? 'feature',
+      section: task.section ?? 'backlog',
+      completed: task.completed ?? false,
+      createdAt: task.createdAt ?? getTimestamp(),
+    }
+    prjctDb.run(projectId, INSERT_SQL, ...insertParams(row))
+  }
 
+  /** Remove a task. */
+  async removeTask(projectId: string, taskId: string): Promise<void> {
+    prjctDb.run(projectId, 'DELETE FROM queue_tasks WHERE id = ?', taskId)
     await this.publishEvent(projectId, 'queue.task_removed', { taskId })
   }
 
@@ -148,16 +233,8 @@ class QueueStorage extends StorageManager<QueueJson> {
    * See spec a50b32d1 AC #13.
    */
   async deleteByFeatureId(projectId: string, featureId: string): Promise<number> {
-    let deleted = 0
-    await this.update(projectId, (queue) => {
-      const before = queue.tasks.length
-      const remaining = queue.tasks.filter((t) => t.featureId !== featureId)
-      deleted = before - remaining.length
-      return {
-        tasks: remaining,
-        lastUpdated: getTimestamp(),
-      }
-    })
+    const result = prjctDb.run(projectId, 'DELETE FROM queue_tasks WHERE feature_id = ?', featureId)
+    const deleted = result.changes
     if (deleted > 0) {
       await this.publishEvent(projectId, 'queue.tasks_removed_by_feature', {
         featureId,
@@ -167,126 +244,93 @@ class QueueStorage extends StorageManager<QueueJson> {
     return deleted
   }
 
-  /**
-   * Mark a task as completed
-   */
+  /** Mark a task as completed. */
   async completeTask(projectId: string, taskId: string): Promise<QueueTask | null> {
-    let completedTask: QueueTask | null = null
+    const completedAt = getTimestamp()
+    const result = prjctDb.run(
+      projectId,
+      'UPDATE queue_tasks SET completed = 1, completed_at = ? WHERE id = ? AND completed = 0',
+      completedAt,
+      taskId
+    )
+    if (result.changes === 0) return null
 
-    await this.update(projectId, (queue) => {
-      const tasks = queue.tasks.map((t) => {
-        if (t.id === taskId) {
-          completedTask = {
-            ...t,
-            completed: true,
-            completedAt: getTimestamp(),
-          }
-          return completedTask
-        }
-        return t
-      })
-      return { tasks, lastUpdated: getTimestamp() }
-    })
-
-    if (completedTask) {
-      const task = completedTask as QueueTask
+    const task = await this.getTask(projectId, taskId)
+    if (task) {
       await this.publishEvent(projectId, 'queue.task_completed', {
         taskId,
         description: task.description,
         completedAt: task.completedAt,
       })
     }
-
-    return completedTask
+    return task
   }
 
-  /**
-   * Move task to different section
-   */
+  /** Move task to a different section. */
   async moveToSection(projectId: string, taskId: string, section: TaskSection): Promise<void> {
-    await this.update(projectId, (queue) => ({
-      tasks: queue.tasks.map((t) => (t.id === taskId ? { ...t, section } : t)),
-      lastUpdated: getTimestamp(),
-    }))
+    prjctDb.run(projectId, 'UPDATE queue_tasks SET section = ? WHERE id = ?', section, taskId)
   }
 
-  /**
-   * Set task priority
-   */
+  /** Set task priority. */
   async setPriority(projectId: string, taskId: string, priority: Priority): Promise<void> {
-    await this.update(projectId, (queue) => ({
-      tasks: queue.tasks.map((t) => (t.id === taskId ? { ...t, priority } : t)),
-      lastUpdated: getTimestamp(),
-    }))
+    prjctDb.run(projectId, 'UPDATE queue_tasks SET priority = ? WHERE id = ?', priority, taskId)
   }
 
-  /**
-   * Get a single task by ID
-   */
+  /** Get a single task by ID. */
   async getTask(projectId: string, taskId: string): Promise<QueueTask | null> {
-    const queue = await this.read(projectId)
-    return queue.tasks.find((t) => t.id === taskId) || null
+    const row = prjctDb.get<QueueTaskRow>(
+      projectId,
+      'SELECT * FROM queue_tasks WHERE id = ?',
+      taskId
+    )
+    return row ? rowToTask(row) : null
   }
 
-  /**
-   * Update task fields (description, body, type, priority, section)
-   */
+  /** Update task fields (description, body, type, priority, section). */
   async updateTask(
     projectId: string,
     taskId: string,
     updates: Partial<Pick<QueueTask, 'description' | 'body' | 'type' | 'priority' | 'section'>>
   ): Promise<QueueTask | null> {
-    let updated: QueueTask | null = null
+    const existing = await this.getTask(projectId, taskId)
+    if (!existing) return null
 
-    await this.update(projectId, (queue) => ({
-      tasks: queue.tasks.map((t) => {
-        if (t.id === taskId) {
-          updated = { ...t, ...updates }
-          return updated
-        }
-        return t
-      }),
-      lastUpdated: getTimestamp(),
-    }))
-
-    if (updated) {
-      await this.publishEvent(projectId, 'queue.task_updated', { taskId })
-    }
-
-    return updated
+    const merged = { ...existing, ...updates }
+    prjctDb.run(
+      projectId,
+      'UPDATE queue_tasks SET description = ?, body = ?, type = ?, priority = ?, section = ? WHERE id = ?',
+      merged.description,
+      merged.body ?? null,
+      merged.type ?? null,
+      merged.priority ?? null,
+      merged.section ?? 'backlog',
+      taskId
+    )
+    await this.publishEvent(projectId, 'queue.task_updated', { taskId })
+    return merged
   }
 
-  /**
-   * Clear completed tasks
-   */
+  /** Clear completed tasks. Returns count removed. */
   async clearCompleted(projectId: string): Promise<number> {
-    const queue = await this.read(projectId)
-    const completedCount = queue.tasks.filter((t) => t.completed).length
-
-    await this.update(projectId, (q) => ({
-      tasks: q.tasks.filter((t) => !t.completed),
-      lastUpdated: getTimestamp(),
-    }))
-
-    return completedCount
+    return prjctDb.run(projectId, 'DELETE FROM queue_tasks WHERE completed = 1').changes
   }
 
   /**
    * Remove completed tasks older than retention period (PRJ-267).
-   * Archives them to SQLite before removal.
-   * Returns count of removed tasks.
+   * Archives them to SQLite before removal. Returns count removed.
    */
   async removeStaleCompleted(projectId: string): Promise<number> {
-    const queue = await this.read(projectId)
-    const threshold = getDaysAgo(ARCHIVE_POLICIES.QUEUE_COMPLETED_DAYS)
+    const thresholdIso = getDaysAgo(ARCHIVE_POLICIES.QUEUE_COMPLETED_DAYS).toISOString()
 
-    const stale = queue.tasks.filter(
-      (t) => t.completed && t.completedAt && new Date(t.completedAt) < threshold
-    )
-
+    const stale = prjctDb
+      .query<QueueTaskRow>(
+        projectId,
+        'SELECT * FROM queue_tasks WHERE completed = 1 AND completed_at IS NOT NULL AND completed_at < ?',
+        thresholdIso
+      )
+      .map(rowToTask)
     if (stale.length === 0) return 0
 
-    // Archive before removal
     archiveStorage.archiveMany(
       projectId,
       stale.map((t) => ({
@@ -298,17 +342,13 @@ class QueueStorage extends StorageManager<QueueJson> {
       }))
     )
 
-    const staleIds = new Set(stale.map((t) => t.id))
+    prjctDb.run(
+      projectId,
+      'DELETE FROM queue_tasks WHERE completed = 1 AND completed_at IS NOT NULL AND completed_at < ?',
+      thresholdIso
+    )
 
-    await this.update(projectId, (q) => ({
-      tasks: q.tasks.filter((t) => !staleIds.has(t.id)),
-      lastUpdated: getTimestamp(),
-    }))
-
-    await this.publishEvent(projectId, 'queue.stale_removed', {
-      count: stale.length,
-    })
-
+    await this.publishEvent(projectId, 'queue.stale_removed', { count: stale.length })
     return stale.length
   }
 }

--- a/core/sync/entity-handlers/queue-tasks.ts
+++ b/core/sync/entity-handlers/queue-tasks.ts
@@ -12,10 +12,17 @@ import type { EntityHandler } from './types'
 
 export const queueTasksHandler: EntityHandler = {
   async upsert(projectId, data) {
+    // A queue task with no description is unusable by every consumer — and
+    // persisting `|| ''` here is exactly what polluted the legacy blob with
+    // 6,046 empty rows (of 6,105 total on the reference project): wire events
+    // lacking `description` each landed as an empty backlog task. Skip them.
+    const description = (data.description as string) || ''
+    if (!description.trim()) return
+
     const id = (data.id as string) || ''
     if (!id) {
       await queueStorage.addTask(projectId, {
-        description: (data.description as string) || '',
+        description,
         priority: (data.priority as Priority) || 'medium',
         type: (data.type as TaskType) || 'feature',
         section: (data.section as TaskSection) || 'backlog',
@@ -23,20 +30,12 @@ export const queueTasksHandler: EntityHandler = {
       return
     }
 
-    await queueStorage.update(projectId, (queue) => {
-      const existingIdx = queue.tasks.findIndex((t) => t.id === id)
-      const next = {
-        id,
-        description: (data.description as string) || '',
-        priority: (data.priority as Priority) || 'medium',
-        type: (data.type as TaskType) || 'feature',
-        section: (data.section as TaskSection) || 'backlog',
-      } as (typeof queue.tasks)[number]
-      const tasks =
-        existingIdx >= 0
-          ? queue.tasks.map((t, i) => (i === existingIdx ? { ...t, ...next } : t))
-          : [...queue.tasks, next]
-      return { ...queue, tasks }
+    await queueStorage.upsertTask(projectId, {
+      id,
+      description,
+      priority: (data.priority as Priority) || 'medium',
+      type: (data.type as TaskType) || 'feature',
+      section: (data.section as TaskSection) || 'backlog',
     })
   },
 

--- a/core/sync/entity-handlers/tasks.ts
+++ b/core/sync/entity-handlers/tasks.ts
@@ -46,20 +46,15 @@ export const tasksHandler: EntityHandler = {
       return
     }
 
-    await queueStorage.update(projectId, (queue) => {
-      const existingIdx = queue.tasks.findIndex((t) => t.id === id)
-      const next = {
-        id,
-        description: data.description as string,
-        priority: (data.priority as Priority) || 'medium',
-        type: (data.type as TaskType) || 'feature',
-        section: 'backlog' as TaskSection,
-      } as (typeof queue.tasks)[number]
-      const tasks =
-        existingIdx >= 0
-          ? queue.tasks.map((t, i) => (i === existingIdx ? { ...t, ...next } : t))
-          : [...queue.tasks, next]
-      return { ...queue, tasks }
+    // Same guard as queue-tasks handler: an empty description is garbage in —
+    // the class of wire event that grew the legacy blob to 6k empty rows.
+    if (!((data.description as string) || '').trim()) return
+    await queueStorage.upsertTask(projectId, {
+      id,
+      description: data.description as string,
+      priority: (data.priority as Priority) || 'medium',
+      type: (data.type as TaskType) || 'feature',
+      section: 'backlog' as TaskSection,
     })
   },
 


### PR DESCRIPTION
The GTD queue blob (`kv_store['queue']`, **1.08MB / 6,105 entries**) was parsed WHOLE on **every prompt** (hooks/prompt.ts) and rewritten whole per mutation, while typed `queue_tasks` sat empty.

**Rewrite:** QueueStorage onto typed SQL — indexed per-prompt reads, row-level writes (16 methods), new `upsertTask` for the sync-pull path. `publishEvent` sync wire unchanged. **Migration 53** adds the missing columns (body/agent/group_*) + index, backfills, retires the key.

**Root-cause find during verification:** 6,046 of 6,105 blob entries had an **EMPTY description** — junk accreted by the sync handlers' `description || ''` on wire events missing the field. The migration deliberately skips them (only the 59 real tasks migrate), and **both handlers now refuse empty-description upserts** — closing the polluter, same class as the shipped ping-pong.

**Verified on a copy of the real DB:** 1.12MB blob → 59 typed rows (2 active / 57 backlog), key deleted; `getActiveTasks` (the per-prompt read) = **0.01ms** vs a 1.08MB JSON.parse.

typecheck + biome clean · **1915/1915 tests** (+6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)