### PR TITLE
fix: cleanup sweep — dead code, edge cases in recent ships, hot-path perf

### DIFF
--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -804,3 +804,70 @@ describe('projectMemory.remember — topic-key UPSERT (write-side supersession)'
     expect(active[0].content).toBe('updated trap description')
   })
 })
+
+describe('topic supersession — edge-case hardening (cleanup sweep)', () => {
+  beforeEach(async () => {
+    await fs.mkdir(path.join(tmpRoot, '.prjct'), { recursive: true })
+    await fs.writeFile(
+      path.join(tmpRoot, '.prjct', 'prjct.config.json'),
+      JSON.stringify({ projectId })
+    )
+  })
+
+  it('dedup-hit with a topic tag FOLDS the topic into the existing entry and supersedes others', async () => {
+    // Older revision of the topic.
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: 'runtime: node',
+      tags: { topic: 'runtime' },
+      projectId,
+    })
+    // Untagged capture (no topic identity yet).
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: 'runtime: bun',
+      projectId,
+    })
+    await new Promise((r) => setTimeout(r, 5))
+    // Re-capture of the SAME content, now claiming the topic → dedup hits,
+    // but the fold-in must stamp topic_key and supersede the 'node' revision.
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: 'runtime: bun',
+      tags: { topic: 'runtime' },
+      projectId,
+    })
+
+    const active = prjctDb.query<{ content: string; topic_key: string | null }>(
+      projectId,
+      "SELECT content, topic_key FROM memory_entries WHERE type = 'decision' AND deleted_at IS NULL"
+    )
+    expect(active).toHaveLength(1)
+    expect(active[0].content).toBe('runtime: bun')
+    expect(active[0].topic_key).toBe('runtime')
+  })
+
+  it('a failed event write must NOT tombstone the topic (supersession gated on eventId)', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: 'the only active revision',
+      tags: { topic: 'fragile' },
+      projectId,
+    })
+    // Simulate the log failure path: call supersession the way remember()
+    // GATES it — with no successful event, applyTopicSupersession is never
+    // invoked. Assert the gate exists by verifying the entry survives a
+    // remember() whose write path is broken (unwritable config → log fails).
+    await projectMemory.remember('/nonexistent/path/xyz', {
+      type: 'decision',
+      content: 'new revision that never lands',
+      tags: { topic: 'fragile' },
+      projectId,
+    })
+    const active = prjctDb.get<{ c: number }>(
+      projectId,
+      "SELECT COUNT(*) AS c FROM memory_entries WHERE topic_key = 'fragile' AND deleted_at IS NULL"
+    )
+    expect(active?.c).toBe(1) // the old revision was NOT tombstoned
+  })
+})

--- a/core/commands/memory-export.ts
+++ b/core/commands/memory-export.ts
@@ -73,9 +73,12 @@ export class MemoryExportCommands extends PrjctCommandsBase {
        FROM memory_entries WHERE deleted_at IS NULL ORDER BY created_at ASC`
     )
     const entries: ExportedEntry[] = rows.map((r) => {
+      // User tags plus the topic/key identity tags: 'key' is machine-classified
+      // by the trigger, but dropping it breaks topic lineage on the importing
+      // machine (future captures would not supersede the imported revision).
       const tagRows = prjctDb.query<{ key: string; value: string }>(
         projectId,
-        'SELECT key, value FROM memory_entry_tags WHERE entry_id = ? AND is_machine = 0',
+        "SELECT key, value FROM memory_entry_tags WHERE entry_id = ? AND (is_machine = 0 OR key IN ('topic', 'key'))",
         r.id
       )
       const tags: Record<string, string> = {}
@@ -134,17 +137,25 @@ export class MemoryExportCommands extends PrjctCommandsBase {
           continue // one corrupt line must not sink the import
         }
         if (!e.type || !e.content || !e.content_hash) continue
-        // Dedup BEFORE writing: the ux_mem_hash unique index would ignore the
-        // row anyway, but skipping here avoids appending a redundant event.
+        // Dedup BEFORE writing — TYPE-AWARE and active-only, matching the
+        // ux_mem_hash index (project, hash, type): the same content under two
+        // types is legal, and a hash-only check silently dropped the second.
         const dup = prjctDb.get<{ id: string }>(
           projectId,
-          'SELECT id FROM memory_entries WHERE content_hash = ? LIMIT 1',
-          e.content_hash
+          'SELECT id FROM memory_entries WHERE content_hash = ? AND type = ? AND deleted_at IS NULL LIMIT 1',
+          e.content_hash,
+          e.type
         )
         if (dup) {
           skipped++
           continue
         }
+        // Origin time: tolerate a missing/garbage created_at on a hand-edited
+        // line (one bad line must not sink the import) — fall back to now.
+        const createdMs = Number(e.created_at)
+        const createdIso = Number.isFinite(createdMs)
+          ? new Date(createdMs).toISOString()
+          : new Date().toISOString()
         // Replay through the normal event path — the memory_entries trigger
         // populates the typed row + tags; created_at preserves origin time.
         prjctDb.appendEvent(projectId, `memory.remember.${e.type}`, {
@@ -153,8 +164,21 @@ export class MemoryExportCommands extends PrjctCommandsBase {
           provenance: e.provenance || 'declared',
           content_hash: e.content_hash,
           project_id: projectId,
-          created_at: new Date(e.created_at).toISOString(),
+          created_at: createdIso,
         })
+        // Topic lineage survives the machine hop: stamp the typed topic_key
+        // (the event replay bypasses remember(), which normally does this).
+        if (e.topic_key) {
+          prjctDb.run(
+            projectId,
+            `UPDATE memory_entries SET topic_key = ?
+             WHERE project_id = ? AND type = ? AND content_hash = ? AND deleted_at IS NULL`,
+            e.topic_key,
+            projectId,
+            e.type,
+            e.content_hash
+          )
+        }
         imported++
       }
     }

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -242,7 +242,11 @@ export class WorkflowCommands extends PrjctCommandsBase {
     let delegationTrigger: string | null = null
     try {
       const { execFileAsync } = await import('../utils/exec')
-      const r = await execFileAsync('git', ['diff', '--name-only', 'HEAD'], {
+      // status --porcelain covers modified AND untracked (diff HEAD misses
+      // brand-new files — often the bulk of a multi-file change). This counts
+      // current working-tree surface, an honest proxy for "this cycle" on
+      // rigs without edit hooks; committed-as-you-go work under-counts.
+      const r = await execFileAsync('git', ['status', '--porcelain'], {
         cwd: projectPath,
         timeout: 2000,
       })

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -218,6 +218,63 @@ function recallEntriesFromV2(
 
 export const projectMemory = {
   /**
+   * Store-level topic supersession (write-side upsert): stamp `topic_key` +
+   * revision lineage on the topic's CURRENT entry (matched by content_hash)
+   * and soft-delete the topic's other active revisions of the same type.
+   * Shared by the fresh-capture path and the dedup-hit fold-in path.
+   * Best-effort — never blocks a capture.
+   */
+  applyTopicSupersession(
+    projectId: string,
+    type: string,
+    contentHash: string,
+    topicKey: string
+  ): void {
+    try {
+      const priorRevisions =
+        prjctDb.get<{ c: number }>(
+          projectId,
+          `SELECT COUNT(*) AS c FROM memory_entries
+           WHERE project_id = ? AND type = ? AND content_hash != ?
+             AND (topic_key = ? OR id IN (
+               SELECT entry_id FROM memory_entry_tags WHERE key IN ('topic', 'key') AND value = ?
+             ))`,
+          projectId,
+          type,
+          contentHash,
+          topicKey,
+          topicKey
+        )?.c ?? 0
+      prjctDb.run(
+        projectId,
+        `UPDATE memory_entries SET topic_key = ?, revision_count = ?
+         WHERE project_id = ? AND type = ? AND content_hash = ? AND deleted_at IS NULL`,
+        topicKey,
+        priorRevisions,
+        projectId,
+        type,
+        contentHash
+      )
+      prjctDb.run(
+        projectId,
+        `UPDATE memory_entries SET deleted_at = ?
+         WHERE project_id = ? AND type = ? AND deleted_at IS NULL AND content_hash != ?
+           AND (topic_key = ? OR id IN (
+             SELECT entry_id FROM memory_entry_tags WHERE key IN ('topic', 'key') AND value = ?
+           ))`,
+        Date.now(),
+        projectId,
+        type,
+        contentHash,
+        topicKey,
+        topicKey
+      )
+    } catch {
+      /* supersession is best-effort — never block a capture */
+    }
+  },
+
+  /**
    * Store an entry. Thin wrapper over memoryService so callers don't need
    * to know the event-type prefix convention.
    */
@@ -259,6 +316,7 @@ export const projectMemory = {
     // so a single detector re-firing each session can't spam the
     // store. Best-effort: any lookup failure falls through to a normal write —
     // a dedup miss is cheaper than a dropped capture.
+    const dedupTopicKey = tags.topic ?? tags.key
     if (projectId) {
       try {
         const dup = prjctDb.get<{ id: string }>(
@@ -267,7 +325,17 @@ export const projectMemory = {
           contentHash,
           args.type
         )
-        if (dup) return
+        if (dup) {
+          // Same content re-captured WITH a topic tag: don't create a row, but
+          // DO fold the topic identity into the existing entry and supersede
+          // the topic's other revisions — otherwise "adopt this entry into
+          // topic X" is a silent no-op and stale revisions keep burning
+          // recall slots (the exact failure the write-side upsert prevents).
+          if (dedupTopicKey) {
+            this.applyTopicSupersession(projectId, args.type, contentHash, dedupTopicKey)
+          }
+          return
+        }
       } catch {
         /* fall through — never block a capture on the dedup check */
       }
@@ -298,53 +366,12 @@ export const projectMemory = {
     // accumulating alongside them. The event log stays append-only (audit +
     // sync intact); supersession is a store-level soft-delete of the older
     // active entries for the same (type, topic), and the new entry gets the
-    // typed `topic_key` column + a revision_count lineage. This moves the
-    // existing read-side latest-winner dedupe to the WRITE side: stale
-    // versions stop burning recall slots and FTS hits at the source.
-    const topicKey = tags.topic ?? tags.key
-    if (projectId && topicKey) {
-      try {
-        const priorRevisions =
-          prjctDb.get<{ c: number }>(
-            projectId,
-            `SELECT COUNT(*) AS c FROM memory_entries
-             WHERE project_id = ? AND type = ? AND content_hash != ?
-               AND (topic_key = ? OR id IN (
-                 SELECT entry_id FROM memory_entry_tags WHERE key IN ('topic', 'key') AND value = ?
-               ))`,
-            projectId,
-            args.type,
-            contentHash,
-            topicKey,
-            topicKey
-          )?.c ?? 0
-        prjctDb.run(
-          projectId,
-          `UPDATE memory_entries SET topic_key = ?, revision_count = ?
-           WHERE project_id = ? AND type = ? AND content_hash = ? AND deleted_at IS NULL`,
-          topicKey,
-          priorRevisions,
-          projectId,
-          args.type,
-          contentHash
-        )
-        prjctDb.run(
-          projectId,
-          `UPDATE memory_entries SET deleted_at = ?
-           WHERE project_id = ? AND type = ? AND deleted_at IS NULL AND content_hash != ?
-             AND (topic_key = ? OR id IN (
-               SELECT entry_id FROM memory_entry_tags WHERE key IN ('topic', 'key') AND value = ?
-             ))`,
-          Date.now(),
-          projectId,
-          args.type,
-          contentHash,
-          topicKey,
-          topicKey
-        )
-      } catch {
-        /* supersession is best-effort — never block a capture */
-      }
+    // typed `topic_key` column + a revision_count lineage. GATED on the event
+    // write actually succeeding (logResult.eventId): if `log()` swallowed a
+    // transient failure, no new row exists — superseding the old revisions
+    // then would silently erase the topic's only active knowledge.
+    if (projectId && dedupTopicKey && logResult?.eventId != null) {
+      this.applyTopicSupersession(projectId, args.type, contentHash, dedupTopicKey)
     }
 
     // Reinforcement loop: credit the entries this new one references — they
@@ -653,9 +680,14 @@ export const projectMemory = {
    */
   countByType(projectId: string, type: string): number {
     try {
+      // project_id predicate lets SQLite SEARCH ix_mem_recall(project_id,
+      // type, ...) instead of scanning the whole index — this runs per prompt.
+      // 'local' is the trigger's fallback stamp for legacy/id-less events in
+      // this same per-project DB; excluding it would silently uncount them.
       const row = prjctDb.get<{ n: number }>(
         projectId,
-        'SELECT COUNT(*) AS n FROM memory_entries WHERE type = ? AND deleted_at IS NULL',
+        "SELECT COUNT(*) AS n FROM memory_entries WHERE project_id IN (?, 'local') AND type = ? AND deleted_at IS NULL",
+        projectId,
         type
       )
       return row?.n ?? 0

--- a/core/schemas/metrics.ts
+++ b/core/schemas/metrics.ts
@@ -34,46 +34,10 @@ export const AgentUsageSchema = z.object({
 /**
  * Main metrics JSON structure
  */
-export const MetricsJsonSchema = z.object({
-  // Token metrics
-  totalTokensSaved: z.number(),
-  avgCompressionRate: z.number(), // 0-1 (e.g., 0.63 = 63% reduction)
-
-  // Sync metrics
-  syncCount: z.number(),
-  watchTriggers: z.number(), // Auto-syncs from watch mode
-  avgSyncDuration: z.number(), // Average in ms
-  totalSyncDuration: z.number(), // Total in ms
-
-  // Agent usage
-  agentUsage: z.array(AgentUsageSchema),
-
-  // Time series for trends
-  dailyStats: z.array(DailyStatsSchema),
-
-  // Metadata
-  firstSync: z.string(), // ISO8601 - when tracking started
-  lastUpdated: z.string(), // ISO8601
-})
-
 // Inferred Types
 
 export type DailyStats = z.infer<typeof DailyStatsSchema>
 export type AgentUsage = z.infer<typeof AgentUsageSchema>
-export type MetricsJson = z.infer<typeof MetricsJsonSchema>
-
-export const DEFAULT_METRICS: MetricsJson = {
-  totalTokensSaved: 0,
-  avgCompressionRate: 0,
-  syncCount: 0,
-  watchTriggers: 0,
-  avgSyncDuration: 0,
-  totalSyncDuration: 0,
-  agentUsage: [],
-  dailyStats: [],
-  firstSync: '',
-  lastUpdated: '',
-}
 
 // Cost Calculation Constants (January 2026 Pricing)
 

--- a/core/services/developer-evolution.ts
+++ b/core/services/developer-evolution.ts
@@ -89,6 +89,7 @@ function buildSummary(s: Omit<DeveloperSnapshot, 'summary' | 'week' | 'capturedA
 export async function captureDeveloperSnapshot(projectId: string): Promise<boolean> {
   const now = new Date().toISOString()
   const week = epochWeek(now)
+  if (week === null) return false // unreachable for a fresh ISO stamp; satisfies the guard
   const since = Date.now() - 7 * 24 * 60 * 60 * 1000
   const sinceIso = new Date(since).toISOString()
 

--- a/core/services/skill-index.ts
+++ b/core/services/skill-index.ts
@@ -33,15 +33,33 @@ function skillRoots(projectPath: string): Array<{ dir: string; scope: 'project' 
   ]
 }
 
-/** Minimal frontmatter parse: `name:` (fallback: dir name) + `description:`. */
+/**
+ * Minimal frontmatter parse: `name:` (fallback: dir name) + `description:`.
+ * Tolerates BOM + CRLF (a Windows-authored skill must not lose its declared
+ * name and collide under the directory-name fallback) and YAML folded blocks
+ * (`description: >` / `>-` / `|`) — the folded value is the following
+ * indented lines joined, not the literal fold marker.
+ */
 function parseFrontmatter(raw: string): { name?: string; description?: string } {
-  const m = raw.match(/^---\n([\s\S]*?)\n---/)
+  const normalized = raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n')
+  const m = normalized.match(/^---\n([\s\S]*?)\n---/)
   if (!m) return {}
   const out: { name?: string; description?: string } = {}
-  for (const line of m[1].split('\n')) {
-    const kv = line.match(/^(name|description):\s*(.+)$/)
+  const lines = m[1].split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const kv = lines[i].match(/^(name|description):\s*(.*)$/)
     if (!kv) continue
-    out[kv[1] as 'name' | 'description'] = kv[2].trim().replace(/^["']|["']$/g, '')
+    const field = kv[1] as 'name' | 'description'
+    let value = kv[2].trim()
+    if (/^[>|][+-]?$/.test(value)) {
+      // Folded/literal block: collect the following indented lines.
+      const parts: string[] = []
+      while (i + 1 < lines.length && /^\s+\S/.test(lines[i + 1])) {
+        parts.push(lines[++i].trim())
+      }
+      value = parts.join(' ')
+    }
+    if (value) out[field] = value.replace(/^["']|["']$/g, '')
   }
   return out
 }

--- a/core/services/sync/persistence.ts
+++ b/core/services/sync/persistence.ts
@@ -37,11 +37,15 @@ export async function recordSyncMetrics(
   duration: number
 ): Promise<SyncMetrics> {
   // Real original size from BM25 index (actual tokens indexed from source files).
+  // Loaded ONCE and reused by the index-stats block below — the second load
+  // used to hit right after the sync invalidated the cache, paying a full
+  // corpus deserialize twice per sync.
+  let bm25Index: ReturnType<typeof loadBm25Index> = null
   let originalSize = 0
   try {
-    const bm25 = loadBm25Index(projectId)
-    if (bm25) {
-      for (const doc of Object.values(bm25.documents)) {
+    bm25Index = loadBm25Index(projectId)
+    if (bm25Index) {
+      for (const doc of Object.values(bm25Index.documents)) {
         originalSize += doc.length
       }
     }
@@ -73,18 +77,25 @@ export async function recordSyncMetrics(
   // Delivery velocity (weekly sprints from tasks+ships) and the weekly
   // developer-evolution snapshot. Both typed, both idempotent, both
   // best-effort — a failure never degrades the sync itself.
+  // Isolated try/catch per rollup: a failure in one must not silently skip
+  // the others (a shared block once let a single bad timestamp starve BOTH
+  // velocity and the weekly snapshot on every sync).
   try {
     const { velocityStorage } = await import('../../storage/velocity-storage')
     await velocityStorage.recompute(projectId)
+  } catch (error) {
+    log.debug('Failed to recompute velocity', { error: getErrorMessage(error) })
+  }
+  try {
     const { captureDeveloperSnapshot } = await import('../developer-evolution')
     await captureDeveloperSnapshot(projectId)
   } catch (error) {
-    log.debug('Failed to update velocity/dev-evolution', { error: getErrorMessage(error) })
+    log.debug('Failed to capture dev snapshot', { error: getErrorMessage(error) })
   }
 
   const indexes: NonNullable<SyncMetrics['indexes']> = {}
   try {
-    const bm25 = loadBm25Index(projectId)
+    const bm25 = bm25Index
     if (bm25) {
       indexes.bm25Files = bm25.totalDocs
       indexes.bm25AvgTokens = Math.round(bm25.avgDocLength)

--- a/core/services/update-checker.ts
+++ b/core/services/update-checker.ts
@@ -105,9 +105,3 @@ export async function fetchLatestVersion(): Promise<string | null> {
     return null
   }
 }
-
-export const _internal = {
-  statusPath,
-  FETCH_THROTTLE_MS,
-  NPM_REGISTRY,
-}

--- a/core/storage/queue-storage.ts
+++ b/core/storage/queue-storage.ts
@@ -192,7 +192,14 @@ class QueueStorage extends StorageManager<QueueJson> {
   ): Promise<void> {
     const existing = await this.getTask(projectId, task.id)
     if (existing) {
-      const merged = { ...existing, ...task }
+      // Field-presence merge: only keys the caller EXPLICITLY sent overwrite
+      // local values. Spreading fabricated defaults here once let a cloud
+      // echo of a minimal payload reset a local 'active/high' task to
+      // 'backlog/medium' — vanishing it from the per-prompt active read.
+      const merged = { ...existing }
+      for (const k of ['description', 'type', 'priority', 'section'] as const) {
+        if (task[k] !== undefined) (merged as Record<string, unknown>)[k] = task[k]
+      }
       prjctDb.run(
         projectId,
         `UPDATE queue_tasks SET description = ?, type = ?, priority = ?, section = ?

--- a/core/storage/velocity-storage.ts
+++ b/core/storage/velocity-storage.ts
@@ -23,9 +23,16 @@ import { StorageManager } from './storage-manager'
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
-/** Stable cross-machine sprint number: whole weeks since the Unix epoch. */
-export function epochWeek(dateIso: string): number {
-  return Math.floor(new Date(dateIso).getTime() / WEEK_MS)
+/**
+ * Stable cross-machine sprint number: whole weeks since the Unix epoch.
+ * Returns null for unparseable timestamps — sync-pulled rows can carry '' or
+ * garbage, and a single NaN week key used to throw in weekStartIso and kill
+ * BOTH velocity and the weekly dev snapshot on every sync thereafter.
+ */
+export function epochWeek(dateIso: string): number | null {
+  const t = new Date(dateIso).getTime()
+  if (!Number.isFinite(t)) return null
+  return Math.floor(t / WEEK_MS)
 }
 
 function weekStartIso(week: number): string {
@@ -87,12 +94,14 @@ class VelocityStorage extends StorageManager<VelocityStoreData> {
     const byWeek = new Map<number, { tasks: number; ships: number }>()
     for (const r of taskRows) {
       const w = epochWeek(r.completed_at)
+      if (w === null) continue // malformed timestamp — skip the row, not the sprint rebuild
       const cur = byWeek.get(w) ?? { tasks: 0, ships: 0 }
       cur.tasks++
       byWeek.set(w, cur)
     }
     for (const r of shipRows) {
       const w = epochWeek(r.shipped_at)
+      if (w === null) continue
       const cur = byWeek.get(w) ?? { tasks: 0, ships: 0 }
       cur.ships++
       byWeek.set(w, cur)
@@ -156,7 +165,9 @@ class VelocityStorage extends StorageManager<VelocityStoreData> {
     const last3 = rows.slice(0, 3).reduce((s, r) => s + r.points_completed, 0)
     const prev3 = rows.slice(3, 6).reduce((s, r) => s + r.points_completed, 0)
     let velocityTrend: VelocityTrend = 'stable'
-    if (rows.length >= 4) {
+    // Balanced windows only: with 4-5 sprints, last-3 vs prev-1/2 compared a
+    // 3-week sum against a smaller one and reported flat delivery "improving".
+    if (rows.length >= 6) {
       if (last3 > prev3 * 1.15) velocityTrend = 'improving'
       else if (last3 < prev3 * 0.85) velocityTrend = 'declining'
     }

--- a/core/sync/entity-handlers/queue-tasks.ts
+++ b/core/sync/entity-handlers/queue-tasks.ts
@@ -30,12 +30,14 @@ export const queueTasksHandler: EntityHandler = {
       return
     }
 
+    // Pass ONLY fields the wire actually carried — fabricated defaults on an
+    // UPDATE clobber local state (upsertTask supplies defaults on INSERT).
     await queueStorage.upsertTask(projectId, {
       id,
       description,
-      priority: (data.priority as Priority) || 'medium',
-      type: (data.type as TaskType) || 'feature',
-      section: (data.section as TaskSection) || 'backlog',
+      ...(data.priority ? { priority: data.priority as Priority } : {}),
+      ...(data.type ? { type: data.type as TaskType } : {}),
+      ...(data.section ? { section: data.section as TaskSection } : {}),
     })
   },
 

--- a/core/sync/entity-handlers/tasks.ts
+++ b/core/sync/entity-handlers/tasks.ts
@@ -11,7 +11,7 @@
  *   - other status → upsert into queue by id.
  */
 
-import type { Priority, TaskSection, TaskType } from '../../schemas/state'
+import type { Priority, TaskType } from '../../schemas/state'
 import { queueStorage } from '../../storage/queue-storage'
 import { stateStorage } from '../../storage/state-storage'
 import type { EntityHandler } from './types'
@@ -52,9 +52,10 @@ export const tasksHandler: EntityHandler = {
     await queueStorage.upsertTask(projectId, {
       id,
       description: data.description as string,
-      priority: (data.priority as Priority) || 'medium',
-      type: (data.type as TaskType) || 'feature',
-      section: 'backlog' as TaskSection,
+      ...(data.priority ? { priority: data.priority as Priority } : {}),
+      ...(data.type ? { type: data.type as TaskType } : {}),
+      // section only defaults on INSERT (inside upsertTask) — an update must
+      // not demote a locally-activated task back to backlog.
     })
   },
 


### PR DESCRIPTION
Adversarial audit: knip + 2 parallel finder agents (edge cases over the week's ships; perf over the hot paths, measured against the real 29MB project DB with EXPLAIN QUERY PLAN).

**Dead code** — knip now 100% clean (metrics blob schema orphaned by the typed rewrite; dead `_internal`).

**Edge cases (10 findings, all verified then fixed):** topic-supersession could tombstone a topic's only revision on a swallowed write error (now gated on eventId) and silently no-op on dedup-hit re-captures (now folds the topic in); one garbage timestamp permanently killed velocity + dev snapshots (NaN guard + isolated try/catch); cloud echoes could demote local active/high queue tasks to backlog/medium (field-presence merge); memory import dropped legal same-content/different-type entries and crashed on missing created_at; topic lineage now survives export/import across machines; skill frontmatter handles BOM/CRLF/YAML-folds; the git delegation trigger now counts untracked files.

**Perf quick wins:** BM25 loaded once per sync (was twice, straight after cache invalidation); per-prompt inbox count now index-SEARCHes. Big items (Stop-hook per-turn O(session) work — 150-400ms/turn measured; BM25 query-path full-corpus deserialize — 477KB JSON.parse; config cache) scoped for a follow-up with the audit's measurements.

typecheck + biome + knip clean · **1927/1927 tests** (+2 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)