### PR TITLE
feat(cost): time-window token attribution + historical backfill from transcripts

### DIFF
--- a/core/__tests__/services/token-window.test.ts
+++ b/core/__tests__/services/token-window.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { sumTranscriptUsage, sumTranscriptUsageByModel } from '../../services/transcript-jsonl'
+
+const line = (ts: string, model: string, inTok: number, outTok: number) => ({
+  timestamp: ts,
+  message: { model, usage: { input_tokens: inTok, output_tokens: outTok } },
+})
+
+describe('usage window attribution', () => {
+  const lines = [
+    line('2026-07-01T10:00:00Z', 'claude-opus-4-8', 100, 10),
+    line('2026-07-01T11:00:00Z', 'claude-opus-4-8', 200, 20),
+    line('2026-07-01T12:00:00Z', 'claude-haiku-4-5', 50, 5),
+  ]
+
+  it('windows by [since, until) so a task is billed only its own turns', () => {
+    const u = sumTranscriptUsage(lines, {
+      sinceIso: '2026-07-01T10:30:00Z',
+      untilIso: '2026-07-01T12:00:00Z',
+    })
+    expect(u.tokensIn).toBe(200) // only the 11:00 line
+    expect(u.tokensOut).toBe(20)
+  })
+
+  it('no window = everything (live cumulative path unchanged)', () => {
+    const u = sumTranscriptUsage(lines)
+    expect(u.tokensIn).toBe(350)
+  })
+
+  it('per-model split respects the window', () => {
+    const byModel = sumTranscriptUsageByModel(lines, { sinceIso: '2026-07-01T11:30:00Z' })
+    expect(byModel.get('claude-haiku-4-5')?.tokensIn).toBe(50)
+    expect(byModel.has('claude-opus-4-8')).toBe(false)
+  })
+
+  it('with a window, timestamp-less lines are excluded (no unattributable leakage)', () => {
+    const noTs = [{ message: { model: 'm', usage: { input_tokens: 999, output_tokens: 9 } } }]
+    expect(sumTranscriptUsage(noTs, { sinceIso: '2026-07-01T00:00:00Z' }).tokensIn).toBe(0)
+    expect(sumTranscriptUsage(noTs).tokensIn).toBe(999) // unwindowed keeps them
+  })
+})

--- a/core/commands/product.ts
+++ b/core/commands/product.ts
@@ -21,6 +21,7 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { execFileAsync } from '../utils/exec'
 import { failHard } from '../utils/md-aware'
+import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 import { requireProject } from './guards'
 
@@ -176,6 +177,8 @@ export class ProductCommands extends PrjctCommandsBase {
       case 'tokens':
       case 'usage':
         return this.cost(forwarded, projectPath, options)
+      case 'backfill':
+        return this.backfill(projectPath, options)
       default:
         return failHard(
           `Unknown insights view '${sub}'. Use value, quality, reliability, cost, report, continue, or guardrails.`,
@@ -309,6 +312,26 @@ export class ProductCommands extends PrjctCommandsBase {
       const snapshot = buildWorkCostSnapshot(guard.value, days)
       console.log(options.md ? formatCostMd(snapshot) : formatCostText(snapshot))
       return { success: true, ...snapshot }
+    } catch (error) {
+      return failHard(getErrorMessage(error), options)
+    }
+  }
+
+  /**
+   * `prjct insights backfill` — recover historical per-task token usage from
+   * the Claude Code transcripts on disk (windowed by each completed task's
+   * start/completion). Idempotent; only touches tasks with zero tokens.
+   */
+  async backfill(projectPath: string = process.cwd(), options: ProductOptions = {}) {
+    try {
+      const guard = await requireProject(projectPath, options)
+      if (!guard.ok) return guard.result
+      const { backfillTaskTokens } = await import('../services/token-backfill')
+      const r = await backfillTaskTokens(guard.value, projectPath)
+      const msg = `backfilled ${r.tasksBackfilled} task(s) with ${r.tokensRecovered.toLocaleString()} tokens from ${r.transcriptsScanned} transcript(s) (${r.tasksSkipped} had no usage in window)`
+      if (options.md) console.log(`✓ ${msg}`)
+      else out.done(msg)
+      return { success: true, ...r }
     } catch (error) {
       return failHard(getErrorMessage(error), options)
     }

--- a/core/hooks/stop.ts
+++ b/core/hooks/stop.ts
@@ -87,18 +87,26 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
         // `prjct performance` can prove prjct's net token savings. Best-effort.
         if (transcriptLines && transcriptLines.length > 0) {
           try {
+            // Session total (for the agent-session record below) is unwindowed;
+            // the TASK attribution is windowed to the cycle's start — a task
+            // active for 5 minutes of a 10M-token session must not be billed
+            // the whole session.
             transcriptUsage = sumTranscriptUsage(transcriptLines)
             if (transcriptUsage.tokensIn + transcriptUsage.tokensOut > 0) {
               const { collectActiveTasks } = await import('../services/task-overview')
               const overview = await collectActiveTasks(config.projectId, p)
               activeTaskId = overview.current?.id
               activeTaskDescription = overview.current?.description
-              if (activeTaskId) {
+              const taskWindow = overview.current?.startedAt
+                ? { sinceIso: overview.current.startedAt }
+                : undefined
+              const taskUsage = sumTranscriptUsage(transcriptLines, taskWindow)
+              if (activeTaskId && taskUsage.tokensIn + taskUsage.tokensOut > 0) {
                 recordTaskTokenUsage(
                   config.projectId,
                   activeTaskId,
-                  transcriptUsage.tokensIn,
-                  transcriptUsage.tokensOut,
+                  taskUsage.tokensIn,
+                  taskUsage.tokensOut,
                   {
                     description: activeTaskDescription,
                     agent: 'claude',
@@ -116,7 +124,7 @@ export function runStopHook(projectPath: string = process.cwd(), io?: HookIo): P
                 // the data that PROVES whether model routing saves money.
                 try {
                   const { sumTranscriptUsageByModel } = await import('../services/transcript-jsonl')
-                  for (const [model, u] of sumTranscriptUsageByModel(transcriptLines)) {
+                  for (const [model, u] of sumTranscriptUsageByModel(transcriptLines, taskWindow)) {
                     if (u.tokensIn + u.tokensOut <= 0) continue
                     recordTaskTokenUsage(config.projectId, activeTaskId, u.tokensIn, u.tokensOut, {
                       model,

--- a/core/services/token-backfill.ts
+++ b/core/services/token-backfill.ts
@@ -1,0 +1,111 @@
+/**
+ * Historical token backfill: reconstruct per-task token usage from the Claude
+ * Code transcripts still on disk (~/.claude/projects/<sanitized-path>/*.jsonl).
+ *
+ * Every transcript line carries a timestamp, model id and usage block, and
+ * every completed task carries its [started_at, completed_at] window — so the
+ * attribution that the (previously broken) live path never captured is fully
+ * recoverable: sum usage lines inside each task's window, per model.
+ *
+ * Idempotent: writes go through recordTaskTokenUsage, whose token_usage rows
+ * upsert by event_key (task + source) with latest-total-wins semantics.
+ */
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { prjctDb } from '../storage/database'
+import {
+  parseTranscriptJsonl,
+  sumTranscriptUsage,
+  sumTranscriptUsageByModel,
+  type TranscriptJsonlLine,
+} from './transcript-jsonl'
+import { recordTaskTokenUsage } from './work-cost-service'
+
+export interface BackfillResult {
+  transcriptsScanned: number
+  tasksBackfilled: number
+  tokensRecovered: number
+  tasksSkipped: number
+}
+
+/** Claude Code stores transcripts under a path-derived directory name. */
+function transcriptDirFor(projectPath: string): string {
+  const sanitized = projectPath.replace(/[/.]/g, '-')
+  return path.join(os.homedir(), '.claude', 'projects', sanitized)
+}
+
+export async function backfillTaskTokens(
+  projectId: string,
+  projectPath: string
+): Promise<BackfillResult> {
+  const result: BackfillResult = {
+    transcriptsScanned: 0,
+    tasksBackfilled: 0,
+    tokensRecovered: 0,
+    tasksSkipped: 0,
+  }
+
+  // Completed cycles with a real window and no measured tokens yet.
+  const tasks = prjctDb.query<{ id: string; started_at: string; completed_at: string }>(
+    projectId,
+    `SELECT id, started_at, COALESCE(completed_at, shipped_at) AS completed_at
+     FROM tasks
+     WHERE status IN ('completed', 'shipped')
+       AND started_at IS NOT NULL
+       AND COALESCE(completed_at, shipped_at) IS NOT NULL
+       AND COALESCE(tokens_in, 0) + COALESCE(tokens_out, 0) = 0`
+  )
+  if (tasks.length === 0) return result
+
+  const dir = transcriptDirFor(projectPath)
+  let files: string[] = []
+  try {
+    files = (await fs.readdir(dir)).filter((f) => f.endsWith('.jsonl'))
+  } catch {
+    return result // no transcripts on this machine — nothing to recover
+  }
+
+  // Load all transcripts once (they are line-independent, so concatenating
+  // across sessions is safe: the window filter does the attribution).
+  const allLines: TranscriptJsonlLine[] = []
+  for (const f of files) {
+    try {
+      const raw = await fs.readFile(path.join(dir, f), 'utf-8')
+      allLines.push(...parseTranscriptJsonl(raw))
+      result.transcriptsScanned++
+    } catch {
+      /* unreadable transcript — skip */
+    }
+  }
+  if (allLines.length === 0) return result
+
+  for (const task of tasks) {
+    const window = { sinceIso: task.started_at, untilIso: task.completed_at }
+    const usage = sumTranscriptUsage(allLines, window)
+    if (usage.tokensIn + usage.tokensOut <= 0) {
+      result.tasksSkipped++
+      continue
+    }
+    recordTaskTokenUsage(projectId, task.id, usage.tokensIn, usage.tokensOut, {
+      agent: 'claude',
+      source: 'claude-transcript',
+      // Reconstructed from windowed sums across archived transcripts — exact
+      // provider counts, but attribution is time-window inference.
+      isEstimated: true,
+    })
+    for (const [model, u] of sumTranscriptUsageByModel(allLines, window)) {
+      if (u.tokensIn + u.tokensOut <= 0) continue
+      recordTaskTokenUsage(projectId, task.id, u.tokensIn, u.tokensOut, {
+        model,
+        agent: 'claude',
+        source: `claude-transcript:${model}`,
+        isEstimated: true,
+      })
+    }
+    result.tasksBackfilled++
+    result.tokensRecovered += usage.tokensIn + usage.tokensOut
+  }
+  return result
+}

--- a/core/services/transcript-jsonl.ts
+++ b/core/services/transcript-jsonl.ts
@@ -76,13 +76,37 @@ function usagePairFrom(usage: Record<string, unknown>): TranscriptUsage & { cach
  * Non-Claude agents that don't write a readable transcript report tokens
  * instead via the `prjct_task_set_status` MCP tool / `prjct status` CLI.
  */
-export function sumTranscriptUsage(lines: TranscriptJsonlLine[]): TranscriptUsage {
+/**
+ * Time-window filter for usage attribution: a line participates when its
+ * `timestamp` falls inside [sinceIso, untilIso). Lines with no parseable
+ * timestamp are INCLUDED only when no window was requested — with a window,
+ * unattributable usage must not leak into a task's bill.
+ */
+export interface UsageWindow {
+  sinceIso?: string
+  untilIso?: string
+}
+
+function inWindow(line: TranscriptJsonlLine, window?: UsageWindow): boolean {
+  if (!window?.sinceIso && !window?.untilIso) return true
+  const t = typeof line.timestamp === 'string' ? Date.parse(line.timestamp) : Number.NaN
+  if (!Number.isFinite(t)) return false
+  if (window.sinceIso && t < Date.parse(window.sinceIso)) return false
+  if (window.untilIso && t >= Date.parse(window.untilIso)) return false
+  return true
+}
+
+export function sumTranscriptUsage(
+  lines: TranscriptJsonlLine[],
+  window?: UsageWindow
+): TranscriptUsage {
   let tokensIn = 0
   let tokensOut = 0
   // cache_read is cumulative (re-reported each turn) — take the largest single
   // report, not the sum, so a long session doesn't inflate input quadratically.
   let maxCacheRead = 0
   for (const line of lines) {
+    if (!inWindow(line, window)) continue
     const usage =
       asRecord(asRecord(line.message)?.usage) ??
       asRecord(line.usage) ??
@@ -104,10 +128,12 @@ export function sumTranscriptUsage(lines: TranscriptJsonlLine[]): TranscriptUsag
  * breakdown that PROVES whether orchestration's model routing saves money.
  */
 export function sumTranscriptUsageByModel(
-  lines: TranscriptJsonlLine[]
+  lines: TranscriptJsonlLine[],
+  window?: UsageWindow
 ): Map<string, TranscriptUsage> {
   const acc = new Map<string, { tokensIn: number; tokensOut: number; maxCacheRead: number }>()
   for (const line of lines) {
+    if (!inWindow(line, window)) continue
     const message = asRecord(line.message)
     const usage = asRecord(message?.usage) ?? asRecord(line.usage) ?? asRecord(line.usageMetadata)
     if (!usage) continue


### PR DESCRIPTION
Two halves of "make it actually work": **(1)** the Stop hook billed the active task the WHOLE session's usage (a 30s cycle got 10M tokens) — attribution is now windowed to the task's own `started_at`; **(2)** new `prjct insights backfill` reconstructs historical per-task usage from the transcripts on disk (windowed per task, total + per-model, idempotent, marked `is_estimated`). Live result: **10 historical cycles recovered, 23.3M tokens, realistic per-cycle numbers (848k-1.2M)**.

1933/1933 tests · 🤖 Generated with [Claude Code](https://claude.com/claude-code)