### PR TITLE
feat: the measured harness — token budget, per-model cost, subagent telemetry, estimation loop

### DIFF
--- a/core/__tests__/storage/velocity-evolution.test.ts
+++ b/core/__tests__/storage/velocity-evolution.test.ts
@@ -100,3 +100,34 @@ describe('velocity — computed weekly sprints from typed delivery data', () => 
     expect(md).toContain('Week digest')
   })
 })
+
+describe('estimation loop — expected vs actual points', () => {
+  it('computes accuracy + under-estimation patterns from completed tasks', async () => {
+    // Accurate: expected 2, actual 2 (same step).
+    prjctDb.run(
+      pid,
+      `INSERT INTO tasks (id, description, status, started_at, completed_at, data)
+       VALUES ('e1', 'small fix', 'completed', ?, ?, json('{"expectedPoints":2,"actualPoints":2,"diffLines":80}'))`,
+      iso(2),
+      iso(1)
+    )
+    // Badly under-estimated: expected 2 (step 1), actual 8 (step 3) — drift 2.
+    prjctDb.run(
+      pid,
+      `INSERT INTO tasks (id, description, type, status, started_at, completed_at, data)
+       VALUES ('e2', 'runaway refactor', 'refactor', 'completed', ?, ?, json('{"expectedPoints":2,"actualPoints":8,"diffLines":900}'))`,
+      iso(2),
+      iso(1)
+    )
+
+    const m = await velocityStorage.getMetrics(pid).catch(() => null)
+    // getMetrics needs at least one sprint row — recompute from the tasks.
+    await velocityStorage.recompute(pid)
+    const metrics = await velocityStorage.getMetrics(pid)
+    expect(metrics.estimationAccuracy).toBe(50) // 1 of 2 within ±1 step
+    expect(metrics.underEstimated).toHaveLength(1)
+    expect(metrics.underEstimated[0].category).toBe('refactor')
+    expect(metrics.underEstimated[0].avgVariance).toBeGreaterThan(0) // actual > expected
+    void m
+  })
+})

--- a/core/commands/product.ts
+++ b/core/commands/product.ts
@@ -115,6 +115,8 @@ interface PerformanceCycle {
   tokensTotal: number | null
   model: string
   runtime: string
+  /** Subagent spawns attributed to this cycle (fan-out cost). */
+  subagents: number
   promptSynthesis: string
   outcome: string
 }
@@ -556,6 +558,23 @@ async function buildReliabilitySnapshot(
   }
 }
 
+/** Subagent spawns per task id (from the subagent.spawned telemetry trail). */
+function subagentCounts(projectId: string, sinceIsoTs: string): Map<string, number> {
+  try {
+    const rows = prjctDb.query<{ task_id: string; c: number }>(
+      projectId,
+      `SELECT json_extract(data, '$.taskId') AS task_id, COUNT(*) AS c
+       FROM events
+       WHERE type = 'subagent.spawned' AND timestamp >= ? AND json_extract(data, '$.taskId') IS NOT NULL
+       GROUP BY task_id`,
+      sinceIsoTs
+    )
+    return new Map(rows.map((r) => [r.task_id, r.c]))
+  } catch {
+    return new Map()
+  }
+}
+
 function buildPerformanceCycles(projectId: string, days: number): PerformanceCycle[] {
   const since = sinceIso(days)
   const rows = query<PerformanceRow>(
@@ -583,6 +602,7 @@ function buildPerformanceCycles(projectId: string, days: number): PerformanceCyc
         tokensIn === null && tokensOut === null ? null : (tokensIn ?? 0) + (tokensOut ?? 0),
       model: 'unknown',
       runtime: 'unknown',
+      subagents: 0,
       promptSynthesis: synthesizePrompt(row.description),
       outcome: row.shipped_at ? 'shipped' : row.completed_at ? 'completed' : row.status,
     }
@@ -592,7 +612,11 @@ function buildPerformanceCycles(projectId: string, days: number): PerformanceCyc
   const measuredEventCycles = buildWorkCostSnapshot(projectId, days)
     .mostExpensive.filter((task) => !seen.has(task.id))
     .map(costTaskToPerformanceCycle)
-  return [...cycles, ...measuredEventCycles].slice(0, 20)
+  const merged = [...cycles, ...measuredEventCycles].slice(0, 20)
+  // Fan-out attribution: how many subagents each cycle spawned.
+  const spawns = subagentCounts(projectId, sinceIso(days))
+  for (const c of merged) c.subagents = spawns.get(c.id) ?? c.subagents ?? 0
+  return merged
 }
 
 function costTaskToPerformanceCycle(task: WorkCostTask): PerformanceCycle {
@@ -606,6 +630,7 @@ function costTaskToPerformanceCycle(task: WorkCostTask): PerformanceCycle {
     tokensTotal: task.tokensTotal,
     model: 'unknown',
     runtime: 'unknown',
+    subagents: 0,
     promptSynthesis: synthesizePrompt(task.description),
     outcome: task.status,
   }
@@ -996,11 +1021,13 @@ function formatPerformanceMd(days: number, cycles: PerformanceCycle[]): string {
     )
     return lines.join('\n')
   }
-  lines.push('| Work cycle | Outcome | Time | Tokens | Model | Runtime | Prompt synthesis |')
-  lines.push('|---|---|---:|---:|---|---|---|')
+  lines.push(
+    '| Work cycle | Outcome | Time | Tokens | Subagents | Model | Runtime | Prompt synthesis |'
+  )
+  lines.push('|---|---|---:|---:|---:|---|---|---|')
   for (const cycle of cycles) {
     lines.push(
-      `| ${escapeCell(cycle.description)} | ${cycle.outcome} | ${cycle.minutes ?? 'unknown'} | ${cycle.tokensTotal ?? 'unknown'} | ${cycle.model} | ${cycle.runtime} | ${escapeCell(cycle.promptSynthesis)} |`
+      `| ${escapeCell(cycle.description)} | ${cycle.outcome} | ${cycle.minutes ?? 'unknown'} | ${cycle.tokensTotal ?? 'unknown'} | ${cycle.subagents} | ${cycle.model} | ${cycle.runtime} | ${escapeCell(cycle.promptSynthesis)} |`
     )
   }
   lines.push(
@@ -1060,6 +1087,15 @@ function formatCostMd(snapshot: WorkCostSnapshot): string {
   lines.push(`| Total tokens | ${snapshot.tokensTotal.toLocaleString()} |`)
   lines.push(`| Agent sessions | ${snapshot.measuredSessions} |`)
   lines.push('')
+  if (snapshot.byModel.length > 0) {
+    lines.push('## By Model', '', '| Model | Input | Output | Total |', '|---|---:|---:|---:|')
+    for (const m of snapshot.byModel) {
+      lines.push(
+        `| ${m.model} | ${m.tokensIn.toLocaleString()} | ${m.tokensOut.toLocaleString()} | ${(m.tokensIn + m.tokensOut).toLocaleString()} |`
+      )
+    }
+    lines.push('')
+  }
   lines.push(...formatNetSavingsMd(snapshot))
   lines.push('## Historical Rescue', '', '| Signal | Value |', '|---|---:|')
   lines.push(`| Inferred work cycles | ${snapshot.historicalRescue.inferredWorkCycles} |`)
@@ -1125,6 +1161,9 @@ function formatCostText(snapshot: WorkCostSnapshot): string {
     `tokens: ${snapshot.tokensTotal.toLocaleString()} total across ${snapshot.knownTokenCycles}/${snapshot.workCycles} measured cycle(s)`,
     `declared historical tokens: ${snapshot.historicalRescue.declaredTokensTotal.toLocaleString()} across ${snapshot.historicalRescue.declaredTokenMentions} mention(s)`,
     `context: ${snapshot.surfacedContext} surfaced, ${snapshot.usefulContext} proven useful`,
+    ...snapshot.byModel.map(
+      (m) => `  ${m.model}: ${(m.tokensIn + m.tokensOut).toLocaleString()} tokens`
+    ),
     snapshot.gaps.length === 0 ? 'gaps: none' : `gaps: ${snapshot.gaps.length}`,
   ].join('\n')
 }

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -117,6 +117,28 @@ export async function buildProjectState(
       }
       hasContent = true
 
+      // Token budget (opt-in via config.maxTokensPerCycle): the tokens-side
+      // twin of the turn budget. The Stop hook writes cumulative usage onto
+      // the active task every turn, so this reads a fresh total for free.
+      try {
+        const budget = config.maxTokensPerCycle ?? 0
+        if (budget > 0) {
+          const task = await stateStorage.getCurrentTask(config.projectId)
+          const spent = (task?.tokensIn ?? 0) + (task?.tokensOut ?? 0)
+          if (spent >= budget) {
+            lines.push(
+              `  ⚠ Token budget: ${spent.toLocaleString()} of ${budget.toLocaleString()} spent on this cycle. STOP growing it — ship the working slice, split the remainder into a new cycle, or check in with the user.`
+            )
+          } else if (spent >= budget * 0.8) {
+            lines.push(
+              `  ↳ Token budget: ${spent.toLocaleString()} of ${budget.toLocaleString()} (${Math.round((spent / budget) * 100)}%). Plan the close: prefer finishing over expanding scope.`
+            )
+          }
+        }
+      } catch {
+        /* budget is advisory — never block the state block */
+      }
+
       // Delegation trigger — the multi-file write rule, ENFORCED by counting
       // (not just stated in a skill): when this cycle has edited 4+ distinct
       // files, say so with the concrete move. Uses the post_edit event trail

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -110,6 +110,23 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
                     source: 'claude-transcript',
                   }
                 )
+                // Per-model breakdown: one token_usage row per model this
+                // session touched (event_key = task:source, so a per-model
+                // source keeps rows distinct + upsert-idempotent). This is
+                // the data that PROVES whether model routing saves money.
+                try {
+                  const { sumTranscriptUsageByModel } = await import('../services/transcript-jsonl')
+                  for (const [model, u] of sumTranscriptUsageByModel(transcriptLines)) {
+                    if (u.tokensIn + u.tokensOut <= 0) continue
+                    recordTaskTokenUsage(config.projectId, activeTaskId, u.tokensIn, u.tokensOut, {
+                      model,
+                      agent: 'claude',
+                      source: `claude-transcript:${model}`,
+                    })
+                  }
+                } catch {
+                  /* per-model breakdown is additive telemetry — never blocks */
+                }
               }
             }
           } catch {

--- a/core/hooks/subagent-start.ts
+++ b/core/hooks/subagent-start.ts
@@ -10,6 +10,8 @@
  * Same rules: describe WHAT, never HOW.
  */
 
+import configManager from '../infrastructure/config-manager'
+import { prjctDb } from '../storage/database'
 import { type HookIo, runHook } from './_runner'
 import { buildSubagentDigest } from './session-start'
 
@@ -22,6 +24,22 @@ export function runSubagentStartHook(
       event: 'SubagentStart',
       projectPath,
       build: (_input, p) => buildSubagentDigest(p),
+      afterEmit: async (_input, p) => {
+        // Fan-out telemetry: one event per spawn, attributed to the active
+        // cycle, so `prjct performance` can show how many subagents a cycle
+        // cost (was the crew worth it?). Best-effort, silent.
+        try {
+          const config = await configManager.readConfig(p)
+          if (!config?.projectId) return
+          const { collectActiveTasks } = await import('../services/task-overview')
+          const overview = await collectActiveTasks(config.projectId, p)
+          prjctDb.appendEvent(config.projectId, 'subagent.spawned', {
+            taskId: overview.current?.id ?? null,
+          })
+        } catch {
+          /* telemetry only */
+        }
+      },
     },
     io
   )

--- a/core/services/task-harness.ts
+++ b/core/services/task-harness.ts
@@ -49,6 +49,8 @@ export interface HarnessCompletionEvaluation {
   changedFiles: string[]
   observedEvidence: string[]
   warnings: string[]
+  /** Changed-line count of the completion diff (estimation-loop input). */
+  diffSize: number
 }
 
 export function buildTaskHarness(description: string): TaskHarness {
@@ -96,7 +98,7 @@ export async function evaluateHarnessCompletion(
 ): Promise<HarnessCompletionEvaluation> {
   const harness = task.harness
   if (!harness || harness.level === 'H0') {
-    return { changedFiles: [], observedEvidence: [], warnings: [] }
+    return { changedFiles: [], observedEvidence: [], warnings: [], diffSize: 0 }
   }
 
   const changedFiles = await readChangedFiles(projectPath)
@@ -123,7 +125,7 @@ export async function evaluateHarnessCompletion(
     warnings.push(`Diff is ${diffSize} changed lines; consider splitting or justify the scope.`)
   }
 
-  return { changedFiles, observedEvidence, warnings }
+  return { changedFiles, observedEvidence, warnings, diffSize }
 }
 
 function detectKind(text: string): HarnessKind {

--- a/core/services/task-orchestration.ts
+++ b/core/services/task-orchestration.ts
@@ -39,6 +39,12 @@ export interface OrchestrationPlan {
   spec: SpecCeremony
   tests: TestCeremony
   fanout: FanOut
+  /**
+   * Size estimate in points (1/2/5/8 by harness level). Stored on the task at
+   * start and compared against the ACTUAL diff at completion — the estimation
+   * loop that teaches velocity the dev's estimation bias.
+   */
+  expectedPoints: number
   /** Agent-facing one-block directive — how to run THIS task efficiently. */
   directive: string
 }
@@ -67,6 +73,7 @@ function baseline(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): Or
         spec: 'none',
         tests: 'none',
         fanout: 'direct',
+        expectedPoints: 1,
         directive: '',
       }
     case 'H1':
@@ -77,6 +84,7 @@ function baseline(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): Or
         spec: 'none',
         tests: code ? 'after' : 'none',
         fanout: 'direct',
+        expectedPoints: 2,
         directive: '',
       }
     case 'H2':
@@ -88,6 +96,7 @@ function baseline(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): Or
         spec: code ? 'frame' : 'none',
         tests: code ? 'first' : 'none',
         fanout: 'parallel',
+        expectedPoints: 5,
         directive: '',
       }
     default:
@@ -98,6 +107,7 @@ function baseline(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): Or
         spec: code ? 'reviewed' : 'none',
         tests: code ? 'first' : 'none',
         fanout: 'crew',
+        expectedPoints: 8,
         directive: '',
       }
   }
@@ -160,6 +170,17 @@ function renderDirective(level: HarnessLevel, kind: HarnessKind, plan: Orchestra
   }
   const forecast = level === 'H2' || level === 'H3' ? ` ${FORECAST_TEXT}` : ''
   return `Orchestrate (${level} ${kind}/${plan.model}${effortNote}): ${SPEC_TEXT[plan.spec]}; ${TEST_TEXT[plan.tests]}; ${FANOUT_TEXT[plan.fanout]}.${forecast}`
+}
+
+/**
+ * Actual size in points from the completed diff's changed-line count — the
+ * same scale expectedPoints uses, so accuracy is a like-for-like comparison.
+ */
+export function pointsFromDiffLines(changedLines: number): number {
+  if (changedLines < 50) return 1
+  if (changedLines < 150) return 2
+  if (changedLines < 400) return 5
+  return 8
 }
 
 /**

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -270,6 +270,21 @@ export async function startTask(
     )
   }
 
+  // Estimation loop (write side): store the triage's size estimate on the
+  // typed row; completion compares it against the ACTUAL diff so velocity can
+  // learn the dev's estimation bias per classification. Best-effort.
+  try {
+    const { prjctDb } = await import('../storage/database')
+    prjctDb.run(
+      projectId,
+      'UPDATE tasks SET expected_value = ? WHERE id = ?',
+      String(orchestration.expectedPoints),
+      taskId
+    )
+  } catch {
+    /* estimate is advisory telemetry */
+  }
+
   const pipelineDecision = decideTaskPipeline(description, linkedSpecId)
   const pipelineState = upsertTaskPipelineState(projectId, {
     taskId,
@@ -485,6 +500,7 @@ export async function setTaskStatus(
         harnessWarnings: verification.warnings,
       })
       await stateStorage.completeTaskInWorkspace(projectId, ws.workspaceId)
+      await recordEstimationOutcome(projectId, wsTask.id, verification.diffSize)
       return {
         ok: true,
         taskId: wsTask.id,
@@ -529,7 +545,7 @@ export async function setTaskStatus(
   const verification =
     normalized === 'done' || normalized === 'completed'
       ? await evaluateHarnessCompletion(projectPath, active)
-      : { warnings: [] }
+      : { warnings: [], diffSize: 0 }
 
   await memoryService.log(projectPath, STATUS_CHANGE_ACTION, {
     taskId: active.id,
@@ -545,6 +561,7 @@ export async function setTaskStatus(
   try {
     if (normalized === 'done' || normalized === 'completed') {
       await stateStorage.completeTask(projectId)
+      await recordEstimationOutcome(projectId, active.id, verification.diffSize)
     } else if (normalized === 'paused' || normalized === 'pause') {
       await stateStorage.pauseTask(projectId)
     } else if (resumeIntent) {
@@ -587,6 +604,41 @@ export async function resolveActiveTask(
  * (main) or per-workspace (child) completion so ship/done isolate correctly.
  * Returns the completed task, or null when nothing was active.
  */
+/**
+ * Estimation loop (close side): fold expected vs ACTUAL size into the
+ * completed task's cold data. Runs AFTER the state-storage completion (whose
+ * history mirror rewrites `data`), so json_set survives. Best-effort.
+ */
+async function recordEstimationOutcome(
+  projectId: string,
+  taskId: string,
+  diffSize: number
+): Promise<void> {
+  try {
+    const { prjctDb } = await import('../storage/database')
+    const { pointsFromDiffLines } = await import('./task-orchestration')
+    const row = prjctDb.get<{ expected_value: string | null }>(
+      projectId,
+      'SELECT expected_value FROM tasks WHERE id = ?',
+      taskId
+    )
+    const expected = Number(row?.expected_value)
+    if (!Number.isFinite(expected) || expected <= 0) return
+    prjctDb.run(
+      projectId,
+      `UPDATE tasks SET data = json_set(COALESCE(data, '{}'),
+         '$.expectedPoints', ?, '$.actualPoints', ?, '$.diffLines', ?)
+       WHERE id = ?`,
+      expected,
+      pointsFromDiffLines(diffSize),
+      diffSize,
+      taskId
+    )
+  } catch {
+    /* estimation telemetry only */
+  }
+}
+
 export async function completeActiveTask(
   projectId: string,
   projectPath: string,

--- a/core/services/transcript-jsonl.ts
+++ b/core/services/transcript-jsonl.ts
@@ -95,3 +95,33 @@ export function sumTranscriptUsage(lines: TranscriptJsonlLine[]): TranscriptUsag
   }
   return { tokensIn: tokensIn + maxCacheRead, tokensOut }
 }
+
+/**
+ * Per-model usage sums — same semantics as sumTranscriptUsage (cache_read is
+ * cumulative → take each model's max single report, not the sum). Model id
+ * comes from the assistant line's `message.model`; usage lines with no model
+ * attribution are grouped under 'unknown'. Powers the per-model cost
+ * breakdown that PROVES whether orchestration's model routing saves money.
+ */
+export function sumTranscriptUsageByModel(
+  lines: TranscriptJsonlLine[]
+): Map<string, TranscriptUsage> {
+  const acc = new Map<string, { tokensIn: number; tokensOut: number; maxCacheRead: number }>()
+  for (const line of lines) {
+    const message = asRecord(line.message)
+    const usage = asRecord(message?.usage) ?? asRecord(line.usage) ?? asRecord(line.usageMetadata)
+    if (!usage) continue
+    const model = typeof message?.model === 'string' && message.model ? message.model : 'unknown'
+    const pair = usagePairFrom(usage)
+    const cur = acc.get(model) ?? { tokensIn: 0, tokensOut: 0, maxCacheRead: 0 }
+    cur.tokensIn += pair.tokensIn
+    cur.tokensOut += pair.tokensOut
+    if (pair.cacheRead > cur.maxCacheRead) cur.maxCacheRead = pair.cacheRead
+    acc.set(model, cur)
+  }
+  const out = new Map<string, TranscriptUsage>()
+  for (const [model, v] of acc) {
+    out.set(model, { tokensIn: v.tokensIn + v.maxCacheRead, tokensOut: v.tokensOut })
+  }
+  return out
+}

--- a/core/services/work-cost-service.ts
+++ b/core/services/work-cost-service.ts
@@ -79,6 +79,8 @@ export interface WorkCostSnapshot {
   commandMs: number
   avgStartupMs: number | null
   mostExpensive: WorkCostTask[]
+  /** Per-model token spend in the window (from token_usage.model_id rows). */
+  byModel: Array<{ model: string; tokensIn: number; tokensOut: number }>
   historicalRescue: HistoricalRescue
   gaps: string[]
 }
@@ -348,6 +350,26 @@ export function buildWorkCostSnapshot(projectId: string, days: number): WorkCost
     )
   }
 
+  // Per-model spend: the claude-transcript:<model> rows written per turn.
+  // model_id IS NOT NULL keeps the un-attributed totals row out of the split.
+  let byModel: WorkCostSnapshot['byModel'] = []
+  try {
+    byModel = prjctDb
+      .query<{ model: string; t_in: number; t_out: number }>(
+        projectId,
+        `SELECT COALESCE(model_id, 'unknown') AS model,
+              SUM(input_tokens) AS t_in, SUM(output_tokens) AS t_out
+       FROM token_usage
+       WHERE model_id IS NOT NULL AND measured_at >= ?
+       GROUP BY COALESCE(model_id, 'unknown')
+       ORDER BY t_in + t_out DESC`,
+        Date.parse(since)
+      )
+      .map((r) => ({ model: r.model, tokensIn: r.t_in, tokensOut: r.t_out }))
+  } catch {
+    /* additive telemetry — absent on older schemas */
+  }
+
   return {
     id: `work-cost-${days}d`,
     windowDays: days,
@@ -368,6 +390,7 @@ export function buildWorkCostSnapshot(projectId: string, days: number): WorkCost
     commandMs: Math.round(command.total ?? 0),
     avgStartupMs: startup.average === null ? null : Math.round(startup.average),
     mostExpensive: measuredTasks.slice(0, 8),
+    byModel,
     historicalRescue: {
       inferredWorkCycles,
       taskTableCycles: taskRows.length,

--- a/core/storage/velocity-storage.ts
+++ b/core/storage/velocity-storage.ts
@@ -172,15 +172,59 @@ class VelocityStorage extends StorageManager<VelocityStoreData> {
       else if (last3 < prev3 * 0.85) velocityTrend = 'declining'
     }
 
+    // Estimation loop (read side): completed tasks carry expected vs actual
+    // points in their cold data (written at start/close by the task service).
+    // Accuracy = % of estimated tasks whose actual landed within ±1 step of
+    // the estimate on the 1/2/5/8 scale; over/under patterns are grouped by
+    // task type so the dev sees WHERE their estimates drift.
+    let estimationAccuracy = 0
+    const overEstimated: VelocityMetrics['overEstimated'] = []
+    const underEstimated: VelocityMetrics['underEstimated'] = []
+    try {
+      const est = prjctDb.query<{ type: string | null; expected: number; actual: number }>(
+        projectId,
+        `SELECT type,
+                CAST(json_extract(data, '$.expectedPoints') AS REAL) AS expected,
+                CAST(json_extract(data, '$.actualPoints') AS REAL) AS actual
+         FROM tasks
+         WHERE status = 'completed'
+           AND json_extract(data, '$.expectedPoints') IS NOT NULL
+           AND json_extract(data, '$.actualPoints') IS NOT NULL`
+      )
+      if (est.length > 0) {
+        const SCALE = [1, 2, 5, 8]
+        const step = (p: number) => SCALE.findIndex((v) => v >= p)
+        let accurate = 0
+        const byType = new Map<string, { sum: number; n: number }>()
+        for (const r of est) {
+          const drift = step(r.actual) - step(r.expected)
+          if (Math.abs(drift) <= 1) accurate++
+          const key = r.type ?? 'unknown'
+          const cur = byType.get(key) ?? { sum: 0, n: 0 }
+          // Positive variance = under-estimated (actual bigger than expected).
+          cur.sum += ((r.actual - r.expected) / r.expected) * 100
+          cur.n++
+          byType.set(key, cur)
+        }
+        estimationAccuracy = Math.round((accurate / est.length) * 100)
+        for (const [category, v] of byType) {
+          const avgVariance = Math.round(v.sum / v.n)
+          const pattern = { category, avgVariance, taskCount: v.n }
+          if (avgVariance <= -20) overEstimated.push(pattern)
+          else if (avgVariance >= 20) underEstimated.push(pattern)
+        }
+      }
+    } catch {
+      /* estimation telemetry absent → honest zeros */
+    }
+
     return {
       sprints,
       averageVelocity,
       velocityTrend,
-      // No estimation data exists yet (tasks carry no point estimates) —
-      // honest zeros rather than invented accuracy.
-      estimationAccuracy: 0,
-      overEstimated: [],
-      underEstimated: [],
+      estimationAccuracy,
+      overEstimated,
+      underEstimated,
       lastUpdated: new Date().toISOString(),
     }
   }

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -105,6 +105,12 @@ export interface LocalConfig {
    */
   maxTurnsPerCycle?: number
   /**
+   * Soft token budget per work cycle. When set, the per-turn state block
+   * warns at 80% and calls for a split/check-in at 100% — measurement-backed
+   * loop discipline (tokens, not just turns). Advisory: never blocks edits.
+   */
+  maxTokensPerCycle?: number
+  /**
    * Desktop notifications. **Default ON** (absent / `on`) — prjct pings you
    * when Claude is waiting for input and when a subagent finishes, so a wait
    * never hangs silently. `off` (via `prjct notify off`) silences the OS


### PR DESCRIPTION
Tier-1 package: prjct stops just measuring cost and starts **budgeting, attributing and learning** from it.

1. **Token budget per cycle** (`config.maxTokensPerCycle`, opt-in) — the tokens twin of the turn budget: per-turn warn at 80%, split/check-in call at 100%. Advisory.
2. **Per-model cost breakdown** — per-model usage extracted from the transcript, one idempotent `token_usage` row per model; `insights cost` gains a "By Model" table. Proves whether model routing saves money.
3. **Subagent telemetry** — `subagent.spawned` events attributed to the cycle; `performance` shows fan-out count per cycle.
4. **Estimation loop** — orchestration estimates size (1/2/5/8 pts by level) at start; completion converts the ACTUAL diff to the same scale; velocity's `estimationAccuracy` + over/under patterns by task type become real ("you under-estimate refactors").

typecheck + biome clean · **1928/1928 tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)