### PR TITLE
fix: fail remember on required write errors

### DIFF
--- a/core/__tests__/commands/remember.test.ts
+++ b/core/__tests__/commands/remember.test.ts
@@ -1,0 +1,50 @@
+/**
+ * `prjct remember` must not print success when the primary memory write fails.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { PrimitiveCommands } from '../../commands/primitives'
+import configManager from '../../infrastructure/config-manager'
+import prjctDb from '../../storage/database'
+
+async function freshProject(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-remember-test-'))
+  await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+  const projectId = `test-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(dir, { projectId, dataPath: path.join(dir, '.prjct-data') })
+  return dir
+}
+
+describe('remember verb', () => {
+  let projectPath: string
+  let cmd: PrimitiveCommands
+
+  beforeEach(async () => {
+    projectPath = await freshProject()
+    cmd = new PrimitiveCommands()
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('fails instead of reporting success when the memory event write fails', async () => {
+    const appendSpy = spyOn(prjctDb, 'appendEvent').mockImplementation(() => {
+      throw new Error('attempt to write a readonly database')
+    })
+    try {
+      const result = await cmd.remember(
+        'context "write failure must not be confirmed"',
+        projectPath,
+        { md: true }
+      )
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('attempt to write a readonly database')
+    } finally {
+      appendSpy.mockRestore()
+    }
+  })
+})

--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -8,7 +8,7 @@
  * accumulates.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -869,5 +869,23 @@ describe('topic supersession — edge-case hardening (cleanup sweep)', () => {
       "SELECT COUNT(*) AS c FROM memory_entries WHERE topic_key = 'fragile' AND deleted_at IS NULL"
     )
     expect(active?.c).toBe(1) // the old revision was NOT tombstoned
+  })
+
+  it('throws when a required remember event write fails', async () => {
+    const appendSpy = spyOn(prjctDb, 'appendEvent').mockImplementation(() => {
+      throw new Error('attempt to write a readonly database')
+    })
+    try {
+      await expect(
+        projectMemory.remember(tmpRoot, {
+          type: 'decision',
+          content: 'required memory must not report success',
+          projectId,
+          requireWrite: true,
+        })
+      ).rejects.toThrow('attempt to write a readonly database')
+    } finally {
+      appendSpy.mockRestore()
+    }
   })
 })

--- a/core/commands/primitives.ts
+++ b/core/commands/primitives.ts
@@ -246,6 +246,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
           content,
           tags,
           projectId: 'global-kb',
+          requireWrite: true,
         })
         const msg = `remembered ${type} (GLOBAL — cross-project): ${content.slice(0, 80)}${content.length > 80 ? '…' : ''}`
         if (options.md) console.log(`✓ ${msg}`)
@@ -291,6 +292,7 @@ export class PrimitiveCommands extends PrjctCommandsBase {
         content,
         tags: finalTags,
         source: active?.id,
+        requireWrite: true,
       })
 
       if (options.md) console.log(`✓ remembered ${type}: ${content}`)

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -291,6 +291,8 @@ export const projectMemory = {
        *  Stop-hook detectors fire several remembers per turn and each used
        *  to re-read + re-parse prjct.config.json. */
       projectId?: string
+      /** For user-facing remember commands, the event write is the operation. */
+      requireWrite?: boolean
     }
   ): Promise<void> {
     const tags = args.tags ?? {}
@@ -357,7 +359,9 @@ export const projectMemory = {
       undefined,
       // Explicit target: same value path-resolution yields for normal
       // captures; the global KB pseudo-project for --global ones.
-      projectId ? { projectId } : undefined
+      projectId || args.requireWrite
+        ? { ...(projectId ? { projectId } : {}), required: args.requireWrite }
+        : undefined
     )
     if (logResult?.projectId && !projectId) projectId = logResult.projectId
 

--- a/core/services/memory-service.ts
+++ b/core/services/memory-service.ts
@@ -27,6 +27,8 @@ class MemoryService {
        * outside any repo.
        */
       projectId?: string
+      /** Treat this write as required and rethrow failures to the caller. */
+      required?: boolean
     }
   ): Promise<{ eventId: number | null; projectId: string } | null> {
     try {
@@ -36,8 +38,12 @@ class MemoryService {
       const eventId = prjctDb.appendEvent(projectId, `memory.${action}`, { ...data, author })
       return { eventId, projectId }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (opts?.required) {
+        throw new Error(message)
+      }
       // Non-critical - don't fail the command
-      console.error(`Memory log error: ${error instanceof Error ? error.message : String(error)}`)
+      console.error(`Memory log error: ${message}`)
       return null
     }
   }


### PR DESCRIPTION
## Summary
- make user-facing remember writes required so readonly SQLite failures do not report success
- keep auxiliary memory logs best-effort unless explicitly required
- add regression coverage for CLI remember and projectMemory required writes

## Verification
- bun test core/__tests__/commands/remember.test.ts
- bun test core/__tests__/memory/project-memory.test.ts
- npm run typecheck
- bun run lint
- bun run format:check
- npm run build
- node bin/prjct.cjs remember context "local shim should fail on readonly db" --md

Generated with [p/](https://www.prjct.app/)