### PR TITLE
feat: tier-2 package — guard PR mode, global KB, memory lifecycle, changelog, bench, import hint

### DIFF
--- a/core/commands/changelog.ts
+++ b/core/commands/changelog.ts
@@ -1,0 +1,90 @@
+/**
+ * `prjct changelog [days]` — release notes from the typed delivery record.
+ *
+ * Assembles what actually shipped (shipped_features) and what was completed
+ * (typed task history) in the window into ready-to-paste markdown, grouped by
+ * version. Zero LLM: the data plane already knows what happened; this just
+ * renders it.
+ */
+
+import { prjctDb } from '../storage/database'
+import type { MdOption } from '../types/cli'
+import type { CommandResult } from '../types/commands'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
+
+interface ShipRow {
+  name: string
+  version: string
+  shipped_at: string
+}
+
+interface DoneRow {
+  description: string
+  type: string | null
+  completed_at: string
+}
+
+export class ChangelogCommands extends PrjctCommandsBase {
+  async changelog(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: MdOption = {}
+  ): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+
+    const days = Number((input ?? '').trim()) || 14
+    const sinceIso = new Date(Date.now() - days * 86400000).toISOString()
+
+    const ships = prjctDb.query<ShipRow>(
+      proj.value,
+      'SELECT name, version, shipped_at FROM shipped_features WHERE shipped_at >= ? ORDER BY shipped_at DESC',
+      sinceIso
+    )
+    const done = prjctDb.query<DoneRow>(
+      proj.value,
+      `SELECT description, type, completed_at FROM tasks
+       WHERE status = 'completed' AND completed_at >= ?
+       ORDER BY completed_at DESC LIMIT 40`,
+      sinceIso
+    )
+
+    if (ships.length === 0 && done.length === 0) {
+      const msg = `Nothing shipped or completed in the last ${days} day(s).`
+      if (options.md) console.log(`> ${msg}`)
+      else out.info(msg)
+      return { success: true, ships: 0, completed: 0 }
+    }
+
+    const lines = [`# Changelog — last ${days} day(s)`, '']
+    if (ships.length > 0) {
+      // Group ships by version; 'unversioned' entries render under their date.
+      const byVersion = new Map<string, ShipRow[]>()
+      for (const s of ships) {
+        const key =
+          s.version && s.version !== 'unversioned' ? `v${s.version}` : s.shipped_at.slice(0, 10)
+        const bucket = byVersion.get(key) ?? []
+        bucket.push(s)
+        byVersion.set(key, bucket)
+      }
+      lines.push('## Shipped')
+      for (const [version, rows] of byVersion) {
+        lines.push('', `### ${version} — ${rows[0].shipped_at.slice(0, 10)}`)
+        for (const r of rows) lines.push(`- ${r.name}`)
+      }
+      lines.push('')
+    }
+    if (done.length > 0) {
+      lines.push('## Completed work cycles', '')
+      for (const d of done) {
+        const tag = d.type ? ` \`${d.type}\`` : ''
+        lines.push(`- ${d.description}${tag} (${d.completed_at.slice(0, 10)})`)
+      }
+    }
+
+    console.log(lines.join('\n'))
+    return { success: true, ships: ships.length, completed: done.length }
+  }
+}

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -212,7 +212,9 @@ export const COMMANDS: CommandMeta[] = [
     group: 'core',
     surface: 'ai-agile',
     routing: { group: 'primitives', method: 'remember' },
-    optionSchema: { strings: ['tags'] },
+    optionSchema: { strings: ['tags'], booleans: ['force', 'global'] },
+    // requiresProject relaxed: the command self-gates for project captures;
+    // `--global` writes to the cross-project KB from any directory.
     description: 'Capture a project memory entry (fact, decision, learning, gotcha, …)',
     usage: {
       claude: 'p. remember learning "message"',
@@ -221,7 +223,7 @@ export const COMMANDS: CommandMeta[] = [
     params: '<type> "<content>" [--tags k:v,...]',
     implemented: true,
     hasTemplate: false,
-    requiresProject: true,
+    requiresProject: false,
     features: [
       'Types: fact, decision, learning, gotcha, pattern, anti-pattern, shipped, inbox, todo, idea, insight, question, source, person — plus user-defined',
       'Grows the project memory consumable via `prjct context memory`',
@@ -776,14 +778,14 @@ export const COMMANDS: CommandMeta[] = [
     group: 'core',
     surface: 'ai-agile',
     routing: { group: 'context', method: 'search' },
-    optionSchema: {},
+    optionSchema: { booleans: ['global'] },
     description:
       'Search project memory (decisions, learnings, gotchas, ships…) — BM25 + semantic + recall',
     usage: { claude: 'p. search "<query>"', terminal: 'prjct search "<query>" [--md]' },
     params: '<query>',
     implemented: true,
     hasTemplate: false,
-    requiresProject: true,
+    requiresProject: false,
     features: [
       'Blended retrieval: FTS5 BM25 + opt-in semantic + recency recall',
       'Reranks by proven usefulness, expands one hop of the memory graph',
@@ -882,6 +884,22 @@ export const COMMANDS: CommandMeta[] = [
     ],
   },
   {
+    name: 'changelog',
+    group: 'changelog',
+    surface: 'ai-agile',
+    requiresProject: true,
+    implemented: true,
+    hasTemplate: false,
+    routing: { group: 'changelog', method: 'changelog' },
+    optionSchema: {},
+    description:
+      'Release notes from the typed delivery record: what shipped (by version) + completed work cycles in the window. Zero LLM — pure data-plane render.',
+    usage: {
+      claude: 'p. changelog 14',
+      terminal: 'prjct changelog [days]',
+    },
+  },
+  {
     name: 'workflows',
     group: 'workflowsReference',
     surface: 'ai-agile',
@@ -918,14 +936,16 @@ export const COMMANDS: CommandMeta[] = [
     group: 'core',
     surface: 'ai-agile',
     routing: { group: 'guard', method: 'guard' },
-    optionSchema: { numbers: ['limit'] },
+    optionSchema: { numbers: ['limit'], strings: ['diff'], booleans: ['strict'] },
     description:
       'Surface preventive memory (gotchas, anti-patterns, recurring-bugs) recorded against a file BEFORE you edit it — anticipation, provider-agnostic.',
     usage: {
       claude: 'p. guard <file>',
-      terminal: 'prjct guard <file>',
+      terminal: 'prjct guard <file> | prjct guard --diff <range> [--strict]',
     },
-    params: '<file>',
+    // Optional at the dispatcher: the command itself errors helpfully when
+    // neither a file nor --diff is given (PR mode has no positional arg).
+    params: '[file]',
     implemented: true,
     hasTemplate: false,
     requiresProject: true,

--- a/core/commands/context.ts
+++ b/core/commands/context.ts
@@ -127,9 +127,12 @@ export class ContextCommands {
   async search(
     query: string | null = null,
     projectPath: string = process.cwd(),
-    options: MdOption = {}
+    options: MdOption & { global?: boolean } = {}
   ): Promise<CommandResult> {
-    const projectId = await configManager.getProjectId(projectPath)
+    // --global searches the cross-project knowledge base ('global-kb'):
+    // personal gotchas/facts captured with `prjct remember --global`,
+    // available from any directory.
+    const projectId = options.global ? 'global-kb' : await configManager.getProjectId(projectPath)
     if (!projectId) {
       return { success: false, message: 'No prjct project. Run `prjct init` first.' }
     }

--- a/core/commands/guard.ts
+++ b/core/commands/guard.ts
@@ -27,6 +27,10 @@ import { requireProject } from './guards'
 
 interface GuardOptions extends MdOption {
   limit?: number
+  /** Diff range for CI/PR mode (e.g. `main...HEAD`); overrides the file arg. */
+  diff?: string
+  /** With --diff: exit non-zero when any trap matches (gate mode for CI). */
+  strict?: boolean
 }
 
 export class GuardCommands extends PrjctCommandsBase {
@@ -35,9 +39,16 @@ export class GuardCommands extends PrjctCommandsBase {
     projectPath: string = process.cwd(),
     options: GuardOptions = {}
   ): Promise<CommandResult> {
+    // PR/CI mode: `prjct guard --diff main...HEAD` sweeps EVERY file the
+    // range touches through the preventive recall — team-level anticipation
+    // with zero LLM cost (pure indexed lookup). `--strict` turns it into a
+    // gate (non-zero exit when traps match) for CI.
+    if (options.diff) return this.guardDiff(options.diff, projectPath, options)
+
     const file = (input ?? '').trim().split(/\s+/).filter(Boolean)[0]
     if (!file) {
-      const msg = 'Usage: prjct guard <file> — surfaces preventive memory before you edit it.'
+      const msg =
+        'Usage: prjct guard <file> — surfaces preventive memory before you edit it. PR mode: prjct guard --diff <range> [--strict].'
       if (options.md) console.log(`> ${msg}`)
       else out.fail(msg)
       return { success: false, error: 'Missing file argument' }
@@ -97,5 +108,95 @@ export class GuardCommands extends PrjctCommandsBase {
     }
 
     return { success: true, file, hits: hits.length }
+  }
+
+  /**
+   * PR/CI sweep: run preventive recall over every file a diff range touches.
+   * Pure indexed recall (no LLM) — cheap enough for a pre-merge gate. Exit
+   * semantics: success unless `--strict` AND traps matched.
+   */
+  private async guardDiff(
+    range: string,
+    projectPath: string,
+    options: GuardOptions
+  ): Promise<CommandResult> {
+    const guard = await requireProject(projectPath, options)
+    if (!guard.ok) return guard.result
+
+    let files: string[] = []
+    try {
+      const { execFileAsync } = await import('../utils/exec')
+      const r = await execFileAsync('git', ['diff', '--name-only', range], {
+        cwd: projectPath,
+        timeout: 10000,
+      })
+      files = r.stdout.split('\n').filter(Boolean)
+    } catch (error) {
+      const msg = `Could not diff \`${range}\`: ${error instanceof Error ? error.message.split('\n')[0] : 'git error'}`
+      if (options.md) console.log(`> ${msg}`)
+      else out.fail(msg)
+      return { success: false, error: 'git diff failed' }
+    }
+    if (files.length === 0) {
+      const msg = `No files changed in \`${range}\` — nothing to guard.`
+      if (options.md) console.log(`> ${msg}`)
+      else out.done(msg)
+      return { success: true, files: 0, hits: 0 }
+    }
+
+    const perFileLimit = typeof options.limit === 'number' && options.limit > 0 ? options.limit : 2
+    const findings: Array<{ file: string; entry: MemoryEntry }> = []
+    const surfacedIds: string[] = []
+    for (const file of files) {
+      let hits: MemoryEntry[] = []
+      try {
+        hits = projectMemory.recallForFile(guard.value, file, perFileLimit, {
+          preventiveOnly: true,
+        })
+      } catch {
+        hits = []
+      }
+      for (const entry of hits) {
+        findings.push({ file, entry })
+        surfacedIds.push(entry.id)
+      }
+    }
+    void recordSurfacedForActiveTask(guard.value, projectPath, surfacedIds)
+
+    if (findings.length === 0) {
+      const msg = `Swept ${files.length} changed file(s) in \`${range}\` — no known traps. Clear.`
+      if (options.md) console.log(`> ✅ ${msg}`)
+      else out.done(msg)
+      return { success: true, files: files.length, hits: 0 }
+    }
+
+    if (options.md) {
+      const lines = [
+        `# prjct guard — ${findings.length} known trap(s) in \`${range}\``,
+        '',
+        `Preventive memory matched ${new Set(findings.map((f) => f.file)).size} of ${files.length} changed file(s):`,
+        '',
+      ]
+      for (const f of findings) {
+        lines.push(
+          `- \`${f.file}\` — [${preventiveLabel(f.entry)}] ${deriveTitle(f.entry)} — ${flatDetail(f.entry.content, 140)} (\`${f.entry.id}\`)`
+        )
+      }
+      lines.push('', 'Resolve any id with `prjct search <id>`.')
+      console.log(lines.join('\n'))
+    } else {
+      out.info(`⚠ ${findings.length} known trap(s) across ${files.length} changed file(s):`)
+      for (const f of findings) {
+        out.info(`  • ${f.file} — ${deriveTitle(f.entry)} (${f.entry.id})`)
+      }
+    }
+
+    // Gate semantics only under --strict: advisory by default.
+    return {
+      success: !options.strict,
+      ...(options.strict ? { error: `${findings.length} known trap(s) matched the diff` } : {}),
+      files: files.length,
+      hits: findings.length,
+    }
   }
 }

--- a/core/commands/planning.ts
+++ b/core/commands/planning.ts
@@ -38,6 +38,30 @@ export class PlanningCommands extends PrjctCommandsBase {
    * @param options.idea - Initial idea for architect mode
    * @param projectPath - Project directory path
    */
+  /**
+   * Team-memory discoverability: a cloned repo may carry a committed
+   * `.prjct/memory-export/` (prjct memory export). Surface it at init so the
+   * import loop actually closes — a shared brain nobody knows about is dead
+   * weight.
+   */
+  private async _hintCommittedMemoryExport(projectPath: string): Promise<void> {
+    try {
+      const fs = await import('node:fs/promises')
+      const path = await import('node:path')
+      const manifestPath = path.join(projectPath, '.prjct', 'memory-export', 'manifest.json')
+      const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf-8')) as {
+        entries?: number
+      }
+      if (manifest?.entries && manifest.entries > 0) {
+        out.info(
+          `📦 This repo ships ${manifest.entries} team memories (.prjct/memory-export/). Load them: prjct memory import`
+        )
+      }
+    } catch {
+      /* no export committed — silent */
+    }
+  }
+
   async init(
     options: InitOptions | string | null = {},
     projectPath: string = process.cwd()
@@ -132,6 +156,7 @@ export class PlanningCommands extends PrjctCommandsBase {
           }).catch(() => null)
 
           out.done('initialized')
+          await this._hintCommittedMemoryExport(projectPath)
           this._printNextSteps(wizardResult, surfaces ?? undefined)
           return { success: true, mode: 'existing', projectId, wizard: wizardResult }
         }

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -197,11 +197,16 @@ export class PrimitiveCommands extends PrjctCommandsBase {
   async remember(
     args: string | null = null,
     projectPath: string = process.cwd(),
-    options: { md?: boolean; tags?: string; force?: boolean } = {}
+    options: { md?: boolean; tags?: string; force?: boolean; global?: boolean } = {}
   ): Promise<CommandResult> {
     try {
-      const initResult = await this.ensureProjectInit(projectPath)
-      if (!initResult.success) return initResult
+      // Global knowledge base: personal, cross-project facts (e.g. "zsh does
+      // not word-split unquoted vars") live in the 'global-kb' pseudo-project
+      // — capturable from ANY directory, no project init required.
+      if (!options.global) {
+        const initResult = await this.ensureProjectInit(projectPath)
+        if (!initResult.success) return initResult
+      }
 
       if (!args) {
         out.info(
@@ -234,6 +239,19 @@ export class PrimitiveCommands extends PrjctCommandsBase {
       }
 
       const tags = parseFlagTags(options.tags)
+
+      if (options.global) {
+        await projectMemory.remember(projectPath, {
+          type,
+          content,
+          tags,
+          projectId: 'global-kb',
+        })
+        const msg = `remembered ${type} (GLOBAL — cross-project): ${content.slice(0, 80)}${content.length > 80 ? '…' : ''}`
+        if (options.md) console.log(`✓ ${msg}`)
+        else out.done(msg)
+        return { success: true, type, scope: 'global' }
+      }
 
       const pid = await requireProject(projectPath)
       if (!pid.ok) return pid.result

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -71,6 +71,7 @@ export const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = 
   workflowsReference: lazy(
     async () => new (await import('./workflows-reference')).WorkflowsReferenceCommands()
   ),
+  changelog: lazy(async () => new (await import('./changelog')).ChangelogCommands()),
   lean: lazy(async () => new (await import('./lean')).LeanCommands()),
   cloud: lazy(async () => new (await import('./cloud')).CloudCommands()),
   tdd: lazy(async () => new (await import('./tdd')).TddCommands()),

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -268,6 +268,16 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
   const llmBoundary = opts?.boundary === 'llm'
   const compact = opts?.compact === true
 
+  // Staleness lifecycle: knowledge older than ~6 months gets a visible
+  // verify-before-trusting cue. Recall still surfaces it (old ≠ wrong), but
+  // the agent is told to confirm against the current code before acting —
+  // the cheap alternative to silently trusting rotted facts.
+  const STALE_MS = 180 * 24 * 60 * 60 * 1000
+  const staleCue = (e: MemoryEntry): string => {
+    const t = Date.parse(e.rememberedAt)
+    return Number.isFinite(t) && Date.now() - t > STALE_MS ? ' ⚠stale>6mo — verify' : ''
+  }
+
   // Compact list emits ONE data-boundary header for the whole block instead
   // of wrapping every row — the rows carry only a truncated cue, never
   // command-like full bodies, so a single signal is enough and stays lean.
@@ -287,7 +297,7 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
         const prov = PROV_PREFIX[e.provenance]
         const flat = flatDetail(e.content, COMPACT_CONTENT_MAX)
         const cue = llmBoundary ? escapeMarkdownInline(flat) : flat
-        lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${cue}`)
+        lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${cue}${staleCue(e)}`)
         continue
       }
       // Vault output hides machine-bookkeeping tags (source=, touches=,

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -353,7 +353,11 @@ export const projectMemory = {
         // content fingerprint (for dedup) + project_id — not a synthetic value.
         content_hash: contentHash,
         ...(projectId ? { project_id: projectId } : {}),
-      }
+      },
+      undefined,
+      // Explicit target: same value path-resolution yields for normal
+      // captures; the global KB pseudo-project for --global ones.
+      projectId ? { projectId } : undefined
     )
     if (logResult?.projectId && !projectId) projectId = logResult.projectId
 

--- a/core/services/memory-service.ts
+++ b/core/services/memory-service.ts
@@ -18,10 +18,19 @@ class MemoryService {
     projectPath: string,
     action: string,
     data: Record<string, unknown>,
-    author?: string
+    author?: string,
+    opts?: {
+      /**
+       * Explicit target project — bypasses path→config resolution. Existing
+       * callers that preload the id pass the SAME value resolution would
+       * yield; the global knowledge base ('global-kb') uses it to write
+       * outside any repo.
+       */
+      projectId?: string
+    }
   ): Promise<{ eventId: number | null; projectId: string } | null> {
     try {
-      const projectId = await configManager.getProjectId(projectPath)
+      const projectId = opts?.projectId ?? (await configManager.getProjectId(projectPath))
       if (!projectId) return null
 
       const eventId = prjctDb.appendEvent(projectId, `memory.${action}`, { ...data, author })

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -41,10 +41,10 @@ export async function runContextTool(
   try {
     switch (toolName) {
       case 'memory':
-        return await runMemoryTool(toolArgs, projectPath, { kind: 'memory' })
+        return await runMemoryTool(toolArgs, projectPath, { kind: 'memory', projectId })
 
       case 'learnings':
-        return await runMemoryTool(toolArgs, projectPath, { kind: 'learnings' })
+        return await runMemoryTool(toolArgs, projectPath, { kind: 'learnings', projectId })
 
       case 'skills': {
         // Index of paths, not summaries — refresh + render the skill catalog
@@ -89,9 +89,11 @@ export async function runContextTool(
 async function runMemoryTool(
   args: string[],
   projectPath: string,
-  opts: { kind: 'memory' | 'learnings' }
+  opts: { kind: 'memory' | 'learnings'; projectId?: string }
 ): Promise<ContextToolOutput> {
-  const projectId = await configManager.getProjectId(projectPath)
+  // Caller-resolved id wins (e.g. the 'global-kb' cross-project KB, which has
+  // no path to resolve from); otherwise resolve from the path as before.
+  const projectId = opts.projectId ?? (await configManager.getProjectId(projectPath))
   if (!projectId) {
     return {
       tool: 'error',

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -334,6 +334,7 @@ export type CommandRoutingGroup =
   | 'shipping'
   | 'memoryExport'
   | 'workflowsReference'
+  | 'changelog'
   | 'analysis'
   | 'setup'
   | 'context'

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "format:check": "biome format .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
-    "test:e2e": "bun test core/__tests__/e2e/"
+    "test:e2e": "bun test core/__tests__/e2e/",
+    "bench:ab": "bun scripts/bench-ab.ts"
   },
   "keywords": [
     "claude-code",

--- a/scripts/bench-ab.ts
+++ b/scripts/bench-ab.ts
@@ -1,0 +1,132 @@
+/**
+ * A/B performance benchmark: the installed/dev build vs a published version.
+ *
+ *   bun scripts/bench-ab.ts 3.20.0          # dev source vs npm version
+ *   bun scripts/bench-ab.ts 3.20.0 3.21.2   # npm version vs npm version
+ *
+ * Real product-lifecycle commands (setup → init → work/remember/search/
+ * guard/status), isolated PRJCT_CLI_HOME per side, median of N runs — the
+ * same methodology used to validate the launcher and Schema v2 wins. Run it
+ * before shipping perf-sensitive changes; a regression here is a regression
+ * for every user turn.
+ */
+
+import { execFileSync, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const REPO = path.resolve(import.meta.dir, '..')
+const REPS = Number(process.env.BENCH_REPS ?? 15)
+
+function fetchVersion(version: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `bench-${version}-`))
+  execFileSync('npm', ['pack', `prjct-cli@${version}`], { cwd: dir, stdio: 'ignore' })
+  execFileSync('tar', ['-xzf', `prjct-cli-${version}.tgz`], { cwd: dir })
+  return path.join(dir, 'package', 'bin', 'prjct.ts')
+}
+
+interface Side {
+  label: string
+  bin: string
+  runner: string
+  home: string
+  proj: string
+}
+
+function makeSide(label: string, runner: string, bin: string): Side {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bench-h-'))
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), 'bench-p-'))
+  fs.writeFileSync(path.join(proj, 'package.json'), '{"name":"bench","version":"0.1.0"}')
+  execFileSync('git', ['init', '-q'], { cwd: proj })
+  const env = {
+    ...process.env,
+    PRJCT_CLI_HOME: home,
+    HOME: home,
+    PRJCT_NO_DAEMON: '1',
+    CI: '1',
+    NO_COLOR: '1',
+  }
+  execFileSync(runner, [bin, 'setup', '--non-interactive', '--md'], {
+    cwd: proj,
+    env,
+    stdio: 'ignore',
+  })
+  execFileSync(runner, [bin, 'init', '--md'], { cwd: proj, env, stdio: 'ignore' })
+  return { label, bin, runner, home, proj }
+}
+
+function once(side: Side, args: string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const t0 = performance.now()
+    const c = spawn(side.runner, [side.bin, ...args], {
+      cwd: side.proj,
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        PRJCT_CLI_HOME: side.home,
+        HOME: side.home,
+        PRJCT_NO_DAEMON: '1',
+        CI: '1',
+        NO_COLOR: '1',
+      },
+    })
+    c.on('exit', () => resolve(performance.now() - t0))
+    c.on('error', () => resolve(-1))
+  })
+}
+
+async function median(side: Side, args: string[]): Promise<number> {
+  const xs: number[] = []
+  for (let i = 0; i < REPS; i++) xs.push(await once(side, args))
+  xs.sort((a, b) => a - b)
+  return xs[xs.length >> 1]
+}
+
+const CASES: Array<[string, string[]]> = [
+  ['--version', ['--version']],
+  ['status --md', ['status', '--md']],
+  ['remember --md', ['remember', 'decision', 'bench probe', '--md']],
+  ['search --md', ['search', 'bench', '--md']],
+  ['guard file --md', ['guard', 'package.json', '--md']],
+]
+
+const [a, b] = process.argv.slice(2)
+if (!a) {
+  console.error('Usage: bun scripts/bench-ab.ts <baseline-version> [candidate-version]')
+  process.exit(1)
+}
+
+console.log(`Fetching baseline prjct-cli@${a}…`)
+const baseline = makeSide(`v${a}`, 'bun', fetchVersion(a))
+let candidate: Side
+if (b) {
+  console.log(`Fetching candidate prjct-cli@${b}…`)
+  candidate = makeSide(`v${b}`, 'bun', fetchVersion(b))
+} else {
+  candidate = makeSide('dev', 'bun', path.join(REPO, 'bin', 'prjct.ts'))
+}
+
+console.log(
+  `\n${'command'.padEnd(18)} ${baseline.label.padStart(10)} ${candidate.label.padStart(10)}   Δ`
+)
+let regressions = 0
+for (const [label, args] of CASES) {
+  const mA = await median(baseline, args)
+  const mB = await median(candidate, args)
+  const pct = ((mA - mB) / mA) * 100
+  if (pct < -10) regressions++
+  console.log(
+    `${label.padEnd(18)} ${`${mA.toFixed(1)}ms`.padStart(10)} ${`${mB.toFixed(1)}ms`.padStart(10)}   ${pct >= 0 ? '-' : '+'}${Math.abs(pct).toFixed(0)}%${pct < -10 ? '  ⚠ REGRESSION' : ''}`
+  )
+}
+
+for (const s of [baseline, candidate]) {
+  fs.rmSync(s.home, { recursive: true, force: true })
+  fs.rmSync(s.proj, { recursive: true, force: true })
+}
+if (regressions > 0) {
+  console.error(`\n${regressions} command(s) regressed >10% vs ${baseline.label}.`)
+  process.exit(1)
+}
+console.log('\nNo regressions >10%.')


### PR DESCRIPTION
Five self-contained capabilities completing the improvement backlog:

1. **`prjct guard --diff <range> [--strict]`** — PR/CI mode: sweeps every changed file through preventive recall. Team-level anticipation, zero LLM; `--strict` = merge gate. E2E: 37 files swept.
2. **Global knowledge base** — `remember/search --global`: cross-project personal facts in the `global-kb` pseudo-project, from any directory. Also fixes a latent bug: the context tool silently ignored its own `projectId` param and re-resolved from the path.
3. **Memory staleness lifecycle** — recall rows >6mo carry "⚠stale>6mo — verify".
4. **`prjct changelog [days]`** — release notes from the typed delivery record. E2E with real data.
5. **`bun run bench:ab`** — the session's A/B perf harness productized (exit 1 on >10% regression).
6. **Init discoverability** — a committed `.prjct/memory-export/` gets surfaced at init.

typecheck + biome clean · **1927/1927 tests**

🤖 Generated with [Claude Code](https://claude.com/claude-code)