### PR TITLE
feat: restore velocity from typed delivery data + developer-evolution weekly snapshots

### DIFF
--- a/core/__tests__/storage/velocity-evolution.test.ts
+++ b/core/__tests__/storage/velocity-evolution.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Velocity restored (Schema v2) + developer-evolution snapshots.
+ * Velocity sprints are COMPUTED from typed delivery tables (tasks + ships)
+ * and persisted in `velocity_sprints`; developer snapshots roll profile +
+ * delivery into one typed row per week with a generated summary.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pathManager from '../../infrastructure/path-manager'
+import {
+  captureDeveloperSnapshot,
+  getDeveloperEvolution,
+  renderDeveloperEvolution,
+} from '../../services/developer-evolution'
+import { prjctDb } from '../../storage/database'
+import { shippedStorage } from '../../storage/shipped-storage'
+import { epochWeek, velocityStorage } from '../../storage/velocity-storage'
+
+let tmpRoot: string
+const pid = 'test-velocity-evo'
+const origGlobal = pathManager.getGlobalProjectPath.bind(pathManager)
+const origFile = pathManager.getFilePath.bind(pathManager)
+const iso = (daysAgo: number) => new Date(Date.now() - daysAgo * 86400000).toISOString()
+
+describe('velocity — computed weekly sprints from typed delivery data', () => {
+  beforeEach(async () => {
+    prjctDb.close()
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-velo-'))
+    pathManager.getGlobalProjectPath = (id: string) => path.join(tmpRoot, id)
+    pathManager.getFilePath = (id: string, layer: string, filename: string) =>
+      path.join(tmpRoot, id, layer, filename)
+    await fs.mkdir(path.join(tmpRoot, pid, 'sync'), { recursive: true })
+    await fs.writeFile(path.join(tmpRoot, pid, 'sync', 'pending.json'), '[]', 'utf-8')
+    prjctDb.getDb(pid)
+  })
+
+  afterEach(async () => {
+    prjctDb.close()
+    pathManager.getGlobalProjectPath = origGlobal
+    pathManager.getFilePath = origFile
+    if (tmpRoot) await fs.rm(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('recompute derives sprints from ships + completed tasks and persists typed rows', async () => {
+    // Two ships this week, one three weeks ago.
+    await shippedStorage.addShipped(pid, { name: 'a', version: '1.0.0' }, iso(1))
+    await shippedStorage.addShipped(pid, { name: 'b', version: '1.1.0' }, iso(2))
+    await shippedStorage.addShipped(pid, { name: 'old', version: '0.9.0' }, iso(21))
+    // One completed work cycle this week (typed tasks mirror).
+    prjctDb.run(
+      pid,
+      "INSERT INTO tasks (id, description, status, started_at, completed_at) VALUES ('t1', 'done thing', 'completed', ?, ?)",
+      iso(2),
+      iso(1)
+    )
+
+    await velocityStorage.recompute(pid)
+
+    const m = await velocityStorage.getMetrics(pid)
+    expect(m.sprints.length).toBeGreaterThanOrEqual(2)
+    const thisWeek = m.sprints.find((s) => s.sprintNumber === epochWeek(iso(1)))
+    expect(thisWeek?.pointsCompleted).toBe(3) // 2 ships + 1 task
+    expect(thisWeek?.tasksCompleted).toBe(1)
+    expect(m.averageVelocity).toBeGreaterThan(0)
+  })
+
+  it('recompute is idempotent (upsert per sprint week)', async () => {
+    await shippedStorage.addShipped(pid, { name: 'x', version: '1.0.0' }, iso(1))
+    await velocityStorage.recompute(pid)
+    await velocityStorage.recompute(pid)
+    const rows = prjctDb.get<{ c: number }>(
+      pid,
+      'SELECT COUNT(*) AS c FROM velocity_sprints WHERE sprint_number = ?',
+      epochWeek(iso(1))
+    )
+    expect(rows?.c).toBe(1)
+  })
+
+  it('developer snapshot: one typed row per week, generated summary, evolution readable', async () => {
+    await shippedStorage.addShipped(pid, { name: 'ship', version: '2.0.0' }, iso(1))
+    await velocityStorage.recompute(pid)
+
+    const first = await captureDeveloperSnapshot(pid)
+    expect(first).toBe(true)
+    const again = await captureDeveloperSnapshot(pid)
+    expect(again).toBe(false) // idempotent within the week
+
+    const evo = getDeveloperEvolution(pid)
+    expect(evo).toHaveLength(1)
+    expect(evo[0].ships7d).toBe(1)
+    expect(evo[0].velocityAvg).toBeGreaterThan(0)
+    expect(evo[0].summary).toContain('shipped 1')
+    expect(evo[0].summary).toContain('standing preferences')
+
+    const md = renderDeveloperEvolution(pid)
+    expect(md).toContain('## Evolution (weekly snapshots)')
+    expect(md).toContain('Week digest')
+  })
+})

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -383,17 +383,17 @@ export function registerProjectTools(server: McpServer) {
       const projectId = await resolveProjectId(args.projectPath)
       const { projectMemory } = await import('../../memory/project-memory')
       const { buildDeveloperProfile } = await import('../../services/developer-profile')
+      const { renderDeveloperEvolution } = await import('../../services/developer-evolution')
       const entries = projectMemory.allEntriesForIndex(projectId)
       const body = buildDeveloperProfile(entries)
+      // Weekly typed snapshots: how the profile + delivery velocity have
+      // evolved over time (developer_profile_snapshots).
+      const evolution = renderDeveloperEvolution(projectId)
+      const text =
+        [body, evolution].filter(Boolean).join('\n\n') ||
+        'No developer profile yet — capture `feedback` memories as preferences emerge.'
       return {
-        content: [
-          {
-            type: 'text',
-            text:
-              body ??
-              'No developer profile yet — capture `feedback` memories as preferences emerge.',
-          },
-        ],
+        content: [{ type: 'text', text }],
       }
     })
   )

--- a/core/services/developer-evolution.ts
+++ b/core/services/developer-evolution.ts
@@ -1,0 +1,173 @@
+/**
+ * Developer evolution — typed weekly snapshots of what the agent knows about
+ * the developer, plus how their delivery is trending.
+ *
+ * Granular facts live in `memory_entries` (preferences as `feedback`,
+ * friction as `improvement-signal`, knowledge as decision/gotcha/learning);
+ * `velocity_sprints` holds delivery. This service rolls both into ONE typed
+ * row per ISO week in `developer_profile_snapshots` with a generated summary
+ * line — so "how has the dev (and the agent's model of them) evolved?" is a
+ * SELECT over snapshots, not an LLM re-read of raw history.
+ *
+ * Writes are idempotent per week (INSERT OR IGNORE on the epoch-week PK):
+ * the first sync of a week captures it, later syncs are no-ops.
+ */
+
+import { prjctDb } from '../storage/database'
+import { epochWeek, velocityStorage } from '../storage/velocity-storage'
+
+export interface DeveloperSnapshot {
+  week: number
+  capturedAt: string
+  preferences: number
+  frictions: number
+  decisions7d: number
+  gotchas7d: number
+  learnings7d: number
+  tasksCompleted7d: number
+  ships7d: number
+  velocityAvg: number
+  summary: string
+}
+
+interface SnapshotRow {
+  week: number
+  captured_at: string
+  preferences: number
+  frictions: number
+  decisions_7d: number
+  gotchas_7d: number
+  learnings_7d: number
+  tasks_completed_7d: number
+  ships_7d: number
+  velocity_avg: number
+  summary: string
+}
+
+const rowToSnapshot = (r: SnapshotRow): DeveloperSnapshot => ({
+  week: r.week,
+  capturedAt: r.captured_at,
+  preferences: r.preferences,
+  frictions: r.frictions,
+  decisions7d: r.decisions_7d,
+  gotchas7d: r.gotchas_7d,
+  learnings7d: r.learnings_7d,
+  tasksCompleted7d: r.tasks_completed_7d,
+  ships7d: r.ships_7d,
+  velocityAvg: r.velocity_avg,
+  summary: r.summary,
+})
+
+/** Count non-deleted memory entries of a type, optionally in the last 7 days. */
+function countEntries(projectId: string, type: string, sinceEpochMs?: number): number {
+  const sql = sinceEpochMs
+    ? 'SELECT COUNT(*) AS c FROM memory_entries WHERE type = ? AND deleted_at IS NULL AND created_at >= ?'
+    : 'SELECT COUNT(*) AS c FROM memory_entries WHERE type = ? AND deleted_at IS NULL'
+  const params = sinceEpochMs ? [type, sinceEpochMs] : [type]
+  return prjctDb.get<{ c: number }>(projectId, sql, ...params)?.c ?? 0
+}
+
+/** Deterministic one-line summary — the row's LLM/human-readable digest. */
+function buildSummary(s: Omit<DeveloperSnapshot, 'summary' | 'week' | 'capturedAt'>): string {
+  const knowledge = s.decisions7d + s.gotchas7d + s.learnings7d
+  const delivery =
+    s.ships7d > 0 || s.tasksCompleted7d > 0
+      ? `shipped ${s.ships7d}, completed ${s.tasksCompleted7d} cycles`
+      : 'no deliveries recorded'
+  return (
+    `Week digest: ${delivery}; velocity avg ${s.velocityAvg.toFixed(1)} pts/wk. ` +
+    `Agent's model of the dev: ${s.preferences} standing preferences, ` +
+    `${s.frictions} friction signals; +${knowledge} knowledge entries this week ` +
+    `(${s.decisions7d} decisions, ${s.gotchas7d} gotchas, ${s.learnings7d} learnings).`
+  )
+}
+
+/**
+ * Capture this week's snapshot (idempotent — first sync of the week wins).
+ * Best-effort: callers must never block on it.
+ */
+export async function captureDeveloperSnapshot(projectId: string): Promise<boolean> {
+  const now = new Date().toISOString()
+  const week = epochWeek(now)
+  const since = Date.now() - 7 * 24 * 60 * 60 * 1000
+  const sinceIso = new Date(since).toISOString()
+
+  const velocity = await velocityStorage.getMetrics(projectId)
+  const fields = {
+    preferences: countEntries(projectId, 'feedback'),
+    frictions: countEntries(projectId, 'improvement-signal'),
+    decisions7d: countEntries(projectId, 'decision', since),
+    gotchas7d: countEntries(projectId, 'gotcha', since),
+    learnings7d: countEntries(projectId, 'learning', since),
+    tasksCompleted7d:
+      prjctDb.get<{ c: number }>(
+        projectId,
+        'SELECT COUNT(*) AS c FROM tasks WHERE completed_at IS NOT NULL AND completed_at >= ?',
+        sinceIso
+      )?.c ?? 0,
+    ships7d:
+      prjctDb.get<{ c: number }>(
+        projectId,
+        'SELECT COUNT(*) AS c FROM shipped_features WHERE shipped_at >= ?',
+        sinceIso
+      )?.c ?? 0,
+    velocityAvg: velocity.averageVelocity,
+  }
+
+  const result = prjctDb.run(
+    projectId,
+    `INSERT OR IGNORE INTO developer_profile_snapshots
+       (week, captured_at, preferences, frictions, decisions_7d, gotchas_7d, learnings_7d,
+        tasks_completed_7d, ships_7d, velocity_avg, summary)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    week,
+    now,
+    fields.preferences,
+    fields.frictions,
+    fields.decisions7d,
+    fields.gotchas7d,
+    fields.learnings7d,
+    fields.tasksCompleted7d,
+    fields.ships7d,
+    fields.velocityAvg,
+    buildSummary(fields)
+  )
+  return result.changes > 0
+}
+
+/** Last N weekly snapshots, newest first. */
+export function getDeveloperEvolution(projectId: string, limit = 8): DeveloperSnapshot[] {
+  return prjctDb
+    .query<SnapshotRow>(
+      projectId,
+      'SELECT * FROM developer_profile_snapshots ORDER BY week DESC LIMIT ?',
+      limit
+    )
+    .map(rowToSnapshot)
+}
+
+/**
+ * Markdown evolution block for agent surfaces (`prjct_developer`): the weekly
+ * digests newest-first plus a one-line trend comparison.
+ */
+export function renderDeveloperEvolution(projectId: string, limit = 6): string | null {
+  const snaps = getDeveloperEvolution(projectId, limit)
+  if (snaps.length === 0) return null
+
+  const lines: string[] = ['## Evolution (weekly snapshots)']
+  if (snaps.length >= 2) {
+    const latest = snaps[0]
+    const prior = snaps[snaps.length - 1]
+    const vDelta = latest.velocityAvg - prior.velocityAvg
+    const pDelta = latest.preferences - prior.preferences
+    lines.push(
+      `Over ${snaps.length} weeks: velocity ${vDelta >= 0 ? '+' : ''}${vDelta.toFixed(1)} pts/wk, ` +
+        `standing preferences ${pDelta >= 0 ? '+' : ''}${pDelta}, ` +
+        `frictions ${latest.frictions - prior.frictions >= 0 ? '+' : ''}${latest.frictions - prior.frictions}.`
+    )
+  }
+  for (const s of snaps) {
+    lines.push(`- ${s.capturedAt.slice(0, 10)} — ${s.summary}`)
+  }
+  return lines.join('\n')
+}

--- a/core/services/sync/persistence.ts
+++ b/core/services/sync/persistence.ts
@@ -70,6 +70,18 @@ export async function recordSyncMetrics(
     log.debug('Failed to record sync metrics', { error: getErrorMessage(error) })
   }
 
+  // Delivery velocity (weekly sprints from tasks+ships) and the weekly
+  // developer-evolution snapshot. Both typed, both idempotent, both
+  // best-effort — a failure never degrades the sync itself.
+  try {
+    const { velocityStorage } = await import('../../storage/velocity-storage')
+    await velocityStorage.recompute(projectId)
+    const { captureDeveloperSnapshot } = await import('../developer-evolution')
+    await captureDeveloperSnapshot(projectId)
+  } catch (error) {
+    log.debug('Failed to update velocity/dev-evolution', { error: getErrorMessage(error) })
+  }
+
   const indexes: NonNullable<SyncMetrics['indexes']> = {}
   try {
     const bm25 = loadBm25Index(projectId)

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2297,6 +2297,40 @@ export const migrations: Migration[] = [
       db.run("DELETE FROM kv_store WHERE key = 'queue'")
     },
   },
+  {
+    version: 54,
+    name: 'velocity-restored-and-dev-evolution',
+    up: (db: SqliteDatabase) => {
+      // Velocity's write path had been amputated (saveMetrics had zero
+      // callers; readers always got defaults). Restored: sprints are now
+      // COMPUTED from the typed tables (tasks.completed_at +
+      // shipped_features.shipped_at) and persisted into the existing
+      // `velocity_sprints` table on every sync. The kv blob only ever held
+      // defaults — retire it.
+      db.run("DELETE FROM kv_store WHERE key = 'velocity'")
+
+      // Developer evolution: weekly typed snapshots of what the agent has
+      // learned about the developer (preference/friction/knowledge counts +
+      // delivery numbers) with a generated one-line summary. Evolution =
+      // SELECT over snapshots ordered by week. Granular facts stay in
+      // memory_entries; this is the queryable rollup.
+      db.run(
+        `CREATE TABLE IF NOT EXISTS developer_profile_snapshots (
+           week               INTEGER PRIMARY KEY,  -- epoch-week (one snapshot per ISO week)
+           captured_at        TEXT NOT NULL,
+           preferences        INTEGER NOT NULL DEFAULT 0,  -- feedback-type entries (lifetime)
+           frictions          INTEGER NOT NULL DEFAULT 0,  -- improvement-signals (lifetime)
+           decisions_7d       INTEGER NOT NULL DEFAULT 0,
+           gotchas_7d         INTEGER NOT NULL DEFAULT 0,
+           learnings_7d       INTEGER NOT NULL DEFAULT 0,
+           tasks_completed_7d INTEGER NOT NULL DEFAULT 0,
+           ships_7d           INTEGER NOT NULL DEFAULT 0,
+           velocity_avg       REAL NOT NULL DEFAULT 0,
+           summary            TEXT NOT NULL
+         )`
+      )
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/storage/velocity-storage.ts
+++ b/core/storage/velocity-storage.ts
@@ -1,36 +1,65 @@
 /**
- * Velocity Storage (PRJ-296)
+ * Velocity Storage (PRJ-296, restored under Schema v2)
  *
- * Manages velocity metrics with write-through pattern:
- * - storage/velocity.json → source of truth
- * - context/velocity.md → Claude-readable summary
+ * Velocity — how much the developer is actually delivering — is COMPUTED from
+ * the typed tables (`tasks.completed_at` + `shipped_features.shipped_at`) and
+ * persisted as weekly rollups in the typed `velocity_sprints` table. The
+ * legacy kv blob's write path had been amputated (zero `saveMetrics` callers),
+ * so every reader silently got DEFAULT_VELOCITY_METRICS; migration 54 retired
+ * that blob and `recompute()` (called on every sync) now keeps the sprints
+ * fresh from real delivery data.
  *
- * Extends StorageManager for consistency with existing storage classes.
+ * A "sprint" is an ISO epoch-week (`floor(epoch-days / 7)`), so sprint numbers
+ * are stable across machines. Points = ships (a ship is the unit of delivered
+ * value) + completed work cycles.
+ *
+ * Extends StorageManager solely for `publishEntityEvent` (the sync wire).
  */
 
-import type { VelocityMetrics } from '../schemas/velocity'
+import type { SprintVelocity, VelocityMetrics, VelocityTrend } from '../schemas/velocity'
 import { DEFAULT_VELOCITY_METRICS } from '../schemas/velocity'
+import { prjctDb } from './database'
 import { StorageManager } from './storage-manager'
 
-// Types
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+/** Stable cross-machine sprint number: whole weeks since the Unix epoch. */
+export function epochWeek(dateIso: string): number {
+  return Math.floor(new Date(dateIso).getTime() / WEEK_MS)
+}
+
+function weekStartIso(week: number): string {
+  return new Date(week * WEEK_MS).toISOString()
+}
+
+function weekEndIso(week: number): string {
+  return new Date((week + 1) * WEEK_MS - 1).toISOString()
+}
+
+interface SprintRow {
+  sprint_number: number
+  points_completed: number
+  tasks_completed: number
+  estimation_accuracy: number
+  avg_variance: number
+  started_at: string | null
+  ended_at: string | null
+}
 
 interface VelocityStoreData {
   metrics: VelocityMetrics
   lastUpdated: string
 }
 
-// Velocity Storage
-
 class VelocityStorage extends StorageManager<VelocityStoreData> {
   constructor() {
     super('velocity.json')
   }
 
+  // Vestigial abstract-method implementations — the blob path is unused; kept
+  // only so `publishEntityEvent` (the sync surface) stays available.
   protected getDefault(): VelocityStoreData {
-    return {
-      metrics: DEFAULT_VELOCITY_METRICS,
-      lastUpdated: '',
-    }
+    return { metrics: DEFAULT_VELOCITY_METRICS, lastUpdated: '' }
   }
 
   protected getEventType(action: 'update' | 'create' | 'delete'): string {
@@ -40,14 +69,55 @@ class VelocityStorage extends StorageManager<VelocityStoreData> {
   // Domain Methods
 
   /**
-   * Save computed velocity metrics.
+   * Recompute weekly sprints from the typed delivery tables and upsert them.
+   * Cheap (two grouped SELECTs) — safe to run on every sync.
    */
-  async saveMetrics(projectId: string, metrics: VelocityMetrics): Promise<void> {
-    await this.write(projectId, {
-      metrics,
-      lastUpdated: metrics.lastUpdated,
-    })
+  async recompute(projectId: string): Promise<void> {
+    // Completed work cycles per week (tasks.completed_at is ISO text; the
+    // division happens in JS after a grouped fetch to keep SQL portable).
+    const taskRows = prjctDb.query<{ completed_at: string }>(
+      projectId,
+      'SELECT completed_at FROM tasks WHERE completed_at IS NOT NULL'
+    )
+    const shipRows = prjctDb.query<{ shipped_at: string }>(
+      projectId,
+      'SELECT shipped_at FROM shipped_features'
+    )
 
+    const byWeek = new Map<number, { tasks: number; ships: number }>()
+    for (const r of taskRows) {
+      const w = epochWeek(r.completed_at)
+      const cur = byWeek.get(w) ?? { tasks: 0, ships: 0 }
+      cur.tasks++
+      byWeek.set(w, cur)
+    }
+    for (const r of shipRows) {
+      const w = epochWeek(r.shipped_at)
+      const cur = byWeek.get(w) ?? { tasks: 0, ships: 0 }
+      cur.ships++
+      byWeek.set(w, cur)
+    }
+
+    for (const [week, agg] of byWeek) {
+      prjctDb.run(
+        projectId,
+        `INSERT INTO velocity_sprints
+           (sprint_number, points_completed, tasks_completed, estimation_accuracy, avg_variance, started_at, ended_at)
+         VALUES (?, ?, ?, 0, 0, ?, ?)
+         ON CONFLICT(sprint_number) DO UPDATE SET
+           points_completed = excluded.points_completed,
+           tasks_completed = excluded.tasks_completed,
+           started_at = excluded.started_at,
+           ended_at = excluded.ended_at`,
+        week,
+        agg.ships + agg.tasks,
+        agg.tasks,
+        weekStartIso(week),
+        weekEndIso(week)
+      )
+    }
+
+    const metrics = await this.getMetrics(projectId)
     await this.publishEntityEvent(projectId, 'velocity', 'updated', {
       averageVelocity: metrics.averageVelocity,
       trend: metrics.velocityTrend,
@@ -56,11 +126,52 @@ class VelocityStorage extends StorageManager<VelocityStoreData> {
   }
 
   /**
-   * Get current velocity metrics.
+   * Velocity metrics from the typed sprints: recent sprints, average velocity
+   * (last 6 weeks), and the trend (last 3 weeks vs the 3 before).
    */
   async getMetrics(projectId: string): Promise<VelocityMetrics> {
-    const data = await this.read(projectId)
-    return data.metrics
+    const rows = prjctDb.query<SprintRow>(
+      projectId,
+      'SELECT * FROM velocity_sprints ORDER BY sprint_number DESC LIMIT 12'
+    )
+    if (rows.length === 0) return DEFAULT_VELOCITY_METRICS
+
+    const sprints: SprintVelocity[] = rows
+      .slice()
+      .reverse()
+      .map((r) => ({
+        sprintNumber: r.sprint_number,
+        startDate: r.started_at ?? weekStartIso(r.sprint_number),
+        endDate: r.ended_at ?? weekEndIso(r.sprint_number),
+        pointsCompleted: r.points_completed,
+        tasksCompleted: r.tasks_completed,
+        avgVariance: r.avg_variance,
+        estimationAccuracy: r.estimation_accuracy,
+      }))
+
+    const recent = rows.slice(0, 6)
+    const averageVelocity =
+      recent.reduce((sum, r) => sum + r.points_completed, 0) / Math.max(1, recent.length)
+
+    const last3 = rows.slice(0, 3).reduce((s, r) => s + r.points_completed, 0)
+    const prev3 = rows.slice(3, 6).reduce((s, r) => s + r.points_completed, 0)
+    let velocityTrend: VelocityTrend = 'stable'
+    if (rows.length >= 4) {
+      if (last3 > prev3 * 1.15) velocityTrend = 'improving'
+      else if (last3 < prev3 * 0.85) velocityTrend = 'declining'
+    }
+
+    return {
+      sprints,
+      averageVelocity,
+      velocityTrend,
+      // No estimation data exists yet (tasks carry no point estimates) —
+      // honest zeros rather than invented accuracy.
+      estimationAccuracy: 0,
+      overEstimated: [],
+      underEstimated: [],
+      lastUpdated: new Date().toISOString(),
+    }
   }
 }
 


### PR DESCRIPTION
**Velocity restored (not deleted)** — it's the dev-delivery metric. Its write path was amputated (zero `saveMetrics` callers → readers always got defaults). Now `recompute()` derives weekly sprints from the typed tables (`tasks.completed_at` + `shipped_features.shipped_at`), persists them in `velocity_sprints`, and `getMetrics()` computes average + trend (improving/stable/declining). Honest zeros for estimation fields (no invented accuracy). Runs on every sync.

**Developer evolution (new)** — migration 54 adds `developer_profile_snapshots`: one typed row per ISO week rolling up what the agent knows about the dev (standing preferences, friction signals, knowledge added) + delivery (ships/tasks 7d, velocity avg) with a **generated summary line**. Evolution = SELECT over snapshots. `prjct_developer` (MCP) now serves the profile + the weekly evolution block with trend deltas.

**Verified on a copy of the real DB:** 9 sprints derived from real ships · avg **9.2 pts/wk** · trend **improving** · digest: "shipped 15, velocity avg 9.2; 9 standing preferences, 23 friction signals, +317 knowledge entries this week".

typecheck + biome clean · **1918/1918 tests** (+3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)