### PR TITLE
feat(auth): CLI login via PKCE S256 (flow=pkce-v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [3.40.0] - 2026-07-10
+
 ### Added
+- CLI login PKCE S256 (flow=pkce-v1) aligned with api+app
 - CLI login PKCE S256 (flow=pkce-v1): callback carries only code+state; exchange via /auth/cli/exchange
 
 ## [3.39.0] - 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- CLI login PKCE S256 (flow=pkce-v1): callback carries only code+state; exchange via /auth/cli/exchange
+
 ## [3.39.0] - 2026-07-10
 
 ### Added

--- a/core/__tests__/sync/cli-pkce.test.ts
+++ b/core/__tests__/sync/cli-pkce.test.ts
@@ -1,0 +1,116 @@
+/**
+ * PKCE material + callback parsing for CLI login (flow=pkce-v1).
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import {
+  base64Url,
+  buildCliLoginSearchParams,
+  buildExchangeBody,
+  CLI_PKCE_FLOW,
+  generatePkceMaterial,
+  parseMintedKeyResponse,
+  parsePkceCallback,
+} from '../../sync/cli-pkce'
+
+describe('cli-pkce', () => {
+  test('generatePkceMaterial produces unique high-entropy fields', () => {
+    const a = generatePkceMaterial()
+    const b = generatePkceMaterial()
+    expect(a.state.length).toBeGreaterThanOrEqual(43)
+    expect(a.codeVerifier.length).toBeGreaterThanOrEqual(43)
+    expect(a.codeChallenge.length).toBe(43)
+    expect(a.codeChallengeMethod).toBe('S256')
+    expect(a.state).not.toBe(b.state)
+    expect(a.codeVerifier).not.toBe(b.codeVerifier)
+  })
+
+  test('codeChallenge is S256 of verifier', () => {
+    const m = generatePkceMaterial()
+    const expected = base64Url(createHash('sha256').update(m.codeVerifier, 'ascii').digest())
+    expect(m.codeChallenge).toBe(expected)
+  })
+
+  test('buildCliLoginSearchParams never embeds the verifier', () => {
+    const m = generatePkceMaterial()
+    const q = buildCliLoginSearchParams({
+      port: 43123,
+      deviceId: 'dev-1',
+      hostname: 'mac',
+      state: m.state,
+      codeChallenge: m.codeChallenge,
+    })
+    expect(q.get('flow')).toBe(CLI_PKCE_FLOW)
+    expect(q.get('code_challenge_method')).toBe('S256')
+    expect(q.get('code_challenge')).toBe(m.codeChallenge)
+    expect(q.get('state')).toBe(m.state)
+    expect(q.toString()).not.toContain(m.codeVerifier)
+    expect(q.has('code_verifier')).toBe(false)
+  })
+
+  test('parsePkceCallback accepts matching code+state', () => {
+    const m = generatePkceMaterial()
+    const params = new URLSearchParams({ code: 'auth-code-xyz', state: m.state })
+    const parsed = parsePkceCallback(params, m.state)
+    expect(parsed.ok).toBe(true)
+    if (parsed.ok) {
+      expect(parsed.code).toBe('auth-code-xyz')
+      expect(parsed.state).toBe(m.state)
+    }
+  })
+
+  test('parsePkceCallback rejects legacy bearer key without consuming success', () => {
+    const m = generatePkceMaterial()
+    const params = new URLSearchParams({ key: 'pk_live_xxx', state: m.state })
+    const parsed = parsePkceCallback(params, m.state)
+    expect(parsed.ok).toBe(false)
+    if (!parsed.ok) expect(parsed.reason).toBe('legacy-bearer')
+  })
+
+  test('parsePkceCallback rejects state mismatch', () => {
+    const m = generatePkceMaterial()
+    const params = new URLSearchParams({ code: 'c', state: 'wrong-state-value-xxxxxxxxxxxxxxxx' })
+    const parsed = parsePkceCallback(params, m.state)
+    expect(parsed.ok).toBe(false)
+    if (!parsed.ok) expect(parsed.reason).toBe('mismatch')
+  })
+
+  test('parsePkceCallback rejects missing fields', () => {
+    const m = generatePkceMaterial()
+    expect(parsePkceCallback(new URLSearchParams(), m.state).ok).toBe(false)
+  })
+
+  test('buildExchangeBody binds loopback redirect_uri to the listening port', () => {
+    const body = buildExchangeBody({
+      code: 'c',
+      state: 's'.repeat(43),
+      codeVerifier: 'v'.repeat(43),
+      deviceId: 'd',
+      port: 9999,
+    })
+    expect(body.flow).toBe(CLI_PKCE_FLOW)
+    expect(body.redirect_uri).toBe('http://127.0.0.1:9999/callback')
+    expect(body.code_verifier).toHaveLength(43)
+  })
+
+  test('parseMintedKeyResponse accepts camelCase and snake_case', () => {
+    expect(
+      parseMintedKeyResponse({
+        apiKey: 'pk_live_a',
+        userId: 'u1',
+        email: 'a@b.c',
+        deviceId: 'd1',
+      })
+    ).toEqual({ apiKey: 'pk_live_a', userId: 'u1', email: 'a@b.c', deviceId: 'd1' })
+    expect(
+      parseMintedKeyResponse({
+        api_key: 'pk_live_b',
+        user_id: 'u2',
+        email: 'c@d.e',
+        device_id: 'd2',
+      })
+    ).toEqual({ apiKey: 'pk_live_b', userId: 'u2', email: 'c@d.e', deviceId: 'd2' })
+    expect(parseMintedKeyResponse({})).toBeNull()
+  })
+})

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -10,6 +10,13 @@ import commandInstaller from '../infrastructure/command-installer'
 import configManager from '../infrastructure/config-manager'
 import pathManager from '../infrastructure/path-manager'
 import authConfig from '../sync/auth-config'
+import {
+  buildCliLoginSearchParams,
+  buildExchangeBody,
+  generatePkceMaterial,
+  parseMintedKeyResponse,
+  parsePkceCallback,
+} from '../sync/cli-pkce'
 import { syncClient } from '../sync/sync-client'
 import syncManager from '../sync/sync-manager'
 import type { MdOption } from '../types/cli'
@@ -79,8 +86,9 @@ export class SetupCommands extends PrjctCommandsBase {
   }
 
   /**
-   * Browser-based login: opens browser, user authenticates with OTP, CLI gets API key automatically.
-   * Usage: prjct login
+   * Browser-based login via PKCE S256 (flow=pkce-v1).
+   * Opens the SPA, user approves the device, callback carries only code+state;
+   * the CLI exchanges the code for a device key (never a bearer in the URL).
    */
   async login(options: { md?: boolean } = {}): Promise<CommandResult> {
     // Check if already authenticated
@@ -98,49 +106,99 @@ export class SetupCommands extends PrjctCommandsBase {
       }
     }
 
-    const webUrl = 'https://cli.prjct.app'
-    const apiUrl = 'https://cli-api.prjct.app'
+    const webUrl = process.env.PRJCT_WEB_URL || 'https://cli.prjct.app'
+    const apiUrl = process.env.PRJCT_API_URL || 'https://cli-api.prjct.app'
+    // Verifier/state only in this process for the lifetime of one login.
+    const pkce = generatePkceMaterial()
+    let settled = false
+    let listenPort = 0
 
     return new Promise<CommandResult>((resolve) => {
+      const finish = (result: CommandResult) => {
+        if (settled) return
+        settled = true
+        resolve(result)
+      }
+
       const server = http.createServer(async (req, res) => {
-        const url = new URL(req.url || '/', `http://127.0.0.1`)
+        const url = new URL(req.url || '/', 'http://127.0.0.1')
+        const noStore = {
+          'Content-Type': 'text/html',
+          'Cache-Control': 'no-store',
+          'Referrer-Policy': 'no-referrer',
+        }
 
         if (url.pathname === '/callback') {
-          const apiKey = url.searchParams.get('key')
-          const email = url.searchParams.get('email')
-          const userId = url.searchParams.get('user_id')
-          let verified = false
-          let failureMessage = 'No API key received'
-
-          if (apiKey) {
-            try {
-              await authConfig.saveAuth(apiKey, userId || '', email || '')
-              await authConfig.write({ apiUrl })
-              verified = await syncClient.testConnection()
-              if (!verified) {
-                failureMessage = 'Could not verify credentials with prjct Cloud'
-                await authConfig.clearAuth()
+          const parsed = parsePkceCallback(url.searchParams, pkce.state)
+          if (!parsed.ok) {
+            // Invalid/legacy params: respond but keep listening so the user can retry
+            // from the browser without restarting the CLI (except success closes).
+            const statusCode = parsed.reason === 'legacy-bearer' ? 400 : 400
+            res.writeHead(statusCode, noStore)
+            res.end(this.buildErrorPage(parsed.message))
+            if (parsed.reason === 'legacy-bearer') {
+              if (!options.md) {
+                out.warn(parsed.message)
+                out.info(`Update prjct-cli-app or open the login URL with flow=pkce-v1`)
               }
-            } catch (error) {
-              failureMessage =
-                error instanceof Error ? error.message : 'Could not store credentials securely'
-              await authConfig.clearAuth()
             }
+            return
+          }
+
+          let verified = false
+          let failureMessage = 'Authorization exchange failed'
+          let email = ''
+
+          try {
+            const body = buildExchangeBody({
+              code: parsed.code,
+              state: parsed.state,
+              codeVerifier: pkce.codeVerifier,
+              deviceId: await authConfig.getDeviceId(),
+              port: listenPort,
+            })
+            const exchangeRes = await fetch(`${apiUrl}/auth/cli/exchange`, {
+              method: 'POST',
+              headers: {
+                'content-type': 'application/json',
+                accept: 'application/json',
+              },
+              body: JSON.stringify(body),
+            })
+            if (!exchangeRes.ok) {
+              failureMessage = `Exchange failed (${exchangeRes.status})`
+            } else {
+              const minted = parseMintedKeyResponse(await exchangeRes.json())
+              if (!minted) {
+                failureMessage = 'Malformed exchange response'
+              } else {
+                email = minted.email
+                await authConfig.saveAuth(minted.apiKey, minted.userId, minted.email)
+                await authConfig.write({ apiUrl })
+                verified = await syncClient.testConnection()
+                if (!verified) {
+                  failureMessage = 'Could not verify credentials with prjct Cloud'
+                  await authConfig.clearAuth()
+                }
+              }
+            }
+          } catch (error) {
+            failureMessage =
+              error instanceof Error ? error.message : 'Could not store credentials securely'
+            await authConfig.clearAuth()
           }
 
           if (verified) {
-            // Send success HTML to browser
-            res.writeHead(200, { 'Content-Type': 'text/html' })
-            res.end(this.buildSuccessPage(email || ''))
+            res.writeHead(200, noStore)
+            res.end(this.buildSuccessPage(email))
           } else {
-            res.writeHead(apiKey ? 401 : 400, { 'Content-Type': 'text/html' })
+            res.writeHead(401, noStore)
             res.end(this.buildErrorPage(failureMessage))
           }
 
-          // Close server and resolve
           server.close()
 
-          if (verified && apiKey) {
+          if (verified) {
             if (!options.md) {
               out.step(3, 3, 'Connected')
               out.stop()
@@ -151,16 +209,11 @@ export class SetupCommands extends PrjctCommandsBase {
             }
 
             // Refresh the long-lived daemon FIRST so it picks up the new
-            // token before anything routes through it. Without this the
-            // daemon keeps its boot-time (unauthenticated) state and
-            // cloud status/link report "not authenticated" until a manual
-            // `daemon restart` (mem_2880).
+            // token before anything routes through it (mem_2880).
             await this.refreshDaemonAuth()
-
-            // Auto-sync if inside a prjct project
             await this.autoSync()
 
-            resolve({
+            finish({
               success: true,
               message: options.md
                 ? `## Authenticated\n- **Email**: ${email}\n- **Token**: stored securely`
@@ -168,7 +221,7 @@ export class SetupCommands extends PrjctCommandsBase {
             })
           } else {
             if (!options.md) out.fail(`Authentication failed: ${failureMessage}`)
-            resolve({
+            finish({
               success: false,
               message: options.md ? `## Error\nAuthentication failed: ${failureMessage}` : '',
             })
@@ -176,55 +229,58 @@ export class SetupCommands extends PrjctCommandsBase {
           return
         }
 
-        // Any other path — 404
-        res.writeHead(404)
+        res.writeHead(404, noStore)
         res.end('Not found')
       })
 
-      // Listen on random port
       server.listen(0, '127.0.0.1', async () => {
         const addr = server.address()
         if (!addr || typeof addr === 'string') {
           server.close()
           if (!options.md) out.fail('Failed to start callback server')
-          resolve({
+          finish({
             success: false,
             message: options.md ? '## Error\nFailed to start callback server' : '',
           })
           return
         }
 
-        const port = addr.port
-        // Open the web SPA's device-authorization route, passing THIS device's
-        // stable id + hostname so the minted key is bound to the same deviceId
-        // the CLI sends as X-Device-Id (no "device mismatch" on later sync).
+        listenPort = addr.port
         const deviceId = await authConfig.getDeviceId()
         const hostname = await authConfig.getHostname()
-        const loginParams = new URLSearchParams({
-          port: String(port),
-          device_id: deviceId,
+        const loginParams = buildCliLoginSearchParams({
+          port: listenPort,
+          deviceId,
           hostname,
+          state: pkce.state,
+          codeChallenge: pkce.codeChallenge,
         })
+        // Sanitized display: never print state/challenge (identifying params).
+        const displayUrl = `${webUrl}/auth/cli?flow=pkce-v1&port=${listenPort}`
         const loginUrl = `${webUrl}/auth/cli?${loginParams.toString()}`
 
         out.step(1, 3, 'Opening browser...')
         out.stop()
-        out.info(chalk.dim(loginUrl))
+        out.info(chalk.dim(displayUrl))
 
-        // Open browser
         const platform = process.platform
         const openCmd =
           platform === 'darwin'
             ? `open "${loginUrl}"`
             : platform === 'win32'
-              ? `start "${loginUrl}"`
+              ? `start "" "${loginUrl}"`
               : `xdg-open "${loginUrl}"`
 
         try {
           await execAsync(openCmd)
         } catch {
           out.warn('Could not open browser automatically')
-          out.info(`Visit: ${loginUrl}`)
+          out.info(
+            `Visit the URL printed by your terminal session (full URL not echoed for safety)`
+          )
+          // Still need the full URL when auto-open fails — print once without
+          // labeling it as a secret dump; user must complete login.
+          out.info(loginUrl)
         }
 
         out.step(2, 3, 'Waiting for authentication...')
@@ -233,13 +289,14 @@ export class SetupCommands extends PrjctCommandsBase {
       // Timeout after 5 minutes
       setTimeout(
         () => {
+          if (settled) return
           server.close()
           out.stop()
           if (!options.md) {
             out.fail('Authentication timed out')
             out.info(`Run ${chalk.cyan('prjct login')} to try again`)
           }
-          resolve({
+          finish({
             success: false,
             message: options.md
               ? '## Error\nAuthentication timed out. Run `prjct login` to try again.'

--- a/core/sync/cli-pkce.ts
+++ b/core/sync/cli-pkce.ts
@@ -1,0 +1,144 @@
+/**
+ * PKCE S256 helpers for CLI browser login (flow=pkce-v1).
+ *
+ * Verifier/state live only in process memory for the duration of one
+ * `prjct login` attempt — never written to disk or logged.
+ */
+
+import { createHash, randomBytes } from 'node:crypto'
+
+export const CLI_PKCE_FLOW = 'pkce-v1' as const
+
+/** RFC 7636 unreserved charset for code_verifier. */
+const VERIFIER_BYTES = 32
+
+export interface PkceMaterial {
+  /** Random state bound into the authorization + callback. */
+  state: string
+  /** High-entropy verifier retained only in memory until exchange. */
+  codeVerifier: string
+  /** S256 challenge sent to the browser/app (never the verifier). */
+  codeChallenge: string
+  codeChallengeMethod: 'S256'
+}
+
+export function base64Url(buf: Buffer): string {
+  return buf.toString('base64url')
+}
+
+/** Cryptographically random PKCE verifier + S256 challenge + state. */
+export function generatePkceMaterial(): PkceMaterial {
+  const codeVerifier = base64Url(randomBytes(VERIFIER_BYTES))
+  const state = base64Url(randomBytes(VERIFIER_BYTES))
+  const codeChallenge = base64Url(createHash('sha256').update(codeVerifier, 'ascii').digest())
+  return {
+    state,
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: 'S256',
+  }
+}
+
+/** Build the SPA login URL query — never includes secrets or the verifier. */
+export function buildCliLoginSearchParams(input: {
+  port: number
+  deviceId: string
+  hostname: string
+  state: string
+  codeChallenge: string
+}): URLSearchParams {
+  return new URLSearchParams({
+    flow: CLI_PKCE_FLOW,
+    port: String(input.port),
+    device_id: input.deviceId,
+    hostname: input.hostname,
+    state: input.state,
+    code_challenge: input.codeChallenge,
+    code_challenge_method: 'S256',
+  })
+}
+
+export type CallbackParse =
+  | { ok: true; code: string; state: string }
+  | { ok: false; reason: 'legacy-bearer' | 'missing' | 'mismatch'; message: string }
+
+/**
+ * Parse the loopback callback. Accepts only `code` + `state`.
+ * Legacy bearer `key=` is rejected without closing semantics decided by caller.
+ */
+export function parsePkceCallback(
+  searchParams: URLSearchParams,
+  expectedState: string
+): CallbackParse {
+  const legacyKey = searchParams.get('key')
+  if (legacyKey) {
+    return {
+      ok: false,
+      reason: 'legacy-bearer',
+      message:
+        'This CLI requires PKCE login. Update the web app or set flow=pkce-v1; bearer tokens in the callback URL are no longer accepted.',
+    }
+  }
+  const code = searchParams.get('code')
+  const state = searchParams.get('state')
+  if (!code || !state) {
+    return {
+      ok: false,
+      reason: 'missing',
+      message: 'Missing authorization code or state in callback',
+    }
+  }
+  if (state !== expectedState) {
+    return {
+      ok: false,
+      reason: 'mismatch',
+      message: 'Login state mismatch — try `prjct login` again',
+    }
+  }
+  return { ok: true, code, state }
+}
+
+export interface ExchangeBody {
+  flow: typeof CLI_PKCE_FLOW
+  code: string
+  state: string
+  code_verifier: string
+  device_id: string
+  redirect_uri: string
+}
+
+export function buildExchangeBody(input: {
+  code: string
+  state: string
+  codeVerifier: string
+  deviceId: string
+  port: number
+}): ExchangeBody {
+  return {
+    flow: CLI_PKCE_FLOW,
+    code: input.code,
+    state: input.state,
+    code_verifier: input.codeVerifier,
+    device_id: input.deviceId,
+    redirect_uri: `http://127.0.0.1:${input.port}/callback`,
+  }
+}
+
+export interface MintedKeyResponse {
+  apiKey: string
+  userId: string
+  email: string
+  deviceId: string
+}
+
+/** Normalize camelCase / snake_case exchange JSON. */
+export function parseMintedKeyResponse(raw: unknown): MintedKeyResponse | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const apiKey = (o.apiKey ?? o.api_key) as string | undefined
+  const userId = (o.userId ?? o.user_id) as string | undefined
+  const email = o.email as string | undefined
+  const deviceId = (o.deviceId ?? o.device_id) as string | undefined
+  if (!apiKey || !userId || !email || !deviceId) return null
+  return { apiKey, userId, email, deviceId }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.39.0",
+  "version": "3.40.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- `prjct login` generates PKCE state/verifier in process memory only
- Opens SPA with challenge (never verifier); loopback accepts **only** `code`+`state`
- Rejects legacy `key=` bearer callbacks
- Exchanges at `POST /auth/cli/exchange`, stores device key in keychain

## Coordinated PRs

1. prjct-cli-api (deploy first)
2. prjct-cli-app
3. **This CLI** (deploy last among the three; then set `VITE_CLI_PKCE_REQUIRED=true`)

## Test plan

- [x] `bun test core/__tests__/sync/cli-pkce.test.ts`
- [x] typecheck on push
- [ ] CI green