### PR TITLE
fix(hooks): pre-secrets CI parity after #534

### DIFF
--- a/core/__tests__/utils/codex-hooks.test.ts
+++ b/core/__tests__/utils/codex-hooks.test.ts
@@ -59,10 +59,12 @@ describe('installCodexHooks', () => {
     expect(sessionHandlers[0]?.command).toContain('prjct hook session-start')
     expect(sessionHandlers[0]?.commandWindows).toContain('prjct hook session-start')
 
-    // Edit|Write pre-edit maps with matcher Codex understands for apply_patch.
+    // Edit|Write carries pre-secrets (credential MUST) + pre-edit (memory nudge).
     const preEdit = body.hooks.PreToolUse.find((b) => b.matcher === 'Edit|Write')
     expect(preEdit).toBeDefined()
-    expect(preEdit!.hooks[0]?.command).toContain('pre-edit')
+    const editCmds = (preEdit!.hooks ?? []).map((h) => String(h.command ?? ''))
+    expect(editCmds.some((c) => c.includes('pre-edit'))).toBe(true)
+    expect(editCmds.some((c) => c.includes('pre-secrets'))).toBe(true)
   })
 
   it('is idempotent on second install', async () => {

--- a/core/cli/bin-commands.ts
+++ b/core/cli/bin-commands.ts
@@ -396,6 +396,11 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
           await runPreCommitHook(projectPath)
           break
         }
+        case 'pre-secrets': {
+          const { runPreSecretsHook } = await import('../hooks/pre-secrets')
+          await runPreSecretsHook(projectPath)
+          break
+        }
         case 'pre-edit': {
           const { runPreEditHook } = await import('../hooks/pre-edit')
           await runPreEditHook(projectPath)

--- a/core/utils/cursor-hooks.ts
+++ b/core/utils/cursor-hooks.ts
@@ -212,9 +212,15 @@ export async function installCursorHooks(
     // Drop legacy unmarked prjct entries
     const cleaned = list.filter((h) => !(isLegacyPrjctHandler(h) && !isPrjctHandler(h)))
     const desired = handlerFor(map)
-    const idx = cleaned.findIndex(
-      (h) => isPrjctHandler(h) && (h.name === map.name || h.command.includes(map.subcommand))
-    )
+    // Prefer exact name match. Falling back to bare subcommand match collides when
+    // the same subcommand installs under two matchers (pre-secrets shell + write).
+    const idx = cleaned.findIndex((h) => {
+      if (!isPrjctHandler(h)) return false
+      if (h.name) return h.name === map.name
+      return (
+        h.command.includes(`hook ${map.subcommand}`) && (h.matcher ?? '') === (map.matcher ?? '')
+      )
+    })
     if (idx >= 0) {
       const existing = cleaned[idx]
       if (


### PR DESCRIPTION
## Summary

Fixes the 4 CI failures that blocked the Release workflow after #534 merged:

1. **case pre-secrets** in bin-commands.ts (dispatcher parity)
2. **Codex test** asserts both pre-secrets + pre-edit under Edit|Write
3. **Cursor install** matches by handler name so shell/write pre-secrets do not collide

## Test plan

- [x] bun test hook-dispatcher-parity, codex-hooks, cursor-hooks, pre-secrets
- [ ] CI green → merge → release publishes 3.38.0