### PR TITLE
fix(triage): research classifies as its own kind → parallel fan-out

### DIFF
--- a/core/__tests__/services/task-orchestration.test.ts
+++ b/core/__tests__/services/task-orchestration.test.ts
@@ -86,3 +86,21 @@ describe('orchestrationFor — determinism', () => {
     expect(a).toEqual(b)
   })
 })
+
+describe('research tasks fan out', () => {
+  it('classifies investigation work as research → parallel', async () => {
+    const { buildTaskHarness } = await import('../../services/task-harness')
+    const { orchestrationFor } = await import('../../services/task-orchestration')
+    const harness = buildTaskHarness('analiza este repo y compara con los 3 mejores harnesses')
+    expect(harness.kind).toBe('research')
+    const plan = orchestrationFor(harness)
+    expect(plan.fanout).toBe('parallel')
+    expect(plan.tests).toBe('none') // read-only work leaves no regression test
+  })
+
+  it('does not shadow bug/security classification', async () => {
+    const { buildTaskHarness } = await import('../../services/task-harness')
+    expect(buildTaskHarness('fix the broken analysis parser').kind).toBe('bug')
+    expect(buildTaskHarness('security review of auth flow').kind).toBe('security')
+  })
+})

--- a/core/schemas/state.ts
+++ b/core/schemas/state.ts
@@ -23,6 +23,7 @@ export const HarnessKindSchema = z.enum([
   'docs',
   'chore',
   'security',
+  'research',
   'unknown',
 ])
 export const HarnessRiskSchema = z.enum(['low', 'medium', 'high'])

--- a/core/services/task-harness.ts
+++ b/core/services/task-harness.ts
@@ -156,6 +156,28 @@ function detectKind(text: string): HarnessKind {
   ) {
     return 'bug'
   }
+  // Research/investigation BEFORE feature: "analiza/investiga/compara X" is
+  // read-only sweep work — the meta-finding from the 2026-07 harness research
+  // was our own triage classifying a 3-way competitive investigation as
+  // "do it yourself — no subagents".
+  if (
+    hasAny(text, [
+      'research',
+      'investiga',
+      'investigate',
+      'analiza',
+      'analyze',
+      'analysis',
+      'análisis',
+      'compare',
+      'compara',
+      'survey',
+      'explore',
+      'explora',
+    ])
+  ) {
+    return 'research'
+  }
   if (hasAny(text, ['refactor', 'cleanup', 'split', 'restructure'])) return 'refactor'
   if (hasAny(text, ['doc', 'docs', 'document', 'readme', 'changelog', 'typo'])) return 'docs'
   if (hasAny(text, ['chore', 'format', 'lint', 'linting', 'linter'])) return 'chore'
@@ -168,6 +190,9 @@ function detectKind(text: string): HarnessKind {
 function detectLevel(kind: HarnessKind, text: string, highRisk: boolean): HarnessLevel {
   if (kind === 'docs' || kind === 'chore') return 'H0'
   if (kind === 'security') return 'H3'
+  // Research is H1 execution risk (read-only, no prod code) but its
+  // orchestration is special-cased to parallel fan-out (see orchestrationFor).
+  if (kind === 'research') return 'H1'
   if (
     highRisk &&
     hasAny(text, ['migration', 'sqlite', 'database', 'architecture', 'arquitectura'])

--- a/core/services/task-orchestration.ts
+++ b/core/services/task-orchestration.ts
@@ -64,6 +64,22 @@ function isCodeKind(kind: HarnessKind): boolean {
 /** Risk-based defaults per harness level (before SDD/TDD mode floors). */
 function baseline(level: HarnessLevel, kind: HarnessKind, risk: HarnessRisk): OrchestrationPlan {
   const code = isCodeKind(kind)
+  // Research is the parallel case regardless of level: independent sweep
+  // angles (per source/subsystem/competitor) are exactly what subagent
+  // fan-out is for — one context reading everything serially wastes both
+  // wall-clock and quality. Meta-finding from the 2026-07 harness research:
+  // our own triage classified a 3-way competitive investigation as 'direct'.
+  if (kind === 'research') {
+    return {
+      model: 'balanced',
+      effort: 'medium',
+      spec: 'none',
+      tests: 'none',
+      fanout: 'parallel',
+      expectedPoints: 2,
+      directive: '',
+    }
+  }
   switch (level) {
     case 'H0':
       // Trivial (docs/chore). Do NOT spend a frontier model on this.


### PR DESCRIPTION
Meta-finding from the harness research: our own triage told a 3-way competitive investigation 'no subagents'. New `research` kind (after bug/security so it never shadows them) → `fanout: parallel`, no test ceremony. E2E-verified. **1944/1944 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)