### PR TITLE
feat(harness): brutal quality vs GSD — friction promote + denser prime

### DIFF
--- a/core/__tests__/services/friction-detector.test.ts
+++ b/core/__tests__/services/friction-detector.test.ts
@@ -1,11 +1,32 @@
 /**
  * Friction detector — extracts user-pushback signals from a Claude
  * Code session transcript. Tests pin: classifier coverage,
- * idempotent dedup, English markers, conservative cap.
+ * idempotent dedup, English markers, conservative cap, specific
+ * constraint distillation, and recurring-pushback → feedback promote.
  */
 
-import { describe, expect, it } from 'bun:test'
-import { _internal } from '../../services/friction-detector'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import { projectMemory } from '../../memory/project-memory'
+import { _internal, detectFriction } from '../../services/friction-detector'
+
+let projectPath = ''
+let projectId = ''
+
+async function freshProject(): Promise<void> {
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-friction-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  projectId = `fric-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  } as Parameters<typeof configManager.writeConfig>[1])
+  await pathManager.ensureProjectStructure(projectId)
+}
 
 describe('friction-detector classify', () => {
   it('flags negation markers', () => {
@@ -99,12 +120,61 @@ describe('friction-detector parseJsonl + extractSignals', () => {
     expect(formatted).toContain('Anti-pattern:')
     expect(formatted).toContain('Next action:')
     expect(formatted).not.toContain('Evidence:')
+    // Raw quote never stored; distilled constraint is.
     expect(formatted).not.toContain('no, run the tests first')
     expect(formatted).not.toContain("I'll run prjct ship now.")
     expect(formatted).not.toStartWith('[negation] User pushback:')
+    expect(formatted).toContain('Run the tests first')
+    expect(formatted).toMatch(/Next action: Always: Run the tests first/i)
+  })
+
+  it('extractSpecificConstraint distills corrections without raw dumps', () => {
+    expect(_internal.extractSpecificConstraint('that should be feat: not fix:')).toMatch(
+      /Prefer feat:/i
+    )
+    expect(_internal.extractSpecificConstraint('no, run the tests first')).toBe(
+      'Run the tests first'
+    )
+    expect(_internal.extractSpecificConstraint('use bun instead of npm')).toMatch(/bun/i)
+    expect(_internal.extractSpecificConstraint('sounds good continue')).toBeNull()
   })
 
   it('caps signals at MAX_SIGNALS_PER_SESSION', () => {
     expect(_internal.MAX_SIGNALS_PER_SESSION).toBeLessThanOrEqual(10)
+  })
+})
+
+describe('friction-detector promote recurring pushback to feedback', () => {
+  beforeEach(freshProject)
+  afterEach(async () => {
+    if (projectPath) {
+      await fs.rm(projectPath, { recursive: true, force: true })
+      projectPath = ''
+    }
+  })
+
+  it('records a signal once, then promotes standing preference on repeat', async () => {
+    const transcript = [
+      JSON.stringify({ role: 'assistant', content: "I'll ship now." }),
+      JSON.stringify({ role: 'user', content: 'no, run the tests first' }),
+    ].join('\n')
+    const file = path.join(projectPath, 't.jsonl')
+    await fs.writeFile(file, transcript)
+
+    const first = await detectFriction(projectPath, file, 'sess-1')
+    expect(first.signalsRecorded).toBe(1)
+
+    const second = await detectFriction(projectPath, file, 'sess-2')
+    expect(second.signalsRecorded).toBe(0)
+    expect(second.signalsSkipped).toBeGreaterThanOrEqual(1)
+
+    const prefs = projectMemory.recall(projectId, {
+      types: ['feedback'],
+      tags: { source: _internal.PROMOTE_SOURCE },
+      limit: 5,
+      dedupeByKey: false,
+    })
+    expect(prefs.length).toBe(1)
+    expect(prefs[0]?.content).toMatch(/Always: Run the tests first/i)
   })
 })

--- a/core/commands/ceremonies.ts
+++ b/core/commands/ceremonies.ts
@@ -19,7 +19,9 @@
  *                                    unfinished — BEFORE the context dies
  */
 
+import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import { extractDeveloperRules } from '../services/developer-profile'
 import { buildTaskHarness } from '../services/task-harness'
 import { orchestrationFor } from '../services/task-orchestration'
 import { collectActiveTasks } from '../services/task-overview'
@@ -30,6 +32,10 @@ import type { CommandResult } from '../types/commands'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
 import { requireProject } from './guards'
+
+/** Cold-start apply-loop: enough rules for a fresh window to act as the dev. */
+const PRIME_DEV_RULES = 4
+const PRIME_TRAPS = 3
 
 interface CeremonyOptions {
   md?: boolean
@@ -212,7 +218,14 @@ export class CeremonyCommands extends PrjctCommandsBase {
     return { success: true, items: ready.length }
   }
 
-  /** Session-open bundle: one pull instead of four. */
+  /**
+   * Session-open bundle: one pull instead of four.
+   *
+   * Brutal bar vs fresh-context harnesses (e.g. GSD): a new window with
+   * `prjct prime` must already *be* this developer on this project — cycle +
+   * frontier + standing rules + top traps — not just a task list. Deeper
+   * recall stays on demand so tokens stay lean.
+   */
   async prime(
     _input: string | null = null,
     projectPath: string = process.cwd(),
@@ -238,6 +251,40 @@ export class CeremonyCommands extends PrjctCommandsBase {
       lines.push('', '**Ready frontier:**')
       for (const i of ready) lines.push(`- \`${i.id.slice(0, 8)}\` ${i.description.slice(0, 90)}`)
     }
+
+    // Apply-loop: push developer model + traps into every fresh window.
+    try {
+      const pool = projectMemory.recall(proj.value, {
+        types: ['feedback', 'improvement-signal'],
+        limit: 40,
+        dedupeByKey: false,
+      })
+      const rules = extractDeveloperRules(pool, PRIME_DEV_RULES)
+      if (rules.length > 0) {
+        lines.push('', '**Act as this developer:**')
+        for (const r of rules) {
+          const tag = r.kind === 'preference' ? 'said' : 'showed'
+          lines.push(`- ${r.rule.slice(0, 140)} _(${tag})_`)
+        }
+      }
+    } catch {
+      // Best-effort — prime never fails for missing memory.
+    }
+    try {
+      const traps = projectMemory.recall(proj.value, {
+        types: ['gotcha', 'anti-pattern'],
+        limit: PRIME_TRAPS,
+      })
+      if (traps.length > 0) {
+        lines.push('', '**Top traps (do not re-pay):**')
+        for (const t of traps) {
+          lines.push(`- ${deriveTitle(t).slice(0, 100)} \`${t.id}\``)
+        }
+      }
+    } catch {
+      // ignore
+    }
+
     lines.push(
       '',
       'Pull deeper context on demand: `prjct brief` · `prjct search "<q>"` · `prjct guard <file>`.'

--- a/core/services/friction-detector.ts
+++ b/core/services/friction-detector.ts
@@ -11,6 +11,13 @@
  * are used only transiently for classification/dedup and are NOT stored
  * in durable memory — context value is the reusable lesson, not the literal.
  *
+ * Quality (brutal apply-loop vs prompt-only harnesses): when the user
+ * names a concrete constraint ("run the tests first", "should be feat:"),
+ * distill that into the Lesson/Next action so developer-profile and
+ * SessionStart can *apply* it — not a generic "recalibrate" template.
+ * Identical pushback seen again (dedup hit) promotes a standing
+ * `feedback` preference so the rule survives as "said", not only "showed".
+ *
  * What counts as friction (precision-over-recall):
  *   - User negation directly after an assistant tool-use:
  *     "no", "stop", "cancel", "wait" → strong signal
@@ -30,8 +37,10 @@ import { projectMemory } from '../memory/project-memory'
 import { parseTranscriptJsonl, type TranscriptJsonlLine } from './transcript-jsonl'
 
 const SOURCE_TAG = 'friction-detector'
+const PROMOTE_SOURCE = 'friction-promote'
 const MAX_SIGNALS_PER_SESSION = 5
 const MAX_EXCERPT_CHARS = 400
+const MAX_CONSTRAINT_CHARS = 160
 
 // Negation / correction markers (English). Matched against the START of a
 // user turn (after the assistant just acted) to avoid false positives in
@@ -109,6 +118,9 @@ export async function detectFriction(
     const dedupKey = hashSignal(signal.excerpt).slice(0, 12)
     if (existing.has(dedupKey)) {
       skipped++
+      // Same pushback again = standing law. Promote concrete constraints
+      // to feedback so SessionStart treats them as developer preference.
+      await maybePromoteStandingPreference(projectPath, projectId, signal).catch(() => {})
       continue
     }
     try {
@@ -125,6 +137,7 @@ export async function detectFriction(
         projectId,
       })
       recorded++
+      existing.add(dedupKey)
     } catch {
       skipped++
     }
@@ -203,15 +216,122 @@ function textOf(content: unknown): string {
 
 function formatSignal(signal: FrictionSignal): string {
   const template = lessonTemplate(signal.category)
+  const specific = extractSpecificConstraint(signal.excerpt)
+  const lesson = specific ? `Obey developer constraint: ${specific}` : template.lesson
+  const nextAction = specific ? `Always: ${specific}` : template.nextAction
   const lines = [
-    `[${signal.category}] Lesson: ${template.lesson}`,
+    `[${signal.category}] Lesson: ${lesson}`,
     'What happened: The user pushed back after the assistant response.',
     `Why it mattered: ${template.why}`,
     `Pattern: ${template.pattern}`,
     `Anti-pattern: ${template.antiPattern}`,
-    `Next action: ${template.nextAction}`,
+    `Next action: ${nextAction}`,
   ]
   return lines.join('\n')
+}
+
+/**
+ * Distill a reusable standing constraint from the user turn without storing
+ * the raw quote. High precision: only patterns that name a concrete rule.
+ * Returns null → fall back to category template (still better than silence).
+ */
+function extractSpecificConstraint(excerpt: string): string | null {
+  let t = excerpt.replace(/\s+/g, ' ').trim()
+  if (!t) return null
+
+  // Drop leading rejection particles so the remainder is the rule.
+  t = t.replace(/^\s*(?:nope|no|stop|wait|cancel)[,.!\s:—-]*/i, '').trim()
+
+  const shouldBe = t.match(/\bshould be\b\s+(.+?)$/i)
+  if (shouldBe?.[1]) return cleanConstraint(`Prefer ${shouldBe[1]}`)
+
+  const rather = t.match(/^(.+?)\s+rather than\s+(.+?)$/i)
+  if (rather?.[1] && rather[2]) {
+    return cleanConstraint(`Prefer ${rather[1].trim()} rather than ${rather[2].trim()}`)
+  }
+
+  const useInstead = t.match(
+    /\b(?:use|prefer|do|run|ship|write|keep)\s+(.+?)\s+instead(?:\s+of\s+(.+))?$/i
+  )
+  if (useInstead?.[1]) {
+    const of = useInstead[2] ? ` instead of ${useInstead[2].trim()}` : ' instead'
+    return cleanConstraint(`Use ${useInstead[1].trim()}${of}`)
+  }
+
+  const insteadOf = t.match(/\binstead of\b\s+(.+?)$/i)
+  if (insteadOf?.[1]) return cleanConstraint(`Avoid ${insteadOf[1].trim()}`)
+
+  const never = t.match(/\b(?:don'?t|do not|never)\s+(.+?)$/i)
+  if (never?.[1]) return cleanConstraint(`Never ${never[1].trim()}`)
+
+  const always = t.match(/\balways\s+(.+?)$/i)
+  if (always?.[1]) return cleanConstraint(`Always ${always[1].trim()}`)
+
+  // Imperative remainder after stripping "no," — "run the tests first".
+  if (
+    t.length >= 12 &&
+    t.length <= MAX_CONSTRAINT_CHARS &&
+    /^(?:run|use|do|ship|write|keep|add|fix|remove|prefer|test|check|verify|read|ask|stop|start)\b/i.test(
+      t
+    )
+  ) {
+    const rule = t.charAt(0).toUpperCase() + t.slice(1)
+    return cleanConstraint(rule.replace(/[.!?]+$/, ''))
+  }
+
+  return null
+}
+
+function cleanConstraint(raw: string): string | null {
+  const r = raw
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[-*•]\s+/, '')
+    .replace(/[.!?]+$/, '')
+    .slice(0, MAX_CONSTRAINT_CHARS)
+  if (r.length < 12) return null
+  // Never persist residual raw negation lead-ins.
+  if (/^(?:nope|no|stop|wait|cancel)\b/i.test(r)) return null
+  return r
+}
+
+/**
+ * Second identical pushback → standing `feedback` preference (apply-loop).
+ * Deduped by key so re-runs never spam preferences.
+ */
+async function maybePromoteStandingPreference(
+  projectPath: string,
+  projectId: string | undefined,
+  signal: FrictionSignal
+): Promise<void> {
+  if (!projectId) return
+  const specific = extractSpecificConstraint(signal.excerpt)
+  if (!specific) return
+  const rule = `Always: ${specific}`
+  const prefKey = `fp:${hashSignal(specific).slice(0, 12)}`
+  try {
+    const existing = projectMemory.recall(projectId, {
+      types: ['feedback'],
+      tags: { source: PROMOTE_SOURCE, key: prefKey },
+      limit: 1,
+      dedupeByKey: false,
+    })
+    if (existing.length > 0) return
+    await projectMemory.remember(projectPath, {
+      type: 'feedback',
+      content: rule,
+      tags: {
+        source: PROMOTE_SOURCE,
+        key: prefKey,
+        category: signal.category,
+        from: 'recurring-friction',
+      },
+      provenance: 'extracted',
+      projectId,
+    })
+  } catch {
+    // Best-effort: promotion must never fail Stop.
+  }
 }
 
 function lessonTemplate(category: FrictionSignal['category']): {
@@ -307,5 +427,7 @@ export const _internal = {
   hashSignal,
   textOf,
   formatSignal,
+  extractSpecificConstraint,
   MAX_SIGNALS_PER_SESSION,
+  PROMOTE_SOURCE,
 }


### PR DESCRIPTION
## Summary

Quality-only slice to make prjct **brutally better** than GSD-class harnesses (fresh context, phase theater, token thrash) without new verbs.

- **Friction → standing law:** distill *specific* constraints from pushback (`run the tests first`, `should be feat:`) into Lesson/Next action instead of generic templates.
- **Recurring pushback → preference:** identical friction on dedup hit promotes `feedback` (`source:friction-promote`) so SessionStart/developer-profile treat it as *said*, not only *showed*.
- **Prime densifies apply-loop:** `prjct prime` injects Act-as-this-developer rules + top traps — a fresh window already *is* this developer on this project (GSD re-researches; we compound).

## North star

Model of project + developer that anticipates (mem_3711). Continuity of engineering judgment, not commodity memory (mem_3919). Absolute world-class bar (mem_8592). No GSD skill-count chase.

## Test plan

- [x] `bun test` friction-detector (+ promote integration) / ceremonies / developer-profile
- [ ] CI green
- [ ] Dogfood: push back twice on same constraint → `prjct context memory feedback` shows promoted rule; `prjct prime` shows Act-as-this-developer