### PR TITLE
fix(release): Node 22 + pin npm@11 so publish is not blocked by engines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 22: npm@11+ trusted publishing, and avoids GHA Node 20 deprecation.
+          node-version: '22'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -162,7 +163,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 22: npm@11+ trusted publishing, and avoids GHA Node 20 deprecation.
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Bun
@@ -433,7 +435,11 @@ jobs:
 
       - name: Upgrade npm (trusted publishing requires >=11.5.1)
         if: ${{ !inputs.dry_run && steps.push.outputs.superseded != 'true' }}
-        run: npm install -g npm@latest
+        # Pin major 11 — `npm@latest` (12+) can require a newer Node than the
+        # runner has (v3.30.0 failed: npm@12 wants Node ^22.22.2 while setup
+        # was still on 20). Major 11 satisfies OIDC trusted publishing and
+        # stays compatible with Node 22 LTS.
+        run: npm install -g npm@11
 
       - name: Publish to npm (OIDC trusted publisher)
         if: ${{ !inputs.dry_run && steps.push.outputs.superseded != 'true' }}


### PR DESCRIPTION
## Summary
- Release for v3.30.0 tagged `main` and pushed the tag, then died on `npm install -g npm@latest` (npm@12 requires Node ^22.22.2; job was on Node 20 → EBADENGINE). **npm still at 3.29.1**; #525 and #526 never published.
- Bump Release jobs to Node 22 and pin the upgrade step to `npm@11` (trusted-publishing floor ≥11.5.1 without floating to engines-incompatible majors).

## Root cause (ship incomplete)
| Layer | State |
|-------|--------|
| main HEAD | `987daba9` (#526) on top of `chore(release): v3.30.0` |
| git tag | `v3.30.0` exists |
| npm `prjct-cli` | **3.29.1** (publish never ran) |

Post-merge CI/Release red on #526 was initially runner queue; the real ship block for users is the publish engines mismatch from #525's Release.

## Test plan
- [ ] PR CI green
- [ ] After merge, Release workflow upgrades npm@11 and publishes next version (includes #525+#526)
- [ ] `npm view prjct-cli version` > 3.29.1