### PR TITLE
feat(storage): ideas in typed table + orphan kv-key sweep (Schema v2)

### DIFF
--- a/core/__tests__/services/pattern-extractor.test.ts
+++ b/core/__tests__/services/pattern-extractor.test.ts
@@ -48,16 +48,11 @@ describe('patternExtractor', () => {
     expect(result.patterns.some((p) => p.source === 'feedback')).toBe(true)
     expect(result.antiPatterns.some((a) => a.source === 'feedback')).toBe(true)
 
-    const saved = prjctDb.getDoc<{
-      repoPathHash: string
-      patterns: Array<{ source: string }>
-      antiPatterns: Array<{ source: string }>
-    }>(projectId, `analysis:derived-rules:${result.repoPathHash}`)
-
-    expect(saved).not.toBeNull()
-    expect(saved?.repoPathHash).toBe(result.repoPathHash)
-    expect(saved?.patterns.length).toBeGreaterThan(0)
-    expect(saved?.antiPatterns.length).toBeGreaterThan(0)
+    // The rules flow through the RETURN into the analysis draft; the old
+    // write-only `analysis:derived-rules:<hash>` kv row must NOT come back
+    // (zero readers — migration 55 swept the accumulated ones).
+    const saved = prjctDb.getDoc(projectId, `analysis:derived-rules:${result.repoPathHash}`)
+    expect(saved).toBeNull()
   })
 
   it('returns empty patterns when no feedback or context7', async () => {

--- a/core/__tests__/storage/archive-storage.test.ts
+++ b/core/__tests__/storage/archive-storage.test.ts
@@ -211,50 +211,37 @@ describe('Archive Storage', () => {
 
   describe('ideas dormancy', () => {
     it('should mark pending ideas older than 180 days as dormant', async () => {
-      await ideasStorage.write(testProjectId, {
-        ideas: [
-          {
-            id: 'new',
-            text: 'New idea',
-            status: 'pending',
-            priority: 'medium',
-            tags: [],
-            addedAt: daysAgoISO(10),
-          },
-          {
-            id: 'stale',
-            text: 'Stale idea',
-            status: 'pending',
-            priority: 'low',
-            tags: [],
-            addedAt: daysAgoISO(200),
-          },
-          {
-            id: 'converted',
-            text: 'Converted',
-            status: 'converted',
-            priority: 'high',
-            tags: [],
-            addedAt: daysAgoISO(300),
-          },
-        ],
-        lastUpdated: getTimestamp(),
+      // Seed typed idea rows: fresh pending, stale pending, converted.
+      await ideasStorage.upsertIdea(testProjectId, {
+        id: 'new',
+        text: 'New idea',
+        status: 'pending',
+        priority: 'medium',
+        addedAt: daysAgoISO(10),
+      })
+      await ideasStorage.upsertIdea(testProjectId, {
+        id: 'stale',
+        text: 'Stale idea',
+        status: 'pending',
+        priority: 'low',
+        addedAt: daysAgoISO(200),
+      })
+      await ideasStorage.upsertIdea(testProjectId, {
+        id: 'converted',
+        text: 'Converted',
+        status: 'converted',
+        priority: 'high',
+        addedAt: daysAgoISO(300),
       })
 
       const dormant = await ideasStorage.markDormantIdeas(testProjectId)
       expect(dormant).toBe(1)
 
-      const data = await ideasStorage.read(testProjectId)
-      const stale = data.ideas.find((i) => i.id === 'stale')
-      expect(stale?.status).toBe('dormant')
-
+      expect((await ideasStorage.getById(testProjectId, 'stale'))?.status).toBe('dormant')
       // New idea should remain pending
-      const fresh = data.ideas.find((i) => i.id === 'new')
-      expect(fresh?.status).toBe('pending')
-
+      expect((await ideasStorage.getById(testProjectId, 'new'))?.status).toBe('pending')
       // Converted should remain converted
-      const conv = data.ideas.find((i) => i.id === 'converted')
-      expect(conv?.status).toBe('converted')
+      expect((await ideasStorage.getById(testProjectId, 'converted'))?.status).toBe('converted')
 
       // Archive table should have the dormant idea
       const records = archiveStorage.getArchived(testProjectId, 'idea')
@@ -262,32 +249,25 @@ describe('Archive Storage', () => {
     })
 
     it('should track dormant status in SQLite', async () => {
-      await ideasStorage.write(testProjectId, {
-        ideas: [
-          {
-            id: 'active',
-            text: 'Active idea',
-            status: 'pending',
-            priority: 'medium',
-            tags: [],
-            addedAt: daysAgoISO(5),
-          },
-          {
-            id: 'dormant',
-            text: 'Dormant idea',
-            status: 'dormant',
-            priority: 'low',
-            tags: [],
-            addedAt: daysAgoISO(200),
-          },
-        ],
-        lastUpdated: getTimestamp(),
+      await ideasStorage.upsertIdea(testProjectId, {
+        id: 'active',
+        text: 'Active idea',
+        status: 'pending',
+        priority: 'medium',
+        addedAt: daysAgoISO(5),
+      })
+      await ideasStorage.upsertIdea(testProjectId, {
+        id: 'dormant',
+        text: 'Dormant idea',
+        status: 'dormant',
+        priority: 'low',
+        addedAt: daysAgoISO(200),
       })
 
       // Read back from storage — dormant ideas preserved in SQLite
-      const data = await ideasStorage.read(testProjectId)
-      const active = data.ideas.filter((i) => i.status === 'pending')
-      const dormant = data.ideas.filter((i) => i.status === 'dormant')
+      const all = await ideasStorage.getAll(testProjectId)
+      const active = all.filter((i) => i.status === 'pending')
+      const dormant = all.filter((i) => i.status === 'dormant')
 
       expect(active).toHaveLength(1)
       expect(active[0].text).toBe('Active idea')

--- a/core/__tests__/storage/queue-storage-typed.test.ts
+++ b/core/__tests__/storage/queue-storage-typed.test.ts
@@ -204,3 +204,56 @@ describe('migration 53 — kv queue blob → typed table', () => {
     db.close()
   })
 })
+
+describe('migration 55 — kv ideas blob → typed table + orphan-key sweep', () => {
+  it('backfills ideas (tags + extras on cold columns) and sweeps orphan keys', () => {
+    const db = openDatabase(':memory:')
+    db.run(
+      `CREATE TABLE ideas (
+         id TEXT PRIMARY KEY, text TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending',
+         priority TEXT NOT NULL DEFAULT 'medium', tags TEXT, added_at TEXT NOT NULL,
+         converted_to TEXT, details TEXT, data TEXT )`
+    )
+    db.run(
+      'CREATE TABLE kv_store (key TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at TEXT NOT NULL)'
+    )
+    const ins = db.prepare('INSERT INTO kv_store (key, data, updated_at) VALUES (?, ?, ?)')
+    ins.run(
+      'ideas',
+      JSON.stringify({
+        ideas: [
+          {
+            id: 'i1',
+            text: 'great idea',
+            status: 'pending',
+            priority: 'high',
+            tags: ['ux'],
+            addedAt: '2026-06-01T00:00:00.000Z',
+            painPoints: ['slow'],
+          },
+          { id: 'i2', text: '', addedAt: '2026-06-01T00:00:00.000Z' }, // empty text → skipped
+        ],
+        lastUpdated: 'x',
+      }),
+      'x'
+    )
+    ins.run('memory:patterns', '{}', 'x')
+    ins.run('analysis:derived-rules:abc123', '{}', 'x')
+    ins.run('project', '{}', 'x') // unrelated key must survive
+
+    const m55 = migrations.find((m) => m.version === 55)
+    expect(m55).toBeTruthy()
+    m55?.up(db)
+
+    const rows = db.prepare('SELECT * FROM ideas').all() as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(1)
+    expect(rows[0].priority).toBe('high')
+    expect(JSON.parse(rows[0].tags as string)).toEqual(['ux'])
+    expect(JSON.parse(rows[0].data as string).painPoints).toEqual(['slow'])
+    const keys = (
+      db.prepare('SELECT key FROM kv_store ORDER BY key').all() as Array<{ key: string }>
+    ).map((k) => k.key)
+    expect(keys).toEqual(['project']) // ideas + orphans swept, unrelated survives
+    db.close()
+  })
+})

--- a/core/services/pattern-extractor.ts
+++ b/core/services/pattern-extractor.ts
@@ -1,5 +1,4 @@
 import path from 'node:path'
-import { prjctDb } from '../storage/database'
 import type {
   ExtractedAntiPattern,
   ExtractedPattern,
@@ -69,16 +68,10 @@ class PatternExtractor {
     const patterns = dedupePatterns([...context7Patterns, ...feedbackPatterns])
     const antiPatterns = dedupeAntiPatterns([...feedbackAntiPatterns])
 
-    const key = `analysis:derived-rules:${hash}`
-    prjctDb.setDoc(input.projectId, key, {
-      projectId: input.projectId,
-      repoPathHash: hash,
-      patterns,
-      antiPatterns,
-      updatedAt: new Date().toISOString(),
-      version: 1,
-    })
-
+    // No kv persistence: the extracted rules flow through the RETURN into the
+    // analysis draft (sync/persistence.ts → analysisStorage.saveDraft). The
+    // old `analysis:derived-rules:<hash>` setDoc here was write-only — zero
+    // readers, one orphan row per repo-path hash; migration 55 swept them.
     return { patterns, antiPatterns, repoPathHash: hash }
   }
 }

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2331,6 +2331,60 @@ export const migrations: Migration[] = [
       )
     },
   },
+  {
+    version: 55,
+    name: 'ideas-typed-store-and-orphan-cleanup',
+    up: (db: SqliteDatabase) => {
+      // Schema v2: ideas lived in the `kv_store['ideas']` blob while the
+      // typed `ideas` table sat empty. Backfill (INSERT OR IGNORE on the id
+      // PK) and retire the key. Extended fields ride the cold columns.
+      const blob = db.prepare("SELECT data FROM kv_store WHERE key = 'ideas'").get() as
+        | { data?: string }
+        | undefined
+      if (blob?.data) {
+        let ideas: Array<Record<string, unknown>> = []
+        try {
+          const parsed = JSON.parse(blob.data) as { ideas?: unknown }
+          if (Array.isArray(parsed?.ideas)) ideas = parsed.ideas as Array<Record<string, unknown>>
+        } catch {
+          ideas = [] // malformed blob must not brick startup
+        }
+        const insert = db.prepare(
+          `INSERT OR IGNORE INTO ideas
+             (id, text, status, priority, tags, added_at, converted_to, details, data)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        for (const i of ideas) {
+          const id = i.id as string | undefined
+          const text = i.text as string | undefined
+          if (!id || !text) continue
+          const extras: Record<string, unknown> = {}
+          for (const k of ['painPoints', 'solutions', 'filesAffected', 'impactEffort']) {
+            if (i[k] !== undefined) extras[k] = i[k]
+          }
+          insert.run(
+            id,
+            text,
+            (i.status as string) ?? 'pending',
+            (i.priority as string) ?? 'medium',
+            Array.isArray(i.tags) && i.tags.length ? JSON.stringify(i.tags) : null,
+            (i.addedAt as string) ?? '1970-01-01T00:00:00.000Z',
+            (i.convertedTo as string) ?? null,
+            (i.details as string) ?? null,
+            Object.keys(extras).length ? JSON.stringify(extras) : null
+          )
+        }
+      }
+      db.run("DELETE FROM kv_store WHERE key = 'ideas'")
+
+      // Orphan kv keys with zero readers (grep-verified):
+      //  - 'memory:patterns'          — exists in real DBs, zero code refs
+      //  - 'analysis:derived-rules:*' — write-only rows nobody reads; sweep
+      //    the accumulated ones (one per repo-path hash).
+      db.run("DELETE FROM kv_store WHERE key = 'memory:patterns'")
+      db.run("DELETE FROM kv_store WHERE key LIKE 'analysis:derived-rules:%'")
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/storage/ideas-storage.ts
+++ b/core/storage/ideas-storage.ts
@@ -1,8 +1,14 @@
 /**
  * Ideas Storage
  *
- * Manages ideas via storage/ideas.json
- * Generates context/ideas.md for Claude
+ * Schema v2: ideas live in the typed `ideas` table — hot fields as columns
+ * (text, status, priority, added_at, converted_to, details), the tag list in
+ * the cold `tags` JSON column (never key-queried), and the rare extras
+ * (painPoints/solutions/filesAffected/impactEffort) in the cold `data`
+ * column. The legacy `kv_store['ideas']` blob was backfilled and retired by
+ * migration 55.
+ *
+ * Extends StorageManager solely for `publishEvent` (the cloud-sync wire).
  */
 
 import { IdeasJsonSchema } from '../schemas/ideas'
@@ -10,18 +16,63 @@ import { generateUUID } from '../schemas/schemas'
 import type { Idea, IdeaPriority, IdeaStatus, IdeasJson } from '../types/storage'
 import { getDaysAgo, getTimestamp } from '../utils/date-helper'
 import { ARCHIVE_POLICIES, archiveStorage } from './archive-storage'
+import { prjctDb } from './database'
 import { StorageManager } from './storage-manager'
+
+/** A row of the typed `ideas` table. */
+interface IdeaRow {
+  id: string
+  text: string
+  status: string
+  priority: string
+  tags: string | null
+  added_at: string
+  converted_to: string | null
+  details: string | null
+  data: string | null
+}
+
+function rowToIdea(r: IdeaRow): Idea {
+  let tags: string[] = []
+  if (r.tags) {
+    try {
+      const parsed = JSON.parse(r.tags)
+      if (Array.isArray(parsed)) tags = parsed
+    } catch {
+      /* cold column — tolerate junk */
+    }
+  }
+  let extra: Partial<Idea> = {}
+  if (r.data) {
+    try {
+      extra = JSON.parse(r.data) as Partial<Idea>
+    } catch {
+      extra = {}
+    }
+  }
+  const idea: Idea = {
+    ...extra,
+    id: r.id,
+    text: r.text,
+    status: r.status as IdeaStatus,
+    priority: r.priority as IdeaPriority,
+    tags,
+    addedAt: r.added_at,
+  }
+  if (r.converted_to != null) idea.convertedTo = r.converted_to
+  if (r.details != null) idea.details = r.details
+  return idea
+}
 
 class IdeasStorage extends StorageManager<IdeasJson> {
   constructor() {
     super('ideas.json', IdeasJsonSchema)
   }
 
+  // Vestigial abstract-method implementations — the blob path is unused; kept
+  // only so `publishEvent` (the sync surface) stays available.
   protected getDefault(): IdeasJson {
-    return {
-      ideas: [],
-      lastUpdated: '',
-    }
+    return { ideas: [], lastUpdated: '' }
   }
 
   protected getEventType(action: 'update' | 'create' | 'delete'): string {
@@ -30,25 +81,24 @@ class IdeasStorage extends StorageManager<IdeasJson> {
 
   // =========== Domain Methods ===========
 
-  /**
-   * Get all ideas
-   */
+  /** All ideas, newest first. */
   async getAll(projectId: string): Promise<Idea[]> {
-    const data = await this.read(projectId)
-    return data.ideas
+    return prjctDb
+      .query<IdeaRow>(projectId, 'SELECT * FROM ideas ORDER BY added_at DESC')
+      .map(rowToIdea)
   }
 
-  /**
-   * Get pending ideas
-   */
+  /** Pending ideas, newest first. */
   async getPending(projectId: string): Promise<Idea[]> {
-    const data = await this.read(projectId)
-    return data.ideas.filter((i) => i.status === 'pending')
+    return prjctDb
+      .query<IdeaRow>(
+        projectId,
+        "SELECT * FROM ideas WHERE status = 'pending' ORDER BY added_at DESC"
+      )
+      .map(rowToIdea)
   }
 
-  /**
-   * Add a new idea
-   */
+  /** Add a new idea. */
   async addIdea(
     projectId: string,
     text: string,
@@ -62,13 +112,18 @@ class IdeasStorage extends StorageManager<IdeasJson> {
       tags: options.tags || [],
       addedAt: getTimestamp(),
     }
+    prjctDb.run(
+      projectId,
+      `INSERT INTO ideas (id, text, status, priority, tags, added_at, converted_to, details, data)
+       VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL)`,
+      idea.id,
+      idea.text,
+      idea.status,
+      idea.priority,
+      idea.tags.length ? JSON.stringify(idea.tags) : null,
+      idea.addedAt
+    )
 
-    await this.update(projectId, (data) => ({
-      ideas: [idea, ...data.ideas], // Prepend new ideas
-      lastUpdated: getTimestamp(),
-    }))
-
-    // Publish event
     await this.publishEvent(projectId, 'idea.created', {
       ideaId: idea.id,
       text: idea.text,
@@ -79,135 +134,126 @@ class IdeasStorage extends StorageManager<IdeasJson> {
   }
 
   /**
-   * Get idea by ID
+   * Upsert an idea by id — the sync-pull apply path (replaces the handler's
+   * blob read-modify-write). Preserves the local addedAt when present.
    */
+  async upsertIdea(
+    projectId: string,
+    fields: {
+      id: string
+      text: string
+      priority: IdeaPriority
+      status: IdeaStatus
+      addedAt: string
+    }
+  ): Promise<void> {
+    prjctDb.run(
+      projectId,
+      `INSERT INTO ideas (id, text, status, priority, tags, added_at)
+       VALUES (?, ?, ?, ?, NULL, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         text = excluded.text,
+         status = excluded.status,
+         priority = excluded.priority`,
+      fields.id,
+      fields.text,
+      fields.status,
+      fields.priority,
+      fields.addedAt
+    )
+  }
+
+  /** Get idea by ID. */
   async getById(projectId: string, id: string): Promise<Idea | undefined> {
-    const data = await this.read(projectId)
-    return data.ideas.find((i) => i.id === id)
+    const row = prjctDb.get<IdeaRow>(projectId, 'SELECT * FROM ideas WHERE id = ?', id)
+    return row ? rowToIdea(row) : undefined
   }
 
-  /**
-   * Convert idea to feature
-   */
+  /** Convert idea to feature. */
   async convertToFeature(projectId: string, ideaId: string, featureId: string): Promise<void> {
-    await this.update(projectId, (data) => ({
-      ideas: data.ideas.map((i) =>
-        i.id === ideaId ? { ...i, status: 'converted' as IdeaStatus, convertedTo: featureId } : i
-      ),
-      lastUpdated: getTimestamp(),
-    }))
-
-    await this.publishEvent(projectId, 'idea.converted', {
-      ideaId,
+    prjctDb.run(
+      projectId,
+      "UPDATE ideas SET status = 'converted', converted_to = ? WHERE id = ?",
       featureId,
-    })
+      ideaId
+    )
+    await this.publishEvent(projectId, 'idea.converted', { ideaId, featureId })
   }
 
-  /**
-   * Archive an idea
-   */
+  /** Archive an idea. */
   async archive(projectId: string, ideaId: string): Promise<void> {
-    await this.update(projectId, (data) => ({
-      ideas: data.ideas.map((i) =>
-        i.id === ideaId ? { ...i, status: 'archived' as IdeaStatus } : i
-      ),
-      lastUpdated: getTimestamp(),
-    }))
-
+    prjctDb.run(projectId, "UPDATE ideas SET status = 'archived' WHERE id = ?", ideaId)
     await this.publishEvent(projectId, 'idea.archived', { ideaId })
   }
 
-  /**
-   * Set priority
-   */
+  /** Set priority. */
   async setPriority(projectId: string, ideaId: string, priority: IdeaPriority): Promise<void> {
-    await this.update(projectId, (data) => ({
-      ideas: data.ideas.map((i) => (i.id === ideaId ? { ...i, priority } : i)),
-      lastUpdated: getTimestamp(),
-    }))
+    prjctDb.run(projectId, 'UPDATE ideas SET priority = ? WHERE id = ?', priority, ideaId)
   }
 
-  /**
-   * Add tags to an idea
-   */
+  /** Add tags to an idea (deduped union — tags are a cold JSON list). */
   async addTags(projectId: string, ideaId: string, tags: string[]): Promise<void> {
-    await this.update(projectId, (data) => ({
-      ideas: data.ideas.map((i) =>
-        i.id === ideaId ? { ...i, tags: [...new Set([...i.tags, ...tags])] } : i
-      ),
-      lastUpdated: getTimestamp(),
-    }))
+    const idea = await this.getById(projectId, ideaId)
+    if (!idea) return
+    const merged = [...new Set([...idea.tags, ...tags])]
+    prjctDb.run(
+      projectId,
+      'UPDATE ideas SET tags = ? WHERE id = ?',
+      merged.length ? JSON.stringify(merged) : null,
+      ideaId
+    )
   }
 
-  /**
-   * Remove an idea
-   */
+  /** Remove an idea. */
   async removeIdea(projectId: string, ideaId: string): Promise<void> {
-    await this.update(projectId, (data) => ({
-      ideas: data.ideas.filter((i) => i.id !== ideaId),
-      lastUpdated: getTimestamp(),
-    }))
+    prjctDb.run(projectId, 'DELETE FROM ideas WHERE id = ?', ideaId)
   }
 
-  /**
-   * Get counts by status
-   */
+  /** Counts by status — SQL aggregate. */
   async getCounts(
     projectId: string
   ): Promise<{ pending: number; converted: number; archived: number }> {
-    const data = await this.read(projectId)
+    const rows = prjctDb.query<{ status: string; c: number }>(
+      projectId,
+      'SELECT status, COUNT(*) AS c FROM ideas GROUP BY status'
+    )
+    const by = new Map(rows.map((r) => [r.status, r.c]))
     return {
-      pending: data.ideas.filter((i) => i.status === 'pending').length,
-      converted: data.ideas.filter((i) => i.status === 'converted').length,
-      archived: data.ideas.filter((i) => i.status === 'archived').length,
+      pending: by.get('pending') ?? 0,
+      converted: by.get('converted') ?? 0,
+      archived: by.get('archived') ?? 0,
     }
   }
 
-  /**
-   * Cleanup old archived ideas (keep last 50)
-   */
+  /** Cleanup old archived ideas (keep newest 50). */
   async cleanup(projectId: string): Promise<{ removed: number }> {
-    const data = await this.read(projectId)
-    const archived = data.ideas.filter((i) => i.status === 'archived')
-
-    if (archived.length <= 50) {
-      return { removed: 0 }
-    }
-
-    // Sort by date and keep newest 50
-    const sortedArchived = archived.sort(
-      (a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime()
+    const result = prjctDb.run(
+      projectId,
+      `DELETE FROM ideas WHERE status = 'archived' AND id NOT IN (
+         SELECT id FROM ideas WHERE status = 'archived' ORDER BY added_at DESC LIMIT 50
+       )`
     )
-    const toRemove = new Set(sortedArchived.slice(50).map((i) => i.id))
-    const removed = toRemove.size
-
-    await this.update(projectId, (d) => ({
-      ideas: d.ideas.filter((i) => !toRemove.has(i.id)),
-      lastUpdated: getTimestamp(),
-    }))
-
-    return { removed }
+    return { removed: result.changes }
   }
 
   /**
    * Mark pending ideas older than retention period as dormant (PRJ-267).
    * Dormant ideas are excluded from LLM context but remain queryable.
-   * Returns count of newly dormant ideas.
    */
   async markDormantIdeas(projectId: string): Promise<number> {
-    const data = await this.read(projectId)
-    const threshold = getDaysAgo(ARCHIVE_POLICIES.IDEA_DORMANT_DAYS)
+    const thresholdIso = getDaysAgo(ARCHIVE_POLICIES.IDEA_DORMANT_DAYS).toISOString()
+    const stale = prjctDb
+      .query<IdeaRow>(
+        projectId,
+        "SELECT * FROM ideas WHERE status = 'pending' AND added_at < ?",
+        thresholdIso
+      )
+      .map(rowToIdea)
+    if (stale.length === 0) return 0
 
-    const stalePending = data.ideas.filter(
-      (i) => i.status === 'pending' && new Date(i.addedAt) < threshold
-    )
-
-    if (stalePending.length === 0) return 0
-
-    // Archive to SQLite for long-term access
     archiveStorage.archiveMany(
       projectId,
-      stalePending.map((idea) => ({
+      stale.map((idea) => ({
         entityType: 'idea' as const,
         entityId: idea.id,
         entityData: idea,
@@ -216,21 +262,14 @@ class IdeasStorage extends StorageManager<IdeasJson> {
       }))
     )
 
-    // Mark as dormant in active storage (excluded from context)
-    const staleIds = new Set(stalePending.map((i) => i.id))
+    prjctDb.run(
+      projectId,
+      "UPDATE ideas SET status = 'dormant' WHERE status = 'pending' AND added_at < ?",
+      thresholdIso
+    )
 
-    await this.update(projectId, (d) => ({
-      ideas: d.ideas.map((i) =>
-        staleIds.has(i.id) ? { ...i, status: 'dormant' as IdeaStatus } : i
-      ),
-      lastUpdated: getTimestamp(),
-    }))
-
-    await this.publishEvent(projectId, 'ideas.dormant', {
-      count: stalePending.length,
-    })
-
-    return stalePending.length
+    await this.publishEvent(projectId, 'ideas.dormant', { count: stale.length })
+    return stale.length
   }
 }
 

--- a/core/sync/entity-handlers/ideas.ts
+++ b/core/sync/entity-handlers/ideas.ts
@@ -14,29 +14,17 @@ export const ideasHandler: EntityHandler = {
     const id = (data.id as string) || ''
     if (!id) return
     const text = (data.title as string) || (data.text as string) || ''
+    // Same guard as the queue handlers: an empty text is garbage in.
+    if (!text.trim()) return
     const priority = (data.priority as IdeaPriority) || 'medium'
     const status = (data.status as string) || 'active'
 
-    await ideasStorage.update(projectId, (ideas) => {
-      const existingIdx = ideas.ideas.findIndex((i) => i.id === id)
-      const desiredStatus = status === 'archived' ? ('archived' as const) : ('pending' as const)
-      const next = {
-        id,
-        text,
-        priority,
-        status: desiredStatus,
-        addedAt:
-          ideas.ideas[existingIdx]?.addedAt ??
-          (data.created_at as string) ??
-          (data.addedAt as string) ??
-          new Date().toISOString(),
-        tags: ideas.ideas[existingIdx]?.tags ?? [],
-      } as (typeof ideas.ideas)[number]
-      const list =
-        existingIdx >= 0
-          ? ideas.ideas.map((i, idx) => (idx === existingIdx ? { ...i, ...next } : i))
-          : [...ideas.ideas, next]
-      return { ...ideas, ideas: list }
+    await ideasStorage.upsertIdea(projectId, {
+      id,
+      text,
+      priority,
+      status: status === 'archived' ? 'archived' : 'pending',
+      addedAt: (data.created_at as string) ?? (data.addedAt as string) ?? new Date().toISOString(),
     })
   },
 


### PR DESCRIPTION
- **ideas → typed `ideas` table**: IdeasStorage rewritten (hot columns + cold tags/data), new `upsertIdea` for the sync-pull path with the empty-text guard (same junk class as the queue's 6k empty rows). Migration 55 backfills the blob and retires the key.
- **Orphan sweep**: `memory:patterns` (zero refs) + `analysis:derived-rules:*` (write-only) deleted; the dead `setDoc` writer in pattern-extractor removed (rules already flow via the return into the analysis draft).

Verified on a copy of the real DB: orphans swept (12→10 kv keys), schema 55. typecheck + biome clean · **1919/1919 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)