### PR TITLE
fix(cost): clamp plausible token overages — per-task tokens finally populate

### DIFF
--- a/core/__tests__/commands/product-cost.test.ts
+++ b/core/__tests__/commands/product-cost.test.ts
@@ -350,3 +350,21 @@ describe('insights cost', () => {
     }
   })
 })
+
+describe('recordTaskTokenUsage — oversized counts clamp instead of vanishing', () => {
+  it('clamps to the CHECK bound and marks the row estimated', async () => {
+    const { recordTaskTokenUsage } = await import('../../services/work-cost-service')
+    const { prjctDb } = await import('../../storage/database')
+    // Marathon-session shape: input+cache beyond the 10M CHECK bound used to
+    // be silently REJECTED by the constraint — token coverage read 0 forever.
+    recordTaskTokenUsage(projectId, 'clamp-task', 25_000_000, 4_000_000, {
+      source: 'claude-transcript',
+    })
+    const row = prjctDb.get<{ input_tokens: number; is_estimated: number }>(
+      projectId,
+      "SELECT input_tokens, is_estimated FROM token_usage WHERE work_cycle_id = 'clamp-task'"
+    )
+    expect(row?.input_tokens).toBe(10_000_000) // clamped, not dropped
+    expect(row?.is_estimated).toBe(1) // honesty flag
+  })
+})

--- a/core/services/work-cost-service.ts
+++ b/core/services/work-cost-service.ts
@@ -123,8 +123,19 @@ export function recordTaskTokenUsage(
   }
 ): void {
   if (!taskId || tokensIn + tokensOut <= 0) return
-  const ti = Math.round(tokensIn)
-  const to = Math.round(tokensOut)
+  // Two failure shapes above the CHECK bound, two policies:
+  //  - PLAUSIBLE overage (a marathon session's input+cache can pass 10M):
+  //    CLAMP to the bound and mark estimated — a dropped row read as "no
+  //    usage at all" and kept token coverage at 0% for exactly the sessions
+  //    that cost the most.
+  //  - IMPLAUSIBLE values (corrupted parse, e.g. 999,999,999): reject, as the
+  //    CHECK always intended — clamping corruption would launder it.
+  const PLAUSIBLE_MAX = 50_000_000
+  if (tokensIn > PLAUSIBLE_MAX || tokensOut > PLAUSIBLE_MAX) return
+  const clamped = tokensIn > TOKEN_COUNT_MAX || tokensOut > TOKEN_COUNT_MAX
+  const ti = Math.min(Math.round(tokensIn), TOKEN_COUNT_MAX)
+  const to = Math.min(Math.round(tokensOut), TOKEN_COUNT_MAX)
+  if (clamped) meta = { ...meta, isEstimated: true }
   try {
     prjctDb.appendEvent(
       projectId,


### PR DESCRIPTION
Root cause of the eternal "token coverage 0%": the 10M CHECK bound silently rejected marathon-session measurements (input+cache legitimately exceeds it) — the most expensive sessions recorded NOTHING. Policy split: plausible overage (≤50M) clamps + marks `is_estimated`; implausible (>50M, corrupted parses) still rejected. **Live-verified with this session's transcript: per-task tokens + the By-Model breakdown (opus/fable/sonnet) populate end-to-end for the first time.**

1929/1929 tests · 🤖 Generated with [Claude Code](https://claude.com/claude-code)