### PR TITLE
feat(harness): deeper project+developer model that applies without pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [3.33.0] - 2026-07-09
+
 ### Added
+- deeper understanding
 - xAI Grok Build CLI compatibility (agent-runtime-registry)
 
 ## [3.32.0] - 2026-07-09
@@ -10,7 +13,6 @@
 ### Features
 
 - passive capture v2, land auto-synthesis, weak-vs-frontier demo (#528)
-
 
 ## [3.31.0] - 2026-07-09
 
@@ -22,13 +24,11 @@
 
 - Node 22 + pin npm@11 so publish is not blocked by engines (#527)
 
-
 ## [3.30.0] - 2026-07-09
 
 ### Features
 
 - xAI Grok Build CLI compatibility (#525)
-
 
 ## [3.29.1] - 2026-07-06
 

--- a/core/__tests__/hooks/session-start.test.ts
+++ b/core/__tests__/hooks/session-start.test.ts
@@ -231,6 +231,19 @@ describe('SessionStart hook — knowledge digest (cold-start only)', () => {
     expect(ctx).toContain('prjct_developer')
     expect(ctx).toContain('prjct search')
   })
+
+  test('digest pushes developer rules so cold-start acts as the developer', async () => {
+    await freshProject({ role: 'DEV' })
+    insertMemory(
+      'feedback',
+      'Memory content MUST be authored in English, regardless of conversation language.'
+    )
+    const ctx = await buildSessionContext(projectPath, null, { digest: true })
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('How this developer works')
+    expect(ctx).toContain('English')
+    expect(ctx).toContain('prjct_developer')
+  })
 })
 
 describe('SessionStart hook — digest slots are proven-first (usefulness rerank)', () => {

--- a/core/__tests__/memory/enriched-recall.test.ts
+++ b/core/__tests__/memory/enriched-recall.test.ts
@@ -56,7 +56,7 @@ describe('enrichedRecall', () => {
 
   it('drops machine-telemetry noise from the RAG (clean recall, 12k retrocompat)', async () => {
     write('decision', 'use bun for everything')
-    write('improvement-signal', 'no, así no')
+    write('improvement-signal', 'no, not that way')
     write('learning', 'file churns a lot', { pattern: 'hot-file' })
     const got = await enrichedRecall(projectPath, projectId, { limit: 10 })
     const types = got.map((e) => e.type)
@@ -66,7 +66,7 @@ describe('enrichedRecall', () => {
   })
 
   it('still returns noise when the caller EXPLICITLY asks for that type', async () => {
-    write('improvement-signal', 'no, así no')
+    write('improvement-signal', 'no, not that way')
     const got = await enrichedRecall(projectPath, projectId, {
       types: ['improvement-signal'],
       limit: 10,

--- a/core/__tests__/services/developer-profile.test.ts
+++ b/core/__tests__/services/developer-profile.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'bun:test'
 import type { MemoryEntry } from '../../memory/entries'
-import { buildDeveloperProfile } from '../../services/developer-profile'
+import { buildDeveloperProfile, extractDeveloperRules } from '../../services/developer-profile'
 
 function entry(
   id: string,
@@ -49,11 +49,13 @@ describe('buildDeveloperProfile', () => {
     ])
     expect(out).not.toBeNull()
     expect(out).toContain('# Developer profile')
+    expect(out).toContain('## Act as this developer')
     expect(out).toContain('## Preferences & guidance')
     expect(out).toContain('English')
+    expect(out).toContain('## Working principles')
+    expect(out).toContain('Check existing dependency policy')
     expect(out).toContain('## Friction history')
     expect(out).toContain('Confirm dependency constraints before adding packages.')
-    expect(out).toContain('Check existing dependency policy')
     expect(out).toContain('`mem_1`')
     expect(out).not.toContain('unrelated decision')
   })
@@ -72,14 +74,45 @@ describe('buildDeveloperProfile', () => {
   it('omits the friction section when there is no friction signal', () => {
     const out = buildDeveloperProfile([entry('mem_1', 'feedback', 'ship as minor')])
     expect(out).toContain('## Preferences & guidance')
+    expect(out).toContain('## Act as this developer')
     expect(out).not.toContain('## Friction history')
+    expect(out).not.toContain('## Working principles')
   })
 
   it('ignores improvement-signals that are not from the friction detector', () => {
     const out = buildDeveloperProfile([
-      entry('mem_1', 'feedback', 'a rule'),
+      entry('mem_1', 'feedback', 'a standing preference rule here'),
       entry('mem_2', 'improvement-signal', 'skill-miss noise', { source: 'skill-miss-detector' }),
     ])
     expect(out).not.toContain('## Friction history')
+    expect(out).not.toContain('skill-miss noise')
+  })
+})
+
+describe('extractDeveloperRules', () => {
+  it('prefers explicit feedback over friction, dedupes, and caps', () => {
+    const rules = extractDeveloperRules(
+      [
+        entry('mem_1', 'feedback', 'Always author memory content in English.'),
+        entry('mem_2', 'feedback', 'Always author memory content in English.'),
+        entry(
+          'mem_3',
+          'improvement-signal',
+          '[negation] Lesson: Stop adding features without a quality gate.\nNext action: Deepen existing loops before shipping new surface.',
+          { source: 'friction-detector' }
+        ),
+        entry('mem_4', 'decision', 'ignore me'),
+      ],
+      4
+    )
+    expect(rules.length).toBe(2)
+    expect(rules[0]!.kind).toBe('preference')
+    expect(rules[0]!.rule).toContain('English')
+    expect(rules[1]!.kind).toBe('friction')
+    expect(rules[1]!.rule).toContain('Deepen existing loops')
+  })
+
+  it('returns empty when nothing is distillable', () => {
+    expect(extractDeveloperRules([entry('mem_1', 'decision', 'sqlite only')])).toEqual([])
   })
 })

--- a/core/__tests__/services/friction-detector.test.ts
+++ b/core/__tests__/services/friction-detector.test.ts
@@ -1,32 +1,29 @@
 /**
  * Friction detector — extracts user-pushback signals from a Claude
  * Code session transcript. Tests pin: classifier coverage,
- * idempotent dedup, language-agnostic markers, conservative cap.
+ * idempotent dedup, English markers, conservative cap.
  */
 
 import { describe, expect, it } from 'bun:test'
 import { _internal } from '../../services/friction-detector'
 
 describe('friction-detector classify', () => {
-  it('flags negation markers (es + en)', () => {
-    expect(_internal.classify('no, así no es')).toBe('negation')
+  it('flags negation markers', () => {
+    expect(_internal.classify('no, that is wrong')).toBe('negation')
     expect(_internal.classify('No. that is wrong')).toBe('negation')
-    expect(_internal.classify('así no')).toBe('negation')
-    expect(_internal.classify('espera, déjame ver')).toBe('negation')
     expect(_internal.classify('stop please')).toBe('negation')
     expect(_internal.classify('wait — ')).toBe('negation')
+    expect(_internal.classify('cancel that')).toBe('negation')
   })
 
   it('flags correction markers', () => {
     expect(_internal.classify('that should be feat: not fix:')).toBe('correction')
     expect(_internal.classify('rather than X, try Y')).toBe('correction')
-    expect(_internal.classify('en realidad lo que necesito es')).toBe('correction')
     expect(_internal.classify('use Y instead of X')).toBe('correction')
   })
 
   it('flags complaint markers', () => {
     expect(_internal.classify("doesn't work")).toBe('complaint')
-    expect(_internal.classify('no funciona el comando')).toBe('complaint')
     expect(_internal.classify('this is broken')).toBe('complaint')
   })
 
@@ -42,7 +39,7 @@ describe('friction-detector parseJsonl + extractSignals', () => {
     const lines = _internal.parseJsonl(
       [
         JSON.stringify({ role: 'assistant', content: "I'll run prjct ship now." }),
-        JSON.stringify({ role: 'user', content: 'no, primero corramos los tests' }),
+        JSON.stringify({ role: 'user', content: 'no, run the tests first' }),
       ].join('\n')
     )
     const signals = _internal.extractSignals(lines)
@@ -90,7 +87,7 @@ describe('friction-detector parseJsonl + extractSignals', () => {
   it('formats friction as a structured lesson instead of a raw quote lead', () => {
     const signal = {
       category: 'negation' as const,
-      excerpt: 'no, primero corramos los tests',
+      excerpt: 'no, run the tests first',
       precedingAssistantPreview: "I'll run prjct ship now.",
     }
     const formatted = _internal.formatSignal(signal)
@@ -102,7 +99,7 @@ describe('friction-detector parseJsonl + extractSignals', () => {
     expect(formatted).toContain('Anti-pattern:')
     expect(formatted).toContain('Next action:')
     expect(formatted).not.toContain('Evidence:')
-    expect(formatted).not.toContain('no, primero corramos los tests')
+    expect(formatted).not.toContain('no, run the tests first')
     expect(formatted).not.toContain("I'll run prjct ship now.")
     expect(formatted).not.toStartWith('[negation] User pushback:')
   })

--- a/core/__tests__/services/land-synthesis.test.ts
+++ b/core/__tests__/services/land-synthesis.test.ts
@@ -16,7 +16,7 @@ describe('land-synthesis — buildLandHandoffContent', () => {
     expect(out).toBeNull()
   })
 
-  test('synthesizes living-context fields from an open cycle alone', () => {
+  test('synthesizes dense living-context fields from an open cycle alone', () => {
     const out = buildLandHandoffContent({
       projectId: 'no-such-project-land-test',
       projectPath: '/tmp/does-not-exist-land-synth',
@@ -36,6 +36,9 @@ describe('land-synthesis — buildLandHandoffContent', () => {
     expect(out!).toContain('fix release engines')
     expect(out!).toContain('Token usage: in=100 out=50')
     expect(out!).toContain('Model: test-model')
+    // Dense hand-off: never spam empty placeholders.
+    expect(out!).not.toContain('Sentiment: unknown')
+    expect(out!).not.toContain('Related files: unknown')
     // Must not instruct the agent to run remember — we already did the hand-off.
     expect(out!).not.toContain('prjct remember context')
   })

--- a/core/__tests__/services/transcript-learner.test.ts
+++ b/core/__tests__/services/transcript-learner.test.ts
@@ -14,6 +14,7 @@ import { _internal } from '../../services/transcript-learner'
 const {
   parseTranscript,
   extractCandidates,
+  extractUserPreferenceCandidates,
   hashContent,
   PHRASE_TYPE_MAP,
   classifyCaptureParagraph,
@@ -188,6 +189,44 @@ describe('transcript-learner — extractCandidates', () => {
     const out = extractCandidates(decisions)
     expect(out.length).toBeLessThanOrEqual(12)
     expect(out.length).toBe(12)
+  })
+})
+
+describe('transcript-learner — extractUserPreferenceCandidates', () => {
+  test('captures standing always/never rules as feedback', () => {
+    const out = extractUserPreferenceCandidates([
+      {
+        role: 'user',
+        text: 'Always author memory content in English regardless of the conversation language.',
+      },
+      {
+        role: 'user',
+        text: 'Never write exploits or attack any system regardless of ownership.',
+      },
+    ])
+    expect(out.length).toBe(2)
+    expect(out.every((c) => c.type === 'feedback')).toBe(true)
+    expect(out[0]!.matchedPhrase).toBe('user:always')
+    expect(out[1]!.matchedPhrase).toBe('user:never')
+  })
+
+  test('captures Spanish prefiero / siempre', () => {
+    const out = extractUserPreferenceCandidates([
+      {
+        role: 'user',
+        text: 'Prefiero que profundices lo existente antes de inventar features nuevas.',
+      },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0]!.type).toBe('feedback')
+    expect(out[0]!.matchedPhrase).toBe('user:prefiero')
+  })
+
+  test('ignores ordinary user chat without preference markers', () => {
+    const out = extractUserPreferenceCandidates([
+      { role: 'user', text: 'can you fix the release engines issue on main please?' },
+    ])
+    expect(out).toHaveLength(0)
   })
 })
 

--- a/core/__tests__/services/transcript-learner.test.ts
+++ b/core/__tests__/services/transcript-learner.test.ts
@@ -210,16 +210,16 @@ describe('transcript-learner — extractUserPreferenceCandidates', () => {
     expect(out[1]!.matchedPhrase).toBe('user:never')
   })
 
-  test('captures Spanish prefiero / siempre', () => {
+  test('captures explicit preference: lines as feedback', () => {
     const out = extractUserPreferenceCandidates([
       {
         role: 'user',
-        text: 'Prefiero que profundices lo existente antes de inventar features nuevas.',
+        text: 'Preference: deepen existing loops before inventing new surface.',
       },
     ])
     expect(out).toHaveLength(1)
     expect(out[0]!.type).toBe('feedback')
-    expect(out[0]!.matchedPhrase).toBe('user:prefiero')
+    expect(out[0]!.matchedPhrase).toBe('user:rule')
   })
 
   test('ignores ordinary user chat without preference markers', () => {

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -36,6 +36,7 @@ import type { MemoryEntry } from '../memory/entries'
 import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
 import { recordAgentSessionStart } from '../services/agent-session-recorder'
+import { extractDeveloperRules } from '../services/developer-profile'
 import { createStalenessChecker } from '../services/staleness-checker'
 import { usefulnessService } from '../services/usefulness'
 import type { LocalConfig, ProjectPersona } from '../types/config'
@@ -57,8 +58,10 @@ interface SessionContextOptions {
   digest?: boolean
 }
 
-const DIGEST_MAX_CHARS = 1400
+const DIGEST_MAX_CHARS = 1600
 const DIGEST_PER_TYPE = 3
+/** How many developer rules to push on cold start (apply without MCP pull). */
+const DIGEST_DEV_RULES = 4
 
 /**
  * Build the additionalContext body for the current project.
@@ -161,14 +164,15 @@ async function buildStalenessNotice(
 }
 
 /**
- * Compact, high-signal recall of what the project already knows — the
- * cross-model-update grounding. Top preventive traps + recent decisions +
- * a pointer to the synthesized developer profile. Recency-ranked, tightly
- * truncated so it never bloats the cold-start context.
+ * Compact, high-signal recall of what the project + developer already know —
+ * cross-model-update grounding. Top traps + decisions + distilled developer
+ * rules (apply-loop: push enough to act without pull instinct). Recency-
+ * ranked with usefulness rerank; tightly truncated.
  */
 function buildKnowledgeDigest(projectId: string): string | null {
   let gotchas: MemoryEntry[] = []
   let decisions: MemoryEntry[] = []
+  let devRules: Array<{ rule: string; sourceId: string }> = []
   try {
     // Overfetch recency-ordered candidates, then let the usefulness
     // ledger reorder before taking the few digest slots: the 3 most
@@ -192,36 +196,79 @@ function buildKnowledgeDigest(projectId: string): string | null {
   } catch {
     return null
   }
+
+  // Developer model: feedback + friction → actionable rules. Pushed here so
+  // a cold model (post-update) acts as the developer without MCP pull.
+  try {
+    const pool = projectMemory.recall(projectId, {
+      types: ['feedback', 'improvement-signal'],
+      limit: 40,
+      dedupeByKey: false,
+    })
+    devRules = extractDeveloperRules(pool, DIGEST_DEV_RULES)
+  } catch {
+    devRules = []
+  }
+
   const repeatMiss = findRepeatMissedEntry(
     projectId,
     new Set([...gotchas, ...decisions].map((e) => e.id))
   )
-  if (gotchas.length === 0 && decisions.length === 0 && !repeatMiss) return null
+  if (gotchas.length === 0 && decisions.length === 0 && !repeatMiss && devRules.length === 0) {
+    return null
+  }
 
   const lines: string[] = ['## What this project already knows', '']
   lines.push(
-    '> Carried across sessions and model updates — this survived even if your conversation context did not.'
+    '> Carried across sessions and model updates — this survived even if your conversation context did not. Apply these; do not re-derive from source.'
   )
+  if (devRules.length > 0) {
+    lines.push('', '**How this developer works (act as them):**')
+    for (const r of devRules) {
+      const short = r.rule.length > 140 ? `${r.rule.slice(0, 139)}…` : r.rule
+      lines.push(`- ${short}  \`${r.sourceId}\``)
+    }
+  }
   if (gotchas.length > 0) {
     lines.push('', '**Traps to avoid:**')
-    for (const e of gotchas) lines.push(`- ${deriveTitle(e)}  \`${e.id}\``)
+    for (const e of gotchas) lines.push(`- ${digestLine(e)}`)
   }
   if (decisions.length > 0) {
     lines.push('', '**Decisions in force:**')
-    for (const e of decisions) lines.push(`- ${deriveTitle(e)}  \`${e.id}\``)
+    for (const e of decisions) lines.push(`- ${digestLine(e)}`)
   }
   if (repeatMiss) {
     lines.push(
       '',
       '**Keeps being missed:**',
-      `- ${deriveTitle(repeatMiss.entry)}  \`${repeatMiss.entry.id}\` — flagged relevant-but-unused ${repeatMiss.count}×. Apply it or supersede it.`
+      `- ${digestLine(repeatMiss.entry)} — flagged relevant-but-unused ${repeatMiss.count}×. Apply it or supersede it.`
     )
   }
   lines.push(
     '',
-    '> Resolve any `mem_id` with `prjct search <id>`. Who the developer is: MCP `prjct_developer`.'
+    '> Resolve any `mem_id` with `prjct search <id>`. Full developer model: MCP `prjct_developer`.'
   )
   return safeTruncate(lines.join('\n'), DIGEST_MAX_CHARS)
+}
+
+/**
+ * One digest line: title is usually enough; when the body is longer and
+ * carries a distinct second clause, append a short teaser so weak models
+ * can apply without a second pull.
+ */
+function digestLine(e: MemoryEntry): string {
+  const title = deriveTitle(e)
+  const body = (e.content ?? '').replace(/\s+/g, ' ').trim()
+  // If body is essentially the title, skip teaser.
+  if (body.length <= title.length + 8) return `${title}  \`${e.id}\``
+  // Prefer content after first sentence for the teaser.
+  const after = body
+    .slice(title.length)
+    .replace(/^[\s.:;—-]+/, '')
+    .trim()
+  if (after.length < 24) return `${title}  \`${e.id}\``
+  const teaser = after.length > 90 ? `${after.slice(0, 89)}…` : after
+  return `${title} — ${teaser}  \`${e.id}\``
 }
 
 /** A memory must be skill-missed at least this often to earn a digest slot. */

--- a/core/services/developer-profile.ts
+++ b/core/services/developer-profile.ts
@@ -11,6 +11,11 @@
  * so an agent can act as the developer would WITHOUT being told each time.
  *
  * Deterministic; no LLM. Returns null when there's nothing to say yet.
+ *
+ * Quality bar (apply-loop): the profile must be *actionable on first read* —
+ * lead with distilled rules the model can obey, not a dump of raw history.
+ * SessionStart digests reuse {@link extractDeveloperRules} so cold-start
+ * models act as the developer without needing the MCP pull instinct.
  */
 
 import type { MemoryEntry } from '../memory/entries'
@@ -19,6 +24,8 @@ import { summarizeFrictionLesson, truncate } from '../utils/text-summary'
 
 const MAX_PREFERENCES = 25
 const MAX_FRICTION = 15
+const MAX_PRINCIPLES = 10
+const MAX_LEAD_RULES = 6
 
 function teaser(content: string): string {
   return truncate(content.replace(/\s+/g, ' ').trim(), 200)
@@ -27,6 +34,87 @@ function teaser(content: string): string {
 /** Structured lessons lead; legacy rows fall back to their first line. */
 function frictionLine(content: string): string {
   return summarizeFrictionLesson(content, 240)
+}
+
+/**
+ * Distill standing rules the agent should obey without re-reading history.
+ * Preferences first (developer said so), then friction next-actions / lessons
+ * (developer showed so by pushback). Deduped, newest-first within each class.
+ */
+export function extractDeveloperRules(
+  declared: MemoryEntry[],
+  limit = MAX_LEAD_RULES
+): Array<{ rule: string; sourceId: string; kind: 'preference' | 'friction' }> {
+  const out: Array<{ rule: string; sourceId: string; kind: 'preference' | 'friction' }> = []
+  const seen = new Set<string>()
+
+  const push = (raw: string, sourceId: string, kind: 'preference' | 'friction') => {
+    const rule = normalizeRule(raw)
+    if (!rule || rule.length < 12) return
+    const key = rule.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    out.push({ rule, sourceId, kind })
+  }
+
+  // `declared` is newest-first; recent guidance reflects current preference.
+  for (const p of declared.filter((e) => e.type === 'feedback')) {
+    if (out.length >= limit) break
+    push(p.content, p.id, 'preference')
+  }
+
+  for (const f of declared.filter(
+    (e) => e.type === 'improvement-signal' && e.tags?.source === 'friction-detector'
+  )) {
+    if (out.length >= limit) break
+    const next = extractNextAction(f.content) ?? extractLesson(f.content)
+    if (next) push(next, f.id, 'friction')
+  }
+
+  return out
+}
+
+function normalizeRule(raw: string): string {
+  return raw
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[-*•]\s+/, '')
+}
+
+function extractNextAction(content: string): string | null {
+  const m = content.match(/^Next action:\s*(.+)$/im)
+  return m?.[1]?.trim() || null
+}
+
+function extractLesson(content: string): string | null {
+  const first = content.split('\n').map((l) => l.trim())[0] ?? ''
+  const m = first.match(/^\[[^\]]+\]\s+Lesson:\s*(.+)$/i)
+  if (m?.[1]) return m[1].trim()
+  // Legacy: "[negation] User pushback: \"…\"" — keep usable.
+  if (/^\[[^\]]+\]/.test(first) && first.length > 20) return first
+  return null
+}
+
+/**
+ * Working principles = friction next-actions only (what NOT to repeat).
+ * Distinct from lead rules so the full profile can show "do this instead".
+ */
+function extractWorkingPrinciples(declared: MemoryEntry[], limit = MAX_PRINCIPLES): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const f of declared.filter(
+    (e) => e.type === 'improvement-signal' && e.tags?.source === 'friction-detector'
+  )) {
+    const next = extractNextAction(f.content)
+    if (!next) continue
+    const n = normalizeRule(next)
+    const key = n.toLowerCase()
+    if (seen.has(key) || n.length < 12) continue
+    seen.add(key)
+    out.push(n)
+    if (out.length >= limit) break
+  }
+  return out
 }
 
 export function buildDeveloperProfile(declared: MemoryEntry[]): string | null {
@@ -38,6 +126,9 @@ export function buildDeveloperProfile(declared: MemoryEntry[]): string | null {
 
   if (preferences.length === 0 && friction.length === 0) return null
 
+  const leadRules = extractDeveloperRules(declared, MAX_LEAD_RULES)
+  const principles = extractWorkingPrinciples(declared, MAX_PRINCIPLES)
+
   const lines: string[] = ['# Developer profile', '']
   lines.push(
     '> Synthesized from the developer’s stated feedback and their pushback.',
@@ -45,10 +136,26 @@ export function buildDeveloperProfile(declared: MemoryEntry[]): string | null {
     ''
   )
 
+  // Lead block: the model of "who to be" on first screenful — apply-loop.
+  if (leadRules.length > 0) {
+    lines.push('## Act as this developer — rules in force', '')
+    for (const r of leadRules) {
+      const tag = r.kind === 'preference' ? 'said' : 'showed'
+      lines.push(`- ${r.rule}  \`${r.sourceId}\` _(${tag})_`)
+    }
+    lines.push('')
+  }
+
   if (preferences.length > 0) {
     lines.push('## Preferences & guidance — the rules to follow', '')
     for (const p of preferences)
       lines.push(`- **${deriveTitle(p)}** — ${teaser(p.content)}  \`${p.id}\``)
+    lines.push('')
+  }
+
+  if (principles.length > 0) {
+    lines.push('## Working principles — from their pushback (do this instead)', '')
+    for (const p of principles) lines.push(`- ${p}`)
     lines.push('')
   }
 

--- a/core/services/friction-detector.ts
+++ b/core/services/friction-detector.ts
@@ -13,11 +13,11 @@
  *
  * What counts as friction (precision-over-recall):
  *   - User negation directly after an assistant tool-use:
- *     "no", "así no", "espera", "stop", "cancel", "wait" → strong signal
+ *     "no", "stop", "cancel", "wait" → strong signal
  *   - User correction phrasing: "should be X", "rather than", "instead"
- *   - Repeated requests for the same surface ("dónde", "where", "how
- *     do I" appearing 3+ times in the session)
- *   - Explicit complaint markers: "doesn't work", "no funciona", "broken"
+ *   - Repeated requests for the same surface ("where", "how do I"
+ *     appearing 3+ times in the session)
+ *   - Explicit complaint markers: "doesn't work", "broken"
  *
  * Conservative cap: max 5 signals per session. Hashed dedup against
  * existing improvement-signal entries so re-running the hook never
@@ -33,35 +33,20 @@ const SOURCE_TAG = 'friction-detector'
 const MAX_SIGNALS_PER_SESSION = 5
 const MAX_EXCERPT_CHARS = 400
 
-// Negation / correction markers — language-agnostic (es/en) since the
-// user codebase mixes both. Matched against the START of a user turn
-// (after the assistant just acted) to avoid false positives in
-// ordinary discussion.
+// Negation / correction markers (English). Matched against the START of a
+// user turn (after the assistant just acted) to avoid false positives in
+// ordinary discussion. Memory content is English-only (feedback contract).
 const NEGATION_MARKERS = [
   /^\s*no[,.!\s]/i,
   /^\s*nope\b/i,
-  /^\s*así no\b/i,
-  /^\s*espera\b/i,
   /^\s*stop\b/i,
   /^\s*wait\b/i,
   /^\s*cancel\b/i,
 ]
 
-const CORRECTION_MARKERS = [
-  /\bshould be\b/i,
-  /\brather than\b/i,
-  /\binstead\b/i,
-  /\bmás bien\b/i,
-  /\ben realidad\b/i,
-]
+const CORRECTION_MARKERS = [/\bshould be\b/i, /\brather than\b/i, /\binstead\b/i]
 
-const COMPLAINT_MARKERS = [
-  /\bdoesn'?t work\b/i,
-  /\bno funciona\b/i,
-  /\bbroken\b/i,
-  /\bestá roto\b/i,
-  /\bagain\b.*\bsame\b/i,
-]
+const COMPLAINT_MARKERS = [/\bdoesn'?t work\b/i, /\bbroken\b/i, /\bagain\b.*\bsame\b/i]
 
 interface TranscriptLine {
   type?: string
@@ -188,10 +173,9 @@ function extractSignals(lines: TranscriptLine[]): FrictionSignal[] {
 }
 
 function classify(text: string): FrictionSignal['category'] | null {
-  // Complaints checked FIRST: phrases like "no funciona" share the
-  // "no" prefix with negation markers, but the multi-word complaint
-  // pattern is more specific and shouldn't be miscategorised as
-  // pure rejection.
+  // Complaints checked FIRST: multi-word complaint patterns are more
+  // specific than a bare "no…" negation prefix and shouldn't be
+  // miscategorised as pure rejection.
   if (COMPLAINT_MARKERS.some((re) => re.test(text))) return 'complaint'
   if (NEGATION_MARKERS.some((re) => re.test(text))) return 'negation'
   if (CORRECTION_MARKERS.some((re) => re.test(text))) return 'correction'

--- a/core/services/land-synthesis.ts
+++ b/core/services/land-synthesis.ts
@@ -7,6 +7,10 @@
  * Stop when a cycle is still open. Deterministic synthesis from durable
  * signals (cycle, journal, recent commits, recent auto-captures) — not a
  * model call — so it works on weak models and never blocks session end.
+ *
+ * Quality bar: every field must carry signal. No "unknown" spam — omit
+ * empty slots so the next session reads a dense model of what happened,
+ * what was learned, and what to do next.
  */
 
 import { execFileSync } from 'node:child_process'
@@ -54,7 +58,9 @@ export async function synthesizeLandHandoff(
       tags: {
         source: SOURCE_TAG,
         topic: TOPIC_KEY,
-        capture: 'land-v1',
+        capture: 'land-v2',
+        context_schema: 'living-v2',
+        synthesis: 'deterministic',
       },
       provenance: 'extracted',
       projectId: input.projectId,
@@ -87,51 +93,89 @@ export function buildLandHandoffContent(input: LandSynthesisInput): string | nul
     return null
   }
 
-  const what = cycle
-    ? `Work cycle "${truncate(cycle, 120)}" still open or just closed.`
-    : 'Session closed with no open work cycle.'
-  const why =
-    journal.length > 0
-      ? `Journal trail: ${journal.map((j) => truncate(j, 80)).join(' · ')}`
-      : 'No task journal entries; synthesis from repo + auto-captures only.'
-  const outcome =
-    commits.length > 0
-      ? `Recent commits: ${commits.join('; ')}`
-      : 'No recent git commits visible from project path.'
-  const traps =
-    autos.length > 0
-      ? autos
-          .slice(0, 4)
+  const parts: string[] = []
+
+  // Lead: one scannable sentence the next agent can act on.
+  if (cycle) {
+    parts.push(`Session close: Work cycle "${truncate(cycle, 120)}" still open or just closed.`)
+  } else {
+    parts.push('Session close: no open work cycle — landed repo + capture signals only.')
+  }
+
+  parts.push(
+    'Context synthesis: Passive land hand-off from durable signals (cycle, journal, commits, auto-captures). Not a model essay.'
+  )
+  parts.push(`Key data: source=${SOURCE_TAG}; topic=${TOPIC_KEY}; capture=land-v2`)
+
+  // What happened — cycle + journal trail (how the work evolved).
+  const whatBits: string[] = []
+  if (cycle) whatBits.push(`cycle="${truncate(cycle, 100)}"`)
+  if (journal.length > 0) {
+    whatBits.push(`journal: ${journal.map((j) => truncate(j, 70)).join(' · ')}`)
+  }
+  if (whatBits.length > 0) {
+    parts.push(`What happened: ${whatBits.join('; ')}`)
+  }
+
+  if (journal.length > 0) {
+    parts.push(
+      `Why it mattered: Journal trail shows progression — ${journal
+        .slice(0, 2)
+        .map((j) => truncate(j, 80))
+        .join(' · ')}`
+    )
+  }
+
+  // Learned / traps — auto-captures are the session's new knowledge.
+  if (autos.length > 0) {
+    const learned = autos
+      .filter((a) => a.type === 'learning' || a.type === 'decision' || a.type === 'fact')
+      .slice(0, 4)
+    const traps = autos.filter((a) => a.type === 'gotcha' || a.type === 'anti-pattern').slice(0, 3)
+    if (learned.length > 0) {
+      parts.push(
+        `Learned this session: ${learned
           .map((a) => `[${a.type}] ${truncate(a.content, 100)}`)
-          .join(' · ')
-      : 'none auto-captured this window'
-  const tokens =
-    input.tokensIn != null || input.tokensOut != null
-      ? `in=${input.tokensIn ?? 0} out=${input.tokensOut ?? 0}`
-      : 'unknown'
+          .join(' · ')}`
+      )
+    }
+    if (traps.length > 0) {
+      parts.push(
+        `Decision/trap: ${traps.map((a) => `[${a.type}] ${truncate(a.content, 100)}`).join(' · ')}`
+      )
+    }
+    // Remainder that wasn't classified above
+    const used = new Set([...learned, ...traps])
+    const rest = autos.filter((a) => !used.has(a)).slice(0, 3)
+    if (rest.length > 0 && learned.length === 0 && traps.length === 0) {
+      parts.push(
+        `Decision/trap: ${rest.map((a) => `[${a.type}] ${truncate(a.content, 100)}`).join(' · ')}`
+      )
+    }
+  }
+
+  if (commits.length > 0) {
+    parts.push(`Outcome: Recent commits: ${commits.join('; ')}`)
+  }
+
+  // Meta only when present — never "unknown".
+  if (input.author) parts.push(`Who/author: ${input.author}`)
+  if (input.model) parts.push(`Model: ${input.model}`)
+  if (input.tokensIn != null || input.tokensOut != null) {
+    parts.push(`Token usage: in=${input.tokensIn ?? 0} out=${input.tokensOut ?? 0}`)
+  }
+
+  parts.push('Feature/domain: session-close')
+  parts.push('Pattern: land auto-synthesis without agent remember')
+  parts.push('Anti-pattern: relying on the model to remember to remember at session end')
+
   const next =
     cycle != null
       ? 'Finish or pause the open cycle (`prjct status done` / `prjct pause`); next agent should `prjct work --md` or `prjct prime`.'
       : 'Next agent: `prjct prime` then pick from `prjct next --md`.'
+  parts.push(`Next implication: ${next}`)
 
-  return [
-    `Session close: ${what}`,
-    `Context synthesis: Passive land hand-off — durable signals only (cycle, journal, commits, auto-captures). Not a model essay.`,
-    `Key data: source=${SOURCE_TAG}; topic=${TOPIC_KEY}`,
-    `What happened: ${what}`,
-    `Why it mattered: ${why}`,
-    `Who/author: ${input.author ?? 'unknown'}`,
-    `Model: ${input.model ?? 'unknown'}`,
-    `Token usage: ${tokens}`,
-    `Sentiment: unknown`,
-    `Related files: unknown`,
-    `Feature/domain: session-close`,
-    `Pattern: land auto-synthesis without agent remember`,
-    `Anti-pattern: relying on the model to remember to remember at session end`,
-    `Decision/trap: ${traps}`,
-    `Outcome: ${outcome}`,
-    `Next implication: ${next}`,
-  ].join(' · ')
+  return parts.join(' · ')
 }
 
 /** Async wrapper that fills cycle from active task when omitted. */

--- a/core/services/transcript-learner.ts
+++ b/core/services/transcript-learner.ts
@@ -70,8 +70,6 @@ const PHRASE_TYPE_MAP: Array<{ phrase: string; type: MemoryType }> = [
   { phrase: 'best approach is', type: 'decision' },
   { phrase: 'we will use', type: 'decision' },
   { phrase: 'shipping with', type: 'decision' },
-  { phrase: 'decidimos', type: 'decision' },
-  { phrase: 'la decisión es', type: 'decision' },
   // Learnings
   { phrase: 'turns out that', type: 'learning' },
   { phrase: 'now i understand', type: 'learning' },
@@ -81,7 +79,6 @@ const PHRASE_TYPE_MAP: Array<{ phrase: string; type: MemoryType }> = [
   { phrase: 'root cause is', type: 'learning' },
   { phrase: 'root cause was', type: 'learning' },
   { phrase: 'the fix is', type: 'learning' },
-  { phrase: 'resulta que', type: 'learning' },
   // Gotchas
   { phrase: 'gotcha:', type: 'gotcha' },
   { phrase: 'bug:', type: 'gotcha' },
@@ -90,7 +87,6 @@ const PHRASE_TYPE_MAP: Array<{ phrase: string; type: MemoryType }> = [
   { phrase: 'be careful', type: 'gotcha' },
   { phrase: 'never do this', type: 'gotcha' },
   { phrase: 'trap:', type: 'gotcha' },
-  { phrase: 'cuidado:', type: 'gotcha' },
   // Facts / durable project truth
   { phrase: 'important:', type: 'fact' },
   { phrase: 'always use', type: 'fact' },
@@ -108,37 +104,37 @@ const PHRASE_TYPE_MAP: Array<{ phrase: string; type: MemoryType }> = [
  */
 const LABEL_TYPE_MAP: Array<{ re: RegExp; type: MemoryType; phrase: string }> = [
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(decision|decisión)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?decision(?:\*\*)?\s*[:—-]\s+/i,
     type: 'decision',
     phrase: 'label:decision',
   },
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(learning|aprendizaje|insight)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?(learning|insight)(?:\*\*)?\s*[:—-]\s+/i,
     type: 'learning',
     phrase: 'label:learning',
   },
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(gotcha|trap|cuidado|warning)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?(gotcha|trap|warning)(?:\*\*)?\s*[:—-]\s+/i,
     type: 'gotcha',
     phrase: 'label:gotcha',
   },
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(fact|dato|note)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?(fact|note)(?:\*\*)?\s*[:—-]\s+/i,
     type: 'fact',
     phrase: 'label:fact',
   },
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(root\s*cause|causa\s*raíz)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?root\s*cause(?:\*\*)?\s*[:—-]\s+/i,
     type: 'learning',
     phrase: 'label:root-cause',
   },
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(pattern|patrón)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?pattern(?:\*\*)?\s*[:—-]\s+/i,
     type: 'pattern',
     phrase: 'label:pattern',
   },
   {
-    re: /^(?:[-*•]\s+)?(?:\*\*)?(anti[- ]?pattern|anti[- ]?patrón)(?:\*\*)?\s*[:—-]\s+/i,
+    re: /^(?:[-*•]\s+)?(?:\*\*)?anti[- ]?pattern(?:\*\*)?\s*[:—-]\s+/i,
     type: 'anti-pattern',
     phrase: 'label:anti-pattern',
   },
@@ -283,9 +279,7 @@ const USER_PREF_PATTERNS: Array<{ re: RegExp; phrase: string }> = [
   { re: /^(?:please\s+)?always\b/i, phrase: 'user:always' },
   { re: /^(?:please\s+)?never\b/i, phrase: 'user:never' },
   { re: /\bi (?:always|never|prefer)\b/i, phrase: 'user:i-prefer' },
-  { re: /^(?:rule|preference|preferencia)\s*[:—-]/i, phrase: 'user:rule' },
-  { re: /^(?:siempre|nunca)\b/i, phrase: 'user:siempre' },
-  { re: /\bprefiero\b/i, phrase: 'user:prefiero' },
+  { re: /^(?:rule|preference)\s*[:—-]/i, phrase: 'user:rule' },
   { re: /\bno more\s+(?:features?|feature\s+creep)\b/i, phrase: 'user:no-more-features' },
   { re: /\bdon'?t add (?:more )?(?:features?|surface)\b/i, phrase: 'user:dont-add-features' },
 ]

--- a/core/services/transcript-learner.ts
+++ b/core/services/transcript-learner.ts
@@ -31,8 +31,12 @@ import { parseTranscriptJsonl, type TranscriptJsonlLine } from './transcript-jso
 const SOURCE_TAG = 'transcript-auto'
 const CAPTURE_VERSION = 'v2'
 const MIN_PARAGRAPH_CHARS = 80
+/** User preference lines can be short ("Always ship as minor.") and still durable. */
+const MIN_PREF_CHARS = 20
 const MAX_CONTENT_CHARS = 1500
 const MAX_CANDIDATES_PER_SESSION = 12
+/** Cap preference captures separately so chatty corrections don't crowd project learnings. */
+const MAX_PREF_PER_SESSION = 4
 
 interface Candidate {
   type: MemoryType
@@ -179,10 +183,16 @@ export async function ingestTranscript(
   }
 
   const messages = projectMessages(lines)
-  result.scanned = messages.length
-  if (messages.length === 0) return result
+  const userMessages = projectUserMessages(lines)
+  result.scanned = messages.length + userMessages.length
+  if (messages.length === 0 && userMessages.length === 0) return result
 
-  const candidates = extractCandidates(messages)
+  // Project knowledge from assistant turns + standing preferences from the
+  // developer's own words (the "know the developer" half of the model).
+  const candidates = [
+    ...extractCandidates(messages),
+    ...extractUserPreferenceCandidates(userMessages),
+  ]
   if (candidates.length === 0) return result
 
   // Dedup against memory we already wrote from previous transcript
@@ -232,8 +242,8 @@ interface TranscriptMessage {
  * version, but the contract we depend on is minimal: each line is JSON
  * with a recognizable role + extractable text content.
  *
- * We only care about `assistant` messages with substantive text. Tool
- * calls, tool results, and user turns are skipped.
+ * Default projection is assistant-only (project knowledge). User turns
+ * are projected separately for preference capture.
  */
 function parseTranscript(raw: string): TranscriptMessage[] {
   return projectMessages(parseTranscriptJsonl(raw))
@@ -250,6 +260,65 @@ function projectMessages(lines: TranscriptJsonlLine[]): TranscriptMessage[] {
     out.push({ role, text })
   }
   return out
+}
+
+/** User turns long enough to hold a standing preference. */
+function projectUserMessages(lines: TranscriptJsonlLine[]): TranscriptMessage[] {
+  const out: TranscriptMessage[] = []
+  for (const parsed of lines) {
+    const role = inferRole(parsed)
+    if (role !== 'user') continue
+    const text = extractText(parsed)
+    if (!text || text.length < MIN_PREF_CHARS) continue
+    out.push({ role, text })
+  }
+  return out
+}
+
+/**
+ * Standing developer rules stated in user turns — high precision only.
+ * These become `feedback` so developer-profile / SessionStart can act as them.
+ */
+const USER_PREF_PATTERNS: Array<{ re: RegExp; phrase: string }> = [
+  { re: /^(?:please\s+)?always\b/i, phrase: 'user:always' },
+  { re: /^(?:please\s+)?never\b/i, phrase: 'user:never' },
+  { re: /\bi (?:always|never|prefer)\b/i, phrase: 'user:i-prefer' },
+  { re: /^(?:rule|preference|preferencia)\s*[:—-]/i, phrase: 'user:rule' },
+  { re: /^(?:siempre|nunca)\b/i, phrase: 'user:siempre' },
+  { re: /\bprefiero\b/i, phrase: 'user:prefiero' },
+  { re: /\bno more\s+(?:features?|feature\s+creep)\b/i, phrase: 'user:no-more-features' },
+  { re: /\bdon'?t add (?:more )?(?:features?|surface)\b/i, phrase: 'user:dont-add-features' },
+]
+
+function extractUserPreferenceCandidates(messages: TranscriptMessage[]): Candidate[] {
+  const candidates: Candidate[] = []
+  const seen = new Set<string>()
+  for (const msg of messages) {
+    if (candidates.length >= MAX_PREF_PER_SESSION) break
+    // Prefer line-level match so a long message still yields a tight rule.
+    const lines = msg.text
+      .split(/\n/)
+      .map((l) => l.replace(/^[-*•]\s+/, '').trim())
+      .filter((l) => l.length >= MIN_PREF_CHARS)
+    const units = lines.length > 0 ? lines : [msg.text.trim()]
+    for (const unit of units) {
+      if (candidates.length >= MAX_PREF_PER_SESSION) break
+      const match = USER_PREF_PATTERNS.find((p) => p.re.test(unit))
+      if (!match) continue
+      const content =
+        unit.length > MAX_CONTENT_CHARS ? `${unit.slice(0, MAX_CONTENT_CHARS)}…` : unit
+      const hash = hashContent(content)
+      if (seen.has(hash)) continue
+      seen.add(hash)
+      candidates.push({
+        type: 'feedback',
+        content,
+        hash,
+        matchedPhrase: match.phrase,
+      })
+    }
+  }
+  return candidates
 }
 
 function inferRole(msg: Record<string, unknown>): TranscriptMessage['role'] | null {
@@ -428,6 +497,7 @@ function collectExistingAutoHashes(projectId: string): Set<string> {
 export const _internal = {
   parseTranscript,
   extractCandidates,
+  extractUserPreferenceCandidates,
   hashContent,
   PHRASE_TYPE_MAP,
   LABEL_TYPE_MAP,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.32.0",
+  "version": "3.33.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Quality-only deepening of the RAG north star (model of project + developer that anticipates) — **no new feature surface**.

1. **Developer profile** — lead with *Act as this developer* distilled rules; working principles from friction next-actions; export `extractDeveloperRules` for reuse.
2. **SessionStart cold-start digest** — **push** top developer rules + slightly richer trap/decision lines so post-model-update sessions act as the developer without needing MCP pull instinct.
3. **Transcript learner** — capture standing user preferences (`always` / `never` / `prefiero` / …) as `feedback` so the developer model grows from how the human actually talks.
4. **Land synthesis** — dense hand-off (`land-v2`): only fields with signal; separate learned vs traps; no `Sentiment: unknown` spam.

## Why

Root cause of “learns but doesn’t apply” (mem_3804): anticipation moved to PULL. Weak/cold models don’t pull. This keeps pull for deep recall, but **pushes** the minimal model of who the developer is + what the project already knows on cold start.

## Test plan

- [x] `bun test` session-start, developer-profile, land-synthesis, transcript-learner
- [x] `bun run typecheck`
- [ ] CI green
- [ ] After merge: cold session should show **How this developer works** when feedback exists