### PR TITLE
perf: hot-path follow-up — stop-hook throttle, BM25 query-path, config cache

### DIFF
--- a/core/domain/bm25.ts
+++ b/core/domain/bm25.ts
@@ -497,9 +497,14 @@ function loadIndexFromPerFileTables(
   stored: StoredBm25Index | null
 ): BM25Index | null {
   try {
-    const docs = prjctDb.query<{ path: string; tokens: string; length: number }>(
+    // tokens column deliberately NOT selected: scoring needs only lengths +
+    // the inverted index, and parsing every doc's token JSON (477KB on the
+    // reference repo) dominated the load. removeDocument's empty-tokens
+    // fallback covers the incremental path; changed files are re-tokenized
+    // fresh before their rows are rewritten.
+    const docs = prjctDb.query<{ path: string; length: number }>(
       projectId,
-      'SELECT path, tokens, length FROM bm25_documents ORDER BY path'
+      'SELECT path, length FROM bm25_documents ORDER BY path'
     )
     if (docs.length === 0) {
       if (stored?.totalDocs === 0) {
@@ -520,8 +525,7 @@ function loadIndexFromPerFileTables(
     const invertedIndex: BM25Index['invertedIndex'] = emptyInvertedIndex()
     let totalLength = 0
     for (const doc of docs) {
-      const tokens = JSON.parse(doc.tokens) as string[]
-      documents[doc.path] = { tokens, length: doc.length }
+      documents[doc.path] = { tokens: [], length: doc.length }
       totalLength += doc.length
     }
 
@@ -546,6 +550,25 @@ function loadIndexFromPerFileTables(
     return index
   } catch {
     return null
+  }
+}
+
+/**
+ * Cheap existence check: the kv meta row is written on every save, so its
+ * presence answers "is there an index?" without deserializing the corpus
+ * (the registry's hasIndex used to trigger a FULL load for this).
+ */
+export function hasIndex(projectId: string): boolean {
+  try {
+    return (
+      prjctDb.get<{ k: string }>(
+        projectId,
+        'SELECT key AS k FROM kv_store WHERE key = ? LIMIT 1',
+        INDEX_KEY
+      ) != null
+    )
+  } catch {
+    return false
   }
 }
 

--- a/core/domain/indexers/registry.ts
+++ b/core/domain/indexers/registry.ts
@@ -15,7 +15,7 @@
  * sum in file-ranker stays straightforward.
  */
 
-import { loadIndex as loadBm25Index, queryFiles } from '../bm25'
+import { hasIndex as bm25HasIndex, queryFiles } from '../bm25'
 import { scoreFromSeeds as cochangeScoreFromSeeds, loadMatrix } from '../git-cochange'
 import { scoreFromSeeds as importScoreFromSeeds, loadGraph } from '../import-graph'
 
@@ -58,7 +58,7 @@ export const indexerRegistry: Indexer[] = [
     name: 'bm25',
     kind: 'query',
     defaultWeight: 0.5,
-    hasIndex: (projectId) => loadBm25Index(projectId) !== null,
+    hasIndex: (projectId) => bm25HasIndex(projectId),
     scoreFromQuery: (projectId, query, topN) => normalize(queryFiles(projectId, query, topN)),
   },
   {

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -40,6 +40,27 @@ interface HookInput {
   session_id?: string
 }
 
+/**
+ * Per-project cooldown for the EXPENSIVE, non-turn-critical Stop steps.
+ * Claude fires Stop after EVERY assistant turn, but pattern detection
+ * (2 git forks, ~110ms), session cleanup (inbox recall + archive prune) and
+ * the embeddings backfill are session-cadence work — running them per turn
+ * made the Stop hook do O(session) duplicated work all day. Daemon-resident
+ * map: the warm daemon (the hot case) honors the cooldown; a cold one-shot
+ * CLI stop simply runs the work — correct either way, since every step is
+ * idempotent.
+ */
+const HEAVY_STEP_COOLDOWN_MS = 10 * 60 * 1000
+const heavyStepLastRun = new Map<string, number>()
+
+function heavyStepsDue(projectId: string): boolean {
+  const last = heavyStepLastRun.get(projectId) ?? 0
+  if (Date.now() - last < HEAVY_STEP_COOLDOWN_MS) return false
+  if (heavyStepLastRun.size > 32) heavyStepLastRun.clear()
+  heavyStepLastRun.set(projectId, Date.now())
+  return true
+}
+
 export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): Promise<void> {
   return runHook<HookInput>(
     {
@@ -121,32 +142,39 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
           }
         }
 
+        // Session-cadence work behind the cooldown (see heavyStepsDue): these
+        // steps are idempotent and their signal changes on the minutes scale,
+        // not per turn.
+        const runHeavySteps = heavyStepsDue(config.projectId)
+
         // M2: detect durable patterns (hot files for now) and persist them
         // as learning memory entries. Lookup-first protocol means Claude
         // finds them on next session start without inflating context.
-        try {
-          await detectAndPersistPatterns(p, config)
-        } catch {
-          // Git failure / non-repo → swallow; nothing to do here.
-        }
+        if (runHeavySteps) {
+          try {
+            await detectAndPersistPatterns(p, config)
+          } catch {
+            // Git failure / non-repo → swallow; nothing to do here.
+          }
 
-        // Lean-debt growth (opt-in via config.lean.mode): flag when `lean:`
-        // simplification markers accumulate. No-op when lean mode is off.
-        try {
-          await detectAndPersistLeanDebt(p, config)
-        } catch {
-          // Same contract — git failure / non-repo → swallow.
-        }
+          // Lean-debt growth (opt-in via config.lean.mode): flag when `lean:`
+          // simplification markers accumulate. No-op when lean mode is off.
+          try {
+            await detectAndPersistLeanDebt(p, config)
+          } catch {
+            // Same contract — git failure / non-repo → swallow.
+          }
 
-        // Session-end housekeeping (Phase A): age-out inbox, prune archives
-        // and old checkpoints, rotate stale on-disk caches. Best-effort —
-        // each step internally swallows its own failures, so the rest of
-        // the cleanup still runs even if one step trips.
-        try {
-          const cleanup = await runSessionCleanup(config.projectId)
-          await recordCleanupReport(config.projectId, cleanup)
-        } catch {
-          /* never block session end on cleanup */
+          // Session-end housekeeping (Phase A): age-out inbox, prune archives
+          // and old checkpoints, rotate stale on-disk caches. Best-effort —
+          // each step internally swallows its own failures, so the rest of
+          // the cleanup still runs even if one step trips.
+          try {
+            const cleanup = await runSessionCleanup(config.projectId)
+            await recordCleanupReport(config.projectId, cleanup)
+          } catch {
+            /* never block session end on cleanup */
+          }
         }
 
         // Session-end friction capture (Phase B): scan the transcript for
@@ -205,14 +233,16 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // every project; a configured HTTP endpoint transparently takes over.
         // Best-effort, idempotent (only un-embedded entries are touched), and
         // must never block session end.
-        try {
-          // First arg is the projectId, NOT the path: passing `p` here keyed
-          // every query to path.join(projectsDir, <abs path>) — a phantom DB
-          // under ~/.prjct-cli/projects/Users/... that made the session-end
-          // backfill a silent no-op (ghost dirs confirmed on disk).
-          await embeddingService.backfill(config.projectId, config, new Date().toISOString())
-        } catch {
-          /* never block session end on index maintenance */
+        if (runHeavySteps) {
+          try {
+            // First arg is the projectId, NOT the path: passing `p` here keyed
+            // every query to path.join(projectsDir, <abs path>) — a phantom DB
+            // under ~/.prjct-cli/projects/Users/... that made the session-end
+            // backfill a silent no-op (ghost dirs confirmed on disk).
+            await embeddingService.backfill(config.projectId, config, new Date().toISOString())
+          } catch {
+            /* never block session end on index maintenance */
+          }
         }
 
         // Cloud sync (opt-in): flush this project's pending queue at session

--- a/core/infrastructure/config-manager.ts
+++ b/core/infrastructure/config-manager.ts
@@ -42,19 +42,44 @@ function parseJsonc<T>(content: string): T {
   return result
 }
 
+/**
+ * mtime-keyed config cache. The hooks read prjct.config.json up to 4× per
+ * EDIT (pre-edit ×2, post-edit + memoryService.getProjectId) and 1-2× per
+ * prompt/stop — each a disk read + jsonc scanner parse (~5-10× slower than
+ * JSON.parse). The daemon keeps this map warm across hook invocations; the
+ * mtime check keeps it correct when the user (or prjct itself) edits the
+ * file. Bounded like the git-snapshot cache: hooks only ever see a handful
+ * of cwds per daemon.
+ */
+const configCache = new Map<string, { mtimeMs: number; config: LocalConfig | null }>()
+
 class ConfigManager {
   /**
    * Read the project configuration file
    * Supports both .json and .jsonc formats (with comments)
    */
   async readConfig(projectPath: string): Promise<LocalConfig | null> {
+    const configPath = pathManager.getLocalConfigPath(projectPath)
+    let mtimeMs = -1
     try {
-      const configPath = pathManager.getLocalConfigPath(projectPath)
+      mtimeMs = (await fs.stat(configPath)).mtimeMs
+    } catch {
+      configCache.delete(configPath)
+      return null // no file — same result the read would produce
+    }
+    const cached = configCache.get(configPath)
+    if (cached && cached.mtimeMs === mtimeMs) return cached.config
+
+    try {
       const content = await fs.readFile(configPath, 'utf-8')
-      return parseJsonc<LocalConfig>(content)
+      const config = parseJsonc<LocalConfig>(content)
+      if (configCache.size > 32) configCache.clear()
+      configCache.set(configPath, { mtimeMs, config })
+      return config
     } catch (error) {
-      // File not found is expected - return null
+      // File vanished between stat and read is expected - return null
       if (isNotFoundError(error)) {
+        configCache.delete(configPath)
         return null
       }
       // JSON parse errors or other issues - log and return null
@@ -69,6 +94,9 @@ class ConfigManager {
   async writeConfig(projectPath: string, config: LocalConfig): Promise<void> {
     const configPath = pathManager.getLocalConfigPath(projectPath)
     await writeJson(configPath, config)
+    // Drop rather than update: the next read re-stats and re-caches, keeping
+    // one authority (the file + its mtime) for what the cache holds.
+    configCache.delete(configPath)
   }
 
   /**


### PR DESCRIPTION
The three big items measured by the cleanup-sweep audit:

1. **Stop hook** — ran session-cadence work on EVERY turn (2 git forks ~110ms + cleanup + embeddings backfill). Now behind a 10-min per-project cooldown (daemon-resident; every step idempotent). The transcript parse deliberately stays per-turn — token-usage measurement depends on it.
2. **BM25** — the loader parsed 477KB of token JSON to score a 5-term query. Tokens column no longer selected. **Measured: cold load 22.7ms (from ~30-60), `hasIndex` 0.23ms vs a full load (~150×).**
3. **Config cache** — prjct.config.json was read + jsonc-parsed up to 4×/edit. mtime-keyed cache; writes invalidate.

typecheck + biome clean · **1927/1927 tests** · stop hook E2E-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)