### PR TITLE
feat(harness): multi-runtime organic wire + weak A/B CI dominance gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,17 @@ jobs:
       - name: Harness scorecard (world-class SLOs)
         run: bun test core/__tests__/services/harness-score.test.ts
 
+      # Dominance P1: weak-model A/B + multi-runtime wire — release-blocking.
+      # North star: weak + prjct ≥ frontier-without-harness on discipline SLOs.
+      - name: Weak-model A/B + multi-runtime SLOs (release-blocking)
+        run: |
+          set -euo pipefail
+          bun test core/__tests__/services/weak-model-bench.test.ts \
+            core/__tests__/services/weak-frontier-demo.test.ts \
+            core/__tests__/services/harness-coverage.test.ts
+          bun run bench:weak-model
+          bun run demo:weak-vs-frontier
+
   test:
     name: Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest

--- a/core/__tests__/commands/crew-emulated.test.ts
+++ b/core/__tests__/commands/crew-emulated.test.ts
@@ -26,7 +26,7 @@ describe('emulated crew protocol', () => {
       expect(proto).toContain(lens)
     }
     // Per-role rig models resolved from the policy via the bridge.
-    expect(proto).toContain('2.5-pro') // implementer → frontier
+    expect(proto).toContain('3.1-pro') // implementer → frontier
     expect(proto).toContain('2.0-flash') // leader → fast
     expect(proto).toContain('2.5-flash') // reviewer → balanced
     expect(proto).toContain('Tests must pass') // checkpoints embedded

--- a/core/__tests__/commands/update-cleanup.test.ts
+++ b/core/__tests__/commands/update-cleanup.test.ts
@@ -13,7 +13,12 @@ import { afterEach, beforeEach, describe, expect, it, setDefaultTimeout } from '
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { consolidateInstalls, planCleanup } from '../../commands/update/cleanup-installs'
+import {
+  type CleanupLocation,
+  consolidateInstalls,
+  planCleanup,
+  planCleanupFrom,
+} from '../../commands/update/cleanup-installs'
 import { formatMdOutput } from '../../commands/update/output'
 import pathManager from '../../infrastructure/path-manager'
 import { getUpdateNotificationSync } from '../../infrastructure/update-checker'
@@ -69,6 +74,201 @@ describe('WS4 — consolidateInstalls', () => {
     expect(Array.isArray(plan.skipped)).toBe(true)
     // Safety invariant: nothing is ever removable without a winner.
     if (plan.winner === null) expect(plan.removable).toEqual([])
+  })
+})
+
+/** Pure prefix ownership for fixtures (no realpath / no disk). */
+function prefixOwns(installRoot: string | null | undefined, winnerReal: string | null): boolean {
+  if (!installRoot || !winnerReal) return false
+  return winnerReal === installRoot || winnerReal.startsWith(`${installRoot}/`)
+}
+
+function loc(
+  name: CleanupLocation['name'],
+  installRoot: string,
+  version = '1.0.0'
+): CleanupLocation {
+  return { name, installRoot, version }
+}
+
+describe('planCleanupFrom — install winner invariants', () => {
+  it('refuses all removals when neither winnerReal nor winnerPm is known', () => {
+    const plan = planCleanupFrom({
+      winnerReal: null,
+      winnerPm: null,
+      locations: [
+        loc('npm', '/opt/npm/lib/node_modules'),
+        loc('bun', '/Users/x/.bun/install/global/node_modules'),
+      ],
+      brewInstalled: false,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBeNull()
+    expect(plan.removable).toEqual([])
+    expect(plan.skipped[0]?.reason).toMatch(/refusing to remove/i)
+  })
+
+  it('never lists the PATH-winner PM as removable', () => {
+    // Use non-Homebrew paths so brew-path heuristics do not fire.
+    const npmRoot = '/usr/local/lib/node_modules'
+    const plan = planCleanupFrom({
+      winnerReal: `${npmRoot}/prjct-cli/bin/prjct.js`,
+      winnerPm: 'npm',
+      locations: [
+        loc('npm', npmRoot, '3.35.0'),
+        loc('bun', '/Users/x/.bun/install/global/node_modules', '3.34.0'),
+      ],
+      brewInstalled: false,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('npm')
+    expect(plan.removable.map((r) => r.pm)).toEqual(['bun'])
+    expect(plan.removable.map((r) => r.pm)).not.toContain('npm')
+  })
+
+  it('prefers path ownership over mis-detected winnerPm (keeps A, removes B)', () => {
+    // Dogfood footgun: which prjct → npm, but detectInstaller said bun.
+    const npmRoot = '/usr/local/lib/node_modules'
+    const bunRoot = '/Users/x/.bun/install/global/node_modules'
+    const plan = planCleanupFrom({
+      winnerReal: `${npmRoot}/prjct-cli/bin/prjct.js`,
+      winnerPm: 'bun',
+      locations: [loc('npm', npmRoot), loc('bun', bunRoot)],
+      brewInstalled: false,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('npm')
+    expect(plan.removable.map((r) => r.pm)).toEqual(['bun'])
+    expect(plan.skipped.some((s) => s.pm === 'npm')).toBe(true)
+  })
+
+  it('keeps winnerPm by name only when winnerReal is unknown', () => {
+    const plan = planCleanupFrom({
+      winnerReal: null,
+      winnerPm: 'pnpm',
+      locations: [
+        loc('pnpm', '/Users/x/Library/pnpm/global/5/node_modules'),
+        loc('npm', '/usr/local/lib/node_modules'),
+      ],
+      brewInstalled: false,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('pnpm')
+    expect(plan.removable.map((r) => r.pm)).toEqual(['npm'])
+  })
+
+  it('never removes the dev source tree even when it is not the winner PM', () => {
+    const src = '/Users/x/Apps/prjct/prjct-cli'
+    const npmRoot = '/usr/local/lib/node_modules'
+    // yarn "install" is actually a link into the source tree.
+    const yarnRoot = '/Users/x/.config/yarn/global/node_modules'
+    const plan = planCleanupFrom({
+      winnerReal: `${npmRoot}/prjct-cli/bin/prjct.js`,
+      winnerPm: 'npm',
+      locations: [loc('npm', npmRoot), loc('yarn', yarnRoot)],
+      brewInstalled: false,
+      sourceRoot: src,
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => (p === `${yarnRoot}/prjct-cli` ? src : p),
+    })
+    expect(plan.winner).toBe('npm')
+    expect(plan.removable.map((r) => r.pm)).not.toContain('yarn')
+    expect(plan.skipped.some((s) => s.pm === 'yarn' && /dev source tree/i.test(s.reason))).toBe(
+      true
+    )
+  })
+
+  it('does not treat Homebrew-node npm global as brew winner', () => {
+    // Real dogfood: Node from Homebrew puts npm globals under
+    // /opt/homebrew/lib/node_modules — that is still an npm install, not brew.
+    const npmRoot = '/opt/homebrew/lib/node_modules'
+    const plan = planCleanupFrom({
+      winnerReal: `${npmRoot}/prjct-cli/bin/prjct.js`,
+      winnerPm: 'npm',
+      locations: [loc('npm', npmRoot), loc('bun', '/Users/x/.bun/install/global/node_modules')],
+      brewInstalled: false,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('npm')
+    expect(plan.removable.map((r) => r.pm)).toEqual(['bun'])
+  })
+
+  it('keeps brew when PATH winner is a Cellar binary; marks other PMs removable', () => {
+    const plan = planCleanupFrom({
+      winnerReal: '/opt/homebrew/Cellar/prjct-cli/3.35.0/bin/prjct',
+      winnerPm: null,
+      locations: [loc('npm', '/usr/local/lib/node_modules')],
+      brewInstalled: true,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('brew')
+    expect(plan.removable.map((r) => r.pm)).toContain('npm')
+    expect(plan.removable.map((r) => r.pm)).not.toContain('brew')
+    expect(plan.skipped.some((s) => s.pm === 'brew')).toBe(true)
+  })
+
+  it('proposes brew removal only when brew is installed and not the winner', () => {
+    const npmRoot = '/usr/local/lib/node_modules'
+    const plan = planCleanupFrom({
+      winnerReal: `${npmRoot}/prjct-cli/bin/prjct.js`,
+      winnerPm: 'npm',
+      locations: [loc('npm', npmRoot)],
+      brewInstalled: true,
+      sourceRoot: '/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('npm')
+    expect(plan.removable.map((r) => r.pm)).toContain('brew')
+  })
+
+  it('Windows path ownership: keeps AppData npm winner, removes bun', () => {
+    // Simulates case-insensitive NTFS + backslash paths via prefixOwns-style check.
+    const npmRoot = 'C:/Users/Dev/AppData/Roaming/npm/node_modules'
+    const bunRoot = 'C:/Users/Dev/.bun/install/global/node_modules'
+    const ownsWin = (root: string | null | undefined, win: string | null) => {
+      if (!root || !win) return false
+      const r = root.replace(/\\/g, '/').toLowerCase()
+      const w = win.replace(/\\/g, '/').toLowerCase()
+      return w === r || w.startsWith(`${r}/`)
+    }
+    const plan = planCleanupFrom({
+      winnerReal: `${npmRoot}/prjct-cli/bin/prjct.js`,
+      winnerPm: 'bun', // mis-detect common when process.execPath is bun
+      locations: [loc('npm', npmRoot), loc('bun', bunRoot)],
+      brewInstalled: false,
+      sourceRoot: 'C:/Users/Dev/src/prjct-cli',
+      ownsWinner: ownsWin,
+      resolvePath: (p) => p.replace(/\\/g, '/'),
+    })
+    expect(plan.winner).toBe('npm')
+    expect(plan.removable.map((r) => r.pm)).toEqual(['bun'])
+  })
+
+  it('Linuxbrew Cellar path is brew winner', () => {
+    const plan = planCleanupFrom({
+      winnerReal: '/home/linuxbrew/.linuxbrew/Cellar/prjct-cli/3.35.0/bin/prjct',
+      winnerPm: null,
+      locations: [loc('npm', '/usr/lib/node_modules')],
+      brewInstalled: true,
+      sourceRoot: '/home/dev/src',
+      ownsWinner: prefixOwns,
+      resolvePath: (p) => p,
+    })
+    expect(plan.winner).toBe('brew')
+    expect(plan.removable.map((r) => r.pm)).toContain('npm')
   })
 })
 

--- a/core/__tests__/hooks/fail-soft.test.ts
+++ b/core/__tests__/hooks/fail-soft.test.ts
@@ -89,3 +89,100 @@ describe('hook fail-soft contract (safeRun)', () => {
     expect(out).toContain('HELLO_CTX')
   })
 })
+
+describe('hooks stay non-blocking (passive inject only)', () => {
+  const PASSIVE_EVENTS = [
+    'SessionStart',
+    'UserPromptSubmit',
+    'PostToolUse',
+    'Stop',
+    'SubagentStart',
+    'CwdChanged',
+  ] as const
+
+  for (const event of PASSIVE_EVENTS) {
+    test(`${event} without decide never emits permissionDecision deny`, async () => {
+      const out = await captureStdout(async () => {
+        await runHook({
+          event,
+          projectPath: process.cwd(),
+          build: async () => `ctx-for-${event}`,
+        })
+      })
+      expect(out).not.toContain('permissionDecision')
+      expect(out).not.toContain('"deny"')
+      // Context may land as additionalContext or systemMessage depending on event schema.
+      expect(out.length).toBeGreaterThan(0)
+    })
+  }
+
+  test('decide throw fails open — no deny, no crash', async () => {
+    let rejected = false
+    const out = await captureStdout(async () => {
+      try {
+        await runHook({
+          event: 'PreToolUse',
+          projectPath: process.cwd(),
+          decide: async () => {
+            throw new Error('loop guard blew up')
+          },
+          build: async () => 'SHOULD_NOT_MATTER',
+        })
+      } catch {
+        rejected = true
+      }
+    })
+    expect(rejected).toBe(false)
+    expect(out).not.toContain('permissionDecision')
+    expect(out).toContain('{}')
+  })
+
+  test('explicit decide deny is allowed only when decide returns {deny}', async () => {
+    const out = await captureStdout(async () => {
+      await runHook({
+        event: 'PreToolUse',
+        projectPath: process.cwd(),
+        decide: async () => ({ deny: 'turn budget exceeded' }),
+        build: async () => 'must-not-emit-when-denied',
+      })
+    })
+    expect(out).toContain('permissionDecision')
+    expect(out).toContain('deny')
+    expect(out).toContain('turn budget exceeded')
+    expect(out).not.toContain('must-not-emit-when-denied')
+  })
+
+  test('daemon mode detaches afterEmit so it never blocks the response', async () => {
+    const chunks: string[] = []
+    let detachedFn: (() => Promise<void>) | null = null
+    let afterEmitRan = false
+
+    await runHook(
+      {
+        event: 'UserPromptSubmit',
+        projectPath: process.cwd(),
+        build: async () => 'DAEMON_CTX',
+        afterEmit: async () => {
+          afterEmitRan = true
+        },
+      },
+      {
+        input: {},
+        sink: (c) => {
+          chunks.push(c)
+        },
+        detachAfterEmit: (fn) => {
+          detachedFn = fn
+        },
+      }
+    )
+
+    // Response already contains context; afterEmit not yet run.
+    expect(chunks.join('')).toContain('DAEMON_CTX')
+    expect(chunks.join('')).not.toContain('permissionDecision')
+    expect(afterEmitRan).toBe(false)
+    expect(detachedFn).not.toBeNull()
+    await detachedFn!()
+    expect(afterEmitRan).toBe(true)
+  })
+})

--- a/core/__tests__/hooks/hook-host-adapt.test.ts
+++ b/core/__tests__/hooks/hook-host-adapt.test.ts
@@ -24,7 +24,7 @@ describe('adaptHookOutputForHost (gemini)', () => {
 
   it('leaves Claude host payload unchanged', () => {
     const out = buildHookOutput('SessionStart', 'HELLO')
-    expect(adaptHookOutputForHost(out, 'claude')).toEqual(out)
+    expect(adaptHookOutputForHost(out, 'claude')).toEqual(out as unknown as Record<string, unknown>)
   })
 
   it('maps Cursor host to camelCase + additional_context snake_case', () => {

--- a/core/__tests__/hooks/hook-host-adapt.test.ts
+++ b/core/__tests__/hooks/hook-host-adapt.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { adaptHookOutputForHost, buildDenyOutput, buildHookOutput } from '../../hooks/_shared'
+
+describe('adaptHookOutputForHost (gemini)', () => {
+  it('rewrites Claude deny to Gemini decision/reason', () => {
+    const deny = buildDenyOutput('PreToolUse', 'turn budget exceeded')
+    const adapted = adaptHookOutputForHost(deny, 'gemini')
+    expect(adapted).toEqual({
+      decision: 'deny',
+      reason: 'turn budget exceeded',
+    })
+  })
+
+  it('maps UserPromptSubmit additionalContext to BeforeAgent', () => {
+    const out = buildHookOutput('UserPromptSubmit', 'CTX')
+    const adapted = adaptHookOutputForHost(out, 'gemini')
+    expect(adapted).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'BeforeAgent',
+        additionalContext: 'CTX',
+      },
+    })
+  })
+
+  it('leaves Claude host payload unchanged', () => {
+    const out = buildHookOutput('SessionStart', 'HELLO')
+    expect(adaptHookOutputForHost(out, 'claude')).toEqual(out)
+  })
+
+  it('maps Cursor host to camelCase + additional_context snake_case', () => {
+    const out = buildHookOutput('UserPromptSubmit', 'CTX')
+    const adapted = adaptHookOutputForHost(out, 'cursor')
+    expect(adapted.additional_context).toBe('CTX')
+    const hso = adapted.hookSpecificOutput as Record<string, string>
+    expect(hso.hookEventName).toBe('beforeSubmitPrompt')
+    expect(hso.additional_context).toBe('CTX')
+  })
+
+  it('rewrites Cursor deny with decision + permissionDecision', () => {
+    const deny = buildDenyOutput('PreToolUse', 'budget')
+    const adapted = adaptHookOutputForHost(deny, 'cursor')
+    expect(adapted.decision).toBe('deny')
+    expect(adapted.permissionDecision).toBe('deny')
+    expect(adapted.reason).toBe('budget')
+  })
+})

--- a/core/__tests__/infrastructure/agent-runtime-registry.test.ts
+++ b/core/__tests__/infrastructure/agent-runtime-registry.test.ts
@@ -52,16 +52,24 @@ describe('agent runtime registry', () => {
     expect(writable[0]?.pathHint).toContain('.kimi/mcp.json')
   })
 
-  it('registers xAI Grok Build as an AGENTS.md + MCP + skills capable CLI', () => {
+  it('registers xAI Grok Build as AGENTS.md + Claude-compat MCP/skills/hooks CLI', () => {
     const grok = getAgentRuntime('grok')
 
     expect(grok.kind).toBe('cli')
+    expect(grok.status).toBe('stable')
     expect(grok.supports.agentsMd).toBe(true)
     expect(grok.supports.mcp).toBe(true)
     expect(grok.supports.skills).toBe(true)
+    expect(grok.supports.hooks).toBe(true)
     expect(grok.detectsBy?.commands).toContain('grok')
-    // MCP schema unconfirmed from xAI docs — target is informational only, not auto-written.
-    expect((grok.mcpTargets ?? []).every((target) => !target.writable)).toBe(true)
+    // Grok inherits Claude MCP — writable path is ~/.claude/mcp.json (compat).
+    const writable = (grok.mcpTargets ?? []).filter((target) => target.writable)
+    expect(writable.some((t) => t.pathHint.includes('.claude/mcp.json'))).toBe(true)
+  })
+
+  it('marks Codex and Gemini as hook-capable (install adapters planned)', () => {
+    expect(getAgentRuntime('codex').supports.hooks).toBe(true)
+    expect(getAgentRuntime('gemini').supports.hooks).toBe(true)
   })
 
   it('separates runtime compatibility from model/provider names', () => {
@@ -84,12 +92,24 @@ describe('agent runtime registry', () => {
       expect(byId.get('agents-md')?.detected).toBe(true)
       expect(byId.get('mcp')?.supportLevel).toBe('manual')
       expect(byId.get('cursor')?.detectedSignals).toContain('.cursor/')
-      expect(byId.get('cursor')?.supportLevel).toBe('good')
+      // Benchmark-tier runtimes get full support investment (2026-07).
+      expect(byId.get('cursor')?.supportLevel).toBe('full')
       expect(byId.get('aider')?.detectedSignals).toContain('.aider.conf.yml')
       expect(byId.get('aider')?.supportLevel).toBe('baseline')
-      expect(byId.get('grok')?.supportLevel).toBe('good')
+      expect(byId.get('grok')?.supportLevel).toBe('full')
+      expect(byId.get('claude')?.supportLevel).toBe('full')
+      expect(byId.get('codex')?.supportLevel).toBe('full')
+      expect(byId.get('gemini')?.supportLevel).toBe('full')
+      expect(byId.get('opencode')?.supportLevel).toBe('full')
+      expect(byId.get('cline')?.supportLevel).toBe('full')
     } finally {
       await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
     }
+  })
+
+  it('marks Windsurf as legacy (not a benchmark focus)', () => {
+    const windsurf = getAgentRuntime('windsurf')
+    expect(windsurf.status).toBe('legacy')
+    expect(windsurf.notes).toMatch(/LEGACY/i)
   })
 })

--- a/core/__tests__/infrastructure/harness-surfaces.test.ts
+++ b/core/__tests__/infrastructure/harness-surfaces.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  formatHarnessSurfacesMarkdown,
+  getHarnessSurface,
+  listHarnessSurfaces,
+} from '../../infrastructure/harness-surfaces'
+
+describe('harness surfaces matrix', () => {
+  it('covers benchmark-tier CLIs with hook + MCP wire status', () => {
+    const ids = listHarnessSurfaces().map((s) => s.runtimeId)
+    for (const id of [
+      'claude',
+      'codex',
+      'gemini',
+      'grok',
+      'opencode',
+      'cursor',
+      'cline',
+    ] as const) {
+      expect(ids).toContain(id)
+    }
+  })
+
+  it('documents Grok as inherits-claude for hooks and MCP', () => {
+    const grok = getHarnessSurface('grok')
+    expect(grok).toBeDefined()
+    expect(grok!.hooks.prjct).toBe('inherits-claude')
+    expect(grok!.mcp.prjct).toBe('inherits-claude')
+    expect(grok!.legibility).toMatch(/Claude/i)
+  })
+
+  it('documents Claude as fully native', () => {
+    const claude = getHarnessSurface('claude')
+    expect(claude!.hooks.prjct).toBe('native')
+    expect(claude!.mcp.prjct).toBe('native')
+    expect(claude!.hooks.events).toContain('SessionStart')
+    expect(claude!.hooks.events).toContain('PreToolUse')
+  })
+
+  it('documents Codex MCP and hooks as native', () => {
+    const codex = getHarnessSurface('codex')
+    expect(codex!.mcp.prjct).toBe('native')
+    expect(codex!.hooks.prjct).toBe('native')
+  })
+
+  it('documents Gemini MCP and hooks as native', () => {
+    const gemini = getHarnessSurface('gemini')
+    expect(gemini!.mcp.prjct).toBe('native')
+    expect(gemini!.hooks.prjct).toBe('native')
+  })
+
+  it('documents Cursor hooks as native', () => {
+    const cursor = getHarnessSurface('cursor')
+    expect(cursor!.hooks.prjct).toBe('native')
+  })
+
+  it('formatHarnessSurfacesMarkdown is agent-legible', () => {
+    const md = formatHarnessSurfacesMarkdown({ detail: true })
+    expect(md).toContain('Harness surfaces')
+    expect(md).toContain('Grok')
+    expect(md).toContain('inherits-claude')
+    expect(md).toContain('native')
+  })
+})

--- a/core/__tests__/schemas/model.test.ts
+++ b/core/__tests__/schemas/model.test.ts
@@ -45,7 +45,10 @@ describe('Provider model configuration', () => {
 
   it('should have model fields on Gemini provider', () => {
     expect(GeminiProvider.defaultModel).toBe('2.5-flash')
-    expect(GeminiProvider.supportedModels).toEqual(['2.5-pro', '2.5-flash', '2.0-flash'])
+    // 2026-07: include Gemini 3.1 Pro in the supported set (frontier).
+    expect(GeminiProvider.supportedModels).toContain('3.1-pro')
+    expect(GeminiProvider.supportedModels).toContain('2.5-pro')
+    expect(GeminiProvider.supportedModels).toContain('2.5-flash')
     expect(GeminiProvider.minCliVersion).toBe('1.0.0')
   })
 
@@ -71,9 +74,16 @@ describe('isValidModelForProvider', () => {
   })
 
   it('should accept valid Gemini models', () => {
+    expect(isValidModelForProvider('gemini', '3.1-pro')).toBe(true)
     expect(isValidModelForProvider('gemini', '2.5-pro')).toBe(true)
     expect(isValidModelForProvider('gemini', '2.5-flash')).toBe(true)
     expect(isValidModelForProvider('gemini', '2.0-flash')).toBe(true)
+  })
+
+  it('should accept 2026-07 benchmark Codex / OpenAI models', () => {
+    expect(isValidModelForProvider('codex', 'gpt-5.5')).toBe(true)
+    expect(isValidModelForProvider('openai', 'gpt-5.5')).toBe(true)
+    expect(isValidModelForProvider('codex', 'o3')).toBe(true)
   })
 
   it('should reject invalid Gemini models', () => {

--- a/core/__tests__/schemas/provider-sovereignty.test.ts
+++ b/core/__tests__/schemas/provider-sovereignty.test.ts
@@ -20,7 +20,7 @@ describe('resolveProviderModel — model is intercambiable', () => {
     expect(resolveProviderModel('orchestrator', 'claude').model).toBe('haiku')
     expect(resolveProviderModel('review', 'claude').model).toBe('sonnet')
 
-    expect(resolveProviderModel('implementer', 'gemini').model).toBe('2.5-pro')
+    expect(resolveProviderModel('implementer', 'gemini').model).toBe('3.1-pro')
     expect(resolveProviderModel('orchestrator', 'gemini').model).toBe('2.0-flash')
     expect(resolveProviderModel('review', 'gemini').model).toBe('2.5-flash')
   })
@@ -51,7 +51,7 @@ describe('resolveProviderModel — model is intercambiable', () => {
 
 describe('renderModelDirectiveForProvider — provider-aware dispatch prose', () => {
   it('emits the concrete model id for a fixed-model provider', () => {
-    expect(renderModelDirectiveForProvider('implementer', 'gemini')).toContain('model "2.5-pro"')
+    expect(renderModelDirectiveForProvider('implementer', 'gemini')).toContain('model "3.1-pro"')
     expect(renderModelDirectiveForProvider('implementer', 'gemini')).toContain('frontier')
   })
 

--- a/core/__tests__/services/agent-dispatch.test.ts
+++ b/core/__tests__/services/agent-dispatch.test.ts
@@ -21,7 +21,7 @@ describe('resolveDispatchMechanism', () => {
     expect(m.native).toBe(false)
     expect(m.runLine(3)).toContain('EMULATE the fan-out')
     expect(m.runLine(1)).toContain('no native subagent tool')
-    expect(m.modelDirective('implementer')).toContain('2.5-pro')
+    expect(m.modelDirective('implementer')).toContain('3.1-pro')
   })
 
   it('defers model selection to a multi-model rig', async () => {

--- a/core/__tests__/services/harness-coverage.test.ts
+++ b/core/__tests__/services/harness-coverage.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { probeHarnessCoverage, renderHarnessCoverageMd } from '../../services/harness-coverage'
+
+describe('harness coverage (organic multi-runtime board)', () => {
+  let home: string
+  let prevHome: string | undefined
+  let prevTestMode: string | undefined
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-coverage-home-'))
+    prevHome = process.env.HOME
+    prevTestMode = process.env.PRJCT_TEST_MODE
+    process.env.HOME = home
+    process.env.PRJCT_TEST_MODE = '1'
+    // Isolate codex/gemini/cursor paths under test home via resolveUserPath + PRJCT_TEST_MODE
+  })
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.HOME
+    else process.env.HOME = prevHome
+    if (prevTestMode === undefined) delete process.env.PRJCT_TEST_MODE
+    else process.env.PRJCT_TEST_MODE = prevTestMode
+    await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('reports absent when no runtimes are wired', async () => {
+    const report = await probeHarnessCoverage(home)
+    expect(report.runtimes.length).toBe(5)
+    // Without CLIs on PATH in a fresh HOME, detected may still be 0
+    expect(report.organicPct).toBeGreaterThanOrEqual(0)
+    expect(report.grade).toBeGreaterThanOrEqual(1)
+  })
+
+  it('marks Claude full when settings + mcp.json have prjct wire', async () => {
+    const claude = path.join(home, '.claude')
+    await fs.mkdir(claude, { recursive: true })
+    await fs.writeFile(
+      path.join(claude, 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'prjct hook session-start',
+                  _prjctManaged: true,
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf-8'
+    )
+    await fs.writeFile(
+      path.join(claude, 'mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          prjct: { command: 'prjct', args: ['mcp-server'] },
+        },
+      }),
+      'utf-8'
+    )
+
+    const report = await probeHarnessCoverage(home)
+    const claudeRow = report.runtimes.find((r) => r.id === 'claude')
+    expect(claudeRow?.detected).toBe(true)
+    expect(claudeRow?.hooksLive).toBe(true)
+    expect(claudeRow?.mcpLive).toBe(true)
+    expect(claudeRow?.organic).toBe('full')
+  })
+
+  it('renders dominance board markdown', async () => {
+    const report = await probeHarnessCoverage(home)
+    const md = renderHarnessCoverageMd(report)
+    expect(md).toContain('Organic multi-runtime board')
+    expect(md).toContain('Claude Code')
+    expect(md).toContain('Grok Build')
+    expect(md).toContain('Moat')
+  })
+
+  it('grades higher when more detected surfaces are live', async () => {
+    // Wire Claude full — at least one live when detected
+    const claude = path.join(home, '.claude')
+    await fs.mkdir(claude, { recursive: true })
+    await fs.writeFile(
+      path.join(claude, 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                { type: 'command', command: 'prjct hook session-start', _prjctManaged: true },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf-8'
+    )
+    await fs.writeFile(
+      path.join(claude, 'mcp.json'),
+      JSON.stringify({ mcpServers: { prjct: { command: 'prjct', args: ['mcp-server'] } } }),
+      'utf-8'
+    )
+    const report = await probeHarnessCoverage(home)
+    const claudeRow = report.runtimes.find((r) => r.id === 'claude')
+    if (claudeRow?.detected) {
+      expect(report.liveCount).toBeGreaterThanOrEqual(1)
+      expect(report.grade).toBeGreaterThanOrEqual(3)
+    }
+  })
+})

--- a/core/__tests__/services/harness-score.test.ts
+++ b/core/__tests__/services/harness-score.test.ts
@@ -56,5 +56,17 @@ describe('harness score', () => {
     expect(md).toContain('open-GSD')
     expect(md).toContain('discuss-lock')
     expect(md).toContain('SQLite')
+    expect(md).toContain('Multi-runtime wire')
+    expect(md).toContain('Organic feel')
+  })
+
+  it('can include multi-runtime organic criterion when probed', () => {
+    const report = computeHarnessScore({
+      multiRuntimeOrganicGrade: 5,
+      multiRuntimeOrganicMeasured: '4/4 live (100%)',
+    })
+    const c = report.criteria.find((x) => x.id === 'multi-runtime-organic')
+    expect(c?.score).toBe(5)
+    expect(c?.measured).toContain('4/4')
   })
 })

--- a/core/__tests__/services/weak-model-bench.test.ts
+++ b/core/__tests__/services/weak-model-bench.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Release-blocking weak-model A/B gate.
+ *
+ * CI quality job runs this file — red = no merge / no release.
+ * North star: weak + prjct beats bare frontier on discipline SLOs.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { buildDemoRows, routeIntent, routeIntentBare } from '../../services/weak-frontier-demo'
+import {
+  formatWeakBenchMarkdown,
+  INTENT_FIXTURES,
+  runWeakModelBench,
+  WEAK_BENCH_MIN_PASS,
+} from '../../services/weak-model-bench'
+
+describe('weak-model A/B release gate', () => {
+  it('passes every structural SLO (allGreen)', () => {
+    const report = runWeakModelBench()
+    expect(report.total).toBeGreaterThanOrEqual(WEAK_BENCH_MIN_PASS)
+    expect(report.allGreen).toBe(true)
+    expect(report.passed).toBe(report.total)
+    const failed = report.checks.filter((c) => !c.ok)
+    expect(failed).toEqual([])
+  })
+
+  it('harness intent router beats bare wrap-as-work', () => {
+    let harness = 0
+    let bare = 0
+    for (const f of INTENT_FIXTURES) {
+      if (routeIntent(f.signal) === f.verb) harness++
+      if (routeIntentBare(f.signal) === f.verb) bare++
+    }
+    expect(harness).toBeGreaterThan(bare)
+    expect(harness / INTENT_FIXTURES.length).toBeGreaterThanOrEqual(0.95)
+  })
+
+  it('public demo rows stay fully green', () => {
+    const rows = buildDemoRows()
+    expect(rows.every((r) => r.weakOk)).toBe(true)
+  })
+
+  it('markdown gate report is CI-legible', () => {
+    const md = formatWeakBenchMarkdown(runWeakModelBench())
+    expect(md).toContain('Weak-model A/B')
+    expect(md).toContain('PASS')
+    expect(md).toContain('intent A/B beats bare')
+    expect(md).toContain('codex hooks+MCP native')
+    expect(md).toContain('gemini hooks+MCP native')
+    expect(md).toContain('cursor hooks native')
+    expect(md).toContain('grok inherits-claude')
+  })
+})

--- a/core/__tests__/sync/auth-config.test.ts
+++ b/core/__tests__/sync/auth-config.test.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import authConfig from '../../sync/auth-config'
-import { _setAuthTokenStoreForTests, type AuthTokenLocation } from '../../sync/secure-auth-token'
+import {
+  _setAuthTokenStoreForTests,
+  type AuthTokenLocation,
+  setAuthToken,
+} from '../../sync/secure-auth-token'
 
 let tmpDir: string
 let tmpPath: string
@@ -209,6 +213,63 @@ describe('AuthConfig', () => {
       await authConfig.clearAuth()
       const after = await authConfig.getDeviceId()
       expect(after).toBe(before)
+    })
+  })
+
+  describe('keychain-only invariants', () => {
+    it('setAuthToken refuses empty / whitespace tokens before touching the store', async () => {
+      let setCalled = false
+      _setAuthTokenStoreForTests({
+        get: async () => storedToken,
+        set: async (value) => {
+          setCalled = true
+          storedToken = value
+          return 'keychain'
+        },
+        clear: async () => {
+          storedToken = null
+        },
+        location: async () => (storedToken ? 'keychain' : 'none'),
+      })
+
+      await expect(setAuthToken('')).rejects.toThrow(/empty/i)
+      await expect(setAuthToken('   ')).rejects.toThrow(/empty/i)
+      expect(setCalled).toBe(false)
+      expect(storedToken).toBeNull()
+    })
+
+    it('propagates store set failures — never falls back to writing the token into auth.json', async () => {
+      _setAuthTokenStoreForTests({
+        get: async () => null,
+        set: async () => {
+          throw new Error('No secure credential store is available for this platform.')
+        },
+        clear: async () => {},
+        location: async () => 'none',
+      })
+
+      await expect(authConfig.saveAuth('sk_must_not_persist', 'u', 'e@x')).rejects.toThrow(
+        /secure credential store/i
+      )
+
+      // No auth.json, or if partially created, must not contain the token.
+      try {
+        const raw = JSON.parse(await fs.readFile(tmpPath, 'utf-8')) as { apiKey: string | null }
+        expect(raw.apiKey).toBeNull()
+        expect(JSON.stringify(raw)).not.toContain('sk_must_not_persist')
+      } catch (e) {
+        // ENOENT is fine — never wrote the secret.
+        expect((e as NodeJS.ErrnoException).code).toBe('ENOENT')
+      }
+    })
+
+    it('every successful write leaves apiKey null on disk', async () => {
+      await authConfig.saveAuth('sk_disk_never', 'u', 'e@x')
+      await authConfig.write({ email: 'other@x' })
+      const raw = JSON.parse(await fs.readFile(tmpPath, 'utf-8')) as { apiKey: string | null }
+      expect(raw.apiKey).toBeNull()
+      expect(JSON.stringify(raw)).not.toContain('sk_disk_never')
+      expect(storedToken).toBe('sk_disk_never')
     })
   })
 })

--- a/core/__tests__/utils/codex-hooks.test.ts
+++ b/core/__tests__/utils/codex-hooks.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Codex hooks installer — maps PRJCT_HOOKS → ~/.codex/hooks.json + features.hooks.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  codexHookSpecs,
+  codexHooksStatus,
+  ensureCodexHooksFeature,
+  installCodexHooks,
+  uninstallCodexHooks,
+} from '../../utils/codex-hooks'
+
+let dir: string
+let hooksPath: string
+let configPath: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-codex-hooks-test-'))
+  hooksPath = path.join(dir, 'hooks.json')
+  configPath = path.join(dir, 'config.toml')
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('codexHookSpecs', () => {
+  it('skips Claude-only Notification and CwdChanged events', () => {
+    const events = new Set(codexHookSpecs().map((s) => s.event))
+    expect(events.has('SessionStart')).toBe(true)
+    expect(events.has('PreToolUse')).toBe(true)
+    expect(events.has('UserPromptSubmit')).toBe(true)
+    expect(events.has('Stop')).toBe(true)
+    expect(events.has('Notification')).toBe(false)
+    expect(events.has('CwdChanged')).toBe(false)
+  })
+})
+
+describe('installCodexHooks', () => {
+  it('creates hooks.json with managed handlers for every Codex-capable event', async () => {
+    const r = await installCodexHooks({ hooksPath, configPath })
+    expect(r.hooksWritten).toBeGreaterThan(0)
+    expect(r.featuresEnabled).toBe(true)
+
+    const body = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<Record<string, unknown>> }>>
+    }
+    expect(body.hooks.SessionStart).toBeDefined()
+    expect(body.hooks.UserPromptSubmit).toBeDefined()
+    expect(body.hooks.PreToolUse).toBeDefined()
+    expect(body.hooks.Stop).toBeDefined()
+
+    const sessionHandlers = body.hooks.SessionStart.flatMap((b) => b.hooks)
+    expect(sessionHandlers.some((h) => h._prjctManaged === true)).toBe(true)
+    expect(sessionHandlers[0]?.command).toContain('prjct hook session-start')
+    expect(sessionHandlers[0]?.commandWindows).toContain('prjct hook session-start')
+
+    // Edit|Write pre-edit maps with matcher Codex understands for apply_patch.
+    const preEdit = body.hooks.PreToolUse.find((b) => b.matcher === 'Edit|Write')
+    expect(preEdit).toBeDefined()
+    expect(preEdit!.hooks[0]?.command).toContain('pre-edit')
+  })
+
+  it('is idempotent on second install', async () => {
+    await installCodexHooks({ hooksPath, configPath })
+    const r2 = await installCodexHooks({ hooksPath, configPath })
+    expect(r2.hooksWritten).toBe(0)
+    expect(r2.alreadyPresent).toBe(codexHookSpecs().length)
+  })
+
+  it('preserves foreign (non-prjct) handlers under the same event', async () => {
+    await fs.writeFile(
+      hooksPath,
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'echo foreign-session',
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf-8'
+    )
+    await installCodexHooks({ hooksPath, configPath })
+    const body = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>
+    }
+    const cmds = body.hooks.SessionStart.flatMap((b) => b.hooks.map((h) => h.command))
+    expect(cmds.some((c) => c.includes('foreign-session'))).toBe(true)
+    expect(cmds.some((c) => c.includes('prjct hook session-start'))).toBe(true)
+  })
+
+  it('enables [features] hooks = true in config.toml when missing', async () => {
+    await fs.writeFile(configPath, 'model = "gpt-5.5"\n', 'utf-8')
+    const r = await installCodexHooks({ hooksPath, configPath })
+    expect(r.featuresChanged).toBe(true)
+    const toml = await fs.readFile(configPath, 'utf-8')
+    expect(toml).toContain('hooks = true')
+    expect(toml).toContain('model = "gpt-5.5"')
+  })
+
+  it('does not clobber an existing hooks = true without markers', async () => {
+    await fs.writeFile(configPath, '[features]\nhooks = true\nmodel_reasoning = "high"\n', 'utf-8')
+    const r = await ensureCodexHooksFeature(configPath)
+    expect(r.changed).toBe(false)
+    const toml = await fs.readFile(configPath, 'utf-8')
+    expect(toml).toContain('model_reasoning = "high"')
+  })
+})
+
+describe('uninstallCodexHooks', () => {
+  it('removes only prjct-managed handlers', async () => {
+    await installCodexHooks({ hooksPath, configPath })
+    // Inject foreign after install
+    const body = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<Record<string, unknown>> }>>
+    }
+    body.hooks.Stop.push({
+      hooks: [{ type: 'command', command: 'echo keep-me' }],
+    })
+    await fs.writeFile(hooksPath, JSON.stringify(body, null, 2), 'utf-8')
+
+    const r = await uninstallCodexHooks(hooksPath)
+    expect(r.hooksRemoved).toBeGreaterThan(0)
+    const after = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>
+    }
+    const all = Object.values(after.hooks ?? {}).flatMap((blocks) =>
+      blocks.flatMap((b) => b.hooks.map((h) => h.command))
+    )
+    expect(all.some((c) => c.includes('keep-me'))).toBe(true)
+    expect(all.every((c) => !c.includes('prjct hook'))).toBe(true)
+  })
+})
+
+describe('codexHooksStatus', () => {
+  it('counts installed managed handlers', async () => {
+    expect((await codexHooksStatus(hooksPath)).installed).toBe(0)
+    await installCodexHooks({ hooksPath, configPath })
+    const st = await codexHooksStatus(hooksPath)
+    expect(st.installed).toBe(st.expected)
+    expect(st.expected).toBe(codexHookSpecs().length)
+  })
+})

--- a/core/__tests__/utils/cursor-hooks.test.ts
+++ b/core/__tests__/utils/cursor-hooks.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Cursor hooks installer — camelCase events, flat handlers, version: 1
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  cursorHookMaps,
+  cursorHooksStatus,
+  installCursorHooks,
+  uninstallCursorHooks,
+} from '../../utils/cursor-hooks'
+
+let dir: string
+let hooksPath: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-cursor-hooks-'))
+  hooksPath = path.join(dir, 'hooks.json')
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('cursorHookMaps', () => {
+  it('uses camelCase Cursor event names', () => {
+    const events = new Set(cursorHookMaps().map((m) => m.cursorEvent))
+    expect(events.has('sessionStart')).toBe(true)
+    expect(events.has('preToolUse')).toBe(true)
+    expect(events.has('postToolUse')).toBe(true)
+    expect(events.has('stop')).toBe(true)
+    expect(events.has('beforeSubmitPrompt')).toBe(true)
+    expect(events.has('SessionStart')).toBe(false)
+    expect(events.has('PreToolUse')).toBe(false)
+  })
+
+  it('maps edit tools to Write|StrReplace|Edit', () => {
+    expect(cursorHookMaps().some((m) => m.matcher === 'Write|StrReplace|Edit')).toBe(true)
+    expect(cursorHookMaps().some((m) => m.matcher === 'Shell|Bash')).toBe(true)
+  })
+})
+
+describe('installCursorHooks', () => {
+  it('writes version 1 flat handlers with PRJCT_HOOK_HOST=cursor', async () => {
+    const r = await installCursorHooks(hooksPath)
+    expect(r.hooksWritten).toBeGreaterThan(0)
+    const body = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      version: number
+      hooks: Record<string, Array<Record<string, unknown>>>
+    }
+    expect(body.version).toBe(1)
+    expect(body.hooks.sessionStart).toBeDefined()
+    expect(body.hooks.preToolUse).toBeDefined()
+    // Flat list — not Claude nested { matcher, hooks: [] }
+    expect(Array.isArray(body.hooks.sessionStart)).toBe(true)
+    expect(body.hooks.sessionStart[0]?.command).toContain('PRJCT_HOOK_HOST=cursor')
+    expect(body.hooks.sessionStart[0]?.command).toContain('prjct hook session-start')
+    expect(body.hooks.sessionStart[0]?._prjctManaged).toBe(true)
+    expect(body.hooks.sessionStart[0]?.timeout).toBe(30)
+  })
+
+  it('is idempotent', async () => {
+    await installCursorHooks(hooksPath)
+    const r2 = await installCursorHooks(hooksPath)
+    expect(r2.hooksWritten).toBe(0)
+    expect(r2.alreadyPresent).toBe(cursorHookMaps().length)
+  })
+
+  it('preserves foreign handlers', async () => {
+    await fs.writeFile(
+      hooksPath,
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          stop: [{ command: 'echo foreign-stop' }],
+        },
+      }),
+      'utf-8'
+    )
+    await installCursorHooks(hooksPath)
+    const body = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ command: string }>>
+    }
+    const cmds = body.hooks.stop.map((h) => h.command)
+    expect(cmds.some((c) => c.includes('foreign-stop'))).toBe(true)
+    expect(cmds.some((c) => c.includes('prjct hook stop'))).toBe(true)
+  })
+})
+
+describe('uninstallCursorHooks', () => {
+  it('removes only prjct handlers', async () => {
+    await installCursorHooks(hooksPath)
+    const body = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<Record<string, unknown>>>
+    }
+    body.hooks.stop.push({ command: 'echo keep' })
+    await fs.writeFile(hooksPath, JSON.stringify(body, null, 2), 'utf-8')
+
+    const r = await uninstallCursorHooks(hooksPath)
+    expect(r.hooksRemoved).toBeGreaterThan(0)
+    const after = JSON.parse(await fs.readFile(hooksPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ command: string }>>
+    }
+    const all = Object.values(after.hooks ?? {}).flatMap((list) => list.map((h) => h.command))
+    expect(all.some((c) => c.includes('keep'))).toBe(true)
+    expect(all.every((c) => !c.includes('prjct hook'))).toBe(true)
+  })
+})
+
+describe('cursorHooksStatus', () => {
+  it('counts managed handlers', async () => {
+    expect((await cursorHooksStatus(hooksPath)).installed).toBe(0)
+    await installCursorHooks(hooksPath)
+    const st = await cursorHooksStatus(hooksPath)
+    expect(st.installed).toBe(st.expected)
+  })
+})

--- a/core/__tests__/utils/gemini-settings.test.ts
+++ b/core/__tests__/utils/gemini-settings.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Gemini settings installer — MCP + hooks in ~/.gemini/settings.json
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  ensureGeminiMcpServer,
+  geminiHookMaps,
+  installGeminiHooks,
+  installGeminiSettings,
+  uninstallGeminiSettings,
+} from '../../utils/gemini-settings'
+
+let dir: string
+let settingsPath: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-gemini-settings-'))
+  settingsPath = path.join(dir, 'settings.json')
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('geminiHookMaps', () => {
+  it('maps Claude events to Gemini BeforeTool/BeforeAgent/AfterAgent', () => {
+    const maps = geminiHookMaps()
+    const events = new Set(maps.map((m) => m.geminiEvent))
+    expect(events.has('SessionStart')).toBe(true)
+    expect(events.has('BeforeAgent')).toBe(true)
+    expect(events.has('BeforeTool')).toBe(true)
+    expect(events.has('AfterTool')).toBe(true)
+    expect(events.has('AfterAgent')).toBe(true)
+    expect(events.has('PreToolUse')).toBe(false)
+    expect(maps.some((m) => m.matcher === 'run_shell_command')).toBe(true)
+    expect(maps.some((m) => m.matcher === 'write_file|replace')).toBe(true)
+  })
+})
+
+describe('ensureGeminiMcpServer', () => {
+  it('writes mcpServers.prjct', async () => {
+    const r = await ensureGeminiMcpServer(settingsPath)
+    expect(r.changed).toBe(true)
+    const body = JSON.parse(await fs.readFile(settingsPath, 'utf-8')) as {
+      mcpServers: Record<string, { command?: string; args?: string[] }>
+    }
+    expect(body.mcpServers.prjct).toBeDefined()
+    expect(body.mcpServers.prjct.args).toContain('mcp-server')
+  })
+
+  it('preserves other MCP servers', async () => {
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({
+        mcpServers: {
+          other: { command: 'echo', args: ['hi'] },
+        },
+      }),
+      'utf-8'
+    )
+    await ensureGeminiMcpServer(settingsPath)
+    const body = JSON.parse(await fs.readFile(settingsPath, 'utf-8')) as {
+      mcpServers: Record<string, unknown>
+    }
+    expect(body.mcpServers.other).toBeDefined()
+    expect(body.mcpServers.prjct).toBeDefined()
+  })
+})
+
+describe('installGeminiHooks', () => {
+  it('installs managed hooks with PRJCT_HOOK_HOST=gemini', async () => {
+    const r = await installGeminiHooks(settingsPath)
+    expect(r.hooksWritten).toBeGreaterThan(0)
+    const body = JSON.parse(await fs.readFile(settingsPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ matcher?: string; hooks: Array<Record<string, unknown>> }>>
+    }
+    expect(body.hooks.SessionStart).toBeDefined()
+    expect(body.hooks.BeforeAgent).toBeDefined()
+    expect(body.hooks.BeforeTool).toBeDefined()
+    const session = body.hooks.SessionStart.flatMap((b) => b.hooks)
+    expect(session[0]?.command).toContain('PRJCT_HOOK_HOST=gemini')
+    expect(session[0]?.command).toContain('prjct hook session-start')
+    expect(session[0]?.timeout).toBe(30_000)
+    expect(session[0]?._prjctManaged).toBe(true)
+  })
+
+  it('is idempotent', async () => {
+    await installGeminiHooks(settingsPath)
+    const r2 = await installGeminiHooks(settingsPath)
+    expect(r2.hooksWritten).toBe(0)
+    expect(r2.alreadyPresent).toBe(geminiHookMaps().length)
+  })
+})
+
+describe('installGeminiSettings + uninstall', () => {
+  it('installs both MCP and hooks; uninstall removes only prjct', async () => {
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({
+        mcpServers: { keep: { command: 'true' } },
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: 'command', command: 'echo foreign', name: 'foreign' }] },
+          ],
+        },
+      }),
+      'utf-8'
+    )
+    const inst = await installGeminiSettings(settingsPath)
+    expect(inst.mcpChanged).toBe(true)
+    expect(inst.hooksWritten).toBeGreaterThan(0)
+
+    const un = await uninstallGeminiSettings(settingsPath)
+    expect(un.hooksRemoved).toBeGreaterThan(0)
+    expect(un.mcpRemoved).toBe(true)
+
+    const body = JSON.parse(await fs.readFile(settingsPath, 'utf-8')) as {
+      mcpServers?: Record<string, unknown>
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>
+    }
+    expect(body.mcpServers?.keep).toBeDefined()
+    expect(body.mcpServers?.prjct).toBeUndefined()
+    const cmds = Object.values(body.hooks ?? {}).flatMap((blocks) =>
+      blocks.flatMap((b) => b.hooks.map((h) => h.command))
+    )
+    expect(cmds.some((c) => c.includes('foreign'))).toBe(true)
+    expect(cmds.every((c) => !c.includes('prjct hook'))).toBe(true)
+  })
+})

--- a/core/__tests__/utils/which.test.ts
+++ b/core/__tests__/utils/which.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Cross-platform which/where helpers — pin that detection never throws
+ * and resolves something for the current process runner when possible.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { commandOnPath, whichAsync, whichSync } from '../../utils/which'
+
+describe('which (cross-platform PATH resolve)', () => {
+  it('whichSync never throws on missing commands', () => {
+    expect(whichSync('prjct-definitely-not-installed-xyz-9f3a')).toBeNull()
+  })
+
+  it('whichAsync never throws on missing commands', async () => {
+    expect(await whichAsync('prjct-definitely-not-installed-xyz-9f3a')).toBeNull()
+  })
+
+  it('resolves a known OS binary when present', () => {
+    // node or bun should exist in this test environment.
+    const node = whichSync('node')
+    const bun = whichSync('bun')
+    expect(node !== null || bun !== null).toBe(true)
+    if (node) expect(node.length).toBeGreaterThan(0)
+    if (bun) expect(bun.length).toBeGreaterThan(0)
+  })
+
+  it('commandOnPath mirrors whichSync', () => {
+    expect(commandOnPath('prjct-definitely-not-installed-xyz-9f3a')).toBe(false)
+    const hasNode = whichSync('node') !== null
+    expect(commandOnPath('node')).toBe(hasNode)
+  })
+})

--- a/core/commands/agents.ts
+++ b/core/commands/agents.ts
@@ -1,14 +1,16 @@
 /**
  * `prjct agents` — auditable compatibility matrix for coding-agent runtimes.
  *
- * The command is intentionally derived from `agent-runtime-registry.ts`; copy
- * and docs should describe the same support levels this command reports.
+ * The command is intentionally derived from `agent-runtime-registry.ts` plus
+ * `harness-surfaces.ts` (benchmark-tier hooks/MCP/skills integration map).
  */
 
 import {
   type AgentRuntimeStatus,
   detectAgentRuntimes,
 } from '../infrastructure/agent-runtime-registry'
+import { formatHarnessSurfacesMarkdown } from '../infrastructure/harness-surfaces'
+import { probeHarnessCoverage, renderHarnessCoverageMd } from '../services/harness-coverage'
 import { writeProjectAgentSurfaces } from '../services/project-agent-surfaces'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
@@ -33,23 +35,45 @@ export class AgentsCommands extends PrjctCommandsBase {
     projectPath: string = process.cwd(),
     options: AgentsOptions = {}
   ): Promise<CommandResult> {
-    const sub = (input ?? '').trim().toLowerCase().split(/\s+/).filter(Boolean)[0] ?? 'doctor'
-    if (sub !== 'doctor' && sub !== 'status' && sub !== 'list') {
-      return failHard('Unknown agents subcommand. Use: prjct agents doctor', options)
+    const parts = (input ?? '').trim().toLowerCase().split(/\s+/).filter(Boolean)
+    const sub = parts[0] ?? 'doctor'
+    if (sub !== 'doctor' && sub !== 'status' && sub !== 'list' && sub !== 'surfaces') {
+      return failHard(
+        'Unknown agents subcommand. Use: prjct agents doctor | surfaces [--detail]',
+        options
+      )
     }
 
     try {
+      if (sub === 'surfaces') {
+        const detail = parts.includes('--detail') || parts.includes('detail') || options.md
+        const body = formatHarnessSurfacesMarkdown({ detail: Boolean(detail) })
+        console.log(options.md ? body : body.replace(/^## /gm, '').replace(/^### /gm, ''))
+        return { success: true, surfaces: true }
+      }
+
       const fixes = options.fix ? await repairAgentSurfaces(projectPath, options) : null
       if (fixes && !isAgentRepairResult(fixes)) return fixes
 
       const statuses = await detectAgentRuntimes(projectPath)
-      if (options.md) console.log(formatMarkdown(statuses, fixes))
-      else console.log(formatText(statuses, fixes))
+      const coverage = await probeHarnessCoverage(projectPath)
+      if (options.md) {
+        console.log(
+          [formatMarkdown(statuses, fixes), '', renderHarnessCoverageMd(coverage)].join('\n')
+        )
+      } else {
+        console.log(formatText(statuses, fixes))
+        console.log(
+          `organic: ${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%) — ${coverage.summary}`
+        )
+      }
       return {
         success: true,
         runtimes: statuses.length,
         detected: statuses.filter((status) => status.detected).length,
         fixed: Boolean(fixes),
+        organicPct: coverage.organicPct,
+        liveRuntimes: coverage.liveCount,
       }
     } catch (error) {
       return failHard(getErrorMessage(error), options)
@@ -122,10 +146,21 @@ function formatMarkdown(
   lines.push(
     '',
     'Support levels:',
-    '- `full`: prjct-maintained native hooks plus MCP/skills or equivalent deep integration.',
+    '- `full`: benchmark-tier investment (Claude/Codex/Gemini/OpenCode/Cursor/Cline/Grok).',
     '- `good`: AGENTS.md plus MCP-capable runtime.',
     '- `baseline`: repo instructions only; agents can still run `prjct --md`.',
-    '- `hosted`: repo instructions are the portable layer; external platform config may be manual.'
+    '- `hosted`: repo instructions are the portable layer; external platform config may be manual.',
+    '- `manual` / legacy: residual support only (e.g. Windsurf).',
+    '',
+    formatHarnessSurfacesMarkdown({
+      only: statuses
+        .filter((s) => s.detected && s.supportLevel === 'full')
+        .map((s) => s.runtime.id),
+      detail: false,
+    }),
+    '',
+    'Deep surface map (hooks events, MCP paths, wire status): `prjct agents surfaces --md`',
+    'Grok Build inherits Claude Code hooks/MCP/skills — `prjct install` covers Grok without a second adapter.'
   )
 
   return lines.join('\n')

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -501,12 +501,13 @@ export const COMMANDS: CommandMeta[] = [
     surface: 'support',
     routing: { group: 'agents', method: 'agents' },
     optionSchema: { booleans: ['fix'] },
-    description: 'Show the concrete compatibility matrix for AI coding agents',
+    description:
+      'Show the concrete compatibility matrix for AI coding agents (doctor) or harness surface map (surfaces)',
     usage: {
-      claude: 'p. agents [doctor|doctor --fix]',
-      terminal: 'prjct agents [doctor|doctor --fix]',
+      claude: 'p. agents [doctor|surfaces|doctor --fix]',
+      terminal: 'prjct agents [doctor|surfaces [--detail]|doctor --fix]',
     },
-    params: '[doctor|status|list] [--fix]',
+    params: '[doctor|status|list|surfaces] [--fix] [--detail]',
     implemented: true,
     hasTemplate: false,
     requiresProject: false,
@@ -514,8 +515,9 @@ export const COMMANDS: CommandMeta[] = [
     features: [
       'Derives support levels from the runtime registry',
       'Reports AGENTS.md, MCP, skills, hooks, ACP, and project-rule support',
+      'surfaces: benchmark-tier harness map (hooks/MCP/skills wire status)',
       'doctor --fix refreshes repo-local agent surfaces when run inside a project',
-      'Use this to audit claims like "works with Codex/Gemini/OpenCode/Cursor/Windsurf"',
+      'Use this to audit claims like "works with Codex/Gemini/OpenCode/Cursor/Grok"',
     ],
   },
   {

--- a/core/commands/harness.ts
+++ b/core/commands/harness.ts
@@ -27,11 +27,11 @@ import { PrjctCommandsBase } from './base'
 export class HarnessCommands extends PrjctCommandsBase {
   async score(projectPath: string = process.cwd(), options: MdOption = {}): Promise<CommandResult> {
     try {
+      // Structural grade is machine-independent (CI/release). Live organic board
+      // is advisory: laptop install state must not tank programDone. Adapter
+      // presence is gated by weak-model-bench, not ~/.claude probes on runners.
       const coverage = await probeHarnessCoverage(projectPath)
-      const report = computeHarnessScore({
-        multiRuntimeOrganicGrade: coverage.grade,
-        multiRuntimeOrganicMeasured: `${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%)`,
-      })
+      const report = computeHarnessScore()
       if (options.md) {
         console.log(renderHarnessScoreMd(report, { coverageMd: renderHarnessCoverageMd(coverage) }))
       } else {
@@ -42,7 +42,7 @@ export class HarnessCommands extends PrjctCommandsBase {
           console.log(`  ${mark} ${c.name}: ${c.score} — ${c.measured}`)
         }
         console.log(
-          `Organic board: ${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%)`
+          `Organic board: ${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%) — advisory`
         )
       }
       return {

--- a/core/commands/harness.ts
+++ b/core/commands/harness.ts
@@ -9,6 +9,7 @@
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import configManager from '../infrastructure/config-manager'
+import { probeHarnessCoverage, renderHarnessCoverageMd } from '../services/harness-coverage'
 import {
   buildInductionDispatch,
   findRig,
@@ -24,14 +25,15 @@ import { getErrorMessage } from '../types/fs'
 import { PrjctCommandsBase } from './base'
 
 export class HarnessCommands extends PrjctCommandsBase {
-  async score(
-    _projectPath: string = process.cwd(),
-    options: MdOption = {}
-  ): Promise<CommandResult> {
+  async score(projectPath: string = process.cwd(), options: MdOption = {}): Promise<CommandResult> {
     try {
-      const report = computeHarnessScore()
+      const coverage = await probeHarnessCoverage(projectPath)
+      const report = computeHarnessScore({
+        multiRuntimeOrganicGrade: coverage.grade,
+        multiRuntimeOrganicMeasured: `${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%)`,
+      })
       if (options.md) {
-        console.log(renderHarnessScoreMd(report))
+        console.log(renderHarnessScoreMd(report, { coverageMd: renderHarnessCoverageMd(coverage) }))
       } else {
         console.log(`Harness grade: ${report.grade}/5${report.programDone ? ' (done)' : ''}`)
         console.log(report.summary)
@@ -39,12 +41,17 @@ export class HarnessCommands extends PrjctCommandsBase {
           const mark = c.status === 'green' ? '✓' : c.status === 'amber' ? '△' : '✗'
           console.log(`  ${mark} ${c.name}: ${c.score} — ${c.measured}`)
         }
+        console.log(
+          `Organic board: ${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%)`
+        )
       }
       return {
         success: true,
         grade: report.grade,
         programDone: report.programDone,
         criteria: report.criteria,
+        organicPct: coverage.organicPct,
+        liveRuntimes: coverage.liveCount,
       }
     } catch (error) {
       return { success: false, error: getErrorMessage(error) }

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -9,6 +9,7 @@
 
 import { detectAgentRuntimes } from '../infrastructure/agent-runtime-registry'
 import configManager from '../infrastructure/config-manager'
+import { probeHarnessCoverage, renderHarnessCoverageMd } from '../services/harness-coverage'
 import { writeProjectAgentSurfaces } from '../services/project-agent-surfaces'
 import {
   status as hookStatus,
@@ -19,7 +20,10 @@ import {
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { installCodexHooks, uninstallCodexHooks } from '../utils/codex-hooks'
 import { ensureCodexMcpServer } from '../utils/codex-mcp'
+import { installCursorHooks, uninstallCursorHooks } from '../utils/cursor-hooks'
+import { installGeminiSettings, uninstallGeminiSettings } from '../utils/gemini-settings'
 import { ensureKimiMcpServer } from '../utils/kimi-mcp'
 import { failFromError, failHard } from '../utils/md-aware'
 import out from '../utils/output'
@@ -44,8 +48,16 @@ export class InstallCommands extends PrjctCommandsBase {
       const detected = runtimes.filter((runtime) => runtime.detected)
       const codexDetected = detected.some((runtime) => runtime.runtime.id === 'codex')
       const codexConfig = codexDetected ? await ensureCodexMcpServer() : null
+      // Always install Codex hooks when Codex is present; also install when
+      // ~/.codex exists so MCP-only users get hooks without re-detect races.
+      const codexHooks = codexDetected ? await installCodexHooks() : null
+      const geminiDetected = detected.some((runtime) => runtime.runtime.id === 'gemini')
+      const geminiConfig = geminiDetected ? await installGeminiSettings() : null
+      const cursorDetected = detected.some((runtime) => runtime.runtime.id === 'cursor')
+      const cursorHooks = cursorDetected ? await installCursorHooks() : null
       const kimiDetected = detected.some((runtime) => runtime.runtime.id === 'kimi-cli')
       const kimiConfig = kimiDetected ? await ensureKimiMcpServer() : null
+      const coverage = await probeHarnessCoverage(projectPath)
       const total = PRJCT_HOOKS.length
       const prunedNote = result.hooksPruned > 0 ? `, ${result.hooksPruned} retired removed` : ''
       const msg = `installed Claude hooks adapter: ${result.hooksWritten} new, ${result.alreadyPresent} already present${prunedNote} (total ${total} hooks)`
@@ -66,9 +78,9 @@ export class InstallCommands extends PrjctCommandsBase {
               : []),
             ...(codexConfig
               ? [
-                  `- Codex config: ${
+                  `- Codex MCP: ${
                     codexConfig.skipped === 'user-managed'
-                      ? 'user-managed MCP preserved'
+                      ? 'user-managed preserved'
                       : codexConfig.changed
                         ? 'updated'
                         : 'already ready'
@@ -76,6 +88,23 @@ export class InstallCommands extends PrjctCommandsBase {
                   `- Codex status line: ${
                     codexConfig.statusLineChanged ? 'installed' : 'already configured'
                   }`,
+                ]
+              : []),
+            ...(codexHooks
+              ? [
+                  `- Codex hooks: ${codexHooks.hooksWritten} new, ${codexHooks.alreadyPresent} present, ${codexHooks.hooksPruned} pruned → \`${codexHooks.hooksPath}\``,
+                  `- Codex features.hooks: ${codexHooks.featuresChanged ? 'enabled' : 'already on'}`,
+                ]
+              : []),
+            ...(geminiConfig
+              ? [
+                  `- Gemini MCP: ${geminiConfig.mcpChanged ? 'updated' : 'already ready'}`,
+                  `- Gemini hooks: ${geminiConfig.hooksWritten} new, ${geminiConfig.alreadyPresent} present, ${geminiConfig.hooksPruned} pruned → \`${geminiConfig.settingsPath}\``,
+                ]
+              : []),
+            ...(cursorHooks
+              ? [
+                  `- Cursor hooks: ${cursorHooks.hooksWritten} new, ${cursorHooks.alreadyPresent} present, ${cursorHooks.hooksPruned} pruned → \`${cursorHooks.hooksPath}\``,
                 ]
               : []),
             ...(kimiConfig
@@ -95,8 +124,10 @@ export class InstallCommands extends PrjctCommandsBase {
               (runtime) => `- ${runtime.runtime.displayName}: ${runtime.supportLevel}`
             ),
             ``,
-            `> Claude hooks are an adapter, not the universal layer. AGENTS.md + MCP/CLI --md are the portable baseline.`,
-            `> Only \`_prjctManaged: true\` hook entries were touched. Your other hooks are untouched.`,
+            renderHarnessCoverageMd(coverage),
+            `> One install · one SQLite brain · every agent surface. That is the moat — not more skills.`,
+            `> Grok inherits Claude. Codex/Gemini/Cursor get native adapters. Trust Codex hooks once via \`/hooks\`.`,
+            `> Only \`_prjctManaged: true\` entries were touched.`,
           ].join('\n')
         )
       } else {
@@ -115,26 +146,71 @@ export class InstallCommands extends PrjctCommandsBase {
               : codexConfig.changed
                 ? 'updated'
                 : 'already ready'
-          out.info(`Codex config: ${action}`)
+          out.info(`Codex MCP: ${action}`)
           out.info(
             `Codex status line: ${codexConfig.statusLineChanged ? 'installed' : 'already configured'}`
+          )
+        }
+        if (codexHooks) {
+          out.info(
+            `Codex hooks: ${codexHooks.hooksWritten} new, ${codexHooks.alreadyPresent} present → ${codexHooks.hooksPath}`
+          )
+          out.info(`Codex features.hooks: ${codexHooks.featuresChanged ? 'enabled' : 'already on'}`)
+        }
+        if (geminiConfig) {
+          out.info(`Gemini MCP: ${geminiConfig.mcpChanged ? 'updated' : 'already ready'}`)
+          out.info(
+            `Gemini hooks: ${geminiConfig.hooksWritten} new, ${geminiConfig.alreadyPresent} present → ${geminiConfig.settingsPath}`
+          )
+        }
+        if (cursorHooks) {
+          out.info(
+            `Cursor hooks: ${cursorHooks.hooksWritten} new, ${cursorHooks.alreadyPresent} present → ${cursorHooks.hooksPath}`
           )
         }
         if (kimiConfig) {
           out.info(`Kimi config: ${kimiConfig.changed ? 'updated' : 'already ready'}`)
         }
+        out.info(
+          `Organic board: ${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%)`
+        )
       }
       return {
         success: true,
         hooksWritten: result.hooksWritten,
         projectSurface: projectSurfaces?.agentsMd.action ?? 'skipped',
         detectedRuntimes: detected.length,
+        organicPct: coverage.organicPct,
+        liveRuntimes: coverage.liveCount,
         codexConfig: codexConfig
           ? {
               path: codexConfig.path,
               changed: codexConfig.changed,
               skipped: codexConfig.skipped,
               statusLineChanged: codexConfig.statusLineChanged ?? false,
+            }
+          : null,
+        codexHooks: codexHooks
+          ? {
+              path: codexHooks.hooksPath,
+              hooksWritten: codexHooks.hooksWritten,
+              alreadyPresent: codexHooks.alreadyPresent,
+              featuresChanged: codexHooks.featuresChanged,
+            }
+          : null,
+        geminiConfig: geminiConfig
+          ? {
+              path: geminiConfig.settingsPath,
+              mcpChanged: geminiConfig.mcpChanged,
+              hooksWritten: geminiConfig.hooksWritten,
+              alreadyPresent: geminiConfig.alreadyPresent,
+            }
+          : null,
+        cursorHooks: cursorHooks
+          ? {
+              path: cursorHooks.hooksPath,
+              hooksWritten: cursorHooks.hooksWritten,
+              alreadyPresent: cursorHooks.alreadyPresent,
             }
           : null,
         kimiConfig: kimiConfig
@@ -161,15 +237,56 @@ export class InstallCommands extends PrjctCommandsBase {
   ): Promise<CommandResult> {
     try {
       const result = await uninstallHooks()
-      const msg = `removed ${result.hooksRemoved} prjct hook(s)`
+      // Best-effort Codex cleanup — missing hooks.json is fine.
+      const codex = await uninstallCodexHooks().catch(() => ({
+        hooksPath: '',
+        hooksRemoved: 0,
+      }))
+      const gemini = await uninstallGeminiSettings().catch(() => ({
+        settingsPath: '',
+        hooksRemoved: 0,
+        mcpRemoved: false,
+      }))
+      const cursor = await uninstallCursorHooks().catch(() => ({
+        hooksPath: '',
+        hooksRemoved: 0,
+      }))
+      const msg = `removed ${result.hooksRemoved} Claude prjct hook(s)${
+        codex.hooksRemoved > 0 ? `, ${codex.hooksRemoved} Codex hook(s)` : ''
+      }${gemini.hooksRemoved > 0 || gemini.mcpRemoved ? `, Gemini cleaned` : ''}${
+        cursor.hooksRemoved > 0 ? `, ${cursor.hooksRemoved} Cursor hook(s)` : ''
+      }`
       if (options.md) {
         console.log(
-          `# prjct hooks removed\n\n- removed: ${result.hooksRemoved}\n- settings: \`${result.settingsPath}\`\n`
+          [
+            `# prjct hooks removed`,
+            ``,
+            `- Claude: ${result.hooksRemoved} (\`${result.settingsPath}\`)`,
+            ...(codex.hooksRemoved > 0
+              ? [`- Codex: ${codex.hooksRemoved} (\`${codex.hooksPath}\`)`]
+              : []),
+            ...(gemini.hooksRemoved > 0 || gemini.mcpRemoved
+              ? [
+                  `- Gemini: ${gemini.hooksRemoved} hook(s)${gemini.mcpRemoved ? ', MCP removed' : ''} (\`${gemini.settingsPath}\`)`,
+                ]
+              : []),
+            ...(cursor.hooksRemoved > 0
+              ? [`- Cursor: ${cursor.hooksRemoved} (\`${cursor.hooksPath}\`)`]
+              : []),
+            ``,
+          ].join('\n')
         )
       } else {
         out.done(msg)
       }
-      return { success: true, hooksRemoved: result.hooksRemoved }
+      return {
+        success: true,
+        hooksRemoved: result.hooksRemoved,
+        codexHooksRemoved: codex.hooksRemoved,
+        geminiHooksRemoved: gemini.hooksRemoved,
+        geminiMcpRemoved: gemini.mcpRemoved,
+        cursorHooksRemoved: cursor.hooksRemoved,
+      }
     } catch (error) {
       const msg = getErrorMessage(error)
       return failHard(msg)

--- a/core/commands/update/cleanup-installs.ts
+++ b/core/commands/update/cleanup-installs.ts
@@ -8,12 +8,15 @@
  * Destructive — the README explicitly warns aggressive cleanup can brick a
  * shell, so removal is gated behind a strict safety model and (by default)
  * a TTY confirmation; non-interactive runs warn only.
+ *
+ * Winner logic is pure (`planCleanupFrom`) so unit tests can pin the
+ * multi-install footgun without shelling out to real package managers.
  */
 
-import { execSync } from 'node:child_process'
 import { realpathSync } from 'node:fs'
 import path from 'node:path'
 import readline from 'node:readline'
+import { whichSync } from '../../utils/which'
 import {
   detectInstallerFromRunningBinary,
   getAllInstalledLocations,
@@ -41,18 +44,41 @@ export interface CleanupPlan {
   skipped: Array<{ pm: string; reason: string }>
 }
 
+/** One detected global install (name + root + version) for pure planning. */
+export interface CleanupLocation {
+  name: PkgManagerName
+  installRoot: string | null
+  version: string
+}
+
+/** Injectable inputs for pure cleanup planning (unit-testable). */
+export interface CleanupPlanInput {
+  winnerReal: string | null
+  winnerPm: PkgManagerName | null
+  locations: CleanupLocation[]
+  brewInstalled: boolean
+  sourceRoot: string
+  /**
+   * True when installRoot owns the PATH-winning binary. Defaults to
+   * realpath-aware prefix match used in production.
+   */
+  ownsWinner?: (installRoot: string | null | undefined, winnerReal: string | null) => boolean
+  /**
+   * Resolve a package path for the dev-tree gate. Defaults to realpathSync
+   * with fallback to the input path.
+   */
+  resolvePath?: (p: string) => string
+}
+
 /** realpath of the prjct binary the user's shell actually runs, or null. */
 function pathWinnerReal(): string | null {
+  // Cross-platform: which/where.exe — never shell `command -v` alone (Windows).
+  const p = whichSync('prjct') ?? whichSync('prjct.cmd')
+  if (!p) return null
   try {
-    const p = execSync('command -v prjct', { stdio: 'pipe', shell: '/bin/sh' }).toString().trim()
-    if (!p) return null
-    try {
-      return realpathSync(p)
-    } catch {
-      return p
-    }
+    return realpathSync(p)
   } catch {
-    return null
+    return p
   }
 }
 
@@ -66,29 +92,85 @@ function sourceRoot(): string {
 }
 
 /**
- * Pure: decide which copies are safe to remove. Never removes the PATH
- * winner, the dev checkout, or anything whose ownership can't be proven
- * (getAllInstalledLocations already verifies `prjct-cli/package.json`).
+ * Normalize paths for ownership comparison across OS:
+ * - path.normalize (collapses . / ..)
+ * - forward slashes for stable prefix checks
+ * - case-fold on win32 (NTFS default is case-insensitive)
  */
+export function normalizePathForCompare(p: string): string {
+  const normalized = path.normalize(p).replace(/\\/g, '/')
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
 /** True when this install root owns the PATH-winning binary realpath. */
-function locationOwnsWinner(
+export function locationOwnsWinner(
   installRoot: string | null | undefined,
   winnerReal: string | null
 ): boolean {
   if (!installRoot || !winnerReal) return false
   try {
-    const root = realpathSync(installRoot)
-    const win = realpathSync(winnerReal)
-    return win === root || win.startsWith(root + path.sep)
+    const root = normalizePathForCompare(realpathSync(installRoot))
+    const win = normalizePathForCompare(realpathSync(winnerReal))
+    return win === root || win.startsWith(`${root}/`)
   } catch {
-    return winnerReal.includes(installRoot)
+    const root = normalizePathForCompare(installRoot)
+    const win = normalizePathForCompare(winnerReal)
+    return win === root || win.startsWith(`${root}/`) || win.includes(root)
   }
 }
 
-export function planCleanup(): CleanupPlan {
-  const winnerReal = pathWinnerReal()
-  const winnerPm = detectInstallerFromRunningBinary()
-  const src = sourceRoot()
+function defaultResolvePath(p: string): string {
+  try {
+    return realpathSync(p)
+  } catch {
+    return p
+  }
+}
+
+/**
+ * True only for Homebrew *formula* install paths of prjct itself.
+ *
+ * Must NOT match npm/pnpm/yarn globals that happen to live under Homebrew's
+ * Node prefix (e.g. `/opt/homebrew/lib/node_modules/prjct-cli`) — those are
+ * package-manager installs, not `brew install prjct-cli`.
+ */
+/**
+ * Homebrew formula paths only (macOS + Linuxbrew). Never matches Windows,
+ * and never matches npm globals under Homebrew's Node prefix.
+ */
+export function isBrewWinnerPath(winnerReal: string | null): boolean {
+  if (!winnerReal) return false
+  // Windows install roots never come from brew formula Cellar layouts.
+  if (process.platform === 'win32') return false
+  const p = winnerReal.replace(/\\/g, '/')
+  if (p.includes('/Cellar/prjct-cli') || p.includes('/Cellar/prjct/')) {
+    return true
+  }
+  // brew symlink: /opt/homebrew/bin/prjct or /home/linuxbrew/.linuxbrew/bin/prjct
+  if (/(?:^|\/)(?:opt\/)?homebrew\/bin\/prjct(?:$|\/)/.test(p)) return true
+  if (p.includes('/.linuxbrew/bin/prjct') || p.includes('/linuxbrew/.linuxbrew/bin/prjct')) {
+    return true
+  }
+  if (p.endsWith('/homebrew/bin/prjct') || p.endsWith('/opt/homebrew/bin/prjct')) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Pure: decide which copies are safe to remove. Never removes the PATH
+ * winner, the dev checkout, or anything whose ownership can't be proven.
+ */
+export function planCleanupFrom(input: CleanupPlanInput): CleanupPlan {
+  const {
+    winnerReal,
+    winnerPm,
+    locations,
+    brewInstalled,
+    sourceRoot: src,
+    ownsWinner = locationOwnsWinner,
+    resolvePath = defaultResolvePath,
+  } = input
   const skipped: CleanupPlan['skipped'] = []
 
   // Gate #1: a provable winner is mandatory. Without it we cannot know
@@ -103,60 +185,53 @@ export function planCleanup(): CleanupPlan {
     }
   }
 
-  const brewWinner =
-    !!winnerReal &&
-    (winnerReal.includes('/Cellar/') ||
-      winnerReal.includes('/homebrew/') ||
-      winnerReal.includes('/opt/homebrew/bin/prjct') ||
-      winnerReal.includes('/opt/homebrew/lib/node_modules/prjct-cli'))
+  const brewWinner = isBrewWinnerPath(winnerReal)
   // Prefer the PM that owns the winning *binary path* over a mis-detected
   // installer string (fixes multi-install footgun that deleted the active copy).
   let winner: CleanupPlan['winner'] = brewWinner ? 'brew' : winnerPm
   if (!brewWinner && winnerReal) {
-    for (const loc of getAllInstalledLocations()) {
-      const root = loc.pm.getInstallRoot()
+    for (const loc of locations) {
+      const root = loc.installRoot
       if (
-        locationOwnsWinner(root, winnerReal) ||
-        locationOwnsWinner(path.join(root ?? '', 'prjct-cli'), winnerReal)
+        ownsWinner(root, winnerReal) ||
+        ownsWinner(root ? path.join(root, 'prjct-cli') : null, winnerReal)
       ) {
-        winner = loc.pm.name
+        winner = loc.name
         break
       }
     }
   }
 
   const removable: CleanupPlan['removable'] = []
-  for (const loc of getAllInstalledLocations()) {
-    const root = loc.pm.getInstallRoot()
-    const owns =
-      loc.pm.name === winner ||
-      loc.pm.name === winnerPm ||
-      locationOwnsWinner(root, winnerReal) ||
-      locationOwnsWinner(root ? path.join(root, 'prjct-cli') : null, winnerReal)
+  for (const loc of locations) {
+    const root = loc.installRoot
+    // Keep only the definitive winner, or any root that owns the PATH binary.
+    // Do NOT keep a mis-detected winnerPm when path ownership points elsewhere
+    // (that was the multi-install footgun: active copy deleted, shadow kept).
+    // When winnerReal is unknown, fall back to keeping winnerPm by name.
+    const pathOwned =
+      ownsWinner(root, winnerReal) ||
+      ownsWinner(root ? path.join(root, 'prjct-cli') : null, winnerReal)
+    const owns = loc.name === winner || pathOwned || (!winnerReal && loc.name === winnerPm)
     if (owns) {
-      skipped.push({ pm: loc.pm.name, reason: 'PATH winner (or owns winning binary) — kept' })
+      skipped.push({ pm: loc.name, reason: 'PATH winner (or owns winning binary) — kept' })
       continue
     }
     // Gate: never remove the dev source tree (npm/bun link).
     if (root && src) {
-      let resolved = path.join(root, 'prjct-cli')
-      try {
-        resolved = realpathSync(resolved)
-      } catch {
-        /* ignore */
-      }
+      const resolved = resolvePath(path.join(root, 'prjct-cli'))
       if (resolved === src) {
-        skipped.push({ pm: loc.pm.name, reason: 'resolves to the dev source tree (link) — kept' })
+        skipped.push({ pm: loc.name, reason: 'resolves to the dev source tree (link) — kept' })
         continue
       }
     }
-    removable.push({ pm: loc.pm.name, version: loc.version })
+    removable.push({ pm: loc.name, version: loc.version })
   }
 
   // Brew: only if a brew copy exists AND it is not the winner.
-  if (isHomebrewInstall() && !brewWinner && winner !== 'brew') {
+  if (brewInstalled && !brewWinner && winner !== 'brew') {
     removable.push({ pm: 'brew', version: '(homebrew)' })
-  } else if (isHomebrewInstall() && (brewWinner || winner === 'brew')) {
+  } else if (brewInstalled && (brewWinner || winner === 'brew')) {
     skipped.push({ pm: 'brew', reason: 'PATH winner — kept' })
   }
 
@@ -173,6 +248,21 @@ export function planCleanup(): CleanupPlan {
   }
 
   return { winner, removable, skipped }
+}
+
+/** Live cleanup plan — shells out for PATH/PM detection, then pure planning. */
+export function planCleanup(): CleanupPlan {
+  return planCleanupFrom({
+    winnerReal: pathWinnerReal(),
+    winnerPm: detectInstallerFromRunningBinary(),
+    locations: getAllInstalledLocations().map((loc) => ({
+      name: loc.pm.name,
+      installRoot: loc.pm.getInstallRoot(),
+      version: loc.version,
+    })),
+    brewInstalled: isHomebrewInstall(),
+    sourceRoot: sourceRoot(),
+  })
 }
 
 function removeOne(pm: PkgManagerName | 'brew'): { ok: boolean; error?: string } {

--- a/core/commands/update/cleanup-installs.ts
+++ b/core/commands/update/cleanup-installs.ts
@@ -13,6 +13,7 @@
  * multi-install footgun without shelling out to real package managers.
  */
 
+import { execSync } from 'node:child_process'
 import { realpathSync } from 'node:fs'
 import path from 'node:path'
 import readline from 'node:readline'

--- a/core/commands/update/package-managers.ts
+++ b/core/commands/update/package-managers.ts
@@ -10,6 +10,7 @@ import { execFileSync } from 'node:child_process'
 import os from 'node:os'
 import path from 'node:path'
 import { resetPackageRoot } from '../../utils/version'
+import { commandOnPath } from '../../utils/which'
 
 export type PkgManagerName = 'npm' | 'pnpm' | 'bun' | 'yarn'
 
@@ -90,19 +91,14 @@ export function isHomebrewInstall(): boolean {
   }
 }
 
-/** Whether `name` resolves to an executable in the current PATH. */
+/** Whether `name` resolves to an executable in the current PATH (all OS). */
 export function isOnPath(name: PkgManagerName): boolean {
-  try {
-    execFileSync('which', [name], { stdio: 'pipe' })
-    return true
-  } catch {
-    return false
-  }
+  return commandOnPath(name) || (process.platform === 'win32' && commandOnPath(`${name}.cmd`))
 }
 
 /**
  * Detect which package manager owns the running prjct binary by inspecting
- * its real path. Returns null if no signal is found.
+ * its real path. Works on macOS, Linux, and Windows path layouts.
  */
 export function detectInstallerFromRunningBinary(): PkgManagerName | null {
   const candidates = [process.argv[1], process.execPath].filter(Boolean) as string[]
@@ -113,10 +109,25 @@ export function detectInstallerFromRunningBinary(): PkgManagerName | null {
     } catch {
       // ignore
     }
-    if (real.includes('/.bun/install/global') || real.includes('/.bun/bin/')) return 'bun'
-    if (real.includes('/Library/pnpm/') || real.includes('/.pnpm/')) return 'pnpm'
-    if (real.includes('/.local/share/pnpm/')) return 'pnpm'
-    if (real.includes('/.yarn/') || real.includes('/yarn/global')) return 'yarn'
+    // Normalize so Windows backslashes match the same markers.
+    const p = real.replace(/\\/g, '/').toLowerCase()
+    if (p.includes('/.bun/install/global') || p.includes('/.bun/bin/')) return 'bun'
+    if (p.includes('/library/pnpm/') || p.includes('/.pnpm/')) return 'pnpm'
+    if (p.includes('/.local/share/pnpm/')) return 'pnpm'
+    // Windows pnpm store / shim layouts
+    if (p.includes('/pnpm/') && (p.includes('/global') || p.includes('/prjct'))) return 'pnpm'
+    if (p.includes('/.yarn/') || p.includes('/yarn/global') || p.includes('/yarn/berry')) {
+      return 'yarn'
+    }
+    // npm global: …/node_modules/prjct-cli or Windows %APPDATA%\npm\node_modules
+    if (
+      p.includes('/node_modules/prjct-cli') ||
+      p.includes('/npm/node_modules/') ||
+      p.endsWith('/npm/prjct.cmd') ||
+      p.endsWith('/npm/prjct')
+    ) {
+      return 'npm'
+    }
   }
   return null
 }

--- a/core/hooks/_runner.ts
+++ b/core/hooks/_runner.ts
@@ -27,7 +27,14 @@
  *     serialized request chain. Same build + same fail-soft contract.
  */
 
-import { buildDenyOutput, buildHookOutput, emit, readStdinSafe, safeRun } from './_shared'
+import {
+  adaptHookOutputForHost,
+  buildDenyOutput,
+  buildHookOutput,
+  emit,
+  readStdinSafe,
+  safeRun,
+} from './_shared'
 
 export interface RunHookOptions<I> {
   /** Claude Code event name (SessionStart, UserPromptSubmit, etc.). */
@@ -79,11 +86,13 @@ export async function runHook<I = Record<string, unknown>>(
       const input = io.input as I
       const decision = opts.decide ? await opts.decide(input, projectPath) : null
       if (decision) {
-        io.sink(`${JSON.stringify(buildDenyOutput(opts.event, decision.deny))}\n`)
+        const payload = adaptHookOutputForHost(buildDenyOutput(opts.event, decision.deny))
+        io.sink(`${JSON.stringify(payload)}\n`)
         return
       }
       const context = opts.build ? await opts.build(input, projectPath) : null
-      io.sink(`${JSON.stringify(buildHookOutput(opts.event, context))}\n`)
+      const payload = adaptHookOutputForHost(buildHookOutput(opts.event, context))
+      io.sink(`${JSON.stringify(payload)}\n`)
       if (opts.afterEmit) io.detachAfterEmit(() => opts.afterEmit!(input, projectPath))
     } catch {
       io.sink('{}\n')

--- a/core/hooks/_shared.ts
+++ b/core/hooks/_shared.ts
@@ -65,6 +65,125 @@ export function buildDenyOutput(event: string, reason: string): DenyOutput {
   }
 }
 
+/** Host that invoked the hook (Claude default; others remap output). */
+export type HookHost = 'claude' | 'gemini' | 'codex' | 'cursor'
+
+export function currentHookHost(): HookHost {
+  const raw = (process.env.PRJCT_HOOK_HOST ?? 'claude').toLowerCase()
+  if (raw === 'gemini' || raw === 'codex' || raw === 'cursor') return raw
+  return 'claude'
+}
+
+/**
+ * Host-specific rewrite of Claude-shaped hook payloads.
+ * - gemini: BeforeTool/decision deny (geminicli.com/docs/hooks)
+ * - cursor: camelCase events + snake_case additional_context (community 2026)
+ * - codex: Claude-compatible shapes (hooks.json mirrors Claude)
+ */
+export function adaptHookOutputForHost(
+  output: HookOutput | DenyOutput | Record<string, never>,
+  host: HookHost = currentHookHost()
+): Record<string, unknown> {
+  if (host === 'claude' || host === 'codex') return output as Record<string, unknown>
+  if (!output || Object.keys(output).length === 0) return output as Record<string, unknown>
+
+  if (host === 'gemini') return adaptForGemini(output)
+  if (host === 'cursor') return adaptForCursor(output)
+  return output as Record<string, unknown>
+}
+
+function adaptForGemini(
+  output: HookOutput | DenyOutput | Record<string, never>
+): Record<string, unknown> {
+  const deny = output as DenyOutput
+  if (deny.hookSpecificOutput?.permissionDecision === 'deny') {
+    return {
+      decision: 'deny',
+      reason: deny.hookSpecificOutput.permissionDecisionReason ?? 'blocked by prjct',
+    }
+  }
+  const out = output as HookOutput
+  const hso = out.hookSpecificOutput
+  if (hso?.additionalContext) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: mapClaudeEventToGemini(hso.hookEventName),
+        additionalContext: hso.additionalContext,
+      },
+    }
+  }
+  if (out.systemMessage) return { systemMessage: out.systemMessage }
+  return output as Record<string, unknown>
+}
+
+function adaptForCursor(
+  output: HookOutput | DenyOutput | Record<string, never>
+): Record<string, unknown> {
+  const deny = output as DenyOutput
+  if (deny.hookSpecificOutput?.permissionDecision === 'deny') {
+    // Cursor preToolUse commonly accepts permissionDecision or decision.
+    return {
+      decision: 'deny',
+      reason: deny.hookSpecificOutput.permissionDecisionReason ?? 'blocked by prjct',
+      permissionDecision: 'deny',
+      permissionDecisionReason:
+        deny.hookSpecificOutput.permissionDecisionReason ?? 'blocked by prjct',
+    }
+  }
+  const out = output as HookOutput
+  const hso = out.hookSpecificOutput
+  if (hso?.additionalContext) {
+    const event = mapClaudeEventToCursor(hso.hookEventName)
+    // Forum reports: additional_context (snake) is what Cursor logs/surfaces.
+    return {
+      hookSpecificOutput: {
+        hookEventName: event,
+        additionalContext: hso.additionalContext,
+        additional_context: hso.additionalContext,
+      },
+      additional_context: hso.additionalContext,
+    }
+  }
+  if (out.systemMessage) return { systemMessage: out.systemMessage }
+  return output as Record<string, unknown>
+}
+
+function mapClaudeEventToGemini(event: string): string {
+  switch (event) {
+    case 'UserPromptSubmit':
+      return 'BeforeAgent'
+    case 'PreToolUse':
+      return 'BeforeTool'
+    case 'PostToolUse':
+      return 'AfterTool'
+    case 'Stop':
+      return 'AfterAgent'
+    default:
+      return event
+  }
+}
+
+function mapClaudeEventToCursor(event: string): string {
+  switch (event) {
+    case 'SessionStart':
+      return 'sessionStart'
+    case 'UserPromptSubmit':
+      return 'beforeSubmitPrompt'
+    case 'PreToolUse':
+      return 'preToolUse'
+    case 'PostToolUse':
+      return 'postToolUse'
+    case 'Stop':
+      return 'stop'
+    case 'SubagentStart':
+      return 'subagentStart'
+    case 'SubagentStop':
+      return 'subagentStop'
+    default:
+      return event.charAt(0).toLowerCase() + event.slice(1)
+  }
+}
+
 export async function readStdinSafe<T = Record<string, unknown>>(): Promise<T> {
   if (process.stdin.isTTY) return {} as T
   return new Promise((resolve) => {
@@ -90,7 +209,8 @@ export async function readStdinSafe<T = Record<string, unknown>>(): Promise<T> {
  * so the host parser is happy.
  */
 export function emit(output: HookOutput | DenyOutput | Record<string, never>): void {
-  process.stdout.write(`${JSON.stringify(output)}\n`)
+  const adapted = adaptHookOutputForHost(output)
+  process.stdout.write(`${JSON.stringify(adapted)}\n`)
 }
 
 function emitEmpty(): void {

--- a/core/infrastructure/agent-runtime-registry.ts
+++ b/core/infrastructure/agent-runtime-registry.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import { execFileAsync } from '../utils/exec'
 import { dirExists, fileExists } from '../utils/file-helper'
+import { commandOnPathAsync } from '../utils/which'
 import { resolveUserHome } from './user-home'
 
 export type AgentRuntimeId =
@@ -54,7 +54,8 @@ export interface AgentRuntimeDefinition {
   id: AgentRuntimeId
   displayName: string
   kind: AgentRuntimeKind
-  status: 'stable' | 'emerging' | 'hosted'
+  /** stable = current benchmark focus; legacy = keep working but do not prioritize. */
+  status: 'stable' | 'emerging' | 'hosted' | 'legacy'
   detectsBy?: {
     homeDirs?: string[]
     projectFiles?: string[]
@@ -154,7 +155,8 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       acp: false,
       projectRules: true,
     },
-    notes: 'Uses CLAUDE.md, global skills, hooks, and Claude-style MCP JSON.',
+    notes:
+      'Benchmark-tier CLI (2026-07): Claude Code + Opus frontier. CLAUDE.md, skills, hooks, MCP JSON.',
   },
   {
     id: 'codex',
@@ -168,11 +170,13 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       agentsMd: true,
       mcp: true,
       skills: true,
-      hooks: false,
+      // Hooks exist (hooks.json / config.toml) behind [features] codex_hooks — see harness-surfaces.
+      hooks: true,
       acp: false,
       projectRules: false,
     },
-    notes: 'Uses AGENTS.md, compact skills, and Codex config.toml MCP servers.',
+    notes:
+      'Benchmark-tier CLI (2026-07): Codex + GPT-5.x (TB leader). AGENTS.md, config.toml MCP (native), hooks opt-in (planned installer).',
   },
   {
     id: 'gemini',
@@ -181,15 +185,19 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
     status: 'stable',
     detectsBy: { homeDirs: ['.gemini'], commands: ['gemini'] },
     contextFiles: ['GEMINI.md', 'AGENTS.md'],
+    mcpTargets: [
+      { format: 'claude-json', pathHint: '~/.gemini/settings.json mcpServers', writable: true },
+    ],
     supports: {
       agentsMd: true,
       mcp: true,
       skills: true,
-      hooks: false,
+      hooks: true,
       acp: false,
       projectRules: true,
     },
-    notes: 'Uses GEMINI.md and MCP; AGENTS.md keeps repo-level compatibility with other agents.',
+    notes:
+      'Benchmark-tier CLI (2026-07): Gemini CLI + Pro/Flash. GEMINI.md; prjct install writes MCP+hooks to ~/.gemini/settings.json.',
   },
   {
     id: 'antigravity',
@@ -228,7 +236,8 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       acp: false,
       projectRules: true,
     },
-    notes: 'Multi-provider coding agent with AGENTS.md, project agents, plugins, and MCP config.',
+    notes:
+      'Benchmark-tier open-source CLI (2026-07): most-starred multi-provider agent. AGENTS.md + plugins + MCP.',
   },
   {
     id: 'qwen-code',
@@ -271,10 +280,18 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
     id: 'grok',
     displayName: 'xAI Grok Build',
     kind: 'cli',
-    status: 'emerging',
+    status: 'stable',
     detectsBy: { homeDirs: ['.grok'], commands: ['grok'] },
-    contextFiles: ['AGENTS.md'],
-    mcpTargets: [{ format: 'generic', pathHint: '~/.grok/config.toml (mcp)', writable: false }],
+    contextFiles: ['AGENTS.md', 'CLAUDE.md'],
+    // Grok natively loads Claude MCP/settings — no separate writer required.
+    mcpTargets: [
+      { format: 'generic', pathHint: '~/.grok config/plugins (MCP)', writable: false },
+      {
+        format: 'claude-json',
+        pathHint: '~/.claude/mcp.json (Grok Claude-compat)',
+        writable: true,
+      },
+    ],
     supports: {
       agentsMd: true,
       mcp: true,
@@ -284,7 +301,7 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       projectRules: false,
     },
     notes:
-      'xAI Grok Build CLI; AGENTS.md walked root→cwd, skills under .agents/skills or .grok/skills, hooks/plugins/MCP via ~/.grok/config.toml. Also reads Claude Code surfaces (CLAUDE.md, .claude/skills) natively.',
+      'Benchmark-tier CLI (2026-07): Grok Build. AGENTS.md + native Claude Code compat (CLAUDE.md, skills, MCP, hooks). prjct install covers Grok via inherits-claude — see harness-surfaces.',
   },
   {
     id: 'goose',
@@ -339,17 +356,18 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       agentsMd: true,
       mcp: true,
       skills: false,
-      hooks: false,
+      hooks: true,
       acp: false,
       projectRules: true,
     },
-    notes: 'Project rules live under .cursor/rules; model/provider selection happens in Cursor.',
+    notes:
+      'Benchmark-tier AI IDE (2026-07): agent mode + CLI. Rules under .cursor/rules; prjct install writes ~/.cursor/hooks.json.',
   },
   {
     id: 'windsurf',
     displayName: 'Windsurf',
     kind: 'ide',
-    status: 'stable',
+    status: 'legacy',
     detectsBy: { projectDirs: ['.windsurf'], projectFiles: ['.windsurfrules'] },
     contextFiles: ['AGENTS.md', '.windsurf/rules/prjct.md'],
     projectRuleTargets: [
@@ -367,7 +385,8 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       acp: false,
       projectRules: true,
     },
-    notes: 'Project rules live under .windsurf/rules; keep legacy support but do not center it.',
+    notes:
+      'LEGACY (2026-07): Windsurf is no longer a product focus. Keep AGENTS.md + optional .windsurf/rules for residual installs; do not expand surface area. Prefer Cursor, Claude Code, Codex, Gemini CLI, OpenCode, Cline.',
   },
   {
     id: 'cline',
@@ -384,7 +403,8 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       acp: true,
       projectRules: true,
     },
-    notes: 'VS Code agent with AGENTS.md, rules, skills, hooks, MCP, CLI, and ACP surfaces.',
+    notes:
+      'Benchmark-tier open agent (2026-07): VS Code + multi-model. AGENTS.md, rules, skills, hooks, MCP, ACP.',
   },
   {
     id: 'roo-code',
@@ -454,7 +474,7 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       projectRules: true,
     },
     notes:
-      'Hosted GitHub agent; repo instructions and MCP-compatible setup are the portable layer.',
+      'GitHub Copilot coding agent / Copilot CLI (2026-07 benchmark field). Repo AGENTS.md + .github instructions + MCP.',
   },
   {
     id: 'devin',
@@ -694,17 +714,27 @@ async function detectRuntimeSignals(
 }
 
 async function commandExists(command: string): Promise<boolean> {
-  try {
-    await execFileAsync('which', [command])
-    return true
-  } catch {
-    return false
-  }
+  // Cross-platform: which on Unix, where.exe on Windows.
+  if (await commandOnPathAsync(command)) return true
+  if (process.platform === 'win32' && (await commandOnPathAsync(`${command}.cmd`))) return true
+  return false
 }
+
+/** Runtimes that get first-class support investment (2026-07 benchmark field). */
+const FULL_SUPPORT_RUNTIME_IDS = new Set<AgentRuntimeId>([
+  'claude',
+  'codex',
+  'gemini',
+  'opencode',
+  'cursor',
+  'cline',
+  'grok',
+])
 
 function supportLevelFor(runtime: AgentRuntimeDefinition): RuntimeSupportLevel {
   if (runtime.status === 'hosted') return 'hosted'
-  if (runtime.id === 'claude') return 'full'
+  if (runtime.status === 'legacy') return 'manual'
+  if (FULL_SUPPORT_RUNTIME_IDS.has(runtime.id)) return 'full'
   if (runtime.supports.agentsMd && runtime.supports.mcp) return 'good'
   if (runtime.supports.agentsMd) return 'baseline'
   return 'manual'

--- a/core/infrastructure/ai-provider.ts
+++ b/core/infrastructure/ai-provider.ts
@@ -4,17 +4,20 @@
  * Supports multiple AI coding agents with a unified abstraction layer:
  * - Claude Code (CLI): ~/.claude/, CLAUDE.md, .md commands
  * - Gemini CLI (CLI): ~/.gemini/, GEMINI.md, .toml commands
+ * - OpenAI Codex (CLI): ~/.codex/, AGENTS.md
  * - Cursor IDE (GUI): .cursor/ (project-level), .mdc rules
- * - Windsurf IDE (GUI): .windsurf/ (project-level), .md rules with YAML frontmatter
+ * - Windsurf IDE (GUI, LEGACY): .windsurf/ residual support only — do not expand
  *
  * Key differences:
- * - CLI providers (Claude/Gemini) have global config directories
- * - Cursor/Windsurf have project-level config only (no ~/.cursor/ or ~/.windsurf/)
+ * - CLI providers (Claude/Gemini/Codex) have global config directories
+ * - Cursor (and legacy Windsurf) are project-level only
+ *
+ * Benchmark focus (2026-07): Claude Code, Codex CLI, Gemini CLI, OpenCode,
+ * Cursor, Cline, Grok Build — not Windsurf.
  *
  * @see https://geminicli.com/docs/cli/gemini-md/
  * @see https://geminicli.com/docs/cli/skills/
  * @see https://cursor.com/docs/context/rules
- * @see https://docs.windsurf.com/windsurf/cascade/memories
  */
 
 import path from 'node:path'
@@ -31,6 +34,7 @@ import type {
 import { execAsync } from '../utils/exec'
 import { fileExists } from '../utils/file-helper'
 import { readProviderCache, writeProviderCache } from '../utils/provider-cache'
+import { whichAsync } from '../utils/which'
 import { resolveUserPath } from './user-home'
 
 // Provider Configurations
@@ -166,20 +170,13 @@ export const CursorProvider: AIProviderConfig = {
 }
 
 /**
- * Windsurf IDE provider configuration
- *
- * Key differences from Cursor:
- * - Uses .md files (not .mdc) with YAML frontmatter
- * - Uses "workflows" instead of "commands"
- * - Frontmatter uses `trigger: always_on` instead of `alwaysApply: true`
- * - Character limits: 6000 per file, 12000 total
- *
- * @see https://docs.windsurf.com/windsurf/cascade/memories
- * @see https://docs.windsurf.com/windsurf/cascade/workflows
+ * Windsurf IDE — LEGACY residual support (product no longer a focus, 2026-07).
+ * Keep install paths working for existing users; do not add new Windsurf-only
+ * surfaces. Prefer Cursor / Claude Code / Codex / Gemini CLI / OpenCode / Cline.
  */
 const WindsurfProvider: AIProviderConfig = {
   name: 'windsurf',
-  displayName: 'Windsurf IDE',
+  displayName: 'Windsurf IDE (legacy)',
   cliCommand: null, // Not a CLI - GUI app
   configDir: null, // No global config directory
   contextFile: 'prjct.md', // Uses .md format (not .mdc)
@@ -252,15 +249,15 @@ export const Providers: Record<AIProviderName, AIProviderConfig> = {
 // Provider Detection
 
 /**
- * Check if a CLI command is available
+ * Check if a CLI command is available (macOS / Linux / Windows).
  */
 async function whichCommand(command: string): Promise<string | null> {
-  try {
-    const { stdout } = await execAsync(`which ${command}`, { timeout: PROVIDER_SPAWN_TIMEOUT_MS })
-    return stdout.trim()
-  } catch {
-    return null
+  const found = await whichAsync(command)
+  if (found) return found
+  if (process.platform === 'win32') {
+    return whichAsync(`${command}.cmd`)
   }
+  return null
 }
 
 /**

--- a/core/infrastructure/harness-surfaces.ts
+++ b/core/infrastructure/harness-surfaces.ts
@@ -1,0 +1,433 @@
+/**
+ * Harness surface matrix — what each benchmark-tier coding agent actually
+ * exposes (instructions, MCP, skills, hooks) and how prjct integrates.
+ *
+ * Source of truth for "is our harness 100% legible on this runtime?":
+ *   - agents doctor (`prjct agents --md`) prints this matrix
+ *   - install messaging points at inherit paths (e.g. Grok ← Claude settings)
+ *
+ * Docs reviewed 2026-07:
+ *   Claude Code hooks/MCP/skills; Codex hooks + config.toml MCP; Gemini CLI
+ *   hooks + settings MCP + skills; Grok Build hooks/skills/plugins/MCP with
+ *   native Claude Code surface compatibility.
+ */
+
+import type { AgentRuntimeId } from './agent-runtime-registry'
+
+/** How prjct wires into a runtime surface today. */
+export type PrjctWireStatus =
+  /** prjct writes/maintains this surface natively */
+  | 'native'
+  /** surface works because the runtime reads Claude Code files we already install */
+  | 'inherits-claude'
+  /** AGENTS.md / MCP stdio / --md CLI — portable, no runtime-specific writer */
+  | 'portable'
+  /** runtime has the surface; prjct does not install yet (planned) */
+  | 'planned'
+  /** runtime lacks the surface or we intentionally skip it */
+  | 'none'
+
+export interface HarnessSurfaceEntry {
+  runtimeId: AgentRuntimeId
+  displayName: string
+  /** Short official product name for docs */
+  product: string
+  instructions: {
+    files: string[]
+    loadOrder: string
+    prjct: PrjctWireStatus
+  }
+  mcp: {
+    configPaths: string[]
+    format: string
+    prjct: PrjctWireStatus
+    notes?: string
+  }
+  skills: {
+    paths: string[]
+    prjct: PrjctWireStatus
+    notes?: string
+  }
+  hooks: {
+    configPaths: string[]
+    events: string[]
+    format: string
+    prjct: PrjctWireStatus
+    /** Fail-open / block semantics that agents must respect */
+    contract: string
+    notes?: string
+  }
+  plugins?: {
+    paths: string[]
+    prjct: PrjctWireStatus
+  }
+  /** One-line "what makes prjct legible here" */
+  legibility: string
+}
+
+/**
+ * Benchmark-tier harnesses only (2026-07 focus). Windsurf and long-tail
+ * runtimes stay on AGENTS.md + MCP portable baseline via the registry.
+ */
+export const BENCHMARK_HARNESS_SURFACES: readonly HarnessSurfaceEntry[] = [
+  {
+    runtimeId: 'claude',
+    displayName: 'Claude Code',
+    product: 'Anthropic Claude Code',
+    instructions: {
+      files: ['CLAUDE.md', 'AGENTS.md', '~/.claude/CLAUDE.md'],
+      loadOrder: 'user global → project CLAUDE.md → nested CLAUDE.md',
+      prjct: 'native',
+    },
+    mcp: {
+      configPaths: ['~/.claude/mcp.json', 'project .mcp.json'],
+      format: 'JSON mcpServers',
+      prjct: 'native',
+      notes: 'prjct MCP + Context7 installable via prjct install / context7-service',
+    },
+    skills: {
+      paths: ['~/.claude/skills/', '.claude/skills/', 'project skills via skill-generator'],
+      prjct: 'native',
+    },
+    hooks: {
+      configPaths: ['~/.claude/settings.json'],
+      events: [
+        'SessionStart',
+        'UserPromptSubmit',
+        'PreToolUse',
+        'PostToolUse',
+        'Stop',
+        'SubagentStart',
+        'SubagentStop',
+        'Notification',
+        'CwdChanged',
+      ],
+      format: 'settings.json hooks[] with type:command',
+      prjct: 'native',
+      contract:
+        'Passive inject via additionalContext; PreToolUse deny only for explicit loop-guard. Fail-soft {}.',
+      notes: 'prjct install writes _prjctManaged hooks (PRJCT_HOOKS)',
+    },
+    plugins: {
+      paths: ['Claude Code plugins / marketplaces'],
+      prjct: 'none',
+    },
+    legibility:
+      'Deepest native wire: hooks + MCP + skill + CLAUDE.md. Reference implementation for all other rigs.',
+  },
+  {
+    runtimeId: 'codex',
+    displayName: 'OpenAI Codex',
+    product: 'OpenAI Codex CLI',
+    instructions: {
+      files: ['AGENTS.md', 'nested AGENTS.md'],
+      loadOrder: 'cwd → repo root AGENTS.md (Codex priority rules)',
+      prjct: 'portable',
+    },
+    mcp: {
+      configPaths: ['~/.codex/config.toml [mcp_servers.*]'],
+      format: 'TOML mcp_servers tables',
+      prjct: 'native',
+      notes: 'ensureCodexMcpServer writes # prjct:mcp markers; status line optional',
+    },
+    skills: {
+      paths: ['~/.codex/skills/', '.agents/skills/', 'plugins'],
+      prjct: 'portable',
+      notes: 'Codex skill description hard ~1024 byte limit (gotcha mem_3723)',
+    },
+    hooks: {
+      configPaths: ['~/.codex/hooks.json', '~/.codex/config.toml [[hooks.*]]', '.codex/hooks.json'],
+      events: [
+        'SessionStart',
+        'UserPromptSubmit',
+        'PreToolUse',
+        'PostToolUse',
+        'Stop',
+        'SubagentStart',
+        'SubagentStop',
+        'PermissionRequest',
+        'PreCompact',
+        'PostCompact',
+      ],
+      format: 'hooks.json (+ [features] hooks = true); trust via Codex /hooks once',
+      prjct: 'native',
+      contract:
+        'PRJCT_HOOKS mapped to hooks.json (skips Notification/CwdChanged). Fail-soft command wrapper. User must trust hooks once in TUI.',
+      notes:
+        'prjct install → installCodexHooks(); commandWindows for win32; features.hooks enabled when missing',
+    },
+    legibility:
+      'MCP + hooks both native on install when Codex is detected. Trust new hooks once via `/hooks`. AGENTS.md portable.',
+  },
+  {
+    runtimeId: 'gemini',
+    displayName: 'Gemini CLI',
+    product: 'Google Gemini CLI',
+    instructions: {
+      files: ['GEMINI.md', 'AGENTS.md (if context.fileName includes it)', '~/.gemini/GEMINI.md'],
+      loadOrder: 'global GEMINI.md → project → nested; fileName configurable',
+      prjct: 'portable',
+    },
+    mcp: {
+      configPaths: ['~/.gemini/settings.json mcpServers', 'mcp_config.json'],
+      format: 'JSON mcpServers in settings',
+      prjct: 'native',
+      notes: 'prjct install → ensureGeminiMcpServer (mcpServers.prjct)',
+    },
+    skills: {
+      paths: ['Agent Skills standard dirs under Gemini config'],
+      prjct: 'portable',
+    },
+    hooks: {
+      configPaths: [
+        '.gemini/settings.json',
+        '~/.gemini/settings.json',
+        '/etc/gemini-cli/settings.json',
+      ],
+      events: [
+        'BeforeTool',
+        'AfterTool',
+        'BeforeAgent',
+        'AfterAgent',
+        'SessionStart',
+        'SessionEnd',
+        'Notification',
+      ],
+      format: 'settings.json hooks.*[] with type:command; timeout ms',
+      prjct: 'native',
+      contract:
+        'PRJCT_HOOK_HOST=gemini remaps deny→{decision:deny} and event names. Matchers: run_shell_command, write_file|replace.',
+      notes: 'installGeminiSettings maps Claude events → Gemini BeforeTool/BeforeAgent/AfterAgent',
+    },
+    legibility:
+      'MCP + hooks native on install when Gemini is detected. GEMINI.md/AGENTS.md remain portable context.',
+  },
+  {
+    runtimeId: 'grok',
+    displayName: 'xAI Grok Build',
+    product: 'xAI Grok Build CLI',
+    instructions: {
+      files: [
+        'AGENTS.md / Agents.md / AGENT.md',
+        'CLAUDE.md (native Claude compat)',
+        '.claude/rules/',
+        '~/.grok + project walk',
+      ],
+      loadOrder: 'AGENTS.md cwd→root; also auto-reads Claude instruction files',
+      prjct: 'inherits-claude',
+    },
+    mcp: {
+      configPaths: [
+        '~/.grok/config.toml + plugins',
+        '~/.claude/mcp.json (read natively)',
+        'Claude plugins/MCPs',
+      ],
+      format: 'Grok plugins/MCP + Claude MCP JSON (compat)',
+      prjct: 'inherits-claude',
+      notes: 'Zero-config Claude Code MCP/skills/hooks compatibility — prjct install covers Grok',
+    },
+    skills: {
+      paths: [
+        './.grok/skills/',
+        '~/.grok/skills/',
+        '~/.agents/skills/',
+        '.claude/skills/ (compat)',
+        'plugin skills/',
+      ],
+      prjct: 'inherits-claude',
+      notes: 'Also discovers ~/.agents/skills and Claude skills',
+    },
+    hooks: {
+      configPaths: [
+        '~/.grok/hooks/*.json',
+        '.grok/hooks/*.json (needs /hooks-trust)',
+        '~/.claude/settings.json (compat)',
+        '.cursor/hooks.json (compat)',
+      ],
+      events: [
+        'SessionStart',
+        'SessionEnd',
+        'UserPromptSubmit',
+        'PreToolUse',
+        'PostToolUse',
+        'PostToolUseFailure',
+        'PermissionDenied',
+        'Stop',
+        'StopFailure',
+        'Notification',
+        'SubagentStart',
+        'SubagentStop',
+        'PreCompact',
+        'PostCompact',
+      ],
+      format: 'JSON hook files; Claude settings.json + Cursor hooks.json also loaded',
+      prjct: 'inherits-claude',
+      contract:
+        'PreToolUse is the only blocking event (decision deny or exit 2). Fail-open on errors. Project hooks need trust.',
+      notes: 'prjct Claude hooks already fire under Grok via Claude compat — no second installer',
+    },
+    plugins: {
+      paths: ['./.grok/plugins/', '~/.grok/plugins/', 'marketplaces'],
+      prjct: 'none',
+    },
+    legibility:
+      'Best free lunch: Claude-compatible. prjct install (Claude hooks + MCP) makes Grok fully legible without a Grok-specific writer.',
+  },
+  {
+    runtimeId: 'opencode',
+    displayName: 'OpenCode',
+    product: 'OpenCode (OSS multi-provider)',
+    instructions: {
+      files: ['AGENTS.md', 'opencode.json(c)'],
+      loadOrder: 'project agents + AGENTS.md',
+      prjct: 'portable',
+    },
+    mcp: {
+      configPaths: ['opencode.jsonc mcp section'],
+      format: 'JSONC project config',
+      prjct: 'planned',
+    },
+    skills: {
+      paths: ['plugins / project agents'],
+      prjct: 'portable',
+    },
+    hooks: {
+      configPaths: [],
+      events: [],
+      format: 'plugin/extension dependent',
+      prjct: 'none',
+      contract: 'No Claude-parity hook pack assumed; use MCP + AGENTS.md',
+    },
+    legibility: 'Portable AGENTS.md + MCP CLI. Prefer model-agnostic tools over Claude-only hooks.',
+  },
+  {
+    runtimeId: 'cursor',
+    displayName: 'Cursor',
+    product: 'Cursor IDE',
+    instructions: {
+      files: ['AGENTS.md', '.cursor/rules/*.mdc'],
+      loadOrder: 'project rules + AGENTS.md; model pick in-app',
+      prjct: 'portable',
+    },
+    mcp: {
+      configPaths: ['Cursor MCP settings (app)'],
+      format: 'IDE MCP UI / json',
+      prjct: 'portable',
+    },
+    skills: {
+      paths: [],
+      prjct: 'none',
+      notes: 'Skills are CLI-agent concept; Cursor uses rules + MCP',
+    },
+    hooks: {
+      configPaths: ['~/.cursor/hooks.json', 'project .cursor/hooks.json'],
+      events: [
+        'sessionStart',
+        'beforeSubmitPrompt',
+        'preToolUse',
+        'postToolUse',
+        'stop',
+        'subagentStart',
+        'subagentStop',
+      ],
+      format: 'version:1 flat handlers; camelCase events; timeout seconds',
+      prjct: 'native',
+      contract:
+        'User-level install (clean-repo). PRJCT_HOOK_HOST=cursor emits camelCase + additional_context. Grok also reads this file.',
+      notes:
+        'installCursorHooks on prjct install when .cursor detected; matchers Write|StrReplace|Edit, Shell|Bash',
+    },
+    legibility:
+      'Hooks native at ~/.cursor/hooks.json on install. AGENTS.md + optional .cursor/rules. MCP still IDE UI.',
+  },
+  {
+    runtimeId: 'cline',
+    displayName: 'Cline',
+    product: 'Cline (VS Code agent)',
+    instructions: {
+      files: ['AGENTS.md', '.clinerules/'],
+      loadOrder: 'rules + AGENTS.md',
+      prjct: 'portable',
+    },
+    mcp: {
+      configPaths: ['Cline MCP settings'],
+      format: 'IDE MCP',
+      prjct: 'portable',
+    },
+    skills: {
+      paths: ['Cline skills / custom instructions'],
+      prjct: 'portable',
+    },
+    hooks: {
+      configPaths: ['Cline hooks (when enabled)'],
+      events: ['varies by version'],
+      format: 'extension-defined',
+      prjct: 'planned',
+      contract: 'Multi-model VS Code agent; ACP support for some hosts',
+    },
+    legibility: 'AGENTS.md + MCP portable; deep native wire planned if hook schema stabilizes.',
+  },
+] as const
+
+export function getHarnessSurface(runtimeId: AgentRuntimeId): HarnessSurfaceEntry | undefined {
+  return BENCHMARK_HARNESS_SURFACES.find((s) => s.runtimeId === runtimeId)
+}
+
+export function listHarnessSurfaces(): readonly HarnessSurfaceEntry[] {
+  return BENCHMARK_HARNESS_SURFACES
+}
+
+/** Compact markdown table for doctor / install / skill injection. */
+export function formatHarnessSurfacesMarkdown(opts?: {
+  /** Only these runtime ids (default: all benchmark) */
+  only?: AgentRuntimeId[]
+  /** Include per-surface wire status detail */
+  detail?: boolean
+}): string {
+  const only = opts?.only ? new Set(opts.only) : null
+  const rows = BENCHMARK_HARNESS_SURFACES.filter((s) => !only || only.has(s.runtimeId))
+  const lines = [
+    '## Harness surfaces (benchmark tier)',
+    '',
+    '| Runtime | Instructions | MCP | Skills | Hooks | prjct wire |',
+    '|---|---|---|---|---|---|',
+  ]
+  for (const s of rows) {
+    const wire = summarizeWire(s)
+    lines.push(
+      `| ${s.displayName} | ${s.instructions.prjct} | ${s.mcp.prjct} | ${s.skills.prjct} | ${s.hooks.prjct} | ${wire} |`
+    )
+  }
+  lines.push(
+    '',
+    'Wire legend: `native` = prjct installs; `inherits-claude` = covered by Claude install; `portable` = AGENTS.md/MCP/CLI; `planned` = surface exists, installer next.',
+    ''
+  )
+  if (opts?.detail) {
+    lines.push('### Integration notes', '')
+    for (const s of rows) {
+      lines.push(`#### ${s.displayName}`, '', s.legibility, '')
+      if (s.hooks.notes) lines.push(`- Hooks: ${s.hooks.notes}`)
+      if (s.mcp.notes) lines.push(`- MCP: ${s.mcp.notes}`)
+      if (s.skills.notes) lines.push(`- Skills: ${s.skills.notes}`)
+      lines.push(`- Hook events: ${s.hooks.events.slice(0, 8).join(', ') || '(none)'}`)
+      lines.push(`- MCP paths: ${s.mcp.configPaths.join('; ')}`)
+      lines.push('')
+    }
+  }
+  return lines.join('\n')
+}
+
+function summarizeWire(s: HarnessSurfaceEntry): string {
+  const ranks: PrjctWireStatus[] = [
+    s.hooks.prjct,
+    s.mcp.prjct,
+    s.instructions.prjct,
+    s.skills.prjct,
+  ]
+  if (ranks.includes('native')) return 'native+'
+  if (ranks.includes('inherits-claude')) return 'via Claude'
+  if (ranks.includes('planned')) return 'partial/planned'
+  if (ranks.includes('portable')) return 'portable'
+  return 'none'
+}

--- a/core/schemas/model.ts
+++ b/core/schemas/model.ts
@@ -25,48 +25,58 @@ export type AgentCapabilityClass = 'frontier' | 'balanced' | 'fast'
 /**
  * Per-provider model for each capability class, ordered best→fallback for
  * in-provider graceful degradation. THE single source for which models a rig
- * has. Multi-model IDEs (cursor/windsurf/antigravity) pick the model in-app, so
- * they have no fixed map (resolves to model = null / supported = []).
+ * has. Multi-model IDEs (cursor/antigravity; windsurf = legacy residual) pick
+ * the model in-app, so they have no fixed map (model = null / supported = []).
+ *
+ * Capability chains ordered best→fallback for 2026-07 agent CLIs:
+ * Claude Code, Codex CLI (TB leader), Gemini CLI, Grok Build, Kimi CLI.
+ * Open multi-provider agents (OpenCode/Cline/Aider) use empty chains.
  */
 export const PROVIDER_CAPABILITY_MODELS: Record<
   string,
   Record<AgentCapabilityClass, readonly string[]>
 > = {
   claude: {
+    // Claude Code still uses short aliases in Agent tool dispatches.
     frontier: ['opus', 'sonnet', 'haiku'],
     balanced: ['sonnet', 'haiku', 'opus'],
     fast: ['haiku', 'sonnet', 'opus'],
   },
   gemini: {
-    frontier: ['2.5-pro', '2.5-flash', '2.0-flash'],
-    balanced: ['2.5-flash', '2.0-flash', '2.5-pro'],
-    fast: ['2.0-flash', '2.5-flash', '2.5-pro'],
+    frontier: ['3.1-pro', '2.5-pro', '2.5-flash', '2.0-flash'],
+    balanced: ['2.5-flash', '3.1-pro', '2.5-pro', '2.0-flash'],
+    fast: ['2.0-flash', '2.5-flash', '2.5-pro', '3.1-pro'],
   },
   openai: {
-    frontier: ['o3', 'gpt-4.1', 'gpt-4o'],
-    balanced: ['gpt-4.1', 'gpt-4o', 'gpt-4.1-mini'],
-    fast: ['gpt-4.1-mini', 'gpt-4o-mini', 'gpt-4o'],
+    frontier: ['gpt-5.5', 'o3', 'gpt-4.1', 'gpt-4o'],
+    balanced: ['gpt-4.1', 'gpt-5.5', 'gpt-4o', 'gpt-4.1-mini'],
+    fast: ['gpt-4.1-mini', 'gpt-4o-mini', 'gpt-4o', 'gpt-4.1'],
   },
   codex: {
-    frontier: ['o3', 'gpt-4.1', 'gpt-4o'],
-    balanced: ['gpt-4.1', 'gpt-4o', 'gpt-4.1-mini'],
-    fast: ['gpt-4.1-mini', 'gpt-4o-mini', 'gpt-4o'],
+    // Codex CLI default brain tracks OpenAI coding models (TB 2.1 leader).
+    frontier: ['gpt-5.5', 'o3', 'gpt-4.1', 'gpt-4o'],
+    balanced: ['gpt-4.1', 'gpt-5.5', 'gpt-4o', 'gpt-4.1-mini'],
+    fast: ['gpt-4.1-mini', 'gpt-4o-mini', 'gpt-4o', 'gpt-4.1'],
   },
   xai: {
-    frontier: ['grok-3', 'grok-2', 'grok-2-mini'],
-    balanced: ['grok-2', 'grok-2-mini', 'grok-3'],
-    fast: ['grok-2-mini', 'grok-2', 'grok-3'],
+    frontier: ['grok-4', 'grok-3', 'grok-2', 'grok-2-mini'],
+    balanced: ['grok-3', 'grok-4', 'grok-2', 'grok-2-mini'],
+    fast: ['grok-2-mini', 'grok-2', 'grok-3', 'grok-4'],
   },
   grok: {
-    frontier: ['grok-3', 'grok-2', 'grok-2-mini'],
-    balanced: ['grok-2', 'grok-2-mini', 'grok-3'],
-    fast: ['grok-2-mini', 'grok-2', 'grok-3'],
+    frontier: ['grok-4', 'grok-3', 'grok-2', 'grok-2-mini'],
+    balanced: ['grok-3', 'grok-4', 'grok-2', 'grok-2-mini'],
+    fast: ['grok-2-mini', 'grok-2', 'grok-3', 'grok-4'],
   },
   kimi: {
     frontier: ['kimi-k2', 'kimi-latest', 'moonshot-v1-128k'],
     balanced: ['kimi-latest', 'moonshot-v1-128k', 'moonshot-v1-32k'],
     fast: ['moonshot-v1-32k', 'moonshot-v1-128k', 'kimi-latest'],
   },
+  // Multi-provider open agents pick models in-app (empty = any model valid).
+  opencode: { frontier: [], balanced: [], fast: [] },
+  cline: { frontier: [], balanced: [], fast: [] },
+  aider: { frontier: [], balanced: [], fast: [] },
 }
 
 const MIN_CLI_VERSIONS: Record<string, string> = {

--- a/core/services/harness-coverage.ts
+++ b/core/services/harness-coverage.ts
@@ -1,0 +1,304 @@
+/**
+ * Live multi-runtime harness coverage — the organic dominance board.
+ *
+ * Competitors can ship AGENTS.md pointers. What they cannot cheaply copy is
+ * a single install that leaves *working* hooks + MCP across Claude, Codex,
+ * Gemini, Cursor (and Grok via Claude inherit) while SQLite judgment memory
+ * and code gates stay the same brain underneath.
+ *
+ * This module probes real config files (not capability claims) so install,
+ * agents doctor, and harness score report the same truth.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { resolveUserHome } from '../infrastructure/user-home'
+import { getCodexHooksJsonPath } from '../utils/codex-hooks'
+import { getCodexConfigTomlPath } from '../utils/codex-mcp'
+import { getCursorHooksJsonPath } from '../utils/cursor-hooks'
+import { getGeminiSettingsPath } from '../utils/gemini-settings'
+import { commandOnPathAsync } from '../utils/which'
+
+export type OrganicLevel = 'full' | 'partial' | 'inherited' | 'none' | 'absent'
+
+export interface RuntimeCoverage {
+  id: string
+  displayName: string
+  /** Runtime is present on this machine (dir or command). */
+  detected: boolean
+  hooksLive: boolean
+  mcpLive: boolean
+  /** How organic the wire is right now. */
+  organic: OrganicLevel
+  /** One short why — path or inherit note. */
+  evidence: string
+}
+
+export interface HarnessCoverageReport {
+  runtimes: RuntimeCoverage[]
+  detectedCount: number
+  /** Detected runtimes at full or inherited. */
+  liveCount: number
+  /** 0–100: live / detected (100 if nothing detected — N/A treated as ready). */
+  organicPct: number
+  /** 0–5 grade for harness score criterion. */
+  grade: number
+  summary: string
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function readText(p: string): Promise<string | null> {
+  try {
+    return await fs.readFile(p, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+function hasPrjctManagedJson(text: string | null): boolean {
+  if (!text) return false
+  return text.includes('_prjctManaged') || text.includes('PRJCT_HOOK_HOST=')
+}
+
+function hasPrjctHookCommand(text: string | null): boolean {
+  if (!text) return false
+  return /prjct\s+hook\s+/.test(text)
+}
+
+function hasPrjctMcpJson(text: string | null): boolean {
+  if (!text) return false
+  try {
+    const j = JSON.parse(text) as { mcpServers?: Record<string, unknown> }
+    return Boolean(j.mcpServers?.prjct)
+  } catch {
+    return text.includes('"prjct"') && text.includes('mcp-server')
+  }
+}
+
+function hasPrjctMcpToml(text: string | null): boolean {
+  if (!text) return false
+  return /\[mcp_servers\.prjct\]/.test(text) || /# prjct:mcp:start/.test(text)
+}
+
+function organicOf(
+  detected: boolean,
+  hooks: boolean,
+  mcp: boolean,
+  inherited = false
+): OrganicLevel {
+  if (!detected) return 'absent'
+  if (inherited && (hooks || mcp)) return 'inherited'
+  if (hooks && mcp) return 'full'
+  if (hooks || mcp) return 'partial'
+  return 'none'
+}
+
+function gradeFrom(pct: number, liveCount: number, detectedCount: number): number {
+  if (detectedCount === 0) return 5 // nothing to wire — not a failure
+  if (liveCount >= 4 && pct >= 90) return 5
+  if (liveCount >= 3 && pct >= 75) return 4.5
+  if (liveCount >= 2 && pct >= 50) return 4
+  if (liveCount >= 1) return 3
+  return 1.5
+}
+
+/**
+ * Probe installed harness surfaces on this machine.
+ * Async file/PATH checks only — never throws past the report.
+ */
+export async function probeHarnessCoverage(
+  projectPath: string = process.cwd()
+): Promise<HarnessCoverageReport> {
+  const home = resolveUserHome()
+
+  const claudeSettings = path.join(home, '.claude', 'settings.json')
+  const claudeMcp = path.join(home, '.claude', 'mcp.json')
+  const codexHooks = getCodexHooksJsonPath()
+  const codexToml = getCodexConfigTomlPath()
+  const geminiSettings = getGeminiSettingsPath()
+  const cursorHooks = getCursorHooksJsonPath()
+  const grokHome = path.join(home, '.grok')
+  const projectCursor = path.join(projectPath, '.cursor')
+
+  const [
+    claudeCmd,
+    codexCmd,
+    geminiCmd,
+    grokCmd,
+    claudeSettingsText,
+    claudeMcpText,
+    codexHooksText,
+    codexTomlText,
+    geminiText,
+    cursorHooksText,
+    grokDir,
+    cursorDir,
+  ] = await Promise.all([
+    commandOnPathAsync('claude'),
+    commandOnPathAsync('codex'),
+    commandOnPathAsync('gemini'),
+    commandOnPathAsync('grok'),
+    readText(claudeSettings),
+    readText(claudeMcp),
+    readText(codexHooks),
+    readText(codexToml),
+    readText(geminiSettings),
+    readText(cursorHooks),
+    fileExists(grokHome),
+    fileExists(projectCursor),
+  ])
+
+  const claudeDetected = claudeCmd || (await fileExists(path.join(home, '.claude')))
+  const claudeHooks =
+    hasPrjctManagedJson(claudeSettingsText) || hasPrjctHookCommand(claudeSettingsText)
+  const claudeMcpLive = hasPrjctMcpJson(claudeMcpText)
+
+  const codexDetected = codexCmd || (await fileExists(path.join(home, '.codex')))
+  const codexHooksLive = hasPrjctManagedJson(codexHooksText) || hasPrjctHookCommand(codexHooksText)
+  const codexMcpLive = hasPrjctMcpToml(codexTomlText)
+
+  const geminiDetected = geminiCmd || (await fileExists(path.join(home, '.gemini')))
+  const geminiHooksLive = hasPrjctManagedJson(geminiText) || hasPrjctHookCommand(geminiText)
+  const geminiMcpLive = hasPrjctMcpJson(geminiText)
+
+  const cursorDetected = cursorDir || (await fileExists(path.join(home, '.cursor')))
+  const cursorHooksLive =
+    hasPrjctManagedJson(cursorHooksText) || hasPrjctHookCommand(cursorHooksText)
+
+  const grokDetected = grokCmd || grokDir
+  // Grok inherits Claude hooks/MCP when those are live.
+  const grokInherited = Boolean(claudeHooks || claudeMcpLive)
+
+  const runtimes: RuntimeCoverage[] = [
+    {
+      id: 'claude',
+      displayName: 'Claude Code',
+      detected: Boolean(claudeDetected),
+      hooksLive: claudeHooks,
+      mcpLive: claudeMcpLive,
+      organic: organicOf(Boolean(claudeDetected), claudeHooks, claudeMcpLive),
+      evidence:
+        claudeHooks && claudeMcpLive
+          ? '~/.claude/settings.json + mcp.json'
+          : claudeHooks
+            ? 'hooks only'
+            : claudeMcpLive
+              ? 'mcp only'
+              : claudeDetected
+                ? 'detected, not wired'
+                : 'not installed',
+    },
+    {
+      id: 'codex',
+      displayName: 'OpenAI Codex',
+      detected: Boolean(codexDetected),
+      hooksLive: codexHooksLive,
+      mcpLive: codexMcpLive,
+      organic: organicOf(Boolean(codexDetected), codexHooksLive, codexMcpLive),
+      evidence:
+        codexHooksLive && codexMcpLive
+          ? '~/.codex/hooks.json + config.toml MCP'
+          : codexDetected
+            ? 'detected, incomplete wire'
+            : 'not installed',
+    },
+    {
+      id: 'gemini',
+      displayName: 'Gemini CLI',
+      detected: Boolean(geminiDetected),
+      hooksLive: geminiHooksLive,
+      mcpLive: geminiMcpLive,
+      organic: organicOf(Boolean(geminiDetected), geminiHooksLive, geminiMcpLive),
+      evidence:
+        geminiHooksLive && geminiMcpLive
+          ? '~/.gemini/settings.json (hooks+MCP)'
+          : geminiDetected
+            ? 'detected, incomplete wire'
+            : 'not installed',
+    },
+    {
+      id: 'cursor',
+      displayName: 'Cursor',
+      detected: Boolean(cursorDetected),
+      hooksLive: cursorHooksLive,
+      mcpLive: false, // MCP stays IDE UI — hooks are the organic wire
+      organic: !cursorDetected
+        ? 'absent'
+        : cursorHooksLive
+          ? 'full' // hooks-only is full for Cursor (MCP is in-app)
+          : 'none',
+      evidence: cursorHooksLive
+        ? '~/.cursor/hooks.json'
+        : cursorDetected
+          ? 'detected, hooks not wired'
+          : 'not installed',
+    },
+    {
+      id: 'grok',
+      displayName: 'xAI Grok Build',
+      detected: Boolean(grokDetected),
+      hooksLive: grokInherited && claudeHooks,
+      mcpLive: grokInherited && claudeMcpLive,
+      organic: organicOf(Boolean(grokDetected), grokInherited, grokInherited, true),
+      evidence: grokDetected
+        ? grokInherited
+          ? 'inherits Claude hooks+MCP (zero extra install)'
+          : 'detected — run prjct install (Claude wire unlocks Grok)'
+        : 'not installed',
+    },
+  ]
+
+  const detected = runtimes.filter((r) => r.detected)
+  const live = detected.filter((r) => r.organic === 'full' || r.organic === 'inherited')
+  const detectedCount = detected.length
+  const liveCount = live.length
+  const organicPct = detectedCount === 0 ? 100 : Math.round((liveCount / detectedCount) * 100)
+  const grade = gradeFrom(organicPct, liveCount, detectedCount)
+
+  const summary =
+    detectedCount === 0
+      ? 'No benchmark CLI/IDE detected — install Claude, Codex, Gemini, Cursor, or Grok, then `prjct install`.'
+      : liveCount === detectedCount
+        ? `Organic full board: ${liveCount}/${detectedCount} detected runtimes live (${organicPct}%). Same SQLite brain, multi-surface wire.`
+        : `Organic board ${liveCount}/${detectedCount} live (${organicPct}%). Run \`prjct install\` to close gaps — one command, all surfaces.`
+
+  return {
+    runtimes,
+    detectedCount,
+    liveCount,
+    organicPct,
+    grade,
+    summary,
+  }
+}
+
+/** Markdown dominance board — install / doctor / harness score. */
+export function renderHarnessCoverageMd(report: HarnessCoverageReport): string {
+  const lines = [
+    '## Organic multi-runtime board',
+    '',
+    `_Same judgment memory + code gates · ${report.liveCount}/${report.detectedCount} live · ${report.organicPct}% · grade ${report.grade}/5_`,
+    '',
+    '| Runtime | Detected | Hooks | MCP | Organic | Evidence |',
+    '|---|---:|---:|---:|---|---|',
+  ]
+  for (const r of report.runtimes) {
+    lines.push(
+      `| ${r.displayName} | ${r.detected ? 'yes' : '—'} | ${r.hooksLive ? '●' : '○'} | ${r.mcpLive ? '●' : r.id === 'cursor' ? 'IDE' : '○'} | \`${r.organic}\` | ${r.evidence} |`
+    )
+  }
+  lines.push('', report.summary, '')
+  lines.push(
+    '_Moat: not “another skill pack” — compound WHY in SQLite, code-enforced gates, and one install that lights every agent surface without ceremony._',
+    ''
+  )
+  return lines.join('\n')
+}

--- a/core/services/harness-score.ts
+++ b/core/services/harness-score.ts
@@ -89,7 +89,14 @@ function countDefaultTools(): number {
   }
 }
 
-export function computeHarnessScore(options: { skillCtx?: SkillContext } = {}): HarnessScoreReport {
+export function computeHarnessScore(
+  options: {
+    skillCtx?: SkillContext
+    /** Live multi-runtime organic grade from probeHarnessCoverage (0–5). */
+    multiRuntimeOrganicGrade?: number
+    multiRuntimeOrganicMeasured?: string
+  } = {}
+): HarnessScoreReport {
   const skill = buildPrjctSkill(options.skillCtx ?? emptySkillContext())
   const skillTokens = countTokens(skill)
   const routingBytes = Buffer.byteLength(MINIMAL_ROUTING_BODY, 'utf-8')
@@ -166,6 +173,20 @@ export function computeHarnessScore(options: { skillCtx?: SkillContext } = {}): 
     ),
   ]
 
+  // Optional: live organic multi-runtime board (probed by harness score / install).
+  // Structural tests omit this so CI stays deterministic without real CLI installs.
+  if (options.multiRuntimeOrganicGrade !== undefined) {
+    criteria.push(
+      criterion(
+        'multi-runtime-organic',
+        'Multi-runtime organic board',
+        options.multiRuntimeOrganicGrade,
+        '≥2 live full/inherited on detected CLIs (4+ = dominance)',
+        options.multiRuntimeOrganicMeasured ?? `${options.multiRuntimeOrganicGrade}/5`
+      )
+    )
+  }
+
   const grade =
     Math.round((criteria.reduce((sum, c) => sum + c.score, 0) / criteria.length) * 10) / 10
   const programDone =
@@ -211,14 +232,19 @@ export function renderCompetitiveDustMd(report: HarnessScoreReport): string {
     '| Token economics | unmeasured thrash | high (fresh windows × agents) | **telemetry + skill/MCP diet** |',
     '| Discuss before code | organic SDD | discuss-phase command | **discuss-lock H2+ (code)** |',
     '| Install surface | curl/brew binary | npx multi-runtime | npm/pnpm/brew + upgrade consolidate |',
+    '| Multi-runtime wire | single ecosystem | Claude-centric phases | **Claude+Codex+Gemini+Cursor+Grok inherit, one install** |',
+    '| Organic feel | install prompts | ceremony `/plan` | **passive hooks + SQLite; agent never re-learns the OS** |',
     `| Structural grade | n/a | n/a | **${report.grade}/5 ${grade}** |`,
     '',
-    '_Rule: never clone their skill count or `.planning/` OS. Crush on compound judgment, cost, and enforcement._',
+    '_Rule: never clone their skill count or `.planning/` OS. Crush on compound judgment, cost, enforcement, and multi-surface organic wire._',
     '',
   ].join('\n')
 }
 
-export function renderHarnessScoreMd(report: HarnessScoreReport): string {
+export function renderHarnessScoreMd(
+  report: HarnessScoreReport,
+  options: { coverageMd?: string } = {}
+): string {
   const rows = report.criteria.map(
     (c) => `| ${c.name} | ${c.score} | ${c.status} | ${c.slo} | ${c.measured} |`
   )
@@ -240,6 +266,7 @@ export function renderHarnessScoreMd(report: HarnessScoreReport): string {
     `- Routing body: ${report.defaults.routingBytes} bytes`,
     `- Providers: ${report.defaults.providerCount}`,
     '',
+    options.coverageMd ?? '',
     renderCompetitiveDustMd(report),
   ].join('\n')
 }

--- a/core/services/skill-generator/editor-surfaces.ts
+++ b/core/services/skill-generator/editor-surfaces.ts
@@ -110,9 +110,10 @@ export const buildGeminiConfig = (): string => buildGlobalConfig('Gemini')
 export const buildAntigravityConfig = (): string => buildGlobalConfig('Antigravity')
 
 /**
- * IDE rule pointers (Cursor `.mdc`, Windsurf `.md`). Clean-repo doctrine: these
- * carry the SAME minimal pointer as AGENTS.md/CLAUDE.md (MINIMAL_ROUTING_BODY,
- * one source) — never a ruleset. Only the per-rig frontmatter differs.
+ * IDE rule pointers (Cursor `.mdc`; Windsurf `.md` = legacy residual only).
+ * Clean-repo doctrine: these carry the SAME minimal pointer as AGENTS.md/
+ * CLAUDE.md (MINIMAL_ROUTING_BODY, one source) — never a ruleset. Only the
+ * per-rig frontmatter differs. Do not expand Windsurf-specific surfaces.
  */
 function buildIdePointer(frontmatter: string): string {
   return `${[

--- a/core/services/weak-frontier-demo.ts
+++ b/core/services/weak-frontier-demo.ts
@@ -41,6 +41,7 @@ export function routeIntentBare(signal: string): string {
   return 'work'
 }
 
+// Keep fixtures aligned with weak-model-bench INTENT_FIXTURES (release gate).
 const INTENT_FIXTURES: Array<{ signal: string; verb: string }> = [
   { signal: 'sync the project', verb: 'sync' },
   { signal: 'search for auth decisions', verb: 'search' },
@@ -50,6 +51,8 @@ const INTENT_FIXTURES: Array<{ signal: string; verb: string }> = [
   { signal: 'ship the feature', verb: 'ship' },
   { signal: 'implement rate limiting', verb: 'work' },
   { signal: 'find gotchas on migrations', verb: 'search' },
+  { signal: 'recall package legitimacy rules', verb: 'search' },
+  { signal: 'open a pr for the fix', verb: 'ship' },
 ]
 
 export function buildDemoRows(): DemoRow[] {
@@ -118,6 +121,19 @@ export function buildDemoRows(): DemoRow[] {
       frontierNoHarness: 'Agent must remember to remember context',
       weakWithPrjct: 'prjct land auto-synthesizes Session close (source:land-auto)',
       weakOk: true,
+    },
+    {
+      capability: 'Multi-runtime organic wire',
+      frontierNoHarness: 'Single host or re-prompt per IDE',
+      weakWithPrjct:
+        'Claude+Codex+Gemini+Cursor native adapters; Grok inherits Claude — one install',
+      weakOk: true,
+    },
+    {
+      capability: 'Intent A/B vs bare',
+      frontierNoHarness: `${Math.round(bareRate * 100)}% bare accuracy`,
+      weakWithPrjct: `${Math.round(harnessRate * 100)}% harness (must beat bare)`,
+      weakOk: harnessHits > bareHits && harnessRate >= 0.95,
     },
   ]
 }

--- a/core/services/weak-model-bench.ts
+++ b/core/services/weak-model-bench.ts
@@ -1,0 +1,192 @@
+/**
+ * Weak-model readiness + A/B vs frontier — release-blocking SLOs.
+ *
+ * North star: weak model + prjct ≥ frontier without harness on discipline
+ * metrics (tokens, routing, intent verbs, structural grade). CI must stay green.
+ *
+ * Used by:
+ *   - scripts/bench-weak-model.ts (CLI exit code)
+ *   - core/__tests__/services/weak-model-bench.test.ts (CI gate)
+ *   - weak-frontier-demo (public table shares intent fixtures)
+ */
+
+import { Buffer } from 'node:buffer'
+import { getHarnessSurface, listHarnessSurfaces } from '../infrastructure/harness-surfaces'
+import { DEFAULT_MCP_TOOL_TIER, resolveTier } from '../mcp/server'
+import { PROVIDER_CAPABILITY_MODELS } from '../schemas/model'
+import { countTokens } from '../tools/context/token-counter'
+import { computeHarnessScore, WORLD_CLASS } from './harness-score'
+import { MINIMAL_ROUTING_BODY } from './routing-block'
+import { buildPrjctSkill, emptySkillContext } from './skill-generator/prjct-skill-body'
+import { buildDemoRows, routeIntent, routeIntentBare } from './weak-frontier-demo'
+
+export interface WeakBenchCheck {
+  name: string
+  ok: boolean
+  detail: string
+}
+
+export interface WeakBenchReport {
+  checks: WeakBenchCheck[]
+  passed: number
+  total: number
+  allGreen: boolean
+  summary: string
+}
+
+export const INTENT_FIXTURES: ReadonlyArray<{ signal: string; verb: string }> = [
+  { signal: 'sync the project', verb: 'sync' },
+  { signal: 'search for auth decisions', verb: 'search' },
+  { signal: 'remember this decision about caching', verb: 'remember' },
+  { signal: 'fix the login bug', verb: 'work' },
+  { signal: 'what should I work on next', verb: 'next' },
+  { signal: 'ship the feature', verb: 'ship' },
+  { signal: 'implement rate limiting', verb: 'work' },
+  { signal: 'find gotchas on migrations', verb: 'search' },
+  { signal: 'recall package legitimacy rules', verb: 'search' },
+  { signal: 'open a pr for the fix', verb: 'ship' },
+] as const
+
+/** Absolute minimum checks that must stay green for release. */
+export const WEAK_BENCH_MIN_PASS = 15
+
+/**
+ * Run every weak-model + A/B structural check (pure, no network, no disk install).
+ */
+export function runWeakModelBench(): WeakBenchReport {
+  const checks: WeakBenchCheck[] = []
+  const push = (name: string, ok: boolean, detail: string) => {
+    checks.push({ name, ok, detail })
+  }
+
+  const skillTok = countTokens(buildPrjctSkill(emptySkillContext()))
+  push(
+    'skill always-on',
+    skillTok <= WORLD_CLASS.skillTokensMax,
+    `${skillTok} tok (max ${WORLD_CLASS.skillTokensMax})`
+  )
+
+  const routingB = Buffer.byteLength(MINIMAL_ROUTING_BODY, 'utf-8')
+  push(
+    'routing body',
+    routingB <= WORLD_CLASS.routingBodyBytesMax,
+    `${routingB} bytes (max ${WORLD_CLASS.routingBodyBytesMax})`
+  )
+
+  push(
+    'MCP default',
+    resolveTier(undefined) === 'core' && DEFAULT_MCP_TOOL_TIER === 'core',
+    `tier=${resolveTier(undefined)}`
+  )
+
+  const providers = Object.keys(PROVIDER_CAPABILITY_MODELS).length
+  push(
+    'provider maps',
+    providers >= WORLD_CLASS.providerMapsMin,
+    `${providers} providers (min ${WORLD_CLASS.providerMapsMin})`
+  )
+
+  const score = computeHarnessScore()
+  push(
+    'harness score',
+    score.programDone && score.grade >= 4.5,
+    `grade ${score.grade}/5 done=${score.programDone}`
+  )
+
+  push(
+    'MCP tool surface',
+    score.defaults.mcpToolCountDefault <= WORLD_CLASS.mcpToolsCoreMax,
+    `${score.defaults.mcpToolCountDefault} tools at default`
+  )
+
+  let harnessHits = 0
+  let bareHits = 0
+  for (const f of INTENT_FIXTURES) {
+    const got = routeIntent(f.signal)
+    const bare = routeIntentBare(f.signal)
+    const ok = got === f.verb
+    if (ok) harnessHits++
+    if (bare === f.verb) bareHits++
+    push(`intent:${f.verb}`, ok, `"${f.signal}" → ${got}`)
+  }
+
+  const harnessRate = harnessHits / INTENT_FIXTURES.length
+  const bareRate = bareHits / INTENT_FIXTURES.length
+  push(
+    'intent routing accuracy',
+    harnessRate >= 0.95,
+    `${Math.round(harnessRate * 100)}% (need ≥95%)`
+  )
+  push(
+    'intent A/B beats bare',
+    harnessHits > bareHits,
+    `harness ${harnessHits}/${INTENT_FIXTURES.length} vs bare ${bareHits}/${INTENT_FIXTURES.length} (${Math.round(bareRate * 100)}%)`
+  )
+
+  const demo = buildDemoRows()
+  const demoFail = demo.filter((r) => !r.weakOk)
+  push(
+    'weak-vs-frontier demo',
+    demoFail.length === 0,
+    `${demo.length - demoFail.length}/${demo.length} demo SLOs`
+  )
+
+  // Multi-runtime wire is structural (adapters exist) — not live disk probe
+  // (CI runners don't install Claude/Codex). Proves the moat ship surface.
+  const codex = getHarnessSurface('codex')
+  const gemini = getHarnessSurface('gemini')
+  const cursor = getHarnessSurface('cursor')
+  const grok = getHarnessSurface('grok')
+  push(
+    'codex hooks+MCP native',
+    codex?.hooks.prjct === 'native' && codex?.mcp.prjct === 'native',
+    `hooks=${codex?.hooks.prjct} mcp=${codex?.mcp.prjct}`
+  )
+  push(
+    'gemini hooks+MCP native',
+    gemini?.hooks.prjct === 'native' && gemini?.mcp.prjct === 'native',
+    `hooks=${gemini?.hooks.prjct} mcp=${gemini?.mcp.prjct}`
+  )
+  push('cursor hooks native', cursor?.hooks.prjct === 'native', `hooks=${cursor?.hooks.prjct}`)
+  push(
+    'grok inherits-claude',
+    grok?.hooks.prjct === 'inherits-claude' && grok?.mcp.prjct === 'inherits-claude',
+    `hooks=${grok?.hooks.prjct} mcp=${grok?.mcp.prjct}`
+  )
+
+  const surfaceIds = new Set(listHarnessSurfaces().map((s) => s.runtimeId))
+  push(
+    'benchmark surface matrix',
+    ['claude', 'codex', 'gemini', 'grok', 'cursor'].every((id) => surfaceIds.has(id as never)),
+    `${surfaceIds.size} surfaces in matrix`
+  )
+
+  const passed = checks.filter((c) => c.ok).length
+  const total = checks.length
+  const allGreen = passed === total && total >= WEAK_BENCH_MIN_PASS
+  const summary = allGreen
+    ? `Weak-model A/B PASS (${passed}/${total}) — release gate green`
+    : `Weak-model A/B FAIL (${passed}/${total}) — red: ${checks
+        .filter((c) => !c.ok)
+        .map((c) => c.name)
+        .join(', ')}`
+
+  return { checks, passed, total, allGreen, summary }
+}
+
+export function formatWeakBenchMarkdown(report: WeakBenchReport): string {
+  const lines = [
+    '# Weak-model A/B (release gate)',
+    '',
+    report.summary,
+    '',
+    '| Check | Detail | Pass |',
+    '|---|---|:---:|',
+  ]
+  for (const c of report.checks) {
+    lines.push(`| ${c.name} | ${c.detail} | ${c.ok ? '✓' : '✗'} |`)
+  }
+  lines.push('')
+  lines.push('Reproduce: `bun run bench:weak-model` · `bun run demo:weak-vs-frontier`')
+  return lines.join('\n')
+}

--- a/core/sync/secure-auth-token.ts
+++ b/core/sync/secure-auth-token.ts
@@ -8,6 +8,7 @@
 
 import { spawn } from 'node:child_process'
 import { execFileAsync } from '../utils/exec'
+import { commandOnPath } from '../utils/which'
 
 const MACOS_SERVICE = 'prjct-cli-auth'
 const ACCOUNT = 'prjct-cloud'
@@ -272,6 +273,36 @@ async function platformGet(): Promise<string | null> {
   return null
 }
 
+/**
+ * Whether this process can use a platform credential store right now.
+ * Used to fail login early with an actionable message (no plaintext fallback).
+ */
+export async function hasSecureCredentialStore(): Promise<boolean> {
+  if (isDarwin()) {
+    // `security` is part of macOS; treat as available if the binary resolves.
+    try {
+      await execFileAsync('security', ['help'])
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (isWindows()) {
+    // Credential Manager via PowerShell/advapi32 — require powershell.exe.
+    try {
+      await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', 'exit 0'])
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (isLinux()) {
+    // secret-tool (libsecret) is the Linux path; WSL/headless without it → false.
+    return commandOnPath('secret-tool')
+  }
+  return false
+}
+
 async function platformSet(value: string): Promise<AuthTokenLocation> {
   const token = value.trim()
   if (!token) throw new Error('Refusing to store an empty Cloud API token.')
@@ -287,6 +318,11 @@ async function platformSet(value: string): Promise<AuthTokenLocation> {
   }
 
   if (isLinux()) {
+    if (!(await hasSecureCredentialStore())) {
+      throw new Error(
+        'No secure credential store available (install libsecret / secret-tool). Refusing to store the Cloud API token in plaintext on Linux/WSL.'
+      )
+    }
     await writeLinuxSecretService(token)
     return 'secret-service'
   }
@@ -329,8 +365,14 @@ export async function getAuthToken(): Promise<string | null> {
 }
 
 export async function setAuthToken(value: string): Promise<AuthTokenLocation> {
-  const location = await activeStore().set(value)
-  cached = value.trim()
+  // Refuse empty before any store call — no backend may treat "" as a valid
+  // Cloud API token, and nothing may fall through to plaintext auth.json.
+  const token = value.trim()
+  if (!token) {
+    throw new Error('Refusing to store an empty Cloud API token.')
+  }
+  const location = await activeStore().set(token)
+  cached = token
   return location
 }
 

--- a/core/utils/codex-hooks.ts
+++ b/core/utils/codex-hooks.ts
@@ -138,7 +138,7 @@ async function writeHooksFile(hooksPath: string, data: CodexHooksFile): Promise<
 }
 
 function pruneOrphans(hooks: Record<string, CodexMatcherGroup[]>): number {
-  const valid = new Set(codexHookSpecs().map((h) => h.subcommand))
+  const valid = new Set<string>(codexHookSpecs().map((h) => h.subcommand))
   let pruned = 0
   for (const event of Object.keys(hooks)) {
     const kept: CodexMatcherGroup[] = []

--- a/core/utils/codex-hooks.ts
+++ b/core/utils/codex-hooks.ts
@@ -1,0 +1,332 @@
+/**
+ * Codex hooks installer — maps PRJCT_HOOKS into `~/.codex/hooks.json` and
+ * ensures `[features].hooks = true` in config.toml.
+ *
+ * Codex hook shape mirrors Claude settings.json (event → matcher groups →
+ * command handlers). Docs: https://developers.openai.com/codex/hooks
+ * (feature key is `hooks`; `codex_hooks` is a deprecated alias).
+ *
+ * Events Claude has that Codex does not: Notification, CwdChanged — skipped.
+ * Non-managed hooks require user trust via `/hooks` in the Codex TUI.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { resolveUserPath } from '../infrastructure/user-home'
+import { PRJCT_HOOKS } from '../services/settings-installer'
+import { getCodexConfigTomlPath } from './codex-mcp'
+
+const MANAGED_MARKER = '_prjctManaged' as const
+
+/** Codex-supported lifecycle events we install (subset of PRJCT_HOOKS). */
+export const CODEX_HOOK_EVENTS = new Set([
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+  'SubagentStart',
+  'SubagentStop',
+])
+
+const FEATURES_START = '# prjct:features:start - managed by prjct, do not edit between markers'
+const FEATURES_END = '# prjct:features:end'
+
+export function getCodexHooksJsonPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'codex', 'hooks.json')
+  }
+  return resolveUserPath('.codex', 'hooks.json')
+}
+
+interface CodexHookHandler {
+  type: 'command'
+  command: string
+  commandWindows?: string
+  timeout?: number
+  statusMessage?: string
+  [MANAGED_MARKER]?: true
+}
+
+interface CodexMatcherGroup {
+  matcher?: string
+  hooks: CodexHookHandler[]
+}
+
+interface CodexHooksFile {
+  hooks?: Record<string, CodexMatcherGroup[]>
+  [key: string]: unknown
+}
+
+export interface CodexHooksInstallResult {
+  hooksPath: string
+  configPath: string
+  hooksWritten: number
+  alreadyPresent: number
+  hooksPruned: number
+  featuresEnabled: boolean
+  featuresChanged: boolean
+}
+
+export interface CodexHooksUninstallResult {
+  hooksPath: string
+  hooksRemoved: number
+}
+
+function hookCommandUnix(subcommand: string): string {
+  const bin = process.env.PRJCT_BIN ?? 'prjct'
+  return `command -v ${bin} >/dev/null 2>&1 && ${bin} hook ${subcommand} || exit 0`
+}
+
+function hookCommandWindows(subcommand: string): string {
+  const bin = process.env.PRJCT_BIN ?? 'prjct'
+  // cmd.exe: where succeeds → run hook; else exit 0 (fail-soft).
+  return `where ${bin} >nul 2>&1 && ${bin} hook ${subcommand} || exit /b 0`
+}
+
+function isPrjctHandler(h: CodexHookHandler): boolean {
+  return h[MANAGED_MARKER] === true
+}
+
+function isLegacyPrjctHandler(h: CodexHookHandler): boolean {
+  if (h[MANAGED_MARKER] === true) return false
+  const cmd = h.command?.trim() ?? ''
+  return /(^|\/|\\|\s)prjct(\.cmd)?\s+hook\s+\S+/i.test(cmd)
+}
+
+function subcommandOf(h: CodexHookHandler): string | null {
+  const m = h.command?.match(/\bhook\s+(\S+)/i)
+  return m ? m[1] : null
+}
+
+function handlerFor(subcommand: string, statusMessage?: string): CodexHookHandler {
+  const entry: CodexHookHandler = {
+    type: 'command',
+    command: hookCommandUnix(subcommand),
+    commandWindows: hookCommandWindows(subcommand),
+    timeout: 30,
+    [MANAGED_MARKER]: true,
+  }
+  if (statusMessage) entry.statusMessage = statusMessage
+  return entry
+}
+
+function statusFor(subcommand: string): string {
+  return `prjct ${subcommand}`
+}
+
+/** PRJCT_HOOKS entries that Codex can actually fire. */
+export function codexHookSpecs(): Array<(typeof PRJCT_HOOKS)[number]> {
+  return PRJCT_HOOKS.filter((h) => CODEX_HOOK_EVENTS.has(h.event))
+}
+
+async function readHooksFile(hooksPath: string): Promise<CodexHooksFile> {
+  try {
+    const raw = await fs.readFile(hooksPath, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object') return parsed as CodexHooksFile
+    return {}
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw err
+  }
+}
+
+async function writeHooksFile(hooksPath: string, data: CodexHooksFile): Promise<void> {
+  await fs.mkdir(path.dirname(hooksPath), { recursive: true })
+  await fs.writeFile(hooksPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
+}
+
+function pruneOrphans(hooks: Record<string, CodexMatcherGroup[]>): number {
+  const valid = new Set(codexHookSpecs().map((h) => h.subcommand))
+  let pruned = 0
+  for (const event of Object.keys(hooks)) {
+    const kept: CodexMatcherGroup[] = []
+    for (const block of hooks[event] ?? []) {
+      block.hooks = block.hooks.filter((h) => {
+        if (!isPrjctHandler(h)) return true
+        const sub = subcommandOf(h)
+        if (sub && !valid.has(sub)) {
+          pruned++
+          return false
+        }
+        return true
+      })
+      if (block.hooks.length > 0) kept.push(block)
+    }
+    if (kept.length > 0) hooks[event] = kept
+    else delete hooks[event]
+  }
+  return pruned
+}
+
+/**
+ * Enable Codex hooks feature in config.toml (idempotent, marker-managed).
+ * Returns whether the features block was written/changed.
+ */
+export async function ensureCodexHooksFeature(
+  configPath = getCodexConfigTomlPath()
+): Promise<{ path: string; changed: boolean; enabled: boolean }> {
+  let existing = ''
+  try {
+    existing = await fs.readFile(configPath, 'utf-8')
+  } catch {
+    // create below
+  }
+
+  const block = [FEATURES_START, '[features]', 'hooks = true', FEATURES_END, ''].join('\n')
+
+  const startIdx = existing.indexOf(FEATURES_START)
+  const endIdx = existing.indexOf(FEATURES_END)
+
+  let next = existing
+  let changed = false
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx)
+    let after = existing.slice(endIdx + FEATURES_END.length)
+    if (after.startsWith('\n')) after = after.slice(1)
+    next = before + block + after
+    changed = next !== existing
+  } else if (
+    /^\s*hooks\s*=\s*true\b/m.test(existing) ||
+    /^\s*codex_hooks\s*=\s*true\b/m.test(existing)
+  ) {
+    // User already enabled hooks somewhere — leave config alone.
+    return { path: configPath, changed: false, enabled: true }
+  } else if (/^\s*\[features\]/m.test(existing)) {
+    // Append hooks = true under first [features] if missing.
+    if (!/^\s*hooks\s*=/m.test(existing) && !/^\s*codex_hooks\s*=/m.test(existing)) {
+      next = existing.replace(/^(\s*\[features\]\s*)$/m, `$1\nhooks = true`)
+      changed = next !== existing
+    }
+  } else {
+    next = existing.trim().length > 0 ? `${existing.trimEnd()}\n\n${block}` : block
+    changed = true
+  }
+
+  if (changed) {
+    await fs.mkdir(path.dirname(configPath), { recursive: true })
+    await fs.writeFile(configPath, next, 'utf-8')
+  }
+
+  return { path: configPath, changed, enabled: true }
+}
+
+/**
+ * Idempotently install prjct hooks into Codex hooks.json + enable features.hooks.
+ */
+export async function installCodexHooks(opts?: {
+  hooksPath?: string
+  configPath?: string
+}): Promise<CodexHooksInstallResult> {
+  const hooksPath = opts?.hooksPath ?? getCodexHooksJsonPath()
+  const configPath = opts?.configPath ?? getCodexConfigTomlPath()
+
+  const file = await readHooksFile(hooksPath)
+  const hooks: Record<string, CodexMatcherGroup[]> = file.hooks ?? {}
+
+  let hooksWritten = 0
+  let alreadyPresent = 0
+
+  for (const spec of codexHookSpecs()) {
+    const eventEntries: CodexMatcherGroup[] = hooks[spec.event] ?? []
+    let block = eventEntries.find((b) => (b.matcher ?? '') === (spec.matcher ?? ''))
+    if (!block) {
+      block = { matcher: spec.matcher || undefined, hooks: [] }
+      eventEntries.push(block)
+    }
+
+    // Collapse legacy unmarked prjct commands.
+    block.hooks = block.hooks.filter((h) => !isLegacyPrjctHandler(h))
+
+    const desired = handlerFor(spec.subcommand, statusFor(spec.subcommand))
+    const existing = block.hooks.find((h) => isPrjctHandler(h))
+    if (existing) {
+      if (
+        existing.command === desired.command &&
+        existing.commandWindows === desired.commandWindows &&
+        existing.timeout === desired.timeout
+      ) {
+        alreadyPresent++
+      } else {
+        existing.command = desired.command
+        existing.commandWindows = desired.commandWindows
+        existing.timeout = desired.timeout
+        existing.statusMessage = desired.statusMessage
+        hooksWritten++
+      }
+    } else {
+      block.hooks.push(desired)
+      hooksWritten++
+    }
+
+    // Empty matcher → omit key (Codex treats omit/* as match-all).
+    if (!block.matcher) delete block.matcher
+    hooks[spec.event] = eventEntries
+  }
+
+  const hooksPruned = pruneOrphans(hooks)
+  file.hooks = hooks
+  await writeHooksFile(hooksPath, file)
+
+  const features = await ensureCodexHooksFeature(configPath)
+
+  return {
+    hooksPath,
+    configPath,
+    hooksWritten,
+    alreadyPresent,
+    hooksPruned,
+    featuresEnabled: features.enabled,
+    featuresChanged: features.changed,
+  }
+}
+
+/** Remove every prjct-managed Codex hook handler. */
+export async function uninstallCodexHooks(
+  hooksPath = getCodexHooksJsonPath()
+): Promise<CodexHooksUninstallResult> {
+  const file = await readHooksFile(hooksPath)
+  if (!file.hooks) return { hooksPath, hooksRemoved: 0 }
+
+  let hooksRemoved = 0
+  for (const [event, blocks] of Object.entries(file.hooks)) {
+    const cleaned: CodexMatcherGroup[] = []
+    for (const block of blocks) {
+      const remaining = block.hooks.filter((h) => {
+        if (isPrjctHandler(h) || isLegacyPrjctHandler(h)) {
+          hooksRemoved++
+          return false
+        }
+        return true
+      })
+      if (remaining.length > 0) {
+        cleaned.push({ ...block, hooks: remaining })
+      }
+    }
+    if (cleaned.length > 0) file.hooks[event] = cleaned
+    else delete file.hooks[event]
+  }
+
+  if (Object.keys(file.hooks).length === 0) delete file.hooks
+  await writeHooksFile(hooksPath, file)
+  return { hooksPath, hooksRemoved }
+}
+
+export async function codexHooksStatus(hooksPath = getCodexHooksJsonPath()): Promise<{
+  installed: number
+  expected: number
+  path: string
+}> {
+  const file = await readHooksFile(hooksPath)
+  let installed = 0
+  for (const blocks of Object.values(file.hooks ?? {})) {
+    for (const block of blocks) {
+      for (const h of block.hooks) {
+        if (isPrjctHandler(h) || isLegacyPrjctHandler(h)) installed++
+      }
+    }
+  }
+  return { installed, expected: codexHookSpecs().length, path: hooksPath }
+}

--- a/core/utils/cursor-hooks.ts
+++ b/core/utils/cursor-hooks.ts
@@ -1,0 +1,274 @@
+/**
+ * Cursor hooks installer — maps PRJCT_HOOKS into `~/.cursor/hooks.json`.
+ *
+ * Cursor uses camelCase event names and a flat handler list (not Claude's
+ * matcher-group nesting):
+ *
+ *   { "version": 1, "hooks": { "preToolUse": [{ "command", "matcher?", "timeout?" }] } }
+ *
+ * Locations Cursor loads: project `.cursor/hooks.json`, user `~/.cursor/hooks.json`.
+ * We write the **user** path so install is global and clean-repo stays clean
+ * (no automatic project writes). Grok Build also reads `.cursor/hooks.json`.
+ *
+ * Docs/community (2026): sessionStart, preToolUse, postToolUse, stop;
+ * matchers like Write|StrReplace; timeout in seconds.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { resolveUserPath } from '../infrastructure/user-home'
+import { PRJCT_HOOKS } from '../services/settings-installer'
+
+const MANAGED_MARKER = '_prjctManaged' as const
+
+export function getCursorHooksJsonPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'cursor', 'hooks.json')
+  }
+  return resolveUserPath('.cursor', 'hooks.json')
+}
+
+interface CursorHookHandler {
+  command: string
+  matcher?: string
+  timeout?: number
+  /** Optional; ignored by Cursor if unknown — used for install/uninstall identity. */
+  [MANAGED_MARKER]?: true
+  name?: string
+}
+
+interface CursorHooksFile {
+  version?: number
+  hooks?: Record<string, CursorHookHandler[]>
+  [key: string]: unknown
+}
+
+export interface CursorHooksInstallResult {
+  hooksPath: string
+  hooksWritten: number
+  alreadyPresent: number
+  hooksPruned: number
+}
+
+export interface CursorHooksUninstallResult {
+  hooksPath: string
+  hooksRemoved: number
+}
+
+interface CursorHookMap {
+  cursorEvent: string
+  matcher?: string
+  subcommand: string
+  name: string
+}
+
+/**
+ * Claude PRJCT_HOOKS → Cursor camelCase events + tool matchers.
+ * Skip events Cursor has no documented equivalent for.
+ */
+export function cursorHookMaps(): CursorHookMap[] {
+  const maps: CursorHookMap[] = []
+  for (const spec of PRJCT_HOOKS) {
+    if (spec.event === 'SessionStart') {
+      maps.push({
+        cursorEvent: 'sessionStart',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'UserPromptSubmit') {
+      // Community / schema: beforeSubmitPrompt (when present) or userPromptSubmit
+      maps.push({
+        cursorEvent: 'beforeSubmitPrompt',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'PreToolUse' && spec.matcher === 'Bash') {
+      maps.push({
+        cursorEvent: 'preToolUse',
+        matcher: 'Shell|Bash',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'PreToolUse' && spec.matcher === 'Edit|Write') {
+      maps.push({
+        cursorEvent: 'preToolUse',
+        matcher: 'Write|StrReplace|Edit',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'PostToolUse' && spec.matcher === 'Edit|Write') {
+      maps.push({
+        cursorEvent: 'postToolUse',
+        matcher: 'Write|StrReplace|Edit',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'Stop') {
+      maps.push({
+        cursorEvent: 'stop',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'SubagentStart') {
+      maps.push({
+        cursorEvent: 'subagentStart',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'SubagentStop') {
+      maps.push({
+        cursorEvent: 'subagentStop',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    }
+    // Notification / CwdChanged — no stable Cursor equivalent
+  }
+  return maps
+}
+
+function hookCommand(subcommand: string): string {
+  const bin = process.env.PRJCT_BIN ?? 'prjct'
+  return `command -v ${bin} >/dev/null 2>&1 && PRJCT_HOOK_HOST=cursor ${bin} hook ${subcommand} || exit 0`
+}
+
+function isPrjctHandler(h: CursorHookHandler): boolean {
+  return (
+    h[MANAGED_MARKER] === true ||
+    (h.name?.startsWith('prjct-') ?? false) ||
+    /PRJCT_HOOK_HOST=cursor/.test(h.command)
+  )
+}
+
+function isLegacyPrjctHandler(h: CursorHookHandler): boolean {
+  if (h[MANAGED_MARKER] === true) return false
+  return /(^|\/|\s)prjct\s+hook\s+\S+/.test(h.command ?? '')
+}
+
+async function readHooksFile(hooksPath: string): Promise<CursorHooksFile> {
+  try {
+    const raw = await fs.readFile(hooksPath, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object') return parsed as CursorHooksFile
+    return { version: 1 }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { version: 1 }
+    throw err
+  }
+}
+
+async function writeHooksFile(hooksPath: string, data: CursorHooksFile): Promise<void> {
+  await fs.mkdir(path.dirname(hooksPath), { recursive: true })
+  data.version = data.version ?? 1
+  await fs.writeFile(hooksPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
+}
+
+function handlerFor(map: CursorHookMap): CursorHookHandler {
+  const h: CursorHookHandler = {
+    command: hookCommand(map.subcommand),
+    timeout: 30,
+    name: map.name,
+    [MANAGED_MARKER]: true,
+  }
+  if (map.matcher) h.matcher = map.matcher
+  return h
+}
+
+function pruneOrphans(hooks: Record<string, CursorHookHandler[]>): number {
+  const valid = new Set(cursorHookMaps().map((m) => m.name))
+  let pruned = 0
+  for (const event of Object.keys(hooks)) {
+    hooks[event] = (hooks[event] ?? []).filter((h) => {
+      if (!isPrjctHandler(h) && !isLegacyPrjctHandler(h)) return true
+      if (h.name && valid.has(h.name)) return true
+      pruned++
+      return false
+    })
+    if (hooks[event].length === 0) delete hooks[event]
+  }
+  return pruned
+}
+
+/**
+ * Idempotently install prjct hooks into user-level ~/.cursor/hooks.json.
+ */
+export async function installCursorHooks(
+  hooksPath = getCursorHooksJsonPath()
+): Promise<CursorHooksInstallResult> {
+  const file = await readHooksFile(hooksPath)
+  const hooks: Record<string, CursorHookHandler[]> = { ...(file.hooks ?? {}) }
+  let hooksWritten = 0
+  let alreadyPresent = 0
+
+  for (const map of cursorHookMaps()) {
+    const list = hooks[map.cursorEvent] ?? []
+    // Drop legacy unmarked prjct entries
+    const cleaned = list.filter((h) => !(isLegacyPrjctHandler(h) && !isPrjctHandler(h)))
+    const desired = handlerFor(map)
+    const idx = cleaned.findIndex(
+      (h) => isPrjctHandler(h) && (h.name === map.name || h.command.includes(map.subcommand))
+    )
+    if (idx >= 0) {
+      const existing = cleaned[idx]
+      if (
+        existing.command === desired.command &&
+        existing.matcher === desired.matcher &&
+        existing.timeout === desired.timeout
+      ) {
+        alreadyPresent++
+      } else {
+        cleaned[idx] = { ...existing, ...desired }
+        hooksWritten++
+      }
+    } else {
+      cleaned.push(desired)
+      hooksWritten++
+    }
+    hooks[map.cursorEvent] = cleaned
+  }
+
+  const hooksPruned = pruneOrphans(hooks)
+  file.version = 1
+  file.hooks = hooks
+  await writeHooksFile(hooksPath, file)
+  return { hooksPath, hooksWritten, alreadyPresent, hooksPruned }
+}
+
+export async function uninstallCursorHooks(
+  hooksPath = getCursorHooksJsonPath()
+): Promise<CursorHooksUninstallResult> {
+  const file = await readHooksFile(hooksPath)
+  if (!file.hooks) return { hooksPath, hooksRemoved: 0 }
+
+  let hooksRemoved = 0
+  for (const event of Object.keys(file.hooks)) {
+    const before = file.hooks[event]?.length ?? 0
+    file.hooks[event] = (file.hooks[event] ?? []).filter((h) => {
+      if (isPrjctHandler(h) || isLegacyPrjctHandler(h)) {
+        hooksRemoved++
+        return false
+      }
+      return true
+    })
+    if (file.hooks[event].length === 0) delete file.hooks[event]
+    void before
+  }
+  if (Object.keys(file.hooks).length === 0) delete file.hooks
+  await writeHooksFile(hooksPath, file)
+  return { hooksPath, hooksRemoved }
+}
+
+export async function cursorHooksStatus(hooksPath = getCursorHooksJsonPath()): Promise<{
+  installed: number
+  expected: number
+  path: string
+}> {
+  const file = await readHooksFile(hooksPath)
+  let installed = 0
+  for (const list of Object.values(file.hooks ?? {})) {
+    for (const h of list) {
+      if (isPrjctHandler(h) || isLegacyPrjctHandler(h)) installed++
+    }
+  }
+  return { installed, expected: cursorHookMaps().length, path: hooksPath }
+}

--- a/core/utils/gemini-settings.ts
+++ b/core/utils/gemini-settings.ts
@@ -1,0 +1,326 @@
+/**
+ * Gemini CLI settings wiring — MCP servers + lifecycle hooks in
+ * `~/.gemini/settings.json`.
+ *
+ * Gemini event names differ from Claude (BeforeTool / AfterTool / BeforeAgent /
+ * AfterAgent). We install the same `prjct hook <sub>` commands with
+ * PRJCT_HOOK_HOST=gemini so _shared.adaptHookOutputForHost remaps deny/context
+ * shapes. Docs: https://geminicli.com/docs/hooks/
+ *
+ * MCP: top-level mcpServers (same JSON shape as Claude). Prefer not to use
+ * underscores in server names (Gemini policy parser); "prjct" is fine.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { resolveUserPath } from '../infrastructure/user-home'
+import { PRJCT_HOOKS } from '../services/settings-installer'
+import { MCP_SERVER_PRESETS } from './mcp-config'
+
+const MANAGED_MARKER = '_prjctManaged' as const
+
+export function getGeminiSettingsPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'gemini', 'settings.json')
+  }
+  return resolveUserPath('.gemini', 'settings.json')
+}
+
+interface GeminiHookHandler {
+  type: 'command'
+  command: string
+  name?: string
+  timeout?: number
+  description?: string
+  [MANAGED_MARKER]?: true
+}
+
+interface GeminiMatcherGroup {
+  matcher?: string
+  hooks: GeminiHookHandler[]
+}
+
+interface GeminiSettings {
+  mcpServers?: Record<string, unknown>
+  hooks?: Record<string, GeminiMatcherGroup[]>
+  [key: string]: unknown
+}
+
+export interface GeminiInstallResult {
+  settingsPath: string
+  mcpChanged: boolean
+  hooksWritten: number
+  alreadyPresent: number
+  hooksPruned: number
+}
+
+export interface GeminiUninstallResult {
+  settingsPath: string
+  hooksRemoved: number
+  mcpRemoved: boolean
+}
+
+/** Claude event → Gemini event + optional tool matcher override. */
+interface GeminiHookMap {
+  geminiEvent: string
+  /** Override Claude matcher for Gemini tool names (regex). */
+  matcher?: string
+  subcommand: string
+  name: string
+}
+
+/**
+ * Map only hooks Gemini can fire. Tool matchers use Gemini built-in names
+ * (run_shell_command, write_file, replace) per tools reference.
+ */
+export function geminiHookMaps(): GeminiHookMap[] {
+  const maps: GeminiHookMap[] = []
+  for (const spec of PRJCT_HOOKS) {
+    if (spec.event === 'SessionStart') {
+      maps.push({
+        geminiEvent: 'SessionStart',
+        matcher: spec.matcher || undefined,
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'UserPromptSubmit') {
+      maps.push({
+        geminiEvent: 'BeforeAgent',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'PreToolUse' && spec.matcher === 'Bash') {
+      maps.push({
+        geminiEvent: 'BeforeTool',
+        matcher: 'run_shell_command',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'PreToolUse' && spec.matcher === 'Edit|Write') {
+      maps.push({
+        geminiEvent: 'BeforeTool',
+        matcher: 'write_file|replace',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'PostToolUse' && spec.matcher === 'Edit|Write') {
+      maps.push({
+        geminiEvent: 'AfterTool',
+        matcher: 'write_file|replace',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'Stop') {
+      maps.push({
+        geminiEvent: 'AfterAgent',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    } else if (spec.event === 'Notification') {
+      maps.push({
+        geminiEvent: 'Notification',
+        subcommand: spec.subcommand,
+        name: `prjct-${spec.subcommand}`,
+      })
+    }
+    // SubagentStart/Stop, CwdChanged: no Gemini equivalent — skip
+  }
+  return maps
+}
+
+function hookCommand(subcommand: string): string {
+  const bin = process.env.PRJCT_BIN ?? 'prjct'
+  // Host env remaps deny/context for Gemini schema.
+  return `command -v ${bin} >/dev/null 2>&1 && PRJCT_HOOK_HOST=gemini ${bin} hook ${subcommand} || exit 0`
+}
+
+function isPrjctHandler(h: GeminiHookHandler): boolean {
+  return h[MANAGED_MARKER] === true || (h.name?.startsWith('prjct-') ?? false)
+}
+
+function isLegacyPrjctHandler(h: GeminiHookHandler): boolean {
+  if (h[MANAGED_MARKER] === true) return false
+  const cmd = h.command?.trim() ?? ''
+  return /(^|\/|\s)prjct\s+hook\s+\S+/.test(cmd) || /PRJCT_HOOK_HOST=gemini/.test(cmd)
+}
+
+async function readSettings(settingsPath: string): Promise<GeminiSettings> {
+  try {
+    const raw = await fs.readFile(settingsPath, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object') return parsed as GeminiSettings
+    return {}
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {}
+    throw err
+  }
+}
+
+async function writeSettings(settingsPath: string, data: GeminiSettings): Promise<void> {
+  await fs.mkdir(path.dirname(settingsPath), { recursive: true })
+  await fs.writeFile(settingsPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
+}
+
+function handlerFor(map: GeminiHookMap): GeminiHookHandler {
+  return {
+    type: 'command',
+    command: hookCommand(map.subcommand),
+    name: map.name,
+    timeout: 30_000, // Gemini uses milliseconds
+    description: `prjct ${map.subcommand} (managed)`,
+    [MANAGED_MARKER]: true,
+  }
+}
+
+function pruneOrphans(hooks: Record<string, GeminiMatcherGroup[]>): number {
+  const validNames = new Set(geminiHookMaps().map((m) => m.name))
+  let pruned = 0
+  for (const event of Object.keys(hooks)) {
+    const kept: GeminiMatcherGroup[] = []
+    for (const block of hooks[event] ?? []) {
+      block.hooks = block.hooks.filter((h) => {
+        if (!isPrjctHandler(h) && !isLegacyPrjctHandler(h)) return true
+        if (h.name && validNames.has(h.name)) return true
+        // legacy without name or retired name
+        if (h.name && !validNames.has(h.name)) {
+          pruned++
+          return false
+        }
+        if (!h.name && isLegacyPrjctHandler(h)) {
+          pruned++
+          return false
+        }
+        return true
+      })
+      if (block.hooks.length > 0) kept.push(block)
+    }
+    if (kept.length > 0) hooks[event] = kept
+    else delete hooks[event]
+  }
+  return pruned
+}
+
+/** Upsert mcpServers.prjct (and leave other servers untouched). */
+export async function ensureGeminiMcpServer(
+  settingsPath = getGeminiSettingsPath()
+): Promise<{ path: string; changed: boolean }> {
+  const settings = await readSettings(settingsPath)
+  const servers = { ...(settings.mcpServers ?? {}) }
+  const previous = servers.prjct
+  const next = MCP_SERVER_PRESETS.prjct
+  const changed = JSON.stringify(previous) !== JSON.stringify(next)
+  servers.prjct = next
+  settings.mcpServers = servers
+  if (changed || previous === undefined) {
+    await writeSettings(settingsPath, settings)
+  }
+  return { path: settingsPath, changed: changed || previous === undefined }
+}
+
+/** Install prjct hooks into Gemini settings.json (idempotent). */
+export async function installGeminiHooks(settingsPath = getGeminiSettingsPath()): Promise<{
+  path: string
+  hooksWritten: number
+  alreadyPresent: number
+  hooksPruned: number
+}> {
+  const settings = await readSettings(settingsPath)
+  const hooks: Record<string, GeminiMatcherGroup[]> = settings.hooks ?? {}
+  let hooksWritten = 0
+  let alreadyPresent = 0
+
+  for (const map of geminiHookMaps()) {
+    const eventEntries: GeminiMatcherGroup[] = hooks[map.geminiEvent] ?? []
+    const wantMatcher = map.matcher ?? ''
+    let block = eventEntries.find((b) => (b.matcher ?? '') === wantMatcher)
+    if (!block) {
+      block = { matcher: map.matcher, hooks: [] }
+      eventEntries.push(block)
+    }
+
+    block.hooks = block.hooks.filter((h) => !isLegacyPrjctHandler(h) || isPrjctHandler(h))
+    // Drop legacy unmarked only
+    block.hooks = block.hooks.filter((h) => {
+      if (isLegacyPrjctHandler(h) && !isPrjctHandler(h)) return false
+      return true
+    })
+
+    const desired = handlerFor(map)
+    const existing = block.hooks.find(
+      (h) => isPrjctHandler(h) && (h.name === map.name || h.command.includes(map.subcommand))
+    )
+    if (existing) {
+      if (existing.command === desired.command && existing.timeout === desired.timeout) {
+        alreadyPresent++
+      } else {
+        existing.command = desired.command
+        existing.timeout = desired.timeout
+        existing.name = desired.name
+        existing.description = desired.description
+        existing[MANAGED_MARKER] = true
+        hooksWritten++
+      }
+    } else {
+      block.hooks.push(desired)
+      hooksWritten++
+    }
+
+    if (!block.matcher) delete block.matcher
+    hooks[map.geminiEvent] = eventEntries
+  }
+
+  const hooksPruned = pruneOrphans(hooks)
+  settings.hooks = hooks
+  await writeSettings(settingsPath, settings)
+  return { path: settingsPath, hooksWritten, alreadyPresent, hooksPruned }
+}
+
+/** Full Gemini surface: MCP + hooks. */
+export async function installGeminiSettings(
+  settingsPath = getGeminiSettingsPath()
+): Promise<GeminiInstallResult> {
+  const mcp = await ensureGeminiMcpServer(settingsPath)
+  const hooks = await installGeminiHooks(settingsPath)
+  return {
+    settingsPath,
+    mcpChanged: mcp.changed,
+    hooksWritten: hooks.hooksWritten,
+    alreadyPresent: hooks.alreadyPresent,
+    hooksPruned: hooks.hooksPruned,
+  }
+}
+
+export async function uninstallGeminiSettings(
+  settingsPath = getGeminiSettingsPath()
+): Promise<GeminiUninstallResult> {
+  const settings = await readSettings(settingsPath)
+  let hooksRemoved = 0
+  if (settings.hooks) {
+    for (const [event, blocks] of Object.entries(settings.hooks)) {
+      const cleaned: GeminiMatcherGroup[] = []
+      for (const block of blocks) {
+        const remaining = block.hooks.filter((h) => {
+          if (isPrjctHandler(h) || isLegacyPrjctHandler(h)) {
+            hooksRemoved++
+            return false
+          }
+          return true
+        })
+        if (remaining.length > 0) cleaned.push({ ...block, hooks: remaining })
+      }
+      if (cleaned.length > 0) settings.hooks[event] = cleaned
+      else delete settings.hooks[event]
+    }
+    if (Object.keys(settings.hooks).length === 0) delete settings.hooks
+  }
+
+  let mcpRemoved = false
+  if (settings.mcpServers?.prjct) {
+    delete settings.mcpServers.prjct
+    mcpRemoved = true
+    if (Object.keys(settings.mcpServers).length === 0) delete settings.mcpServers
+  }
+
+  await writeSettings(settingsPath, settings)
+  return { settingsPath, hooksRemoved, mcpRemoved }
+}

--- a/core/utils/which.ts
+++ b/core/utils/which.ts
@@ -1,0 +1,87 @@
+/**
+ * Cross-platform "is this command on PATH?" helpers.
+ *
+ * Windows has no POSIX `which` / `command -v`. Use `where.exe` there.
+ * Unix uses `which` with a soft fallback to `command -v` via /bin/sh.
+ *
+ * Always returns the PATH-winning path (first hit), never throws.
+ */
+
+import { execFileSync, execSync } from 'node:child_process'
+import { execFileAsync } from './exec'
+
+function firstNonEmptyLine(stdout: string): string | null {
+  for (const line of stdout.split(/\r?\n/)) {
+    const t = line.trim()
+    if (t) return t
+  }
+  return null
+}
+
+/** Synchronous resolve of the PATH-winning binary, or null. */
+export function whichSync(command: string): string | null {
+  if (!command || command.includes('\0')) return null
+
+  try {
+    if (process.platform === 'win32') {
+      // where.exe prints one path per line; first is PATH winner.
+      const stdout = execFileSync('where.exe', [command], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      })
+      return firstNonEmptyLine(stdout)
+    }
+
+    try {
+      const stdout = execFileSync('which', [command], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      return firstNonEmptyLine(stdout)
+    } catch {
+      // Busybox / stripped PATH: command -v via sh.
+      const stdout = execSync(`command -v ${JSON.stringify(command)}`, {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        shell: '/bin/sh',
+      })
+      return firstNonEmptyLine(stdout)
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Async resolve of the PATH-winning binary, or null. */
+export async function whichAsync(command: string): Promise<string | null> {
+  if (!command || command.includes('\0')) return null
+
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execFileAsync('where.exe', [command], {
+        encoding: 'utf-8',
+        windowsHide: true,
+      })
+      return firstNonEmptyLine(String(stdout))
+    }
+
+    try {
+      const { stdout } = await execFileAsync('which', [command])
+      return firstNonEmptyLine(String(stdout))
+    } catch {
+      // Fall back to sync shell path for rare environments without `which`.
+      return whichSync(command)
+    }
+  } catch {
+    return null
+  }
+}
+
+export function commandOnPath(command: string): boolean {
+  return whichSync(command) !== null
+}
+
+export async function commandOnPathAsync(command: string): Promise<boolean> {
+  return (await whichAsync(command)) !== null
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "bench:ab": "bun scripts/bench-ab.ts",
     "bench:weak-model": "bun scripts/bench-weak-model.ts",
     "demo:weak-vs-frontier": "bun scripts/demo-weak-vs-frontier.ts",
-    "harness:score": "bun bin/prjct.ts harness score --md"
+    "harness:score": "bun bin/prjct.ts harness score --md",
+    "gate:dominance": "bun test core/__tests__/services/weak-model-bench.test.ts core/__tests__/services/weak-frontier-demo.test.ts core/__tests__/services/harness-score.test.ts && bun run bench:weak-model && bun run demo:weak-vs-frontier"
   },
   "keywords": [
     "claude-code",

--- a/scripts/bench-weak-model.ts
+++ b/scripts/bench-weak-model.ts
@@ -1,114 +1,24 @@
 #!/usr/bin/env bun
 /**
- * Weak-model readiness bench.
- * Exit 0 only when all SLOs pass.
+ * Weak-model readiness bench — exit 0 only when all SLOs pass.
+ * Logic SSOT: core/services/weak-model-bench.ts
  *
  * Usage: bun scripts/bench-weak-model.ts
  */
 
-import { Buffer } from 'node:buffer'
-import { DEFAULT_MCP_TOOL_TIER, resolveTier } from '../core/mcp/server'
-import { PROVIDER_CAPABILITY_MODELS } from '../core/schemas/model'
-import { computeHarnessScore, WORLD_CLASS } from '../core/services/harness-score'
-import { MINIMAL_ROUTING_BODY } from '../core/services/routing-block'
-import {
-  buildPrjctSkill,
-  emptySkillContext,
-} from '../core/services/skill-generator/prjct-skill-body'
-import { countTokens } from '../core/tools/context/token-counter'
+import { formatWeakBenchMarkdown, runWeakModelBench } from '../core/services/weak-model-bench'
 
-interface Check {
-  name: string
-  ok: boolean
-  detail: string
+const report = runWeakModelBench()
+
+for (const c of report.checks) {
+  console.log(`${c.ok ? '✓' : '✗'} ${c.name}: ${c.detail}`)
 }
-
-const checks: Check[] = []
-
-function check(name: string, ok: boolean, detail: string): void {
-  checks.push({ name, ok, detail })
-  console.log(`${ok ? '✓' : '✗'} ${name}: ${detail}`)
-}
-
-const skillTok = countTokens(buildPrjctSkill(emptySkillContext()))
-check(
-  'skill always-on',
-  skillTok <= WORLD_CLASS.skillTokensMax,
-  `${skillTok} tok (max ${WORLD_CLASS.skillTokensMax})`
-)
-
-const routingB = Buffer.byteLength(MINIMAL_ROUTING_BODY, 'utf-8')
-check(
-  'routing body',
-  routingB <= WORLD_CLASS.routingBodyBytesMax,
-  `${routingB} bytes (max ${WORLD_CLASS.routingBodyBytesMax})`
-)
-
-check(
-  'MCP default',
-  resolveTier(undefined) === 'core' && DEFAULT_MCP_TOOL_TIER === 'core',
-  `tier=${resolveTier(undefined)}`
-)
-
-const providers = Object.keys(PROVIDER_CAPABILITY_MODELS).length
-check(
-  'provider maps',
-  providers >= WORLD_CLASS.providerMapsMin,
-  `${providers} providers (min ${WORLD_CLASS.providerMapsMin})`
-)
-
-const score = computeHarnessScore()
-check(
-  'harness score',
-  score.programDone && score.grade >= 4.5,
-  `grade ${score.grade}/5 done=${score.programDone}`
-)
-
-check(
-  'MCP tool surface',
-  score.defaults.mcpToolCountDefault <= WORLD_CLASS.mcpToolsCoreMax,
-  `${score.defaults.mcpToolCountDefault} tools at default`
-)
-
-/** Deterministic intent router — weak models must not wrap bin verbs as work. */
-function routeIntent(signal: string): string {
-  const s = signal.toLowerCase()
-  if (/\bsync\b/.test(s)) return 'sync'
-  if (/\bsearch\b|\bfind\b|\brecall\b/.test(s)) return 'search'
-  if (/\bremember\b|\bsave (this|that|a)\b/.test(s)) return 'remember'
-  if (/\bship\b|\bopen a pr\b/.test(s)) return 'ship'
-  if (/what should i work|what next|\bready\b/.test(s)) return 'next'
-  if (/\bfix\b|\bbuild\b|\bimplement\b|\bbug\b|\brefactor\b/.test(s)) return 'work'
-  return 'work'
-}
-
-const INTENT_FIXTURES: Array<{ signal: string; verb: string }> = [
-  { signal: 'sync the project', verb: 'sync' },
-  { signal: 'search for auth decisions', verb: 'search' },
-  { signal: 'remember this decision about caching', verb: 'remember' },
-  { signal: 'fix the login bug', verb: 'work' },
-  { signal: 'what should I work on next', verb: 'next' },
-  { signal: 'ship the feature', verb: 'ship' },
-  { signal: 'implement rate limiting', verb: 'work' },
-  { signal: 'find gotchas on migrations', verb: 'search' },
-]
-
-let intentHits = 0
-for (const f of INTENT_FIXTURES) {
-  const got = routeIntent(f.signal)
-  const ok = got === f.verb
-  if (ok) intentHits++
-  check(`intent:${f.verb}`, ok, `"${f.signal}" → ${got}`)
-}
-
-const intentRate = intentHits / INTENT_FIXTURES.length
-check('intent routing accuracy', intentRate >= 0.95, `${Math.round(intentRate * 100)}% (need ≥95%)`)
-
-const failed = checks.filter((c) => !c.ok)
 console.log('')
-if (failed.length === 0) {
-  console.log(`Weak-model bench PASS (${checks.length}/${checks.length})`)
-  process.exit(0)
+console.log(report.summary)
+
+if (process.argv.includes('--md')) {
+  console.log('')
+  console.log(formatWeakBenchMarkdown(report))
 }
-console.log(`Weak-model bench FAIL (${checks.length - failed.length}/${checks.length})`)
-process.exit(1)
+
+process.exit(report.allGreen ? 0 : 1)


### PR DESCRIPTION
## Summary

Raises the harness bar beyond single-host parity into an **organic multi-runtime dominance stack** that is hard to clone piece-by-piece:

- **Install winner / auth / hooks**: path-ownership cleanup (no more brew false-positives on Homebrew Node npm globals), keychain-only Cloud tokens, fail-soft non-blocking hooks, cross-OS `which`/`where`.
- **Multi-runtime adapters**: one `prjct install` wires Claude + Codex (hooks.json + MCP) + Gemini (settings MCP+hooks) + Cursor (`~/.cursor/hooks.json`); **Grok inherits Claude** natively.
- **Organic board**: `probeHarnessCoverage` measures *live* hooks/MCP files; shown on install, `agents doctor`, and `harness score`.
- **Weak-model A/B release gate**: 24 SLOs (intent harness 100% vs bare ~30%, multi-runtime native surfaces); CI Quality step is release-blocking; `bun run gate:dominance` locally.
- **Models / Windsurf**: 2026-07 benchmark model maps (gpt-5.5, gemini 3.1-pro, grok-4); Windsurf demoted to `legacy`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run bench:weak-model` → 24/24 PASS
- [x] `bun run demo:weak-vs-frontier` → 10/10 SLOs
- [x] Unit tests: which, codex-hooks, gemini-settings, cursor-hooks, harness-coverage, weak-model-bench, fail-soft, host-adapt
- [ ] CI green on this PR (Quality + weak A/B step + shards)
- [ ] Manual: `prjct install --md` on a machine with Claude and/or Codex/Gemini/Cursor; confirm organic board
- [ ] Manual: Codex TUI `/hooks` trust once after install