### PR TITLE
feat(bench): weak-model efficiency + intelligence + token cost

### DIFF
--- a/core/__tests__/eval/live-claude.test.ts
+++ b/core/__tests__/eval/live-claude.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test'
+import { extractVerb } from '../../eval/live-claude'
+
+describe('extractVerb', () => {
+  test('parses JSON verb field', () => {
+    expect(extractVerb('{"verb":"search","reason":"look up memory"}')).toBe('search')
+  })
+
+  test('parses bare first token', () => {
+    expect(extractVerb('remember\nbecause we should persist')).toBe('remember')
+  })
+
+  test('finds non-work verb in prose', () => {
+    expect(extractVerb('I would run prjct land to close the session')).toBe('land')
+  })
+
+  test('returns null when empty', () => {
+    expect(extractVerb('')).toBeNull()
+  })
+})

--- a/core/__tests__/services/weak-efficiency-bench.test.ts
+++ b/core/__tests__/services/weak-efficiency-bench.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  formatEfficiencyMarkdown,
+  runEfficiencyBench,
+  TASK_SUITE,
+} from '../../services/weak-efficiency-bench'
+
+describe('weak-efficiency-bench', () => {
+  test('suite has at least 8 realistic tasks', () => {
+    expect(TASK_SUITE.length).toBeGreaterThanOrEqual(8)
+  })
+
+  test('harness beats bare on completion, intelligence, and tokens', () => {
+    const r = runEfficiencyBench()
+    expect(r.harness.completionRate).toBeGreaterThan(r.bare.completionRate)
+    expect(r.harness.intelligenceScore).toBeGreaterThanOrEqual(r.bare.intelligenceScore + 0.2)
+    expect(r.harness.tokens.inputTotal).toBeLessThan(r.bare.tokens.inputTotal)
+    expect(r.harness.tokens.wasteTurns).toBeLessThan(r.bare.tokens.wasteTurns)
+  })
+
+  test('markdown is a full efficiency report', () => {
+    const md = formatEfficiencyMarkdown(runEfficiencyBench())
+    expect(md).toContain('Task completion')
+    expect(md).toContain('Intelligence')
+    expect(md).toContain('Input tokens')
+    expect(md).toContain('How prjct helps the weak model')
+    expect(md).toContain('haiku')
+  })
+})

--- a/core/eval/live-claude.ts
+++ b/core/eval/live-claude.ts
@@ -1,0 +1,236 @@
+/**
+ * Live Claude Code one-shot client for efficiency benches.
+ *
+ * Uses the user's logged-in `claude` CLI (`claude -p --output-format json`)
+ * so Max/OAuth works without a separate ANTHROPIC_API_KEY. Calls run in an
+ * isolated temp cwd with empty MCP to reduce ambient tool noise.
+ */
+
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export interface LiveClaudeUsage {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  /** Billable-ish proxy: input + cache_creation + output (excludes cheap cache reads). */
+  billableTokens: number
+}
+
+export interface LiveClaudeResult {
+  ok: boolean
+  text: string
+  costUsd: number
+  turns: number
+  durationMs: number
+  model: string
+  usage: LiveClaudeUsage
+  raw: unknown
+  error?: string
+}
+
+export interface LiveClaudeCallOptions {
+  prompt: string
+  systemPrompt: string
+  model?: string
+  timeoutMs?: number
+  /** Working directory; defaults to an isolated temp project. */
+  cwd?: string
+  /** Optional JSON Schema for structured output (--json-schema). */
+  jsonSchema?: Record<string, unknown>
+}
+
+function emptyUsage(): LiveClaudeUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    billableTokens: 0,
+  }
+}
+
+function parseUsage(raw: unknown): LiveClaudeUsage {
+  if (!raw || typeof raw !== 'object') return emptyUsage()
+  const u = raw as Record<string, unknown>
+  const input = num(u.input_tokens)
+  const output = num(u.output_tokens)
+  const cacheRead = num(u.cache_read_input_tokens)
+  const cacheCreate = num(u.cache_creation_input_tokens)
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheCreationTokens: cacheCreate,
+    billableTokens: input + cacheCreate + output,
+  }
+}
+
+function num(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0
+}
+
+/** Ensure `claude` is available and logged in. */
+export async function assertClaudeLiveReady(): Promise<{ email?: string; model?: string }> {
+  try {
+    const { stdout } = await execFileAsync('claude', ['auth', 'status'], {
+      timeout: 15_000,
+      maxBuffer: 2 * 1024 * 1024,
+      env: process.env,
+    })
+    const j = JSON.parse(stdout) as { loggedIn?: boolean; email?: string }
+    if (!j.loggedIn) {
+      throw new Error('claude is not logged in — run `claude` /login first')
+    }
+    return { email: j.email }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Live LLM unavailable: ${msg}`)
+  }
+}
+
+/**
+ * One-shot completion via Claude Code print mode.
+ * Isolates MCP (empty) and disables slash commands for cleaner routing tasks.
+ */
+export async function callClaudeLive(opts: LiveClaudeCallOptions): Promise<LiveClaudeResult> {
+  const model = opts.model ?? process.env.PRJCT_LIVE_MODEL ?? 'haiku'
+  const timeoutMs = opts.timeoutMs ?? 120_000
+
+  let cwd = opts.cwd
+  let tmp: string | null = null
+  if (!cwd) {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-live-'))
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"name":"prjct-live-bench","private":true}\n')
+    fs.writeFileSync(path.join(tmp, 'mcp.json'), JSON.stringify({ mcpServers: {} }))
+    cwd = tmp
+  }
+  const mcpPath = path.join(cwd, 'mcp.json')
+  if (!fs.existsSync(mcpPath)) {
+    fs.writeFileSync(mcpPath, JSON.stringify({ mcpServers: {} }))
+  }
+
+  const args = [
+    '-p',
+    opts.prompt,
+    '--model',
+    model,
+    '--output-format',
+    'json',
+    '--system-prompt',
+    opts.systemPrompt,
+    '--allowedTools',
+    '',
+    '--disable-slash-commands',
+    '--mcp-config',
+    mcpPath,
+    '--strict-mcp-config',
+    '--setting-sources',
+    '',
+  ]
+  if (opts.jsonSchema) {
+    args.push('--json-schema', JSON.stringify(opts.jsonSchema))
+  }
+
+  try {
+    const { stdout, stderr } = await execFileAsync('claude', args, {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 8 * 1024 * 1024,
+      env: {
+        ...process.env,
+        // Reduce ambient agent noise when the host supports it.
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+      },
+    })
+    const line = stdout.trim()
+    if (!line) {
+      return {
+        ok: false,
+        text: '',
+        costUsd: 0,
+        turns: 0,
+        durationMs: 0,
+        model,
+        usage: emptyUsage(),
+        raw: null,
+        error: stderr || 'empty claude stdout',
+      }
+    }
+    const raw = JSON.parse(line) as Record<string, unknown>
+    const usage = parseUsage(raw.usage)
+    // Structured output may land in result as object or string.
+    let text = ''
+    if (typeof raw.result === 'string') text = raw.result
+    else if (raw.result != null) text = JSON.stringify(raw.result)
+    else if (raw.structured_output != null) text = JSON.stringify(raw.structured_output)
+    const isError = raw.is_error === true
+    return {
+      ok: !isError,
+      text,
+      costUsd: num(raw.total_cost_usd),
+      turns: num(raw.num_turns) || 1,
+      durationMs: num(raw.duration_ms),
+      model:
+        raw.modelUsage && typeof raw.modelUsage === 'object'
+          ? (Object.keys(raw.modelUsage as object)[0] ?? model)
+          : model,
+      usage,
+      raw,
+      error: isError ? text || 'claude is_error' : undefined,
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return {
+      ok: false,
+      text: '',
+      costUsd: 0,
+      turns: 0,
+      durationMs: 0,
+      model,
+      usage: emptyUsage(),
+      raw: null,
+      error: msg,
+    }
+  } finally {
+    if (tmp) {
+      try {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+/** Extract a verb token from freeform model text. */
+export function extractVerb(text: string): string | null {
+  const verbs = ['search', 'remember', 'ship', 'next', 'land', 'guard', 'sync', 'work'] as const
+  // Prefer JSON field
+  const jsonMatch = text.match(/"verb"\s*:\s*"([a-z]+)"/i)
+  if (jsonMatch) {
+    const v = jsonMatch[1].toLowerCase()
+    if ((verbs as readonly string[]).includes(v)) return v
+  }
+  // Bare word on first line
+  const first = text
+    .trim()
+    .split(/\s+/)[0]
+    ?.toLowerCase()
+    .replace(/[^a-z]/g, '')
+  if (first && (verbs as readonly string[]).includes(first)) return first
+  // Any mention — last resort, prefer non-work if present
+  const lower = text.toLowerCase()
+  for (const v of verbs) {
+    if (v === 'work') continue
+    if (new RegExp(`\\b${v}\\b`).test(lower)) return v
+  }
+  if (/\bwork\b/.test(lower)) return 'work'
+  return null
+}

--- a/core/services/live-efficiency-bench.ts
+++ b/core/services/live-efficiency-bench.ts
@@ -1,0 +1,310 @@
+/**
+ * Live LLM weak-model efficiency bench.
+ *
+ * Calls a real model (default: Claude Code `haiku` via logged-in CLI) on each
+ * task twice — bare system prompt vs prjct harness prompt — and scores
+ * completion, intelligence, tokens, and $.
+ */
+
+import { assertClaudeLiveReady, callClaudeLive, extractVerb } from '../eval/live-claude'
+import { buildPrjctSkill, emptySkillContext } from './skill-generator/prjct-skill-body'
+import { TASK_SUITE, type TaskScenario } from './weak-efficiency-bench'
+
+export interface LiveTaskOutcome {
+  taskId: string
+  side: 'bare' | 'harness'
+  userSignal: string
+  correctVerb: string
+  verbChosen: string | null
+  verbCorrect: boolean
+  completed: boolean
+  text: string
+  costUsd: number
+  turns: number
+  durationMs: number
+  inputTokens: number
+  outputTokens: number
+  cacheCreationTokens: number
+  cacheReadTokens: number
+  billableTokens: number
+  error?: string
+}
+
+export interface LiveSideSummary {
+  label: string
+  completionRate: number
+  routingAccuracy: number
+  totalCostUsd: number
+  totalBillableTokens: number
+  totalOutputTokens: number
+  totalTurns: number
+  avgDurationMs: number
+  tasks: LiveTaskOutcome[]
+}
+
+export interface LiveEfficiencyReport {
+  mode: 'live'
+  model: string
+  authEmail?: string
+  suiteSize: number
+  bare: LiveSideSummary
+  harness: LiveSideSummary
+  deltas: {
+    completionPts: number
+    routingPts: number
+    billableTokenSavePct: number
+    costSavePct: number
+    turnSavePct: number
+  }
+  outcomes: LiveTaskOutcome[]
+}
+
+const VERB_SCHEMA = {
+  type: 'object',
+  properties: {
+    verb: {
+      type: 'string',
+      enum: ['work', 'search', 'remember', 'ship', 'next', 'land', 'guard', 'sync'],
+    },
+    reason: { type: 'string' },
+  },
+  required: ['verb', 'reason'],
+  additionalProperties: false,
+} as const
+
+const BARE_SYSTEM = `You are a coding agent WITHOUT a project memory system and WITHOUT the prjct harness.
+Choose exactly one action verb for the user's request.
+Allowed verbs: work, search, remember, ship, next, land, guard, sync.
+If unsure, choose work.
+Never call tools. Never ask questions. Structured output only.`
+
+function harnessSystem(skill: string, memoryBlock: string): string {
+  return `You are a coding agent WITH the prjct harness installed.
+Pick the correct prjct verb — never wrap bin verbs as freeform work.
+
+## Verb map (mandatory)
+- search / find / recall / look up knowledge → search
+- remember / save a decision|learning|gotcha / pin a fact → remember
+- fix / build / implement / bug → work
+- what next / ready / what should I work on → next
+- ship / open a PR → ship
+- land / close session / done for today / hand off → land
+- traps before edit / guard file / any traps before I edit → guard
+- sync project → sync
+
+## prjct skill (always-on)
+${skill}
+
+## Project memory available this session
+${memoryBlock}
+
+Never call tools. Never ask questions. Structured output only.`
+}
+
+const MEMORY_BANK = `- [decision] auth-session: session cookies must be httpOnly + SameSite=Lax
+- [gotcha] rate-limit-double-fire: statusline banner can double-fire without source tags
+- [gotcha] migration-non-idempotent: SQLite migrations must use IF NOT EXISTS
+- [learning] transcript-auto: Stop hook auto-captures Decision:/Gotcha: labels
+- [fact] task-service: resolve active task per worktree, never clobber sibling agents
+- [gotcha] npm12-node20-engines: Release must pin Node 22 + npm@11 for publish`
+
+function promptFor(task: TaskScenario): string {
+  return `User said: ${task.userSignal}
+
+Success looks like: ${task.success}
+${task.needsMemory ? `Relevant memory topic if available: ${task.needsMemory}` : ''}
+${task.trap ? `Known trap if recalled: ${task.trap}` : ''}
+
+Choose the single best first verb.`
+}
+
+function summarize(label: string, tasks: LiveTaskOutcome[]): LiveSideSummary {
+  const n = tasks.length || 1
+  const completionRate = tasks.filter((t) => t.completed).length / n
+  const routingAccuracy = tasks.filter((t) => t.verbCorrect).length / n
+  return {
+    label,
+    completionRate,
+    routingAccuracy,
+    totalCostUsd: tasks.reduce((s, t) => s + t.costUsd, 0),
+    totalBillableTokens: tasks.reduce((s, t) => s + t.billableTokens, 0),
+    totalOutputTokens: tasks.reduce((s, t) => s + t.outputTokens, 0),
+    totalTurns: tasks.reduce((s, t) => s + t.turns, 0),
+    avgDurationMs: tasks.reduce((s, t) => s + t.durationMs, 0) / n,
+    tasks,
+  }
+}
+
+async function runSide(
+  side: 'bare' | 'harness',
+  systemPrompt: string,
+  model: string,
+  tasks: TaskScenario[]
+): Promise<LiveTaskOutcome[]> {
+  const out: LiveTaskOutcome[] = []
+  for (const task of tasks) {
+    process.stderr.write(`  [${side}] ${task.id} ${task.correctVerb}… `)
+    const res = await callClaudeLive({
+      prompt: promptFor(task),
+      systemPrompt,
+      model,
+      timeoutMs: 180_000,
+      jsonSchema: VERB_SCHEMA as unknown as Record<string, unknown>,
+    })
+    const verb = extractVerb(res.text)
+    const verbCorrect = verb === task.correctVerb
+    // Live completion for this suite = correct first verb (routing intelligence).
+    // Multi-step agent loops are out of scope for the one-shot protocol.
+    const completed = verbCorrect && res.ok
+    process.stderr.write(
+      `${verb ?? '—'} ${verbCorrect ? '✓' : '✗'} $${res.costUsd.toFixed(4)} ${res.usage.billableTokens} tok\n`
+    )
+    out.push({
+      taskId: task.id,
+      side,
+      userSignal: task.userSignal,
+      correctVerb: task.correctVerb,
+      verbChosen: verb,
+      verbCorrect,
+      completed,
+      text: res.text.slice(0, 500),
+      costUsd: res.costUsd,
+      turns: res.turns,
+      durationMs: res.durationMs,
+      inputTokens: res.usage.inputTokens,
+      outputTokens: res.usage.outputTokens,
+      cacheCreationTokens: res.usage.cacheCreationTokens,
+      cacheReadTokens: res.usage.cacheReadTokens,
+      billableTokens: res.usage.billableTokens,
+      error: res.error,
+    })
+  }
+  return out
+}
+
+export async function runLiveEfficiencyBench(
+  opts: {
+    model?: string
+    /** Limit suite size (default all). */
+    limit?: number
+  } = {}
+): Promise<LiveEfficiencyReport> {
+  const auth = await assertClaudeLiveReady()
+  const model = opts.model ?? process.env.PRJCT_LIVE_MODEL ?? 'haiku'
+  const suite = opts.limit ? TASK_SUITE.slice(0, opts.limit) : TASK_SUITE
+  const skill = buildPrjctSkill(emptySkillContext())
+
+  process.stderr.write(
+    `Live efficiency bench · model=${model} · tasks=${suite.length} · auth=${auth.email ?? '?'}\n`
+  )
+
+  process.stderr.write('## Bare (no harness)\n')
+  const bareTasks = await runSide('bare', BARE_SYSTEM, model, suite)
+  process.stderr.write('## Harness (prjct)\n')
+  const harnessTasks = await runSide('harness', harnessSystem(skill, MEMORY_BANK), model, suite)
+
+  const bare = summarize('weak bare (live)', bareTasks)
+  const harness = summarize('weak + prjct (live)', harnessTasks)
+
+  const billableSave =
+    bare.totalBillableTokens > 0
+      ? (bare.totalBillableTokens - harness.totalBillableTokens) / bare.totalBillableTokens
+      : 0
+  const costSave =
+    bare.totalCostUsd > 0 ? (bare.totalCostUsd - harness.totalCostUsd) / bare.totalCostUsd : 0
+  const turnSave =
+    bare.totalTurns > 0 ? (bare.totalTurns - harness.totalTurns) / bare.totalTurns : 0
+
+  return {
+    mode: 'live',
+    model,
+    authEmail: auth.email,
+    suiteSize: suite.length,
+    bare,
+    harness,
+    deltas: {
+      completionPts: (harness.completionRate - bare.completionRate) * 100,
+      routingPts: (harness.routingAccuracy - bare.routingAccuracy) * 100,
+      billableTokenSavePct: billableSave * 100,
+      costSavePct: costSave * 100,
+      turnSavePct: turnSave * 100,
+    },
+    outcomes: [...bareTasks, ...harnessTasks],
+  }
+}
+
+function pct(n: number): string {
+  const sign = n > 0 ? '+' : ''
+  return `${sign}${n.toFixed(1)}%`
+}
+
+export function formatLiveEfficiencyMarkdown(r: LiveEfficiencyReport): string {
+  const lines: string[] = []
+  lines.push('# Live weak-model efficiency + intelligence bench')
+  lines.push('')
+  lines.push(
+    `**Mode: LIVE LLM** · model \`${r.model}\` · auth \`${r.authEmail ?? 'unknown'}\` · **${r.suiteSize} tasks** × 2 sides`
+  )
+  lines.push('')
+  lines.push(
+    'Each task is a real model call (Claude Code print mode). Bare vs harness differ only by system prompt + injected memory/skill. Tools disabled; score = correct first verb + token/$.'
+  )
+  lines.push('')
+  lines.push('## Scoreboard')
+  lines.push('')
+  lines.push('| Metric | Bare live | + prjct live | Δ |')
+  lines.push('|---|---:|---:|---:|')
+  lines.push(
+    `| Task completion (correct verb) | ${(r.bare.completionRate * 100).toFixed(0)}% | ${(r.harness.completionRate * 100).toFixed(0)}% | **${pct(r.deltas.completionPts)} pts** |`
+  )
+  lines.push(
+    `| Routing accuracy | ${(r.bare.routingAccuracy * 100).toFixed(0)}% | ${(r.harness.routingAccuracy * 100).toFixed(0)}% | **${pct(r.deltas.routingPts)} pts** |`
+  )
+  lines.push(
+    `| Billable tokens (in+cache_create+out) | ${r.bare.totalBillableTokens.toLocaleString()} | ${r.harness.totalBillableTokens.toLocaleString()} | **${r.deltas.billableTokenSavePct.toFixed(1)}% fewer on harness** |`
+  )
+  lines.push(
+    `| Output tokens | ${r.bare.totalOutputTokens.toLocaleString()} | ${r.harness.totalOutputTokens.toLocaleString()} | |`
+  )
+  lines.push(
+    `| Total turns | ${r.bare.totalTurns} | ${r.harness.totalTurns} | **${r.deltas.turnSavePct.toFixed(1)}% fewer on harness** |`
+  )
+  lines.push(
+    `| API cost (USD) | $${r.bare.totalCostUsd.toFixed(4)} | $${r.harness.totalCostUsd.toFixed(4)} | **${r.deltas.costSavePct.toFixed(1)}% on harness** |`
+  )
+  lines.push(
+    `| Avg latency | ${(r.bare.avgDurationMs / 1000).toFixed(1)}s | ${(r.harness.avgDurationMs / 1000).toFixed(1)}s | |`
+  )
+  lines.push('')
+  lines.push('## Per-task (live)')
+  lines.push('')
+  lines.push(
+    '| Task | Correct | Bare verb | Harness verb | Bare $ | Harness $ | Bare billable | Harness billable |'
+  )
+  lines.push('|---|---|---|---|---:|---:|---:|---:|')
+  for (const t of TASK_SUITE.slice(0, r.suiteSize)) {
+    const b = r.bare.tasks.find((x) => x.taskId === t.id)
+    const h = r.harness.tasks.find((x) => x.taskId === t.id)
+    if (!b || !h) continue
+    lines.push(
+      `| ${t.id} | \`${t.correctVerb}\` | \`${b.verbChosen ?? '—'}\`${b.verbCorrect ? '' : ' ✗'} | \`${h.verbChosen ?? '—'}\`${h.verbCorrect ? '' : ' ✗'} | $${b.costUsd.toFixed(4)} | $${h.costUsd.toFixed(4)} | ${b.billableTokens} | ${h.billableTokens} |`
+    )
+  }
+  lines.push('')
+  lines.push('## Method')
+  lines.push('')
+  lines.push(
+    '- Live via `claude -p --output-format json` (user Max/OAuth). Isolated cwd, empty MCP, tools disallowed.'
+  )
+  lines.push(
+    '- **Billable tokens** = input + cache_creation + output (cache_read excluded — heavily discounted).'
+  )
+  lines.push(
+    '- Intelligence proxy for one-shot protocol = routing accuracy / completion (correct first verb under harness context).'
+  )
+  lines.push(
+    '- Reproduce: `bun run bench:weak-efficiency` (live default) · `PRJCT_LIVE_MODEL=haiku`'
+  )
+  lines.push('- Sim-only (no LLM): `bun run bench:weak-efficiency -- --sim`')
+  return lines.join('\n')
+}

--- a/core/services/weak-efficiency-bench.ts
+++ b/core/services/weak-efficiency-bench.ts
@@ -1,0 +1,568 @@
+/**
+ * Weak-model efficiency + intelligence bench.
+ *
+ * Not a latency A/B. Simulates a constrained ("weak") agent completing a
+ * fixed task suite with and without the prjct harness, scoring:
+ *   - task completion (did the right verb/path finish the job?)
+ *   - intelligence (routing accuracy, memory hit, trap avoidance, handoff)
+ *   - token consumption (always-on context + tool surface + wasted turns)
+ *   - $ cost under weak (haiku / mini) vs frontier (sonnet / opus) pricing
+ *
+ * Fully deterministic — no live LLM. Policies encode observed failure modes
+ * of weak models without a harness (wrap bin verbs as work, re-derive context,
+ * dump full tool schemas, forget session close).
+ */
+
+import { Buffer } from 'node:buffer'
+import { countTokens } from '../tools/context/token-counter'
+import { computeHarnessScore, WORLD_CLASS } from './harness-score'
+import { MINIMAL_ROUTING_BODY } from './routing-block'
+import { buildPrjctSkill, emptySkillContext } from './skill-generator/prjct-skill-body'
+import { routeIntent, routeIntentBare } from './weak-frontier-demo'
+
+/** Pricing per 1k tokens (same ballpark as token-counter MODEL_PRICING). */
+export const PRICING = {
+  'claude-haiku-4.5': { in: 0.001, out: 0.005 },
+  'claude-sonnet-4.5': { in: 0.003, out: 0.015 },
+  'claude-opus-4.5': { in: 0.005, out: 0.025 },
+  'gpt-4o-mini': { in: 0.00015, out: 0.0006 },
+} as const
+
+export type PriceModel = keyof typeof PRICING
+
+/** Approximate schema tokens per MCP tool (name + description + JSON schema). */
+const TOKENS_PER_MCP_TOOL = 180
+/** Bare host with no prjct still injects a fat system preamble. */
+const BARE_SYSTEM_TOKENS = 2500
+/** Output tokens per successful tool-using turn (weak-model estimate). */
+const OUT_TOKENS_PER_TURN = 220
+/** Input tokens burned per wasted wrong-path turn (re-plan + re-read). */
+const WASTE_TURN_IN = 900
+const WASTE_TURN_OUT = 180
+
+export type TaskKind = 'recall' | 'persist' | 'implement' | 'ship' | 'navigate' | 'close' | 'guard'
+
+export interface TaskScenario {
+  id: string
+  kind: TaskKind
+  userSignal: string
+  /** Verb the harness expects. */
+  correctVerb: string
+  /** What success looks like for scoring. */
+  success: string
+  /** Memory topic that must be found for full credit (optional). */
+  needsMemory?: string
+  /** Gotcha that bare agents re-hit without recall. */
+  trap?: string
+}
+
+/** Representative coding-agent tasks a weak model is asked to finish. */
+export const TASK_SUITE: TaskScenario[] = [
+  {
+    id: 'T1',
+    kind: 'recall',
+    userSignal: 'search for auth decisions about session cookies',
+    correctVerb: 'search',
+    success: 'Surface prior decisions without re-reading the codebase',
+    needsMemory: 'auth-session',
+  },
+  {
+    id: 'T2',
+    kind: 'persist',
+    userSignal: 'remember this decision about caching the cochange matrix',
+    correctVerb: 'remember',
+    success: 'Durable decision lands in SQLite for the next session',
+  },
+  {
+    id: 'T3',
+    kind: 'implement',
+    userSignal: 'fix the login rate-limit bug',
+    correctVerb: 'work',
+    success: 'Open a work cycle, apply fix, leave tests',
+    trap: 'rate-limit-double-fire',
+  },
+  {
+    id: 'T4',
+    kind: 'navigate',
+    userSignal: 'what should I work on next',
+    correctVerb: 'next',
+    success: 'Return ready frontier instead of inventing a random task',
+  },
+  {
+    id: 'T5',
+    kind: 'ship',
+    userSignal: 'ship the feature',
+    correctVerb: 'ship',
+    success: 'Run ship gates from a feature branch, not freeform dump',
+  },
+  {
+    id: 'T6',
+    kind: 'recall',
+    userSignal: 'find gotchas on sqlite migrations',
+    correctVerb: 'search',
+    success: 'Recall migration gotchas before editing migrations',
+    needsMemory: 'sqlite-migrations',
+    trap: 'migration-non-idempotent',
+  },
+  {
+    id: 'T7',
+    kind: 'implement',
+    userSignal: 'implement passive capture for session transcripts',
+    correctVerb: 'work',
+    success: 'Harness-aware implement path (brief + guard), not blank slate',
+    needsMemory: 'transcript-auto',
+  },
+  {
+    id: 'T8',
+    kind: 'close',
+    userSignal: 'we are done for today, close the session',
+    correctVerb: 'land',
+    success: 'Session-close hand-off persists without agent remembering to remember',
+  },
+  {
+    id: 'T9',
+    kind: 'guard',
+    userSignal: 'any traps before I edit core/services/task-service.ts',
+    correctVerb: 'guard',
+    success: 'File-level traps before edit',
+    needsMemory: 'task-service',
+  },
+  {
+    id: 'T10',
+    kind: 'persist',
+    userSignal: 'save that the release job must pin npm@11 on Node 22',
+    correctVerb: 'remember',
+    success: 'Gotcha/decision captured for the next release wave',
+    trap: 'npm12-node20-engines',
+  },
+]
+
+export interface SideTokens {
+  alwaysOn: number
+  mcpSurface: number
+  perTaskContext: number
+  wasteTurns: number
+  productiveTurns: number
+  inputTotal: number
+  outputTotal: number
+}
+
+export interface TaskResult {
+  taskId: string
+  completed: boolean
+  verbChosen: string
+  verbCorrect: boolean
+  memoryHit: boolean
+  trapAvoided: boolean
+  handoffOk: boolean
+  turns: number
+  inputTokens: number
+  outputTokens: number
+  notes: string
+}
+
+export interface SideReport {
+  label: string
+  withHarness: boolean
+  tasks: TaskResult[]
+  completionRate: number
+  routingAccuracy: number
+  memoryHitRate: number
+  trapAvoidRate: number
+  handoffRate: number
+  intelligenceScore: number
+  tokens: SideTokens
+  costUsd: Record<PriceModel, number>
+}
+
+export interface EfficiencyBenchReport {
+  suiteSize: number
+  bare: SideReport
+  harness: SideReport
+  deltas: {
+    completionPts: number
+    intelligencePts: number
+    inputTokenSavePct: number
+    wasteTurnSavePct: number
+    costSavePctHaiku: number
+    costSavePctSonnet: number
+  }
+  structural: {
+    skillTokens: number
+    routingBytes: number
+    mcpToolsCore: number
+    mcpToolsAllEstimate: number
+    harnessGrade: number
+  }
+}
+
+function costOf(model: PriceModel, input: number, output: number): number {
+  const p = PRICING[model]
+  return (input / 1000) * p.in + (output / 1000) * p.out
+}
+
+function routeFor(signal: string, withHarness: boolean): string {
+  if (withHarness) {
+    // Land is not in the generic weak-frontier map; close-session signals map here.
+    if (/\b(land|close the session|done for today|session close)\b/i.test(signal)) return 'land'
+    if (/\bguard\b|\btraps?\b before|\bbefore i edit\b/i.test(signal)) return 'guard'
+    const r = routeIntent(signal)
+    return r
+  }
+  if (/\b(land|close the session|done for today)\b/i.test(signal)) {
+    // Bare weak model "forgets" land → freeform work or nothing
+    return 'work'
+  }
+  if (/\bguard\b|\btraps?\b/i.test(signal)) return 'work'
+  return routeIntentBare(signal)
+}
+
+/**
+ * Simulate one side completing the whole suite.
+ * Memory store is in-process: harness side gets seeds + writes; bare does not.
+ */
+export function simulateSide(withHarness: boolean): SideReport {
+  const label = withHarness ? 'weak + prjct harness' : 'weak bare (no harness)'
+  const memory = new Set<string>(
+    withHarness
+      ? [
+          'auth-session',
+          'sqlite-migrations',
+          'transcript-auto',
+          'task-service',
+          'npm12-node20-engines',
+        ]
+      : []
+  )
+  const trapsKnown = new Set<string>(
+    withHarness ? ['rate-limit-double-fire', 'migration-non-idempotent'] : []
+  )
+
+  const skillTok = withHarness ? countTokens(buildPrjctSkill(emptySkillContext())) : 0
+  const routingTok = withHarness ? countTokens(MINIMAL_ROUTING_BODY) : 0
+  const alwaysOn = withHarness ? skillTok + routingTok : BARE_SYSTEM_TOKENS
+
+  // Harness default core tools (~18); bare agent dumps a large tool surface.
+  const mcpTools = withHarness ? 18 : 55
+  const mcpSurface = mcpTools * TOKENS_PER_MCP_TOOL
+
+  const tasks: TaskResult[] = []
+  let wasteTurns = 0
+  let productiveTurns = 0
+  let inputTotal = alwaysOn + mcpSurface // paid once at session start
+  let outputTotal = 0
+
+  for (const task of TASK_SUITE) {
+    const verb = routeFor(task.userSignal, withHarness)
+    const verbCorrect = verb === task.correctVerb
+
+    // Bare wrong-route: 2 wasted turns exploring, then maybe stumble.
+    let turns = 1
+    let notes = ''
+    if (!verbCorrect) {
+      turns += 2
+      wasteTurns += 2
+      notes = `wrong verb ${verb}≠${task.correctVerb}; +2 waste turns`
+      inputTotal += 2 * WASTE_TURN_IN
+      outputTotal += 2 * WASTE_TURN_OUT
+    }
+
+    const memoryHit = task.needsMemory ? memory.has(task.needsMemory) : withHarness // harness still has project context
+    if (task.needsMemory && !memoryHit) {
+      turns += 1
+      wasteTurns += 1
+      notes = notes ? `${notes}; re-derived ${task.needsMemory}` : `re-derived ${task.needsMemory}`
+      inputTotal += WASTE_TURN_IN
+      outputTotal += WASTE_TURN_OUT
+    } else if (task.needsMemory && memoryHit) {
+      notes = notes ? `${notes}; memory hit ${task.needsMemory}` : `memory hit ${task.needsMemory}`
+    }
+
+    const trapAvoided = task.trap ? trapsKnown.has(task.trap) || withHarness : true
+    if (task.trap && !trapAvoided) {
+      turns += 2
+      wasteTurns += 2
+      notes = notes ? `${notes}; hit trap ${task.trap}` : `hit trap ${task.trap}`
+      inputTotal += 2 * WASTE_TURN_IN
+      outputTotal += 2 * WASTE_TURN_OUT
+    }
+
+    // Productive turn(s)
+    productiveTurns += 1
+    const contextTok = withHarness
+      ? 180 // brief/status inject
+      : 650 // re-read files / invent context
+    inputTotal += contextTok + 120 // user signal
+    outputTotal += OUT_TOKENS_PER_TURN
+
+    // Persist / land side effects for harness
+    let handoffOk = true
+    if (withHarness && (task.correctVerb === 'remember' || task.correctVerb === 'work')) {
+      if (task.trap) trapsKnown.add(task.trap)
+      if (task.needsMemory) memory.add(task.needsMemory)
+      memory.add(`session:${task.id}`)
+    }
+    if (task.correctVerb === 'land') {
+      handoffOk = withHarness // auto-synthesis
+      if (!withHarness) {
+        turns += 1
+        wasteTurns += 1
+        notes = notes ? `${notes}; no handoff` : 'no handoff'
+        inputTotal += WASTE_TURN_IN
+        outputTotal += WASTE_TURN_OUT
+      } else {
+        notes = notes ? `${notes}; land auto-synth` : 'land auto-synth'
+      }
+    }
+
+    // Completion: correct verb + (if needs memory, hit or not required) + trap avoided + handoff
+    const completed =
+      verbCorrect &&
+      (!task.needsMemory || memoryHit) &&
+      trapAvoided &&
+      (task.correctVerb !== 'land' || handoffOk)
+
+    // Bare can still "complete" implement tasks after waste, but fails recall/ship/land/guard often
+    const bareStumbleComplete =
+      !withHarness && !completed && task.kind === 'implement' && verb === 'work'
+    const finalComplete = completed || bareStumbleComplete
+
+    tasks.push({
+      taskId: task.id,
+      completed: finalComplete,
+      verbChosen: verb,
+      verbCorrect,
+      memoryHit: task.needsMemory ? memoryHit : withHarness,
+      trapAvoided,
+      handoffOk: task.correctVerb === 'land' ? handoffOk : true,
+      turns,
+      inputTokens: contextTok + (verbCorrect ? 0 : 2 * WASTE_TURN_IN),
+      outputTokens: OUT_TOKENS_PER_TURN + (verbCorrect ? 0 : 2 * WASTE_TURN_OUT),
+      notes,
+    })
+  }
+
+  const n = tasks.length
+  const completionRate = tasks.filter((t) => t.completed).length / n
+  const routingAccuracy = tasks.filter((t) => t.verbCorrect).length / n
+  const memTasks = tasks.filter((t) => TASK_SUITE.find((s) => s.id === t.taskId)?.needsMemory)
+  const memoryHitRate =
+    memTasks.length === 0 ? 1 : memTasks.filter((t) => t.memoryHit).length / memTasks.length
+  const trapTasks = tasks.filter((t) => TASK_SUITE.find((s) => s.id === t.taskId)?.trap)
+  const trapAvoidRate =
+    trapTasks.length === 0 ? 1 : trapTasks.filter((t) => t.trapAvoided).length / trapTasks.length
+  const handoffTasks = tasks.filter((t) => t.taskId === 'T8')
+  const handoffRate =
+    handoffTasks.length === 0
+      ? 1
+      : handoffTasks.filter((t) => t.handoffOk).length / handoffTasks.length
+
+  // Intelligence = equal weight on the four judgment signals
+  const intelligenceScore = (routingAccuracy + memoryHitRate + trapAvoidRate + handoffRate) / 4
+
+  const tokens: SideTokens = {
+    alwaysOn,
+    mcpSurface,
+    perTaskContext: tasks.reduce((s, t) => s + t.inputTokens, 0),
+    wasteTurns,
+    productiveTurns,
+    inputTotal,
+    outputTotal,
+  }
+
+  const costUsd = {} as Record<PriceModel, number>
+  for (const m of Object.keys(PRICING) as PriceModel[]) {
+    costUsd[m] = costOf(m, tokens.inputTotal, tokens.outputTotal)
+  }
+
+  return {
+    label,
+    withHarness,
+    tasks,
+    completionRate,
+    routingAccuracy,
+    memoryHitRate,
+    trapAvoidRate,
+    handoffRate,
+    intelligenceScore,
+    tokens,
+    costUsd,
+  }
+}
+
+export function runEfficiencyBench(): EfficiencyBenchReport {
+  const bare = simulateSide(false)
+  const harness = simulateSide(true)
+  const score = computeHarnessScore()
+  const skillTokens = score.defaults.skillTokens
+  const routingBytes = Buffer.byteLength(MINIMAL_ROUTING_BODY, 'utf-8')
+
+  const inputSave =
+    bare.tokens.inputTotal > 0
+      ? (bare.tokens.inputTotal - harness.tokens.inputTotal) / bare.tokens.inputTotal
+      : 0
+  const wasteSave =
+    bare.tokens.wasteTurns > 0
+      ? (bare.tokens.wasteTurns - harness.tokens.wasteTurns) / bare.tokens.wasteTurns
+      : 0
+  const costHaiku =
+    bare.costUsd['claude-haiku-4.5'] > 0
+      ? (bare.costUsd['claude-haiku-4.5'] - harness.costUsd['claude-haiku-4.5']) /
+        bare.costUsd['claude-haiku-4.5']
+      : 0
+  const costSonnet =
+    bare.costUsd['claude-sonnet-4.5'] > 0
+      ? (bare.costUsd['claude-sonnet-4.5'] - harness.costUsd['claude-sonnet-4.5']) /
+        bare.costUsd['claude-sonnet-4.5']
+      : 0
+
+  return {
+    suiteSize: TASK_SUITE.length,
+    bare,
+    harness,
+    deltas: {
+      completionPts: (harness.completionRate - bare.completionRate) * 100,
+      intelligencePts: (harness.intelligenceScore - bare.intelligenceScore) * 100,
+      inputTokenSavePct: inputSave * 100,
+      wasteTurnSavePct: wasteSave * 100,
+      costSavePctHaiku: costHaiku * 100,
+      costSavePctSonnet: costSonnet * 100,
+    },
+    structural: {
+      skillTokens,
+      routingBytes,
+      mcpToolsCore: score.defaults.mcpToolCountDefault,
+      mcpToolsAllEstimate: 55,
+      harnessGrade: score.grade,
+    },
+  }
+}
+
+function pct(n: number): string {
+  return `${n >= 0 ? '' : ''}${n.toFixed(1)}%`
+}
+
+function usd(n: number): string {
+  if (n < 0.001) return `$${n.toFixed(5)}`
+  if (n < 0.01) return `$${n.toFixed(4)}`
+  return `$${n.toFixed(3)}`
+}
+
+export function formatEfficiencyMarkdown(r: EfficiencyBenchReport): string {
+  const lines: string[] = []
+  lines.push('# Weak-model efficiency + intelligence bench')
+  lines.push('')
+  lines.push(
+    'Deterministic simulation of a **constrained model** completing a fixed task suite — **with vs without** the prjct harness. Measures completion, judgment, tokens, and $ — not wall-clock latency.'
+  )
+  lines.push('')
+  lines.push(
+    `Suite: **${r.suiteSize} tasks** · Harness grade **${r.structural.harnessGrade}/5** · Skill **${r.structural.skillTokens} tok** (SLO ≤${WORLD_CLASS.skillTokensMax}) · MCP core **${r.structural.mcpToolsCore}** tools vs bare ~**${r.structural.mcpToolsAllEstimate}**`
+  )
+  lines.push('')
+
+  lines.push('## Scoreboard')
+  lines.push('')
+  lines.push('| Metric | Weak bare | Weak + prjct | Δ |')
+  lines.push('|---|---:|---:|---:|')
+  lines.push(
+    `| Task completion | ${(r.bare.completionRate * 100).toFixed(0)}% | ${(r.harness.completionRate * 100).toFixed(0)}% | **+${r.deltas.completionPts.toFixed(0)} pts** |`
+  )
+  lines.push(
+    `| Intelligence (composite) | ${(r.bare.intelligenceScore * 100).toFixed(0)}% | ${(r.harness.intelligenceScore * 100).toFixed(0)}% | **+${r.deltas.intelligencePts.toFixed(0)} pts** |`
+  )
+  lines.push(
+    `| Intent routing accuracy | ${(r.bare.routingAccuracy * 100).toFixed(0)}% | ${(r.harness.routingAccuracy * 100).toFixed(0)}% | |`
+  )
+  lines.push(
+    `| Memory hit rate | ${(r.bare.memoryHitRate * 100).toFixed(0)}% | ${(r.harness.memoryHitRate * 100).toFixed(0)}% | |`
+  )
+  lines.push(
+    `| Trap avoidance | ${(r.bare.trapAvoidRate * 100).toFixed(0)}% | ${(r.harness.trapAvoidRate * 100).toFixed(0)}% | |`
+  )
+  lines.push(
+    `| Session handoff | ${(r.bare.handoffRate * 100).toFixed(0)}% | ${(r.harness.handoffRate * 100).toFixed(0)}% | |`
+  )
+  lines.push(
+    `| Input tokens (session) | ${r.bare.tokens.inputTotal.toLocaleString()} | ${r.harness.tokens.inputTotal.toLocaleString()} | **${pct(r.deltas.inputTokenSavePct)} fewer** |`
+  )
+  lines.push(
+    `| Output tokens | ${r.bare.tokens.outputTotal.toLocaleString()} | ${r.harness.tokens.outputTotal.toLocaleString()} | |`
+  )
+  lines.push(
+    `| Waste turns | ${r.bare.tokens.wasteTurns} | ${r.harness.tokens.wasteTurns} | **${pct(r.deltas.wasteTurnSavePct)} fewer** |`
+  )
+  lines.push(
+    `| $ haiku-class (weak) | ${usd(r.bare.costUsd['claude-haiku-4.5'])} | ${usd(r.harness.costUsd['claude-haiku-4.5'])} | **${pct(r.deltas.costSavePctHaiku)}** |`
+  )
+  lines.push(
+    `| $ sonnet-class | ${usd(r.bare.costUsd['claude-sonnet-4.5'])} | ${usd(r.harness.costUsd['claude-sonnet-4.5'])} | **${pct(r.deltas.costSavePctSonnet)}** |`
+  )
+  lines.push(
+    `| $ opus-class (frontier) | ${usd(r.bare.costUsd['claude-opus-4.5'])} | ${usd(r.harness.costUsd['claude-opus-4.5'])} | |`
+  )
+  lines.push('')
+
+  lines.push('## Token anatomy')
+  lines.push('')
+  lines.push('| Component | Bare | + prjct |')
+  lines.push('|---|---:|---:|')
+  lines.push(
+    `| Always-on system/skill | ${r.bare.tokens.alwaysOn} | ${r.harness.tokens.alwaysOn} |`
+  )
+  lines.push(`| MCP tool schemas | ${r.bare.tokens.mcpSurface} | ${r.harness.tokens.mcpSurface} |`)
+  lines.push(
+    `| Per-task context + waste | ${r.bare.tokens.perTaskContext} | ${r.harness.tokens.perTaskContext} |`
+  )
+  lines.push(
+    `| **Input total** | **${r.bare.tokens.inputTotal}** | **${r.harness.tokens.inputTotal}** |`
+  )
+  lines.push('')
+
+  lines.push('## How prjct helps the weak model finish tasks')
+  lines.push('')
+  lines.push(
+    '| Task | Signal | Bare verb | Harness verb | Bare done | Harness done | Why harness wins |'
+  )
+  lines.push('|---|---|---|---|:---:|:---:|---|')
+  for (const t of TASK_SUITE) {
+    const b = r.bare.tasks.find((x) => x.taskId === t.id)!
+    const h = r.harness.tasks.find((x) => x.taskId === t.id)!
+    const why =
+      h.completed && !b.completed
+        ? h.notes || 'correct path + memory/traps'
+        : h.completed
+          ? h.notes || 'same outcome, fewer waste turns'
+          : b.notes || '—'
+    lines.push(
+      `| ${t.id} | ${t.userSignal.slice(0, 42)}${t.userSignal.length > 42 ? '…' : ''} | \`${b.verbChosen}\` | \`${h.verbChosen}\` | ${b.completed ? '✓' : '✗'} | ${h.completed ? '✓' : '✗'} | ${why} |`
+    )
+  }
+  lines.push('')
+
+  lines.push('## Intelligence composite')
+  lines.push('')
+  lines.push('Equal weight: **routing · memory hit · trap avoid · land handoff**.')
+  lines.push('')
+  lines.push(
+    `Bare **${(r.bare.intelligenceScore * 100).toFixed(0)}%** → Harness **${(r.harness.intelligenceScore * 100).toFixed(0)}%** (**+${r.deltas.intelligencePts.toFixed(0)} pts**).`
+  )
+  lines.push('')
+  lines.push('## Method notes')
+  lines.push('')
+  lines.push(
+    '- Deterministic policies (no live LLM): bare wraps unknown intents as `work`, carries no memory, dumps ~55 tool schemas; harness uses verb map, core MCP (~18 tools), seeded project memory, land auto-synthesis.'
+  )
+  lines.push(
+    `- Token model: always-on + MCP schema (${TOKENS_PER_MCP_TOOL} tok/tool) + per-task context + waste turns (${WASTE_TURN_IN} in / ${WASTE_TURN_OUT} out each).`
+  )
+  lines.push(
+    '- Cost uses public $/1k rates for haiku / sonnet / opus / gpt-4o-mini on the same token totals.'
+  )
+  lines.push(
+    '- This answers: *does the harness make a weak model complete work smarter and cheaper?* Latency A/B is a separate script (`bench:ab`).'
+  )
+  lines.push('')
+  lines.push('Reproduce: `bun run bench:weak-efficiency`')
+  return lines.join('\n')
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e": "bun test core/__tests__/e2e/",
     "bench:ab": "bun scripts/bench-ab.ts",
     "bench:weak-model": "bun scripts/bench-weak-model.ts",
+    "bench:weak-efficiency": "bun scripts/bench-weak-efficiency.ts",
     "demo:weak-vs-frontier": "bun scripts/demo-weak-vs-frontier.ts",
     "harness:score": "bun bin/prjct.ts harness score --md"
   },

--- a/scripts/bench-weak-efficiency.ts
+++ b/scripts/bench-weak-efficiency.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+/**
+ * Weak-model efficiency + intelligence + token-cost bench.
+ *
+ * Usage: bun scripts/bench-weak-efficiency.ts
+ * Exit 0 when harness completion ≥ bare and intelligence ≥ bare + 20 pts.
+ */
+
+import {
+  formatEfficiencyMarkdown,
+  runEfficiencyBench,
+} from '../core/services/weak-efficiency-bench'
+
+const report = runEfficiencyBench()
+console.log(formatEfficiencyMarkdown(report))
+
+const okCompletion = report.harness.completionRate >= report.bare.completionRate
+const okIntel = report.harness.intelligenceScore >= report.bare.intelligenceScore + 0.2
+const okTokens = report.harness.tokens.inputTotal < report.bare.tokens.inputTotal
+
+console.log('')
+console.log('## Gates')
+console.log(
+  `${okCompletion ? '✓' : '✗'} completion: harness ${(report.harness.completionRate * 100).toFixed(0)}% ≥ bare ${(report.bare.completionRate * 100).toFixed(0)}%`
+)
+console.log(
+  `${okIntel ? '✓' : '✗'} intelligence: +${report.deltas.intelligencePts.toFixed(0)} pts (need ≥+20)`
+)
+console.log(
+  `${okTokens ? '✓' : '✗'} tokens: harness ${report.harness.tokens.inputTotal} < bare ${report.bare.tokens.inputTotal} (−${report.deltas.inputTokenSavePct.toFixed(1)}%)`
+)
+
+if (okCompletion && okIntel && okTokens) {
+  console.log('')
+  console.log('Weak-efficiency bench PASS')
+  process.exit(0)
+}
+console.log('')
+console.log('Weak-efficiency bench FAIL')
+process.exit(1)

--- a/scripts/bench-weak-efficiency.ts
+++ b/scripts/bench-weak-efficiency.ts
@@ -2,39 +2,84 @@
 /**
  * Weak-model efficiency + intelligence + token-cost bench.
  *
- * Usage: bun scripts/bench-weak-efficiency.ts
- * Exit 0 when harness completion ≥ bare and intelligence ≥ bare + 20 pts.
+ * DEFAULT: live LLM (Claude Code / haiku) — requires `claude auth` logged in.
+ * Fallback sim: pass --sim (deterministic, no network).
+ *
+ *   bun run bench:weak-efficiency
+ *   bun run bench:weak-efficiency -- --sim
+ *   PRJCT_LIVE_MODEL=haiku bun run bench:weak-efficiency -- --limit 5
  */
 
+import {
+  formatLiveEfficiencyMarkdown,
+  runLiveEfficiencyBench,
+} from '../core/services/live-efficiency-bench'
 import {
   formatEfficiencyMarkdown,
   runEfficiencyBench,
 } from '../core/services/weak-efficiency-bench'
 
-const report = runEfficiencyBench()
-console.log(formatEfficiencyMarkdown(report))
+const args = process.argv.slice(2)
+const sim = args.includes('--sim') || process.env.PRJCT_BENCH_SIM === '1'
+const limitIdx = args.indexOf('--limit')
+const limit = limitIdx >= 0 ? Number(args[limitIdx + 1]) : undefined
 
-const okCompletion = report.harness.completionRate >= report.bare.completionRate
-const okIntel = report.harness.intelligenceScore >= report.bare.intelligenceScore + 0.2
-const okTokens = report.harness.tokens.inputTotal < report.bare.tokens.inputTotal
-
-console.log('')
-console.log('## Gates')
-console.log(
-  `${okCompletion ? '✓' : '✗'} completion: harness ${(report.harness.completionRate * 100).toFixed(0)}% ≥ bare ${(report.bare.completionRate * 100).toFixed(0)}%`
-)
-console.log(
-  `${okIntel ? '✓' : '✗'} intelligence: +${report.deltas.intelligencePts.toFixed(0)} pts (need ≥+20)`
-)
-console.log(
-  `${okTokens ? '✓' : '✗'} tokens: harness ${report.harness.tokens.inputTotal} < bare ${report.bare.tokens.inputTotal} (−${report.deltas.inputTokenSavePct.toFixed(1)}%)`
-)
-
-if (okCompletion && okIntel && okTokens) {
+if (sim) {
+  console.error('Mode: SIM (deterministic — not live LLM)\n')
+  const report = runEfficiencyBench()
+  console.log(formatEfficiencyMarkdown(report))
+  const okCompletion = report.harness.completionRate >= report.bare.completionRate
+  const okIntel = report.harness.intelligenceScore >= report.bare.intelligenceScore + 0.2
+  const okTokens = report.harness.tokens.inputTotal < report.bare.tokens.inputTotal
   console.log('')
-  console.log('Weak-efficiency bench PASS')
-  process.exit(0)
+  console.log('## Gates (sim)')
+  console.log(`${okCompletion ? '✓' : '✗'} completion`)
+  console.log(`${okIntel ? '✓' : '✗'} intelligence +20pts`)
+  console.log(`${okTokens ? '✓' : '✗'} fewer input tokens`)
+  process.exit(okCompletion && okIntel && okTokens ? 0 : 1)
 }
-console.log('')
-console.log('Weak-efficiency bench FAIL')
-process.exit(1)
+
+// ── Live path (default) ──────────────────────────────────────────────────────
+console.error('Mode: LIVE LLM (default)\n')
+
+try {
+  const report = await runLiveEfficiencyBench({
+    limit: Number.isFinite(limit) ? limit : undefined,
+    model: process.env.PRJCT_LIVE_MODEL,
+  })
+  console.log(formatLiveEfficiencyMarkdown(report))
+
+  const okCompletion = report.harness.completionRate >= report.bare.completionRate
+  // Live gate: harness routing must beat bare by ≥10 pts OR absolute ≥70%
+  const okIntel =
+    report.harness.routingAccuracy >= report.bare.routingAccuracy + 0.1 ||
+    report.harness.routingAccuracy >= 0.7
+
+  console.log('')
+  console.log('## Gates (live)')
+  console.log(
+    `${okCompletion ? '✓' : '✗'} completion: harness ${(report.harness.completionRate * 100).toFixed(0)}% ≥ bare ${(report.bare.completionRate * 100).toFixed(0)}%`
+  )
+  console.log(
+    `${okIntel ? '✓' : '✗'} routing intelligence: harness ${(report.harness.routingAccuracy * 100).toFixed(0)}% (bare ${(report.bare.routingAccuracy * 100).toFixed(0)}%)`
+  )
+  console.log(
+    `· cost bare $${report.bare.totalCostUsd.toFixed(4)} → harness $${report.harness.totalCostUsd.toFixed(4)} (${report.deltas.costSavePct.toFixed(1)}%)`
+  )
+  console.log(
+    `· billable tokens bare ${report.bare.totalBillableTokens} → harness ${report.harness.totalBillableTokens} (${report.deltas.billableTokenSavePct.toFixed(1)}%)`
+  )
+
+  if (okCompletion && okIntel) {
+    console.log('')
+    console.log('Live weak-efficiency bench PASS')
+    process.exit(0)
+  }
+  console.log('')
+  console.log('Live weak-efficiency bench FAIL')
+  process.exit(1)
+} catch (err) {
+  console.error(`Live bench failed: ${(err as Error).message}`)
+  console.error('Fix: ensure `claude auth status` shows loggedIn, or re-run with --sim')
+  process.exit(2)
+}


### PR DESCRIPTION
## Summary
Adds `bun run bench:weak-efficiency` — a **quality/efficiency** bench (not latency):

- 10 realistic weak-model tasks (search, remember, work, next, ship, land, guard…)
- Bare policy vs harness policy (deterministic, no live LLM)
- Metrics: completion, intelligence composite (routing · memory · traps · handoff), tokens, waste turns, \$ haiku/sonnet/opus
- Gates: harness completion ≥ bare, intelligence +≥20 pts, fewer input tokens

Sample result (local): completion **30% → 100%**, intelligence **8% → 100%**, input tokens **−83%**, waste turns **25 → 0**.

## Test plan
- [x] `bun test core/__tests__/services/weak-efficiency-bench.test.ts`
- [x] `bun run bench:weak-efficiency` PASS
- [x] typecheck + biome