### PR TITLE
feat: xAI Grok Build CLI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+## [3.30.0] - 2026-07-09
+
+### Added
+- xAI Grok Build CLI compatibility (agent-runtime-registry)
+
 ## [3.29.0] - 2026-07-03
 
 ### Features
 
 - surface work-graph + ceremony verbs in the verb map (#523)
-
 
 ## [3.28.1] - 2026-07-03
 
@@ -16,13 +20,11 @@
 - import 'it' in task-orchestration test (#522)
 - research classifies as its own kind → parallel fan-out (#521)
 
-
 ## [3.28.0] - 2026-07-03
 
 ### Features
 
 - Tier-3 hygiene — tiered MCP loading + bounded working-set renders (#520)
-
 
 ## [3.27.0] - 2026-07-03
 
@@ -30,13 +32,11 @@
 
 - Tier-2 ceremonies — journal, compiled briefs, replan, prime/land, adversarial review (#519)
 
-
 ## [3.26.0] - 2026-07-03
 
 ### Features
 
 - the work graph — deps, ready frontier, atomic claim, phases, decompose loop (Tier 1) (#518)
-
 
 ## [3.25.0] - 2026-07-03
 
@@ -44,13 +44,11 @@
 
 - time-window token attribution + historical backfill from transcripts (#517)
 
-
 ## [3.24.3] - 2026-07-03
 
 ### Bug Fixes
 
 - completion no longer clobbers measured task tokens with zero (#516)
-
 
 ## [3.24.2] - 2026-07-03
 
@@ -58,13 +56,11 @@
 
 - clamp plausible token overages — per-task tokens finally populate (#515)
 
-
 ## [3.24.1] - 2026-07-03
 
 ### Bug Fixes
 
 - run packed versions via the production launcher with installed deps (#514)
-
 
 ## [3.24.0] - 2026-07-02
 
@@ -72,13 +68,11 @@
 
 - session tracker on typed tables + token-budget default — storage backlog closed (#513)
 
-
 ## [3.23.0] - 2026-07-02
 
 ### Features
 
 - tier-2 package — guard PR mode, global KB, memory lifecycle, changelog, bench, import hint (#512)
-
 
 ## [3.22.0] - 2026-07-02
 
@@ -90,13 +84,11 @@
 
 - refresh AGENTS.md routing block (v3.21.2 dogfood) (#510)
 
-
 ## [3.21.2] - 2026-07-02
 
 ### Performance
 
 - hot-path follow-up — stop-hook throttle, BM25 query-path, config cache (#509)
-
 
 ## [3.21.1] - 2026-07-02
 
@@ -104,13 +96,11 @@
 
 - cleanup sweep — dead code, edge cases in recent ships, hot-path perf (#508)
 
-
 ## [3.21.0] - 2026-07-02
 
 ### Features
 
 - gentle-ai learnings — ALL 8 mechanisms (#507)
-
 
 ## [3.20.0] - 2026-07-02
 
@@ -118,13 +108,11 @@
 
 - task history in typed tasks table — state blob −94% (Schema v2 C4, history slice) (#506)
 
-
 ## [3.19.0] - 2026-07-02
 
 ### Features
 
 - ideas in typed table + orphan kv-key sweep (Schema v2) (#505)
-
 
 ## [3.18.0] - 2026-07-02
 
@@ -132,13 +120,11 @@
 
 - restore velocity from typed delivery data + developer-evolution weekly snapshots (#504)
 
-
 ## [3.17.0] - 2026-07-02
 
 ### Features
 
 - queue in typed queue_tasks — retire the 1.08MB per-prompt blob (Schema v2) (#503)
-
 
 ## [3.16.0] - 2026-07-02
 
@@ -146,20 +132,17 @@
 
 - metrics in typed tables + stamp tasks.shipped_at — two more dual-store bugs fixed (#502)
 
-
 ## [3.15.1] - 2026-07-02
 
 ### Bug Fixes
 
 - harden session ships — sync ping-pong, node 22.5–22.12 fallback, classifier false positives (#501)
 
-
 ## [3.15.0] - 2026-07-01
 
 ### Features
 
 - ships in typed shipped_features table — retire the 5.4MB kv_store blob (Schema v2 C5) (#500)
-
 
 ## [3.14.0] - 2026-07-01
 
@@ -171,13 +154,11 @@
 
 - run bundled entry in-process — 41% faster commands (#498)
 
-
 ## [3.13.0] - 2026-07-01
 
 ### Features
 
 - Schema v2 relational redesign + vault removal + legacy cleanup (#497)
-
 
 ## [3.12.2] - 2026-06-29
 
@@ -185,13 +166,11 @@
 
 - regenerate statusline body on upgrade so the version-check fix ships (#496)
 
-
 ## [3.12.1] - 2026-06-29
 
 ### Bug Fixes
 
 - statusline version check owned by daemon, not legacy files (#495)
-
 
 ## [3.12.0] - 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ It reports concrete support levels:
 | `hosted` | Repo instructions are the portable layer; platform config may be manual. |
 
 Run `prjct agents doctor --md` to see the current machine/project matrix for
-Claude Code, Codex, Gemini CLI, OpenCode, Qwen Code, Kimi CLI, Cursor,
-Windsurf, Cline/Roo-family agents, hosted agents, and future AGENTS.md/MCP
-clients.
+Claude Code, Codex, Gemini CLI, OpenCode, Qwen Code, Kimi CLI, Grok Build,
+Cursor, Windsurf, Cline/Roo-family agents, hosted agents, and future
+AGENTS.md/MCP clients.
 
 Use `prjct agents doctor --fix` inside a prjct project to refresh the portable
 `AGENTS.md` surface and any repo-local IDE rule adapters prjct manages. The

--- a/core/__tests__/infrastructure/agent-runtime-registry.test.ts
+++ b/core/__tests__/infrastructure/agent-runtime-registry.test.ts
@@ -24,6 +24,7 @@ describe('agent runtime registry', () => {
       'opencode',
       'qwen-code',
       'kimi-cli',
+      'grok',
       'goose',
       'aider',
       'cline',
@@ -51,6 +52,18 @@ describe('agent runtime registry', () => {
     expect(writable[0]?.pathHint).toContain('.kimi/mcp.json')
   })
 
+  it('registers xAI Grok Build as an AGENTS.md + MCP + skills capable CLI', () => {
+    const grok = getAgentRuntime('grok')
+
+    expect(grok.kind).toBe('cli')
+    expect(grok.supports.agentsMd).toBe(true)
+    expect(grok.supports.mcp).toBe(true)
+    expect(grok.supports.skills).toBe(true)
+    expect(grok.detectsBy?.commands).toContain('grok')
+    // MCP schema unconfirmed from xAI docs — target is informational only, not auto-written.
+    expect((grok.mcpTargets ?? []).every((target) => !target.writable)).toBe(true)
+  })
+
   it('separates runtime compatibility from model/provider names', () => {
     const qwen = getAgentRuntime('qwen-code')
 
@@ -74,6 +87,7 @@ describe('agent runtime registry', () => {
       expect(byId.get('cursor')?.supportLevel).toBe('good')
       expect(byId.get('aider')?.detectedSignals).toContain('.aider.conf.yml')
       expect(byId.get('aider')?.supportLevel).toBe('baseline')
+      expect(byId.get('grok')?.supportLevel).toBe('good')
     } finally {
       await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
     }

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -572,7 +572,7 @@ export const COMMANDS: CommandMeta[] = [
     isOptional: true,
     features: [
       'Gives the next agent the active task, required prjct checks, and high-value memories',
-      'Works across Codex, Claude, Gemini, Cursor, OpenCode, Qwen, Kimi, and unknown future agents',
+      'Works across Codex, Claude, Gemini, Cursor, OpenCode, Qwen, Kimi, Grok, and unknown future agents',
       'Makes multi-agent continuity concrete instead of relying on private model memory',
     ],
   },

--- a/core/infrastructure/agent-runtime-registry.ts
+++ b/core/infrastructure/agent-runtime-registry.ts
@@ -14,6 +14,7 @@ export type AgentRuntimeId =
   | 'opencode'
   | 'qwen-code'
   | 'kimi-cli'
+  | 'grok'
   | 'goose'
   | 'aider'
   | 'cursor'
@@ -265,6 +266,25 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
     },
     notes:
       'Kimi-family coding runtime; AGENTS.md and MCP/CLI markdown output are the portable contract.',
+  },
+  {
+    id: 'grok',
+    displayName: 'xAI Grok Build',
+    kind: 'cli',
+    status: 'emerging',
+    detectsBy: { homeDirs: ['.grok'], commands: ['grok'] },
+    contextFiles: ['AGENTS.md'],
+    mcpTargets: [{ format: 'generic', pathHint: '~/.grok/config.toml (mcp)', writable: false }],
+    supports: {
+      agentsMd: true,
+      mcp: true,
+      skills: true,
+      hooks: true,
+      acp: false,
+      projectRules: false,
+    },
+    notes:
+      'xAI Grok Build CLI; AGENTS.md walked root→cwd, skills under .agents/skills or .grok/skills, hooks/plugins/MCP via ~/.grok/config.toml. Also reads Claude Code surfaces (CLAUDE.md, .claude/skills) natively.',
   },
   {
     id: 'goose',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.29.0",
+  "version": "3.30.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Adds xAI Grok Build (`grok` CLI, x.ai/cli) to the universal `agent-runtime-registry.ts` compatibility tier — detects `~/.grok`/`grok` on PATH, declares support for AGENTS.md, MCP, skills, and hooks (`supportLevel: good`).
- Deliberately kept at the registry-only tier (not the full first-class provider tier used by Claude/Gemini/Codex) — Grok's exact MCP config schema is unconfirmed/conflicting across sources, so no bespoke MCP-config writer was built to avoid guessing wrong against a user's real config file.

## Test plan
- [x] `bun test core/__tests__/infrastructure/agent-runtime-registry.test.ts` — 6 pass, including 3 new assertions for the `grok` entry
- [x] `bun test core/__tests__/infrastructure/ core/__tests__/commands/` — 211 pass, no regressions
- [x] `biome check --write` — clean
- [x] `tsc --noEmit` — clean
- [x] Verified live: `prjct agents doctor --md` shows a `xAI Grok Build` row (`good`, AGENTS.md/MCP/skills: yes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)