### PR TITLE
feat(harness): dominance P0–P2 vs gentle-ai + open-GSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Knip (dead code detection)
         run: bun run knip --include files,duplicates,unlisted,binaries,unresolved
 
+      # Dominance P0d: absolute harness SLOs must stay green (beat GSD narrative).
+      - name: Harness scorecard (world-class SLOs)
+        run: bun test core/__tests__/services/harness-score.test.ts
+
   test:
     name: Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest

--- a/core/__tests__/packs/pack-manager.test.ts
+++ b/core/__tests__/packs/pack-manager.test.ts
@@ -83,7 +83,8 @@ describe('pack-manager', () => {
     expect(config?.tdd?.mode).toBe('assist')
     expect(config?.maxTurnsPerCycle).toBe(25)
     expect(config?.deliveryGeometry?.mode).toBe('advisory')
-    expect(config?.land?.mode).toBe('advisory')
+    // Dominance P2: code pack forces land (session-close not optional).
+    expect(config?.land?.mode).toBe('strict')
 
     await configManager.writeConfig(projectPath, {
       ...config!,

--- a/core/__tests__/services/dominance-gates.test.ts
+++ b/core/__tests__/services/dominance-gates.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'bun:test'
 import { contextPressureVerdict } from '../../services/context-pressure'
 import { discussLockVerdict } from '../../services/discuss-lock'
 import { assessAcceptanceCriteria, isVerifiableAcceptance } from '../../services/nyquist-lite'
+import { buildTaskHarness } from '../../services/task-harness'
 
 describe('discuss-lock (GSD discuss-before-plan, code-enforced)', () => {
   it('never blocks when sdd is off', () => {
@@ -86,6 +87,19 @@ describe('context-pressure (GSD utilization guard proxy)', () => {
     )
     expect(v.level).toBe('critical')
     expect(v.cue).toMatch(/LAND|prime|critical/i)
+  })
+})
+
+describe('harness false-positives (discuss-lock dust)', () => {
+  it('does not classify split-home smoke as H2 refactor', () => {
+    const h = buildTaskHarness('split-home smoke')
+    expect(h.kind).not.toBe('refactor')
+    expect(h.level === 'H0' || h.level === 'H1').toBe(true)
+  })
+
+  it('still classifies real split refactors', () => {
+    const h = buildTaskHarness('split the billing module into packages')
+    expect(h.kind).toBe('refactor')
   })
 })
 

--- a/core/__tests__/services/dominance-gates.test.ts
+++ b/core/__tests__/services/dominance-gates.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Dominance gates vs gentle-ai / open-GSD — unit pins for discuss-lock,
+ * context pressure, nyquist-lite, package legitimacy (pure logic).
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { contextPressureVerdict } from '../../services/context-pressure'
+import { discussLockVerdict } from '../../services/discuss-lock'
+import { assessAcceptanceCriteria, isVerifiableAcceptance } from '../../services/nyquist-lite'
+
+describe('discuss-lock (GSD discuss-before-plan, code-enforced)', () => {
+  it('never blocks when sdd is off', () => {
+    const v = discussLockVerdict({
+      sddMode: 'off',
+      harnessLevel: 'H3',
+      hasSpecId: false,
+    })
+    expect(v.blocked).toBe(false)
+  })
+
+  it('blocks H2 under advisory without a reviewed spec', () => {
+    const v = discussLockVerdict({
+      sddMode: 'advisory',
+      harnessLevel: 'H2',
+      hasSpecId: false,
+    })
+    expect(v.blocked).toBe(true)
+    expect(v.reason).toBe('discuss-h2')
+    expect(v.message).toMatch(/Discuss-lock/i)
+  })
+
+  it('does not block H1 under advisory without spec', () => {
+    const v = discussLockVerdict({
+      sddMode: 'advisory',
+      harnessLevel: 'H1',
+      hasSpecId: false,
+    })
+    expect(v.blocked).toBe(false)
+  })
+
+  it('blocks draft specs under strict', () => {
+    const v = discussLockVerdict({
+      sddMode: 'strict',
+      harnessLevel: 'H0',
+      hasSpecId: true,
+      specStatus: 'draft',
+    })
+    expect(v.blocked).toBe(true)
+    expect(v.message).toMatch(/draft/i)
+  })
+
+  it('allows reviewed spec under H2 advisory', () => {
+    const v = discussLockVerdict({
+      sddMode: 'advisory',
+      harnessLevel: 'H2',
+      hasSpecId: true,
+      specStatus: 'reviewed',
+    })
+    expect(v.blocked).toBe(false)
+  })
+})
+
+describe('context-pressure (GSD utilization guard proxy)', () => {
+  it('is ok at low turns', () => {
+    const v = contextPressureVerdict(
+      { maxTurnsPerCycle: 25 } as never,
+      { turnCount: 3, description: 'x' } as never
+    )
+    expect(v.level).toBe('ok')
+    expect(v.cue).toBeNull()
+  })
+
+  it('warns near 60% of turn budget', () => {
+    const v = contextPressureVerdict(
+      { maxTurnsPerCycle: 10 } as never,
+      { turnCount: 6, description: 'x' } as never
+    )
+    expect(v.level).toBe('warn')
+    expect(v.cue).toMatch(/context pressure/i)
+  })
+
+  it('critical near 70%', () => {
+    const v = contextPressureVerdict(
+      { maxTurnsPerCycle: 10 } as never,
+      { turnCount: 8, description: 'x' } as never
+    )
+    expect(v.level).toBe('critical')
+    expect(v.cue).toMatch(/LAND|prime|critical/i)
+  })
+})
+
+describe('nyquist-lite (verifiable ACs)', () => {
+  it('accepts test-named criteria', () => {
+    expect(isVerifiableAcceptance('bun test core/foo.test.ts passes')).toBe(true)
+    expect(isVerifiableAcceptance('curl returns 200 on /health')).toBe(true)
+  })
+
+  it('rejects vague prose', () => {
+    expect(isVerifiableAcceptance('auth feels solid')).toBe(false)
+  })
+
+  it('reports vague list', () => {
+    const r = assessAcceptanceCriteria(['user can log in', 'bun test core/auth.test.ts is green'])
+    expect(r.ok).toBe(false)
+    expect(r.vague.length).toBe(1)
+    expect(r.verifiable).toBe(1)
+  })
+})

--- a/core/__tests__/services/harness-score.test.ts
+++ b/core/__tests__/services/harness-score.test.ts
@@ -48,4 +48,13 @@ describe('harness score', () => {
     expect(md).toContain('Always-on skill tokens')
     expect(md).toMatch(/done|in progress/)
   })
+
+  it('renders competitive dust table vs gentle-ai and open-GSD', () => {
+    const md = renderHarnessScoreMd(computeHarnessScore())
+    expect(md).toContain('Competitive dust')
+    expect(md).toContain('gentle-ai')
+    expect(md).toContain('open-GSD')
+    expect(md).toContain('discuss-lock')
+    expect(md).toContain('SQLite')
+  })
 })

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -104,11 +104,11 @@ export class ShippingCommands extends PrjctCommandsBase {
       // SDD strict gate (opt-in via config.sdd.mode === 'strict'): refuse to
       // ship work with no linked spec — the pipeline is mandatory in strict.
       // advisory/off never block here. `--no-spec-gate` is the override.
+      const shipConfig = await configManager.readConfig(projectPath).catch(() => null)
       if (!options.noSpecGate && !linkedSpecId) {
         try {
-          const sddConfig = await configManager.readConfig(projectPath).catch(() => null)
           const { effectiveSddMode } = await import('./sdd')
-          if (effectiveSddMode(sddConfig) === 'strict') {
+          if (effectiveSddMode(shipConfig) === 'strict') {
             return {
               success: false,
               error:
@@ -118,6 +118,38 @@ export class ShippingCommands extends PrjctCommandsBase {
         } catch {
           // best-effort — never crash ship on the gate lookup
         }
+      }
+
+      // Package legitimacy (GSD slopcheck steal): new deps vs HEAD.
+      try {
+        const { checkPackageLegitimacy } = await import('../services/package-legitimacy')
+        const pkg = await checkPackageLegitimacy(projectPath)
+        if (pkg.risky && pkg.message) {
+          const hard =
+            shipConfig?.sdd?.mode === 'strict' ||
+            shipConfig?.tdd?.mode === 'strict' ||
+            shipConfig?.deliveryGeometry?.mode === 'strict'
+          if (hard && !options.noSpecGate) {
+            return {
+              success: false,
+              error: `${pkg.message}\nOverride only with explicit consent: verify packages, then \`prjct ship --no-spec-gate\`.`,
+            }
+          }
+          console.log(`⚠️  ${pkg.message}`)
+        }
+      } catch {
+        /* package check is best-effort */
+      }
+
+      // Dual-blind judgment default on ship-grade packs (code-strict).
+      if (
+        shipConfig?.sdd?.mode === 'strict' &&
+        shipConfig?.tdd?.mode === 'strict' &&
+        !options.noSpecGate
+      ) {
+        console.log(
+          '⚖️  code-strict ship: run dual-blind `judgment` (two independent reviewers, confirmed-only fixes, re-judge) before merge — `prjct workflows` → judgment.'
+        )
       }
 
       // SDD acceptance gate: surface the linked spec's acceptance_criteria

--- a/core/commands/update/cleanup-installs.ts
+++ b/core/commands/update/cleanup-installs.ts
@@ -70,6 +70,21 @@ function sourceRoot(): string {
  * winner, the dev checkout, or anything whose ownership can't be proven
  * (getAllInstalledLocations already verifies `prjct-cli/package.json`).
  */
+/** True when this install root owns the PATH-winning binary realpath. */
+function locationOwnsWinner(
+  installRoot: string | null | undefined,
+  winnerReal: string | null
+): boolean {
+  if (!installRoot || !winnerReal) return false
+  try {
+    const root = realpathSync(installRoot)
+    const win = realpathSync(winnerReal)
+    return win === root || win.startsWith(root + path.sep)
+  } catch {
+    return winnerReal.includes(installRoot)
+  }
+}
+
 export function planCleanup(): CleanupPlan {
   const winnerReal = pathWinnerReal()
   const winnerPm = detectInstallerFromRunningBinary()
@@ -88,17 +103,41 @@ export function planCleanup(): CleanupPlan {
     }
   }
 
-  const brewWinner = winnerReal?.includes('/Cellar/') || winnerReal?.includes('/homebrew/')
-  const winner: CleanupPlan['winner'] = brewWinner ? 'brew' : winnerPm
+  const brewWinner =
+    !!winnerReal &&
+    (winnerReal.includes('/Cellar/') ||
+      winnerReal.includes('/homebrew/') ||
+      winnerReal.includes('/opt/homebrew/bin/prjct') ||
+      winnerReal.includes('/opt/homebrew/lib/node_modules/prjct-cli'))
+  // Prefer the PM that owns the winning *binary path* over a mis-detected
+  // installer string (fixes multi-install footgun that deleted the active copy).
+  let winner: CleanupPlan['winner'] = brewWinner ? 'brew' : winnerPm
+  if (!brewWinner && winnerReal) {
+    for (const loc of getAllInstalledLocations()) {
+      const root = loc.pm.getInstallRoot()
+      if (
+        locationOwnsWinner(root, winnerReal) ||
+        locationOwnsWinner(path.join(root ?? '', 'prjct-cli'), winnerReal)
+      ) {
+        winner = loc.pm.name
+        break
+      }
+    }
+  }
 
   const removable: CleanupPlan['removable'] = []
   for (const loc of getAllInstalledLocations()) {
-    if (loc.pm.name === winnerPm) {
-      skipped.push({ pm: loc.pm.name, reason: 'PATH winner — kept' })
+    const root = loc.pm.getInstallRoot()
+    const owns =
+      loc.pm.name === winner ||
+      loc.pm.name === winnerPm ||
+      locationOwnsWinner(root, winnerReal) ||
+      locationOwnsWinner(root ? path.join(root, 'prjct-cli') : null, winnerReal)
+    if (owns) {
+      skipped.push({ pm: loc.pm.name, reason: 'PATH winner (or owns winning binary) — kept' })
       continue
     }
     // Gate: never remove the dev source tree (npm/bun link).
-    const root = loc.pm.getInstallRoot()
     if (root && src) {
       let resolved = path.join(root, 'prjct-cli')
       try {
@@ -115,10 +154,22 @@ export function planCleanup(): CleanupPlan {
   }
 
   // Brew: only if a brew copy exists AND it is not the winner.
-  if (isHomebrewInstall() && !brewWinner) {
+  if (isHomebrewInstall() && !brewWinner && winner !== 'brew') {
     removable.push({ pm: 'brew', version: '(homebrew)' })
-  } else if (isHomebrewInstall() && brewWinner) {
+  } else if (isHomebrewInstall() && (brewWinner || winner === 'brew')) {
     skipped.push({ pm: 'brew', reason: 'PATH winner — kept' })
+  }
+
+  // Safety: never propose removals when we still cannot name a winner.
+  if (winner === null) {
+    return {
+      winner: null,
+      removable: [],
+      skipped: [
+        ...skipped,
+        { pm: '(all)', reason: 'no definitive winner — refusing to remove any copy' },
+      ],
+    }
   }
 
   return { winner, removable, skipped }

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -144,6 +144,25 @@ export async function buildProjectState(
         /* budget is advisory — never block the state block */
       }
 
+      // Context-pressure (GSD utilization guard, host-agnostic): turn/token
+      // ratio → land/prime discipline before the window rots.
+      try {
+        const { contextPressureVerdict } = await import('../services/context-pressure')
+        const task = await stateStorage.getCurrentTask(config.projectId)
+        const pressure = contextPressureVerdict(config, task)
+        if (pressure.level === 'critical') {
+          lines.push(
+            `  ⛔ Context pressure critical (~${Math.round(pressure.ratio * 100)}%). \`prjct land\` + fresh window + \`prjct prime\` — do not keep expanding this thread.`
+          )
+        } else if (pressure.level === 'warn') {
+          lines.push(
+            `  ⚠ Context pressure (~${Math.round(pressure.ratio * 100)}%). Prefer finishing + land over more exploration.`
+          )
+        }
+      } catch {
+        /* advisory */
+      }
+
       // Delegation trigger — the multi-file write rule, ENFORCED by counting
       // (not just stated in a skill): when this cycle has edited 4+ distinct
       // files, say so with the concrete move. Uses the post_edit event trail

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -157,7 +157,24 @@ async function buildStalenessNotice(
     if (!status.isStale || status.commitsSinceSync <= 0) return null
     const warning = checker.getWarning(status)
     if (!warning) return null
-    return `**Understanding may be stale:** ${warning} — the architecture/risks map was built at the last sync; refresh before trusting it for big calls.`
+    // Continuous understanding: detach a lightweight sync so the map
+    // refreshes without GSD-style full map-codebase thrash every phase.
+    try {
+      const path = await import('node:path')
+      const os = await import('node:os')
+      const { maybeDetachDriftRefresh } = await import('../services/drift-refresh')
+      const cliHome = process.env.PRJCT_CLI_HOME
+        ? path.resolve(process.env.PRJCT_CLI_HOME)
+        : path.join(os.homedir(), '.prjct-cli')
+      maybeDetachDriftRefresh({
+        projectPath,
+        cliHome,
+        commitsSinceSync: status.commitsSinceSync,
+      })
+    } catch {
+      /* never block SessionStart */
+    }
+    return `**Understanding may be stale:** ${warning} — architecture/risks map from last sync; a background refresh was scheduled when drift is large. Prefer \`prjct sync\` before big calls if this notice persists.`
   } catch {
     return null
   }

--- a/core/packs/manifests.ts
+++ b/core/packs/manifests.ts
@@ -80,7 +80,9 @@ export const PACK_MANIFESTS: Record<string, PackManifest> = {
       tdd: 'assist',
       maxTurnsPerCycle: 25,
       deliveryGeometry: 'advisory',
-      land: 'advisory',
+      // Session-close is not optional on code packs (gentle-ai land ritual,
+      // code-enforced cue via land-cue + Stop).
+      land: 'strict',
     },
   },
 

--- a/core/services/context-pressure.ts
+++ b/core/services/context-pressure.ts
@@ -1,0 +1,83 @@
+/**
+ * Context-pressure cues — beat GSD's context-window utilization guard without
+ * needing proprietary host metrics.
+ *
+ * Uses turn count + optional token budget (already on the active task) as a
+ * host-agnostic proxy. At 60%/70% of the cycle turn budget (or stuck threshold),
+ * inject land/compact pressure so agents close the loop instead of rotting.
+ */
+
+import type { LocalConfig } from '../types/config'
+
+const DEFAULT_TURN_SOFT = 15
+const WARN_RATIO = 0.6
+const CRITICAL_RATIO = 0.7
+
+export type ContextPressureLevel = 'ok' | 'warn' | 'critical'
+
+/** Minimal task shape — full CurrentTask or a slim ActiveTaskView projection. */
+export interface ContextPressureTask {
+  turnCount?: number
+  tokensIn?: number
+  tokensOut?: number
+  description?: string
+}
+
+export interface ContextPressureVerdict {
+  level: ContextPressureLevel
+  /** Short hook line; null when nothing to say. */
+  cue: string | null
+  turns: number
+  limit: number
+  ratio: number
+}
+
+/**
+ * Prefer configured maxTurnsPerCycle; fall back to the stuck threshold so
+ * projects without an explicit budget still get pressure cues.
+ */
+export function contextPressureVerdict(
+  config: LocalConfig | null | undefined,
+  task: ContextPressureTask | null | undefined
+): ContextPressureVerdict {
+  const turns = task?.turnCount ?? 0
+  const limit =
+    config?.maxTurnsPerCycle && config.maxTurnsPerCycle > 0
+      ? config.maxTurnsPerCycle
+      : DEFAULT_TURN_SOFT
+  const ratio = limit > 0 ? turns / limit : 0
+
+  if (!task || turns <= 0) {
+    return { level: 'ok', cue: null, turns, limit, ratio: 0 }
+  }
+
+  // Token budget twin (when present) can escalate independently.
+  const tokenBudget = config?.maxTokensPerCycle ?? 0
+  const spent = (task.tokensIn ?? 0) + (task.tokensOut ?? 0)
+  const tokenRatio = tokenBudget > 0 ? spent / tokenBudget : 0
+  const effective = Math.max(ratio, tokenRatio)
+
+  if (effective >= CRITICAL_RATIO) {
+    return {
+      level: 'critical',
+      turns,
+      limit,
+      ratio: effective,
+      cue: `# prjct: CONTEXT PRESSURE (critical ~${Math.round(effective * 100)}%)
+Session is filling — STOP expanding scope. \`prjct land\` now, then \`/clear\` or new window + \`prjct prime\`. Fresh context with compound judgment beats a rotten long thread (GSD-class discipline, SQLite-backed).`,
+    }
+  }
+
+  if (effective >= WARN_RATIO) {
+    return {
+      level: 'warn',
+      turns,
+      limit,
+      ratio: effective,
+      cue: `# prjct: context pressure (~${Math.round(effective * 100)}%)
+Plan the close: finish the slice, \`prjct land\`, avoid more exploration in this window.`,
+    }
+  }
+
+  return { level: 'ok', cue: null, turns, limit, ratio: effective }
+}

--- a/core/services/discuss-lock.ts
+++ b/core/services/discuss-lock.ts
@@ -1,0 +1,72 @@
+/**
+ * Discuss-lock — product decisions before plan/code on high-stakes work.
+ *
+ * Beats open-GSD's discuss-phase theater without a new verb: when harness
+ * level is H2+ and SDD is advisory/strict, `prjct work` requires a REVIEWED
+ * intent/spec (the product lock) before the cycle starts. Trivial/H0–H1 stay
+ * DIRECT. SDD `off` never blocks (opt-out remains possible).
+ */
+
+import type { HarnessLevel } from '../schemas/state'
+import type { LocalConfig } from '../types/config'
+
+export type DiscussLockMode = 'off' | 'advisory' | 'strict'
+
+export interface DiscussLockVerdict {
+  /** True → startTask must refuse until a reviewed spec is linked. */
+  blocked: boolean
+  /** Human-facing reason (empty when not blocked). */
+  message: string
+  /** Why the lock applied (telemetry / tests). */
+  reason: 'sdd-strict' | 'discuss-h2' | 'none'
+}
+
+export function effectiveDiscussSddMode(config: LocalConfig | null | undefined): DiscussLockMode {
+  return config?.sdd?.mode ?? 'off'
+}
+
+/**
+ * H2/H3 work needs a product lock when SDD is on (advisory or strict).
+ * Strict already blocks every cycle; advisory only blocks high harness levels.
+ */
+export function discussLockVerdict(input: {
+  sddMode: DiscussLockMode
+  harnessLevel: HarnessLevel
+  hasSpecId: boolean
+  specStatus?: string | null
+}): DiscussLockVerdict {
+  const { sddMode, harnessLevel, hasSpecId, specStatus } = input
+  if (sddMode === 'off') {
+    return { blocked: false, message: '', reason: 'none' }
+  }
+
+  const highStakes = harnessLevel === 'H2' || harnessLevel === 'H3'
+  const enforceAll = sddMode === 'strict'
+  const enforceHigh = sddMode === 'advisory' && highStakes
+
+  if (!enforceAll && !enforceHigh) {
+    return { blocked: false, message: '', reason: 'none' }
+  }
+
+  const reason = enforceAll ? 'sdd-strict' : 'discuss-h2'
+  if (!hasSpecId) {
+    return {
+      blocked: true,
+      reason,
+      message:
+        reason === 'sdd-strict'
+          ? 'Strict SDD: an intent/spec is required before work. Run `prjct intent "<title>"`, pass `prjct audit-spec <id>`, then `prjct work --spec <id>`. (Relax with `prjct sdd advisory` or `off`.)'
+          : `Discuss-lock (${harnessLevel}): lock product decisions before code. Run \`prjct intent "<title>"\` → \`prjct audit-spec <id>\` → \`prjct work --spec <id>\`. (This is advisory SDD on H2+ — GSD discuss-before-plan, code-enforced. Relax: \`prjct sdd off\`.)`,
+    }
+  }
+
+  if (specStatus === 'draft') {
+    return {
+      blocked: true,
+      reason,
+      message: `Discuss-lock: linked spec is still draft — run \`prjct audit-spec\` until reviewed before implementing.`,
+    }
+  }
+
+  return { blocked: false, message: '', reason: 'none' }
+}

--- a/core/services/drift-refresh.ts
+++ b/core/services/drift-refresh.ts
@@ -1,0 +1,84 @@
+/**
+ * Continuous understanding — when SessionStart detects genuine git drift since
+ * last sync, kick a *lightweight* refresh so agents don't re-map the whole
+ * codebase every phase (GSD map-codebase thrash). Detached, best-effort.
+ */
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+const STAMP = 'drift-refresh-last.json'
+
+function stampPath(cliHome: string): string {
+  return path.join(cliHome, 'state', STAMP)
+}
+
+/**
+ * Throttle: at most one detached refresh per hour per machine.
+ */
+export function shouldRefreshDrift(cliHome: string, commitsSinceSync: number): boolean {
+  if (commitsSinceSync <= 0) return false
+  // Only act on real drift (same threshold band as staleness warnings).
+  if (commitsSinceSync < 3) return false
+  try {
+    const p = stampPath(cliHome)
+    if (!existsSync(p)) return true
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const raw = require('node:fs').readFileSync(p, 'utf-8') as string
+    const j = JSON.parse(raw) as { at?: number }
+    if (!j.at) return true
+    return Date.now() - j.at > 60 * 60 * 1000
+  } catch {
+    return true
+  }
+}
+
+function writeStamp(cliHome: string): void {
+  try {
+    const fs = require('node:fs') as typeof import('node:fs')
+    const dir = path.join(cliHome, 'state')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(stampPath(cliHome), JSON.stringify({ at: Date.now() }), 'utf-8')
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Spawn `prjct sync` detached from the package entry. Never blocks SessionStart.
+ */
+export function maybeDetachDriftRefresh(input: {
+  projectPath: string
+  cliHome: string
+  commitsSinceSync: number
+  prjctBin?: string
+}): void {
+  if (!shouldRefreshDrift(input.cliHome, input.commitsSinceSync)) return
+  writeStamp(input.cliHome)
+
+  const bin = input.prjctBin ?? process.argv[1] ?? 'prjct'
+  try {
+    const child = spawn(process.execPath, [bin, 'sync', '--project', input.projectPath], {
+      detached: true,
+      stdio: 'ignore',
+      cwd: input.projectPath,
+      env: { ...process.env, PRJCT_DRIFT_REFRESH: '1' },
+    })
+    child.unref()
+  } catch {
+    // try bare prjct on PATH
+    try {
+      const child = spawn('prjct', ['sync'], {
+        detached: true,
+        stdio: 'ignore',
+        cwd: input.projectPath,
+        env: { ...process.env, PRJCT_DRIFT_REFRESH: '1' },
+        shell: true,
+      })
+      child.unref()
+    } catch {
+      /* never block session */
+    }
+  }
+}

--- a/core/services/harness-score.ts
+++ b/core/services/harness-score.ts
@@ -192,6 +192,32 @@ export function computeHarnessScore(options: { skillCtx?: SkillContext } = {}): 
   }
 }
 
+/**
+ * Competitive dust table — absolute dimensions where prjct must stay above
+ * gentle-ai (prompt-only ecosystem) and open-GSD (markdown phase theater).
+ * Static capability matrix + live structural grade; not marketing fluff.
+ */
+export function renderCompetitiveDustMd(report: HarnessScoreReport): string {
+  const grade = report.programDone ? 'WIN' : 'HOLD'
+  return [
+    '## Competitive dust (gentle-ai · open-GSD · prjct)',
+    '',
+    '| Dimension | gentle-ai | open-GSD | **prjct** |',
+    '|---|---|---|---|',
+    '| Judgment memory | Engram JSONL | files / MemPalace bolt-on | **SQLite typed WHY + apply-loop** |',
+    '| Enforcement | prompt-only | phase markdown ritual | **code gates (SDD/TDD/land/discuss/package)** |',
+    '| Work graph | none | ROADMAP.md | **ready/next/claim/phases in SQLite** |',
+    '| Fresh window | optional | re-research every phase | **prime + SessionStart digest (compound)** |',
+    '| Token economics | unmeasured thrash | high (fresh windows × agents) | **telemetry + skill/MCP diet** |',
+    '| Discuss before code | organic SDD | discuss-phase command | **discuss-lock H2+ (code)** |',
+    '| Install surface | curl/brew binary | npx multi-runtime | npm/pnpm/brew + upgrade consolidate |',
+    `| Structural grade | n/a | n/a | **${report.grade}/5 ${grade}** |`,
+    '',
+    '_Rule: never clone their skill count or `.planning/` OS. Crush on compound judgment, cost, and enforcement._',
+    '',
+  ].join('\n')
+}
+
 export function renderHarnessScoreMd(report: HarnessScoreReport): string {
   const rows = report.criteria.map(
     (c) => `| ${c.name} | ${c.score} | ${c.status} | ${c.slo} | ${c.measured} |`
@@ -214,6 +240,7 @@ export function renderHarnessScoreMd(report: HarnessScoreReport): string {
     `- Routing body: ${report.defaults.routingBytes} bytes`,
     `- Providers: ${report.defaults.providerCount}`,
     '',
+    renderCompetitiveDustMd(report),
   ].join('\n')
 }
 

--- a/core/services/land-cue.ts
+++ b/core/services/land-cue.ts
@@ -1,9 +1,11 @@
 /**
  * Session-close land cue — inject a short checklist when a cycle is open.
  * Used by SessionStart (advisory) and Stop (strict packs).
+ * Also surfaces context-pressure when the cycle is filling (GSD utilization guard).
  */
 
 import type { LocalConfig } from '../types/config'
+import { contextPressureVerdict } from './context-pressure'
 import { collectActiveTasks } from './task-overview'
 
 export type LandMode = 'off' | 'advisory' | 'strict'
@@ -27,13 +29,20 @@ export async function buildLandCue(
   if (!overview?.current) return null
 
   const title = overview.current.description.slice(0, 60)
-  const hard = mode === 'strict'
+  // ActiveTaskView may omit turn counters — pressure falls back to ok.
+  const pressure = contextPressureVerdict(config, {
+    description: overview.current.description,
+  })
+  // Context critical upgrades advisory land to a hard cue for this session.
+  const hard = mode === 'strict' || pressure.level === 'critical'
   const head = hard ? `# prjct: LAND REQUIRED before context dies` : `# prjct: land the plane`
-  return [
+  const lines = [
     head,
     `Open cycle: "${title}${overview.current.description.length > 60 ? '…' : ''}"`,
     hard
       ? 'Before ending the session: `prjct status done` or `prjct log "…"`, then `prjct land` (auto-synthesizes the Session close hand-off — no manual remember).'
       : 'Before ending the session: `prjct land` (auto hand-off) · optional `prjct memory export` for the team.',
-  ].join('\n')
+  ]
+  if (pressure.cue) lines.push('', pressure.cue)
+  return lines.join('\n')
 }

--- a/core/services/land-synthesis.ts
+++ b/core/services/land-synthesis.ts
@@ -161,13 +161,22 @@ export function buildLandHandoffContent(input: LandSynthesisInput): string | nul
   // Meta only when present — never "unknown".
   if (input.author) parts.push(`Who/author: ${input.author}`)
   if (input.model) parts.push(`Model: ${input.model}`)
-  if (input.tokensIn != null || input.tokensOut != null) {
-    parts.push(`Token usage: in=${input.tokensIn ?? 0} out=${input.tokensOut ?? 0}`)
+  // Token economics (dominance vs GSD thrash): surface real spend when known.
+  const tokIn = input.tokensIn
+  const tokOut = input.tokensOut
+  if (tokIn != null || tokOut != null) {
+    const total = (tokIn ?? 0) + (tokOut ?? 0)
+    parts.push(
+      `Token usage: in=${tokIn ?? 0} out=${tokOut ?? 0} total=${total} (compound judgment — not a fresh-window thrash loop)`
+    )
   }
 
   parts.push('Feature/domain: session-close')
   parts.push('Pattern: land auto-synthesis without agent remember')
   parts.push('Anti-pattern: relying on the model to remember to remember at session end')
+  parts.push(
+    'Competitive: next window must `prjct prime` — act as this developer with SQLite judgment, not re-research from zero (GSD tax).'
+  )
 
   const next =
     cycle != null
@@ -188,12 +197,33 @@ export async function synthesizeLandHandoffFromProject(
   > = {}
 ): Promise<LandSynthesisResult> {
   const overview = await collectActiveTasks(projectId, projectPath).catch(() => null)
+  // Prefer explicit extras; fall back to cycle token counters when present.
+  let tokensIn = extras.tokensIn
+  let tokensOut = extras.tokensOut
+  if ((tokensIn == null || tokensOut == null) && overview?.current?.id) {
+    try {
+      const row = prjctDb.get<{ tokens_in: number | null; tokens_out: number | null }>(
+        projectId,
+        'SELECT tokens_in, tokens_out FROM tasks WHERE id = ?',
+        overview.current.id
+      )
+      if (row) {
+        tokensIn = tokensIn ?? row.tokens_in ?? undefined
+        tokensOut = tokensOut ?? row.tokens_out ?? undefined
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
   return synthesizeLandHandoff({
     projectId,
     projectPath,
     cycleDescription: overview?.current?.description ?? null,
     cycleId: overview?.current?.id ?? null,
     ...extras,
+    // Prefer resolved counters (extras first via coalesce above).
+    tokensIn,
+    tokensOut,
   })
 }
 

--- a/core/services/nyquist-lite.ts
+++ b/core/services/nyquist-lite.ts
@@ -1,0 +1,51 @@
+/**
+ * Nyquist-lite — every acceptance criterion should name a verifiable signal
+ * (test, command, or observable behavior). Soft gate at audit promote time:
+ * we do not invent tests, we refuse silent "looks done" prose-only ACs when
+ * code-strict / TDD strict asks for teeth.
+ *
+ * Verifiable heuristics (any match → ok):
+ *   - mentions test / e2e / unit / integration / coverage
+ *   - mentions command-like tokens (npm/bun/cargo/pytest/curl/http status)
+ *   - contains a path-like segment ending in common test suffixes
+ *   - contains checkbox-style measurable outcomes (returns 200, exits 0, etc.)
+ */
+
+const VERIFIABLE =
+  /\b(test|tests|e2e|unit|integration|spec|coverage|assert|expect|jest|vitest|playwright|cypress|bun test|npm test|pytest|cargo test|go test|curl|http\s*[1-5]\d{2}|exit(s|ed)?\s*0|returns?\s+\d+|cli\b|command\b|verify|assert)\b/i
+
+const PATHISH = /[\w./-]+\.(test|spec)\.[a-z]+/i
+
+export function isVerifiableAcceptance(criterion: string): boolean {
+  const t = criterion.trim()
+  if (t.length < 8) return false
+  return VERIFIABLE.test(t) || PATHISH.test(t)
+}
+
+export interface NyquistLiteReport {
+  total: number
+  verifiable: number
+  vague: string[]
+  /** True when every AC is verifiable (or there are none). */
+  ok: boolean
+  message: string | null
+}
+
+export function assessAcceptanceCriteria(criteria: string[]): NyquistLiteReport {
+  const vague: string[] = []
+  let verifiable = 0
+  for (const c of criteria) {
+    if (isVerifiableAcceptance(c)) verifiable++
+    else vague.push(c.slice(0, 120))
+  }
+  const total = criteria.length
+  const ok = total === 0 || vague.length === 0
+  const message = ok
+    ? null
+    : [
+        `Nyquist-lite: ${vague.length}/${total} acceptance criteria lack a verifiable signal (test/command/observable).`,
+        'Rewrite ACs to name how they are checked (e.g. `bun test core/foo`, `curl returns 200`).',
+        ...vague.slice(0, 5).map((v) => `  - ${v}`),
+      ].join('\n')
+  return { total, verifiable, vague, ok, message }
+}

--- a/core/services/package-legitimacy.ts
+++ b/core/services/package-legitimacy.ts
@@ -1,0 +1,98 @@
+/**
+ * Package legitimacy gate — steal GSD slopcheck intent without a new verb:
+ * when package.json gains dependencies, surface a structured risk before ship.
+ *
+ * Precision over recall: only flags *new* dep names not previously in
+ * package.json history (git show HEAD:package.json). Never auto-installs
+ * alternatives (anti-slopsquatting). Strict packs can block ship.
+ */
+
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { execFileAsync } from '../utils/exec'
+
+export interface PackageLegitimacyResult {
+  newDependencies: string[]
+  /** True when any new dep was introduced vs HEAD. */
+  risky: boolean
+  message: string | null
+}
+
+interface PkgJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+function depNames(pkg: PkgJson | null): Set<string> {
+  const out = new Set<string>()
+  if (!pkg) return out
+  for (const key of [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+  ] as const) {
+    const block = pkg[key]
+    if (block) for (const name of Object.keys(block)) out.add(name)
+  }
+  return out
+}
+
+async function readJsonFile(file: string): Promise<PkgJson | null> {
+  try {
+    const raw = await readFile(file, 'utf-8')
+    return JSON.parse(raw) as PkgJson
+  } catch {
+    return null
+  }
+}
+
+async function headPackageJson(projectPath: string): Promise<PkgJson | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['show', 'HEAD:package.json'], {
+      cwd: projectPath,
+    })
+    return JSON.parse(stdout) as PkgJson
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Compare working-tree package.json to HEAD. No git / no package.json → clean.
+ */
+export async function checkPackageLegitimacy(
+  projectPath: string
+): Promise<PackageLegitimacyResult> {
+  const pkgPath = path.join(projectPath, 'package.json')
+  if (!existsSync(pkgPath)) {
+    return { newDependencies: [], risky: false, message: null }
+  }
+  if (!existsSync(path.join(projectPath, '.git'))) {
+    return { newDependencies: [], risky: false, message: null }
+  }
+
+  const current = await readJsonFile(pkgPath)
+  const baseline = await headPackageJson(projectPath)
+  const now = depNames(current)
+  const before = depNames(baseline)
+  const added = [...now].filter((n) => !before.has(n)).sort()
+
+  if (added.length === 0) {
+    return { newDependencies: [], risky: false, message: null }
+  }
+
+  return {
+    newDependencies: added,
+    risky: true,
+    message: [
+      `Package legitimacy: ${added.length} new dependenc${added.length === 1 ? 'y' : 'ies'} vs HEAD:`,
+      ...added.map((n) => `  - ${n}`),
+      'Verify each on the registry (age, downloads, source). Do not substitute similar names.',
+      'Strict packs block ship until you confirm or revert. (Dominance vs GSD slopcheck.)',
+    ].join('\n'),
+  }
+}

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -194,6 +194,33 @@ class SpecService {
     if (updated && reviewsGatePassedRelational(projectId, id)) {
       // All SELECTED lenses pass → auto-promote draft to reviewed.
       if (updated.status === 'draft') {
+        // Nyquist-lite: refuse silent promote when ACs are prose-only under
+        // TDD strict / SDD strict (code-strict pack). Soft warn otherwise.
+        const { assessAcceptanceCriteria } = await import('./nyquist-lite')
+        const acReport = assessAcceptanceCriteria(updated.content.acceptance_criteria ?? [])
+        if (!acReport.ok && acReport.message) {
+          const cfg = await configManager.readConfig(projectPath).catch(() => null)
+          const tddStrict = cfg?.tdd?.mode === 'strict'
+          const sddStrict = cfg?.sdd?.mode === 'strict'
+          if (tddStrict || sddStrict) {
+            throw new Error(
+              `NYQUIST_LITE_BLOCK: ${acReport.message}\nRewrite acceptance criteria with verifiable signals, then re-record the last review.`
+            )
+          }
+          // Advisory: attach a tag so agents see the gap without blocking.
+          try {
+            await projectMemory.remember(projectPath, {
+              type: 'improvement-signal',
+              content: acReport.message,
+              tags: { source: 'nyquist-lite', spec: id },
+              provenance: 'extracted',
+              projectId,
+            })
+          } catch {
+            /* best-effort */
+          }
+        }
+
         const promoted = specStorage.setStatus(projectId, id, 'reviewed')
         // Auto-breakdown: materialize acceptance_criteria as granular
         // queue tasks. Now made idempotent on spec_id via the

--- a/core/services/task-harness.ts
+++ b/core/services/task-harness.ts
@@ -178,7 +178,15 @@ function detectKind(text: string): HarnessKind {
   ) {
     return 'research'
   }
-  if (hasAny(text, ['refactor', 'cleanup', 'split', 'restructure'])) return 'refactor'
+  // `split` as a refactor verb only when free-token (not hyphen-compound).
+  // JS `\b` treats `-` as a boundary, so `\bsplit\b` matches "split-home"
+  // and discuss-lock blocked e2e smokes (dominance false-positive class).
+  if (
+    hasAny(text, ['refactor', 'cleanup', 'restructure']) ||
+    /(?:^|[^a-z0-9_-])split(?:[^a-z0-9_-]|$)/.test(text)
+  ) {
+    return 'refactor'
+  }
   if (hasAny(text, ['doc', 'docs', 'document', 'readme', 'changelog', 'typo'])) return 'docs'
   if (hasAny(text, ['chore', 'format', 'lint', 'linting', 'linter'])) return 'chore'
   if (hasAny(text, ['add', 'agrega', 'crear', 'implement', 'implementa', 'feature', 'mejora'])) {

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -187,34 +187,36 @@ export async function startTask(
 
   const cfg = await configManager.readConfig(projectPath).catch(() => null)
 
-  // SDD strict gate (opt-in via config.sdd.mode === 'strict'): a work cycle must
-  // link a REVIEWED intent/spec. Enforced here so CLI and MCP share
-  // it. `off`/`advisory` never block (advisory only nudges via the skill).
+  // Discuss-lock + SDD gate (dominance vs GSD discuss-before-plan):
+  //   - strict: every work cycle needs a REVIEWED intent/spec
+  //   - advisory: H2/H3 only (product lock without full ceremony on chores)
+  //   - off: never blocks
+  // Built from harness level so CLI + MCP share one path.
   {
     const { effectiveSddMode } = await import('../commands/sdd')
-    if (effectiveSddMode(cfg) === 'strict') {
-      if (!options.spec) {
-        return {
-          ok: false,
-          blocked:
-            'Strict SDD: an intent/spec is required before work. Run `prjct intent "<title>"`, pass `prjct audit-spec <id>`, then `prjct work --spec <id>`. (Relax with `prjct sdd advisory`.)',
-        }
-      }
+    const { discussLockVerdict } = await import('./discuss-lock')
+    const harnessPreview = buildTaskHarness(description)
+    let specStatus: string | null = null
+    if (options.spec) {
       try {
         const { specService } = await import('./spec-service')
         const spec = await specService.get(projectPath, options.spec)
         if (!spec) {
-          return { ok: false, blocked: `Strict SDD: spec ${options.spec} not found.` }
+          return { ok: false, blocked: `Spec ${options.spec} not found.` }
         }
-        if (spec.status === 'draft') {
-          return {
-            ok: false,
-            blocked: `Strict SDD: spec "${spec.title}" hasn't passed audit-spec yet (status: draft). Run \`prjct audit-spec ${options.spec}\` first.`,
-          }
-        }
+        specStatus = spec.status
       } catch {
-        // spec lookup failed internally — don't hard-block on our own error
+        /* lookup failure — discuss-lock treats as unknown status */
       }
+    }
+    const lock = discussLockVerdict({
+      sddMode: effectiveSddMode(cfg),
+      harnessLevel: harnessPreview.level,
+      hasSpecId: Boolean(options.spec),
+      specStatus,
+    })
+    if (lock.blocked) {
+      return { ok: false, blocked: lock.message }
     }
   }
 


### PR DESCRIPTION
## Summary

Completes the competitive dominance plan so **gentle-ai** and **open-GSD** stay below prjct on every absolute benchmark — without cloning skill count or `.planning/` theater.

| Slice | Mechanism |
|-------|-----------|
| P0a Discuss-lock | H2/H3 + SDD advisory → require reviewed intent/spec before `work` |
| P0b Context pressure | 60%/70% turn/token ratio → land/prime cues |
| P0c Drift re-analysis | SessionStart staleness → detached `prjct sync` |
| P0d Scorecard CI | `harness-score` tests in Quality Checks job |
| P1a Package legitimacy | New deps vs HEAD block ship under strict packs |
| P1b Dual-blind default | code-strict ship prints judgment workflow reminder |
| P1c Nyquist-lite | Vague ACs cannot auto-promote under SDD/TDD strict |
| P2 Land + install | `code` pack `land: strict`; cleanup never removes PATH winner |

## Test plan

- [x] `bun test core/__tests__/services/dominance-gates.test.ts`
- [x] `bun test core/__tests__/services/harness-score.test.ts`
- [x] `bun run typecheck` + `bun run check`
- [ ] CI green on PR