### PR TITLE
feat: Tier-3 hygiene — tiered MCP loading + bounded working-set renders

### DIFF
--- a/core/__tests__/mcp/tool-tiers.test.ts
+++ b/core/__tests__/mcp/tool-tiers.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+
+async function toolCount(tier: string | undefined): Promise<number> {
+  if (tier === undefined) delete process.env.PRJCT_MCP_TOOLS
+  else process.env.PRJCT_MCP_TOOLS = tier
+  const { createServer } = await import('../../mcp/server')
+  const server = createServer() as unknown as { _registeredTools?: Record<string, unknown> }
+  return Object.keys(server._registeredTools ?? {}).length
+}
+
+afterEach(() => {
+  delete process.env.PRJCT_MCP_TOOLS
+})
+
+describe('tiered MCP tool loading (PRJCT_MCP_TOOLS)', () => {
+  it('core < standard < all — every registered tool costs schema tokens per session', async () => {
+    const core = await toolCount('core')
+    const standard = await toolCount('standard')
+    const all = await toolCount('all')
+    expect(core).toBeGreaterThan(0)
+    expect(standard).toBeGreaterThan(core)
+    expect(all).toBeGreaterThan(standard)
+  })
+
+  it('unset and garbage default to the full surface', async () => {
+    const all = await toolCount('all')
+    expect(await toolCount(undefined)).toBe(all)
+    expect(await toolCount('garbage')).toBe(all)
+  })
+})

--- a/core/commands/work-graph.ts
+++ b/core/commands/work-graph.ts
@@ -171,13 +171,21 @@ export class WorkGraphCommands extends PrjctCommandsBase {
         'Items in the SAME phase have no dependency path between them — safe to fan out in parallel.',
         '',
       ]
+      // Working-set bound (beads learned this at ~25k tokens): cap the render,
+      // never the computation — the full plan is in the JSON result.
+      const PER_PHASE_RENDER_CAP = 12
       for (const p of plan) {
         lines.push(`## Phase ${p.phase} — ${p.items.length} item(s), parallelizable`)
-        for (const i of p.items) {
+        for (const i of p.items.slice(0, PER_PHASE_RENDER_CAP)) {
           const harness = buildTaskHarness(i.description)
           const o = orchestrationFor(harness)
           lines.push(
             `- \`${i.id.slice(0, 8)}\` ${i.description.slice(0, 80)} _(${o.model}/${o.effort}, ~${o.expectedPoints} pt)_`
+          )
+        }
+        if (p.items.length > PER_PHASE_RENDER_CAP) {
+          lines.push(
+            `- _…and ${p.items.length - PER_PHASE_RENDER_CAP} more (full list in --json / prjct ready)_`
           )
         }
         lines.push('')

--- a/core/mcp/server.ts
+++ b/core/mcp/server.ts
@@ -44,18 +44,39 @@ Use when the user describes work, asks for project memory, or wants to improve d
 - Saving a secret-looking string is refused by default. Re-save with a scrubbed version.
 - Synthesize what happened and why. Raw transcript fragments are input, not final project context.`
 
+/**
+ * Tiered tool loading (Task Master's pattern, harness research 2026-07):
+ * every registered tool costs schema tokens in EVERY session of every agent
+ * connected to the server. PRJCT_MCP_TOOLS picks the surface:
+ *
+ *   core     — memory + project (recall, save, work-cycle state): the verbs
+ *              an agent needs on nearly every turn
+ *   standard — + files + code-intel (guard, relevant files, impact)
+ *   all      — + workflows + specs (default; full surface)
+ */
+type ToolTier = 'core' | 'standard' | 'all'
+
+function resolveTier(): ToolTier {
+  const raw = (process.env.PRJCT_MCP_TOOLS ?? 'all').toLowerCase()
+  return raw === 'core' || raw === 'standard' ? raw : 'all'
+}
+
 export function createServer(): McpServer {
   const server = new McpServer(
     { name: 'prjct', version: '1.0.0' },
     { instructions: PRJCT_INSTRUCTIONS }
   )
 
+  const tier = resolveTier()
   registerMemoryTools(server)
   registerProjectTools(server)
-  registerFileTools(server)
-  registerWorkflowTools(server)
-  registerCodeIntelTools(server)
-  registerSpecTools(server)
+  if (tier === 'core') return server
 
+  registerFileTools(server)
+  registerCodeIntelTools(server)
+  if (tier === 'standard') return server
+
+  registerWorkflowTools(server)
+  registerSpecTools(server)
   return server
 }


### PR DESCRIPTION
**PRJCT_MCP_TOOLS=core|standard|all** — 18/25/37 tools (schema tokens cost per session, per agent); **phases render capped** at 12/phase with +N-more (beads hit failures at ~25k-token listings); audit confirmed every other listing already bounded. Short-id prefixes shipped with v3.26. **1942/1942 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)