### PR TITLE
fix(test): import 'it' in task-orchestration test

### DIFF
--- a/core/__tests__/services/task-orchestration.test.ts
+++ b/core/__tests__/services/task-orchestration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import type { HarnessKind, HarnessLevel, HarnessRisk } from '../../schemas/state'
 import { orchestrationFor } from '../../services/task-orchestration'
 


### PR DESCRIPTION
Release CI's tsc pass caught a missing `it` import my local bun-test run tolerated. One-line import fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)