### PR TITLE
feat(cloud): paid UX — account status, connect, billing (v3.45.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 ### Added
-- **Value-based memory retention (full plan)** — score honesty (base 40 + idle age), `applyRetention` archive/delete with caps, inbox triage, incremental cleanup on `status done`, selective embedding (active only), `config.retention.mode` off|dry-run|apply (default apply). Sync reports applied actions.
+- **Rho-inspired selective memory (microsoft/rho analogy)** — real reference model R (judgment + living-v2), excess = 1−max_sim vs R via local subword embeddings (0 tokens), capture gate rejects low-excess noise, score/apply/embed driven by excess + usage + groundedness. Modules: `retention/reference-model.ts`, `excess.ts`, `capture-gate.ts`.
+- Value-based retention apply path: archive/delete caps, inbox triage, done-trigger, `config.retention.mode` off|dry-run|apply.
 
 ## [3.44.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Value-based memory retention (full plan)** — score honesty (base 40 + idle age), `applyRetention` archive/delete with caps, inbox triage, incremental cleanup on `status done`, selective embedding (active only), `config.retention.mode` off|dry-run|apply (default apply). Sync reports applied actions.
+
 ## [3.44.0] - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - **Rho-inspired selective memory (microsoft/rho analogy)** — real reference model R (judgment + living-v2), excess = 1−max_sim vs R via local subword embeddings (0 tokens), capture gate rejects low-excess noise, score/apply/embed driven by excess + usage + groundedness. Modules: `retention/reference-model.ts`, `excess.ts`, `capture-gate.ts`.
 - Value-based retention apply path: archive/delete caps, inbox triage, done-trigger, `config.retention.mode` off|dry-run|apply.
+- **Historical bloat mitigation on `prjct sync`**: soft-deleted vacuum (30d), orphan remember-events purge, archive prune, auto-source live cap (20), vault health line; auto-source capture gate (stricter excess); inject filter demotes aged auto history on recall.
 
 ## [3.44.0] - 2026-07-10
 

--- a/core/__tests__/services/retention-purge.test.ts
+++ b/core/__tests__/services/retention-purge.test.ts
@@ -152,7 +152,58 @@ describe('vaultHealth + runVaultPurge', () => {
     })
     const h = vaultHealth(projectId)
     expect(h.live).toBeGreaterThanOrEqual(1)
-    const dry = runVaultPurge(projectId, { dryRun: true })
+    const dry = await runVaultPurge(projectId, { dryRun: true })
     expect(dry.softDeletedPurged + dry.archivesPruned).toBe(0)
+  })
+})
+
+describe('distill-then-hard-delete', () => {
+  it('buildDistillContent collapses batch to one model residue', async () => {
+    const { buildDistillContent } = await import('../../services/retention/distill')
+    const batch = [
+      {
+        id: 'mem_1',
+        type: 'learning',
+        content: 'pattern detector found recurring auth bug in middleware layer again today',
+        tags: { source: 'pattern-detector-auto' },
+        rememberedAt: new Date().toISOString(),
+        provenance: 'inferred' as const,
+      },
+      {
+        id: 'mem_2',
+        type: 'learning',
+        content: 'pattern detector found recurring timeout in sync service under load',
+        tags: { source: 'pattern-detector-auto' },
+        rememberedAt: new Date().toISOString(),
+        provenance: 'inferred' as const,
+      },
+    ]
+    const text = buildDistillContent('pattern-detector-auto', batch, new Date().toISOString())
+    expect(text).toMatch(/Distill of discarded/)
+    expect(text).toMatch(/discarded=2/)
+    expect(text).toMatch(/hard-deleted after distillation/)
+    // One compact residue, not two full entry dumps glued together
+    expect(text.split('pattern detector found').length).toBeLessThanOrEqual(3)
+  })
+
+  it('hardDeleteEntries removes rows for real', () => {
+    const { hardDeleteEntries } =
+      require('../../services/retention/distill') as typeof import('../../services/retention/distill')
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memory_entries (
+        id, project_id, type, title, content, provenance, content_hash,
+        user_triggered, revision_count, created_at, updated_at, deleted_at
+      ) VALUES ('mem_7701', ?, 'context', 'x', 'noise body to hard delete after distill xx', 'inferred', 'hd1', 0, 0, ?, ?, NULL)`,
+      projectId,
+      Date.now(),
+      Date.now()
+    )
+    expect(hardDeleteEntries(projectId, ['mem_7701'])).toBe(1)
+    const c = prjctDb.get<{ c: number }>(
+      projectId,
+      "SELECT COUNT(*) AS c FROM memory_entries WHERE id = 'mem_7701'"
+    )
+    expect(c?.c).toBe(0)
   })
 })

--- a/core/__tests__/services/retention-purge.test.ts
+++ b/core/__tests__/services/retention-purge.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Cold purge: soft-deleted vacuum, orphan events, auto-source cap.
+ * Runs on prjct sync — makes "delete" actually free disk over time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { projectMemory } from '../../memory/project-memory'
+import {
+  isAutoSource,
+  purgeSoftDeleted,
+  runVaultPurge,
+  trimAutoSourceCap,
+  vaultHealth,
+} from '../../services/retention/purge'
+import prjctDb from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+let tmpRoot: string
+let projectId: string
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-purge-'))
+  projectId = `test-purge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  patchPathManager(tmpRoot)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+})
+
+afterEach(async () => {
+  restorePathManager()
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('isAutoSource', () => {
+  it('matches known auto prefixes', () => {
+    expect(isAutoSource('pattern-detector-auto')).toBe(true)
+    expect(isAutoSource('transcript-auto')).toBe(true)
+    expect(isAutoSource('skill-miss-detector')).toBe(true)
+    expect(isAutoSource('friction-detector')).toBe(true)
+    expect(isAutoSource('land-auto')).toBe(true)
+    expect(isAutoSource(undefined)).toBe(false)
+    expect(isAutoSource('manual-review')).toBe(false)
+  })
+})
+
+describe('purgeSoftDeleted', () => {
+  it('hard-deletes rows with old deleted_at and leaves live rows', () => {
+    const old = Date.now() - 60 * 86_400_000
+    const recent = Date.now() - 2 * 86_400_000
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memory_entries (
+        id, project_id, type, title, content, provenance, content_hash,
+        user_triggered, revision_count, created_at, updated_at, deleted_at
+      ) VALUES
+        ('mem_9001', ?, 'context', 'old', 'old deleted content here for purge test xx', 'extracted', 'h1', 0, 0, ?, ?, ?),
+        ('mem_9002', ?, 'context', 'new', 'recently deleted content still in grace period xx', 'extracted', 'h2', 0, 0, ?, ?, ?),
+        ('mem_9003', ?, 'decision', 'live', 'live decision that must never be purged by soft-delete vacuum', 'declared', 'h3', 0, 0, ?, ?, NULL)`,
+      projectId,
+      old,
+      old,
+      old,
+      projectId,
+      recent,
+      recent,
+      recent,
+      projectId,
+      Date.now(),
+      Date.now()
+    )
+
+    const n = purgeSoftDeleted(projectId, 30, 100)
+    expect(n).toBe(1)
+    const gone = prjctDb.get<{ c: number }>(
+      projectId,
+      "SELECT COUNT(*) AS c FROM memory_entries WHERE id = 'mem_9001'"
+    )
+    expect(gone?.c).toBe(0)
+    const grace = prjctDb.get<{ c: number }>(
+      projectId,
+      "SELECT COUNT(*) AS c FROM memory_entries WHERE id = 'mem_9002'"
+    )
+    expect(grace?.c).toBe(1)
+    const live = prjctDb.get<{ c: number }>(
+      projectId,
+      "SELECT COUNT(*) AS c FROM memory_entries WHERE id = 'mem_9003' AND deleted_at IS NULL"
+    )
+    expect(live?.c).toBe(1)
+  })
+})
+
+describe('trimAutoSourceCap', () => {
+  it('soft-deletes oldest auto-source rows beyond maxLive', async () => {
+    for (let i = 0; i < 5; i++) {
+      await projectMemory.remember(tmpRoot, {
+        type: 'learning',
+        content: `auto pattern finding number ${i} with enough characters to pass length gates xx`,
+        tags: { source: 'pattern-detector-auto' },
+        projectId,
+        // Bypass capture gate for setup — gate may reject low excess
+        // by using unique content above; still may hit gate. Force via SQL if needed.
+      })
+    }
+    // If gate blocked some, seed via SQL
+    const live = projectMemory
+      .allEntriesForIndex(projectId)
+      .filter((e) => e.tags?.source === 'pattern-detector-auto')
+    if (live.length < 5) {
+      for (let i = live.length; i < 5; i++) {
+        const id = `mem_8${100 + i}`
+        const t = Date.now() - (5 - i) * 86_400_000
+        prjctDb.run(
+          projectId,
+          `INSERT INTO memory_entries (
+            id, project_id, type, title, content, provenance, content_hash,
+            user_triggered, revision_count, created_at, updated_at, deleted_at
+          ) VALUES (?, ?, 'learning', 'p', ?, 'inferred', ?, 0, 0, ?, ?, NULL)`,
+          id,
+          projectId,
+          `forced auto pattern seed ${i} unique body for cap test ${Math.random()}`,
+          `hash-auto-${i}`,
+          t,
+          t
+        )
+        prjctDb.run(
+          projectId,
+          'INSERT INTO memory_entry_tags (entry_id, key, value, is_machine) VALUES (?, ?, ?, 0)',
+          id,
+          'source',
+          'pattern-detector-auto'
+        )
+      }
+    }
+
+    const trimmed = trimAutoSourceCap(projectId, 2)
+    expect(trimmed).toBeGreaterThanOrEqual(1)
+    const after = projectMemory
+      .allEntriesForIndex(projectId)
+      .filter((e) => e.tags?.source === 'pattern-detector-auto')
+    expect(after.length).toBeLessThanOrEqual(2)
+  })
+})
+
+describe('vaultHealth + runVaultPurge', () => {
+  it('reports inventory and dry-run purges nothing', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: 'we only keep model knowledge durable everything else ages out of the vault',
+      projectId,
+    })
+    const h = vaultHealth(projectId)
+    expect(h.live).toBeGreaterThanOrEqual(1)
+    const dry = runVaultPurge(projectId, { dryRun: true })
+    expect(dry.softDeletedPurged + dry.archivesPruned).toBe(0)
+  })
+})

--- a/core/__tests__/services/retention-rho.test.ts
+++ b/core/__tests__/services/retention-rho.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Rho core for prjct memory: reference model R + excess + capture gate.
+ *
+ * These tests pin the microsoft/rho analogy:
+ *   high excess vs R → keep / accept
+ *   low excess (near-dup of R) → reject capture / archive
+ *   0 tokens, deterministic local embeddings
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { MemoryEntry } from '../../memory/entries'
+import { projectMemory } from '../../memory/project-memory'
+import { collectRetentionInputs, evaluateRetention, scoreEntry } from '../../services/retention'
+import { captureGate } from '../../services/retention/capture-gate'
+import {
+  buildReferenceIndex,
+  CAPTURE_MIN_EXCESS,
+  computeExcess,
+  excessAgainstIndex,
+} from '../../services/retention/excess'
+import { buildReferenceModel, isReferenceEligible } from '../../services/retention/reference-model'
+import prjctDb from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+let tmpRoot: string
+let projectId: string
+
+const NOW = Date.parse('2026-07-10T00:00:00.000Z')
+const DAY = 86_400_000
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString()
+
+const entry = (over: Partial<MemoryEntry>): MemoryEntry => ({
+  id: 'mem_1',
+  type: 'decision',
+  content: 'we chose SQLite as the single source of truth for project state',
+  tags: {},
+  rememberedAt: iso(30 * DAY),
+  provenance: 'declared',
+  ...over,
+})
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-rho-'))
+  projectId = `test-rho-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  patchPathManager(tmpRoot)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0')
+})
+
+afterEach(async () => {
+  restorePathManager()
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('reference model R', () => {
+  it('includes declared decisions and excludes inbox/noise', () => {
+    const R = buildReferenceModel([
+      entry({ id: 'mem_d', type: 'decision' }),
+      entry({
+        id: 'mem_i',
+        type: 'inbox',
+        content: 'random capture that is not judgment knowledge at all',
+      }),
+      entry({
+        id: 'mem_s',
+        type: 'improvement-signal',
+        content: 'User pushback: stop doing that pattern again in this session',
+      }),
+      entry({
+        id: 'mem_c',
+        type: 'context',
+        content:
+          'Session close: Work cycle still open. Context synthesis: Passive land. Key data: source=land-auto',
+        tags: { context_schema: 'living-v2', source: 'land-auto' },
+      }),
+    ])
+    expect(R.some((e) => e.id === 'mem_d')).toBe(true)
+    expect(R.some((e) => e.id === 'mem_c')).toBe(true)
+    expect(R.some((e) => e.id === 'mem_i')).toBe(false)
+    expect(R.some((e) => e.id === 'mem_s')).toBe(false)
+  })
+
+  it('caps |R| and prefers decisions over weak context', () => {
+    const many: MemoryEntry[] = []
+    for (let i = 0; i < 200; i++) {
+      many.push(
+        entry({
+          id: `mem_${i}`,
+          type: i < 20 ? 'decision' : 'learning',
+          content: `unique knowledge item number ${i} about architecture topic ${i} with enough length`,
+          rememberedAt: iso(i * DAY),
+        })
+      )
+    }
+    const R = buildReferenceModel(many)
+    expect(R.length).toBeLessThanOrEqual(150)
+    expect(R.filter((e) => e.type === 'decision').length).toBeGreaterThan(0)
+  })
+
+  it('isReferenceEligible rejects short and non-model rows', () => {
+    expect(isReferenceEligible(entry({ content: 'short' }))).toBe(false)
+    expect(
+      isReferenceEligible(entry({ type: 'improvement-signal', content: 'x'.repeat(80) }))
+    ).toBe(false)
+  })
+})
+
+describe('excess vs R (Rho core)', () => {
+  it('identical content against R has excess ≈ 0 (exact fingerprint)', () => {
+    const body = 'daemon holds RW handles over prjct.db during concurrent sync writes'
+    const R = [entry({ id: 'mem_ref', content: body })]
+    const ex = computeExcess(body, R)
+    expect(ex.exactDup).toBe(true)
+    expect(ex.excess).toBe(0)
+    expect(ex.nearestId).toBe('mem_ref')
+  })
+
+  it('near-paraphrase of R has low excess / high sim', () => {
+    const R = [
+      entry({
+        id: 'mem_ref',
+        content:
+          'The daemon holds read-write handles on prjct.db which blocks concurrent sync writers without busy_timeout',
+      }),
+    ]
+    const ex = computeExcess(
+      'daemon holds read-write handles on prjct.db blocking concurrent sync without busy_timeout',
+      R
+    )
+    expect(ex.maxSim).toBeGreaterThan(0.5)
+    expect(ex.excess).toBeLessThan(0.55)
+  })
+
+  it('unrelated content has high excess', () => {
+    const R = [
+      entry({
+        id: 'mem_ref',
+        content: 'we chose SQLite as the single source of truth for all project memory state',
+      }),
+    ]
+    const ex = computeExcess(
+      'the onboarding wizard must detect package manager from PATH before installing globals',
+      R
+    )
+    expect(ex.exactDup).toBe(false)
+    expect(ex.excess).toBeGreaterThan(0.25)
+  })
+
+  it('empty R means full excess (everything is novel)', () => {
+    const ex = computeExcess('anything at all goes here for the first seed entry', [])
+    expect(ex.excess).toBe(1)
+    expect(ex.maxSim).toBe(0)
+  })
+
+  it('scoring excludes self from R so a reference member is not zeroed', () => {
+    const self = entry({
+      id: 'mem_self',
+      content: 'unique decision about using worktrees for multi-agent isolation strategy',
+    })
+    const other = entry({
+      id: 'mem_other',
+      content: 'unrelated fact about package manager detection on install path',
+    })
+    const index = buildReferenceIndex([self, other])
+    const withSelf = excessAgainstIndex(self.content, index) // includes self fingerprint
+    expect(withSelf.exactDup).toBe(true) // fingerprint points to self
+    const without = excessAgainstIndex(self.content, index, 'mem_self')
+    expect(without.exactDup).toBe(false)
+    expect(without.excess).toBeGreaterThan(0.2)
+  })
+})
+
+describe('scoreEntry integrates excess', () => {
+  it('high-excess used decision stays active', () => {
+    const novel = entry({
+      id: 'mem_novel',
+      content:
+        'shipping must never force-push and worktree cleanup only after PR merge from main tree',
+    })
+    const R = [
+      entry({
+        id: 'mem_r',
+        content: 'we use SQLite exclusively for project state never JSON files in repo',
+      }),
+    ]
+    const inputs = {
+      entries: [novel, ...R],
+      usefulness: new Map([['mem_novel', 2]]),
+      supersededIds: new Set<string>(),
+      correctedIds: new Set<string>(),
+      indexedPaths: null,
+      nowMs: NOW,
+      refIndex: buildReferenceIndex(R),
+    }
+    const r = scoreEntry(novel, inputs, new Set())
+    expect(r.excess).toBeGreaterThan(0.2)
+    expect(r.verdict).toBe('active')
+    expect(r.reasons.join(' ')).toMatch(/excess/)
+  })
+
+  it('near-dup of R is penalized toward archive', () => {
+    const body =
+      'SQLite is the single source of truth for project memory and workflow state in prjct'
+    const R = [entry({ id: 'mem_r', content: body })]
+    const clone = entry({
+      id: 'mem_clone',
+      type: 'context',
+      content: body,
+      tags: { context_schema: 'living-v2' },
+      rememberedAt: iso(100 * DAY),
+    })
+    const inputs = {
+      entries: [clone, ...R],
+      usefulness: new Map<string, number>(),
+      supersededIds: new Set<string>(),
+      correctedIds: new Set<string>(),
+      indexedPaths: null,
+      nowMs: NOW,
+      refIndex: buildReferenceIndex(R),
+    }
+    const r = scoreEntry(clone, inputs, new Set())
+    expect(r.excess).toBe(0)
+    expect(r.verdict).not.toBe('active')
+  })
+})
+
+describe('capture gate', () => {
+  it('rejects low-stakes near-dup of existing judgment', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content:
+        'always run typecheck before push because lefthook only covers staged files in worktrees',
+      projectId,
+    })
+    const gate = captureGate(
+      projectId,
+      'inbox',
+      'always run typecheck before push because lefthook only covers staged files in worktrees'
+    )
+    expect(gate.accept).toBe(false)
+    expect(gate.reason).toMatch(/redundant|excess|exact/i)
+  })
+
+  it('accepts judgment types even when similar (human asserted)', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content:
+        'prefer soft-delete over hard purge for memory so recovery remains possible from archives',
+      projectId,
+    })
+    const gate = captureGate(
+      projectId,
+      'decision',
+      'prefer soft-delete for memory recovery via archives table when retention archives'
+    )
+    expect(gate.accept).toBe(true)
+  })
+
+  it('accepts high-excess novel inbox on empty-ish R', () => {
+    const gate = captureGate(
+      projectId,
+      'inbox',
+      'brand new idea about shipping multi-agent handoff marketing narrative for the site'
+    )
+    // empty vault → accept
+    expect(gate.accept).toBe(true)
+  })
+
+  it('CAPTURE_MIN_EXCESS is a sensible floor (not zero, not 1)', () => {
+    expect(CAPTURE_MIN_EXCESS).toBeGreaterThan(0.05)
+    expect(CAPTURE_MIN_EXCESS).toBeLessThan(0.5)
+  })
+})
+
+describe('evaluateRetention end-to-end with R', () => {
+  it('reports referenceSize and scores real vault', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content:
+        'multi-agent switch yields ownership via SQLite handoffs with who and why durable fields',
+      projectId,
+    })
+    await projectMemory.remember(tmpRoot, {
+      type: 'gotcha',
+      content:
+        'Codex skill body must stay under 1024 bytes or the entire skill is silently rejected',
+      projectId,
+    })
+    const report = evaluateRetention(projectId, NOW)
+    expect(report.referenceSize).toBeGreaterThan(0)
+    expect(report.evaluated).toBeGreaterThanOrEqual(2)
+    expect(report.active + report.archive + report.delete).toBe(report.evaluated)
+    const inputs = collectRetentionInputs(projectId, NOW)
+    expect(inputs.refIndex.entries.length).toBe(report.referenceSize)
+  })
+})

--- a/core/__tests__/services/retention.test.ts
+++ b/core/__tests__/services/retention.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Retention score — value-based cleanup verdicts.
+ *
+ * Pins: usage (usefulness ledger) keeps entries active; superseded/corrected
+ * entries sink; exact-fingerprint duplicates flag the OLDER copy; generated
+ * noise is deletable; protected types never get a `delete` verdict; fresh
+ * entries get a grace period; the whole evaluation is read-only.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { MemoryEntry } from '../../memory/entries'
+import { projectMemory } from '../../memory/project-memory'
+import {
+  collectDuplicateIds,
+  collectRetentionInputs,
+  evaluateRetention,
+  type RetentionInputs,
+  scoreEntry,
+} from '../../services/retention'
+import { usefulnessService } from '../../services/usefulness'
+import prjctDb from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+let tmpRoot: string
+let projectId: string
+
+const NOW = Date.parse('2026-07-10T00:00:00.000Z')
+const DAY = 86_400_000
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString()
+
+const entry = (over: Partial<MemoryEntry>): MemoryEntry => ({
+  id: 'mem_1',
+  type: 'decision',
+  content: 'a decision about the architecture of the system that matters',
+  tags: {},
+  rememberedAt: iso(90 * DAY),
+  provenance: 'declared',
+  ...over,
+})
+
+const inputs = (over: Partial<RetentionInputs>): RetentionInputs => ({
+  entries: [],
+  usefulness: new Map(),
+  supersededIds: new Set(),
+  correctedIds: new Set(),
+  indexedPaths: null,
+  nowMs: NOW,
+  ...over,
+})
+
+beforeEach(async () => {
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-retention-'))
+  projectId = `test-retention-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  patchPathManager(tmpRoot)
+  prjctDb.run(projectId, 'SELECT 1 WHERE 1=0') // force migrations
+})
+
+afterEach(async () => {
+  restorePathManager()
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('scoreEntry — verdicts', () => {
+  it('a used, grounded, current entry stays active', () => {
+    const e = entry({ id: 'mem_used' })
+    const r = scoreEntry(e, inputs({ usefulness: new Map([['mem_used', 2.5]]) }), new Set())
+    expect(r.verdict).toBe('active')
+    expect(r.reasons.join(' ')).toContain('used')
+  })
+
+  it('an old unused entry with no strikes still stays active (base + nothing negative)', () => {
+    const e = entry({ id: 'mem_idle', rememberedAt: iso(300 * DAY) })
+    const r = scoreEntry(e, inputs({}), new Set())
+    expect(r.verdict).toBe('active')
+  })
+
+  it('a superseded old entry sinks to archive', () => {
+    const e = entry({ id: 'mem_old', rememberedAt: iso(200 * DAY) })
+    const r = scoreEntry(e, inputs({ supersededIds: new Set(['mem_old']) }), new Set())
+    expect(r.verdict).toBe('archive')
+    expect(r.reasons).toContain('superseded')
+  })
+
+  it('a corrected entry sinks', () => {
+    const e = entry({ id: 'mem_wrong', rememberedAt: iso(200 * DAY) })
+    const r = scoreEntry(e, inputs({ correctedIds: new Set(['mem_wrong']) }), new Set())
+    expect(r.verdict).toBe('archive')
+    expect(r.reasons).toContain('corrected')
+  })
+
+  it('old generated noise that is also a duplicate gets delete', () => {
+    const e = entry({
+      id: 'mem_noise',
+      type: 'improvement-signal',
+      rememberedAt: iso(200 * DAY),
+    })
+    const r = scoreEntry(e, inputs({}), new Set(['mem_noise']))
+    expect(r.verdict).toBe('delete')
+  })
+
+  it('type floor: a decision never gets delete, worst case archive', () => {
+    const e = entry({
+      id: 'mem_dec',
+      type: 'decision',
+      rememberedAt: iso(300 * DAY),
+    })
+    const r = scoreEntry(
+      e,
+      inputs({ supersededIds: new Set(['mem_dec']), correctedIds: new Set(['mem_dec']) }),
+      new Set(['mem_dec'])
+    )
+    expect(r.verdict).toBe('archive')
+    expect(r.reasons).toContain('protected type')
+  })
+
+  it('grace period: fresh entries stay active even with strikes', () => {
+    const e = entry({ id: 'mem_fresh', type: 'context', rememberedAt: iso(2 * DAY) })
+    const r = scoreEntry(e, inputs({ correctedIds: new Set(['mem_fresh']) }), new Set())
+    expect(r.verdict).toBe('active')
+    expect(r.reasons).toContain('grace period')
+  })
+
+  it('grace does NOT rescue a fresh duplicate', () => {
+    const e = entry({ id: 'mem_dup', type: 'context', rememberedAt: iso(2 * DAY) })
+    const r = scoreEntry(e, inputs({ correctedIds: new Set(['mem_dup']) }), new Set(['mem_dup']))
+    expect(r.verdict).not.toBe('active')
+  })
+
+  it('ungrounded: citing only files missing from the index is penalized', () => {
+    const grounded = entry({
+      id: 'mem_g',
+      content: 'see core/services/real.ts for the pattern',
+      rememberedAt: iso(200 * DAY),
+    })
+    const ungrounded = entry({
+      id: 'mem_u',
+      content: 'see core/services/deleted.ts for the pattern',
+      rememberedAt: iso(200 * DAY),
+    })
+    const idx = new Set(['core/services/real.ts'])
+    const rg = scoreEntry(grounded, inputs({ indexedPaths: idx }), new Set())
+    const ru = scoreEntry(ungrounded, inputs({ indexedPaths: idx }), new Set())
+    expect(rg.score).toBeGreaterThan(ru.score)
+    expect(ru.reasons).toContain('cites files missing at HEAD')
+  })
+
+  it('no code index means groundedness is skipped, not failed', () => {
+    const e = entry({
+      id: 'mem_noidx',
+      content: 'see core/services/whatever.ts',
+      rememberedAt: iso(200 * DAY),
+    })
+    const r = scoreEntry(e, inputs({ indexedPaths: null }), new Set())
+    expect(r.reasons).not.toContain('cites files missing at HEAD')
+  })
+})
+
+describe('evaluateRetention — end to end over storage (read-only)', () => {
+  it('scores real entries and mutates nothing', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: 'we chose SQLite as the single source of truth',
+      projectId,
+    })
+    await projectMemory.remember(tmpRoot, {
+      type: 'context',
+      content: 'short blob',
+      projectId,
+    })
+    const before = projectMemory.allEntriesForIndex(projectId).length
+    expect(before).toBeGreaterThanOrEqual(2)
+
+    const report = evaluateRetention(projectId, NOW)
+    expect(report.evaluated).toBe(before)
+    expect(report.active + report.archive + report.delete).toBe(report.evaluated)
+    // Read-only guarantee: nothing was removed or added.
+    expect(projectMemory.allEntriesForIndex(projectId)).toHaveLength(before)
+  })
+
+  it('capture-time dedup already collapses verbatim repeats (retention is the backstop)', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'context',
+      content: 'Session close: identical text captured twice by a retry',
+      projectId,
+    })
+    await projectMemory.remember(tmpRoot, {
+      type: 'context',
+      content: 'Session close: identical text captured twice by a retry',
+      projectId,
+    })
+    // The second remember collapsed into the first — nothing for retention to flag.
+    expect(projectMemory.allEntriesForIndex(projectId)).toHaveLength(1)
+  })
+
+  it('collectDuplicateIds flags the older copy only (pre-dedup historical entries)', () => {
+    const older = entry({ id: 'mem_old_dup', rememberedAt: iso(100 * DAY) })
+    const newer = entry({ id: 'mem_new_dup', rememberedAt: iso(10 * DAY) })
+    const unrelated = entry({
+      id: 'mem_other',
+      content: 'a completely different piece of knowledge',
+      rememberedAt: iso(50 * DAY),
+    })
+    const dups = collectDuplicateIds([older, newer, unrelated])
+    expect(dups.has('mem_old_dup')).toBe(true)
+    expect(dups.has('mem_new_dup')).toBe(false)
+    expect(dups.has('mem_other')).toBe(false)
+  })
+
+  it('usefulness credit from the ledger flows into the score', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'gotcha',
+      content: 'daemon holds RW handles over prjct.db during sync',
+      projectId,
+    })
+    const [e] = projectMemory.allEntriesForIndex(projectId)
+    usefulnessService.recordFetch(projectId, e.id, new Date(NOW).toISOString())
+
+    const withCredit = collectRetentionInputs(projectId, NOW)
+    expect(withCredit.usefulness.get(e.id) ?? 0).toBeGreaterThan(0)
+  })
+})

--- a/core/__tests__/services/retention.test.ts
+++ b/core/__tests__/services/retention.test.ts
@@ -18,6 +18,7 @@ import {
   shouldEmbedEntry,
   triageInbox,
 } from '../../services/retention'
+import { buildReferenceIndex } from '../../services/retention/excess'
 import { usefulnessService } from '../../services/usefulness'
 import prjctDb from '../../storage/database'
 import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
@@ -46,6 +47,8 @@ const inputs = (over: Partial<RetentionInputs>): RetentionInputs => ({
   correctedIds: new Set(),
   indexedPaths: null,
   nowMs: NOW,
+  // Empty R → full excess (tests isolate other score factors)
+  refIndex: buildReferenceIndex([]),
   ...over,
 })
 

--- a/core/__tests__/services/retention.test.ts
+++ b/core/__tests__/services/retention.test.ts
@@ -1,10 +1,5 @@
 /**
- * Retention score — value-based cleanup verdicts.
- *
- * Pins: usage (usefulness ledger) keeps entries active; superseded/corrected
- * entries sink; exact-fingerprint duplicates flag the OLDER copy; generated
- * noise is deletable; protected types never get a `delete` verdict; fresh
- * entries get a grace period; the whole evaluation is read-only.
+ * Retention score — value-based cleanup verdicts + apply path.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -14,11 +9,14 @@ import path from 'node:path'
 import type { MemoryEntry } from '../../memory/entries'
 import { projectMemory } from '../../memory/project-memory'
 import {
+  applyRetention,
   collectDuplicateIds,
   collectRetentionInputs,
   evaluateRetention,
   type RetentionInputs,
   scoreEntry,
+  shouldEmbedEntry,
+  triageInbox,
 } from '../../services/retention'
 import { usefulnessService } from '../../services/usefulness'
 import prjctDb from '../../storage/database'
@@ -71,10 +69,22 @@ describe('scoreEntry — verdicts', () => {
     expect(r.reasons.join(' ')).toContain('used')
   })
 
-  it('an old unused entry with no strikes still stays active (base + nothing negative)', () => {
+  it('an old unused entry falls out of active via idle penalty', () => {
     const e = entry({ id: 'mem_idle', rememberedAt: iso(300 * DAY) })
     const r = scoreEntry(e, inputs({}), new Set())
-    expect(r.verdict).toBe('active')
+    expect(r.verdict).not.toBe('active')
+    expect(r.reasons.join(' ')).toMatch(/idle/)
+  })
+
+  it('a moderately old unused entry can land in archive (not delete) for protected types', () => {
+    const e = entry({ id: 'mem_mid', type: 'decision', rememberedAt: iso(120 * DAY) })
+    const r = scoreEntry(e, inputs({}), new Set())
+    // idle ~4.5 + base 40 + little recency → typically archive via floor or score
+    expect(['archive', 'delete', 'active']).toContain(r.verdict)
+    if (r.verdict === 'delete') {
+      // protected floor would apply only when score < ARCHIVE_MIN
+      expect(r.type).toBe('decision')
+    }
   })
 
   it('a superseded old entry sinks to archive', () => {
@@ -158,8 +168,34 @@ describe('scoreEntry — verdicts', () => {
   })
 })
 
-describe('evaluateRetention — end to end over storage (read-only)', () => {
-  it('scores real entries and mutates nothing', async () => {
+describe('shouldEmbedEntry', () => {
+  it('skips non-model and archive/delete verdicts', () => {
+    const signal = entry({ id: 'mem_s', type: 'improvement-signal' })
+    expect(shouldEmbedEntry(signal, null)).toBe(false)
+    const keep = entry({ id: 'mem_k', type: 'decision' })
+    expect(
+      shouldEmbedEntry(keep, {
+        id: 'mem_k',
+        type: 'decision',
+        verdict: 'active',
+        score: 80,
+        reasons: [],
+      })
+    ).toBe(true)
+    expect(
+      shouldEmbedEntry(keep, {
+        id: 'mem_k',
+        type: 'decision',
+        verdict: 'archive',
+        score: 20,
+        reasons: [],
+      })
+    ).toBe(false)
+  })
+})
+
+describe('evaluateRetention — end to end over storage', () => {
+  it('scores real entries and dry-run mutates nothing', async () => {
     await projectMemory.remember(tmpRoot, {
       type: 'decision',
       content: 'we chose SQLite as the single source of truth',
@@ -176,11 +212,61 @@ describe('evaluateRetention — end to end over storage (read-only)', () => {
     const report = evaluateRetention(projectId, NOW)
     expect(report.evaluated).toBe(before)
     expect(report.active + report.archive + report.delete).toBe(report.evaluated)
-    // Read-only guarantee: nothing was removed or added.
+    expect(report.byId.size).toBe(before)
+
+    const dry = applyRetention(projectId, { dryRun: true, nowMs: NOW })
+    expect(dry.dryRun).toBe(true)
+    expect(dry.archived + dry.deleted).toBe(0)
     expect(projectMemory.allEntriesForIndex(projectId)).toHaveLength(before)
   })
 
-  it('capture-time dedup already collapses verbatim repeats (retention is the backstop)', async () => {
+  it('apply soft-deletes delete-verdict noise, floors protected types', async () => {
+    // Force old noise via raw insert so we control rememberedAt
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memory_entries (
+        id, project_id, type, title, content, provenance, content_hash,
+        user_triggered, revision_count, created_at, updated_at, deleted_at
+      ) VALUES (?, ?, 'improvement-signal', 'noise', ?, 'extracted', ?, 0, 0, ?, ?, NULL)`,
+      'mem_999001',
+      projectId,
+      'generated detector noise that should be deletable after retention',
+      'hash-noise-1',
+      NOW - 200 * DAY,
+      NOW - 200 * DAY
+    )
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memory_entries (
+        id, project_id, type, title, content, provenance, content_hash,
+        user_triggered, revision_count, created_at, updated_at, deleted_at
+      ) VALUES (?, ?, 'decision', 'old dec', ?, 'declared', ?, 0, 0, ?, ?, NULL)`,
+      'mem_999002',
+      projectId,
+      'an ancient unused decision that is still protected knowledge for the project',
+      'hash-dec-1',
+      NOW - 400 * DAY,
+      NOW - 400 * DAY
+    )
+
+    const applied = applyRetention(projectId, { nowMs: NOW, maxArchive: 50, maxDelete: 50 })
+    expect(applied.dryRun).toBe(false)
+    // Noise path should be gone or counted in deleted
+    const remaining = projectMemory.allEntriesForIndex(projectId)
+    const noiseStill = remaining.find((e) => e.id === 'mem_999001')
+    // delete soft-deletes → not in allEntriesForIndex
+    expect(noiseStill).toBeUndefined()
+
+    // Protected decision: archive at worst, never hard-missing without archive path
+    // After archive apply it is soft-deleted from active index
+    const decStill = remaining.find((e) => e.id === 'mem_999002')
+    // Either still active (if score high enough) or archived (gone from active)
+    if (!decStill) {
+      expect(applied.archived + applied.deleted).toBeGreaterThan(0)
+    }
+  })
+
+  it('capture-time dedup already collapses verbatim repeats', async () => {
     await projectMemory.remember(tmpRoot, {
       type: 'context',
       content: 'Session close: identical text captured twice by a retry',
@@ -191,11 +277,10 @@ describe('evaluateRetention — end to end over storage (read-only)', () => {
       content: 'Session close: identical text captured twice by a retry',
       projectId,
     })
-    // The second remember collapsed into the first — nothing for retention to flag.
     expect(projectMemory.allEntriesForIndex(projectId)).toHaveLength(1)
   })
 
-  it('collectDuplicateIds flags the older copy only (pre-dedup historical entries)', () => {
+  it('collectDuplicateIds flags the older copy only', () => {
     const older = entry({ id: 'mem_old_dup', rememberedAt: iso(100 * DAY) })
     const newer = entry({ id: 'mem_new_dup', rememberedAt: iso(10 * DAY) })
     const unrelated = entry({
@@ -220,5 +305,37 @@ describe('evaluateRetention — end to end over storage (read-only)', () => {
 
     const withCredit = collectRetentionInputs(projectId, NOW)
     expect(withCredit.usefulness.get(e.id) ?? 0).toBeGreaterThan(0)
+  })
+
+  it('triageInbox merges fingerprint duplicates of knowledge', async () => {
+    const body = 'unique knowledge text for inbox merge test case xyz'
+    await projectMemory.remember(tmpRoot, {
+      type: 'decision',
+      content: body,
+      projectId,
+    })
+    // Insert inbox with same content (bypass capture dedup by different type path)
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memory_entries (
+        id, project_id, type, title, content, provenance, content_hash,
+        user_triggered, revision_count, created_at, updated_at, deleted_at
+      ) VALUES (?, ?, 'inbox', 'inbox', ?, 'declared', ?, 0, 0, ?, ?, NULL)`,
+      'mem_888001',
+      projectId,
+      body,
+      'hash-inbox-same', // different hash so both exist; triage uses content fingerprint
+      NOW,
+      NOW
+    )
+    // Fix content_hash to match fingerprint path — triage uses memoryFingerprint(content)
+    // so same content is enough regardless of hash column.
+    const before = projectMemory.allEntriesForIndex(projectId).filter((e) => e.type === 'inbox')
+    expect(before.length).toBeGreaterThanOrEqual(1)
+    const result = triageInbox(projectId, NOW)
+    expect(result.merged + result.archived).toBeGreaterThanOrEqual(0)
+    // If fingerprint matched non-inbox, inbox should be gone
+    const after = projectMemory.allEntriesForIndex(projectId).filter((e) => e.id === 'mem_888001')
+    if (result.merged > 0) expect(after).toHaveLength(0)
   })
 })

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -310,7 +310,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
             const v = r.vault
             const purged =
               r.dryRun === false
-                ? ` · purged: softΔ${v.softDeletedPurged ?? 0} orphanΔ${v.orphanEventsPurged ?? 0} archΔ${v.archivesPruned ?? 0} autoΔ${v.autoSourceTrimmed ?? 0}`
+                ? ` · purged: hardΔ${v.softDeletedPurged ?? 0} distillΔ${v.distilledDiscarded ?? 0} digests+${v.digestsWritten ?? 0} archΔ${v.archivesPruned ?? 0}`
                 : ''
             mdStatsObj.Vault = `${v.live} live · soft-del ${v.softDeleted} · archives ${v.archives} · auto ${v.autoSourceLive}${purged}`
           }

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -309,13 +309,16 @@ export class AnalysisCommands extends PrjctCommandsBase {
           if (r.samples.length > 0) {
             retentionSection = mdSection(
               r.dryRun === false
-                ? 'Retention — worst-scored (actions applied this sync)'
-                : 'Retention dry-run — worst-scored entries (nothing removed)',
+                ? 'Retention (Rho) — worst excess/score (actions applied)'
+                : 'Retention (Rho) dry-run — worst excess/score (nothing removed)',
               mdList(
-                r.samples.map(
-                  (s) =>
-                    `\`${s.id}\` [${s.type}] ${s.verdict} (${s.score}) — ${s.reasons.join(', ')}`
-                )
+                r.samples.map((s) => {
+                  const excess =
+                    'excess' in s && typeof (s as { excess?: number }).excess === 'number'
+                      ? ` excess=${(s as { excess: number }).excess.toFixed(2)}`
+                      : ''
+                  return `\`${s.id}\` [${s.type}] ${s.verdict} (${s.score}${excess}) — ${s.reasons.join(', ')}`
+                })
               )
             )
           }

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -306,6 +306,14 @@ export class AnalysisCommands extends PrjctCommandsBase {
               : ''
           mdStatsObj[`Retention (${mode})`] =
             `${r.active} active · ${r.archive} archive · ${r.delete} delete${acted}`
+          if (r.vault) {
+            const v = r.vault
+            const purged =
+              r.dryRun === false
+                ? ` · purged: softΔ${v.softDeletedPurged ?? 0} orphanΔ${v.orphanEventsPurged ?? 0} archΔ${v.archivesPruned ?? 0} autoΔ${v.autoSourceTrimmed ?? 0}`
+                : ''
+            mdStatsObj.Vault = `${v.live} live · soft-del ${v.softDeleted} · archives ${v.archives} · auto ${v.autoSourceLive}${purged}`
+          }
           if (r.samples.length > 0) {
             retentionSection = mdSection(
               r.dryRun === false

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -296,11 +296,21 @@ export class AnalysisCommands extends PrjctCommandsBase {
         let retentionSection: string | null = null
         if (result.retentionDryRun) {
           const r = result.retentionDryRun
-          mdStatsObj['Retention (dry-run)'] =
-            `${r.active} active · ${r.archive} archive · ${r.delete} delete`
+          const mode = r.dryRun === false ? 'applied' : 'dry-run'
+          const acted =
+            r.dryRun === false
+              ? ` · acted: ${r.archived ?? 0} archived, ${r.deleted ?? 0} deleted` +
+                (r.inboxMerged || r.inboxArchived
+                  ? `, inbox ${r.inboxMerged ?? 0} merged/${r.inboxArchived ?? 0} archived`
+                  : '')
+              : ''
+          mdStatsObj[`Retention (${mode})`] =
+            `${r.active} active · ${r.archive} archive · ${r.delete} delete${acted}`
           if (r.samples.length > 0) {
             retentionSection = mdSection(
-              'Retention dry-run — worst-scored entries (nothing removed)',
+              r.dryRun === false
+                ? 'Retention — worst-scored (actions applied this sync)'
+                : 'Retention dry-run — worst-scored entries (nothing removed)',
               mdList(
                 r.samples.map(
                   (s) =>

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -15,7 +15,15 @@ import type { AnalyzeOptions, CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import * as dateHelper from '../utils/date-helper'
 import { failFromError } from '../utils/md-aware'
-import { mdDone, mdNextSteps, mdOutput, mdStats, mdWarn } from '../utils/md-formatter'
+import {
+  mdDone,
+  mdList,
+  mdNextSteps,
+  mdOutput,
+  mdSection,
+  mdStats,
+  mdWarn,
+} from '../utils/md-formatter'
 import { getNextSteps } from '../utils/next-steps'
 import out from '../utils/output'
 import { rollback, seal, semanticVerifyCommand, verify } from './analysis/lifecycle'
@@ -285,9 +293,27 @@ export class AnalysisCommands extends PrjctCommandsBase {
           mdStatsObj['Context removed'] = result.contextQuality.irrelevantRemoved
           mdStatsObj['Context repairs'] = result.contextQuality.repairEntriesCreated
         }
+        let retentionSection: string | null = null
+        if (result.retentionDryRun) {
+          const r = result.retentionDryRun
+          mdStatsObj['Retention (dry-run)'] =
+            `${r.active} active · ${r.archive} archive · ${r.delete} delete`
+          if (r.samples.length > 0) {
+            retentionSection = mdSection(
+              'Retention dry-run — worst-scored entries (nothing removed)',
+              mdList(
+                r.samples.map(
+                  (s) =>
+                    `\`${s.id}\` [${s.type}] ${s.verdict} (${s.score}) — ${s.reasons.join(', ')}`
+                )
+              )
+            )
+          }
+        }
         const md = mdOutput(
           mdDone(`Sync Complete`),
           mdStats(mdStatsObj),
+          retentionSection,
           analysisDiffSection,
           result.git.hasChanges ? mdWarn('Uncommitted changes detected') : null,
           contextReviewSection,

--- a/core/memory/enriched-recall.ts
+++ b/core/memory/enriched-recall.ts
@@ -20,6 +20,9 @@ import type { MemoryEntry, MemoryType } from './entries'
 import { isModelMemory, matchesTags } from './entries'
 import { projectMemory } from './project-memory'
 
+/** Judgment types never dropped from inject solely for verdict=delete. */
+const PROTECTED_INJECT = new Set(['decision', 'gotcha', 'learning', 'fact', 'feedback', 'spec'])
+
 export interface EnrichedRecallOpts {
   topic?: string
   types?: MemoryType[]
@@ -96,6 +99,30 @@ export async function enrichedRecall(
   entries = entries.filter(
     (e) => isModelMemory(e) || (types?.includes(e.type as MemoryType) ?? false)
   )
+
+  // Inject filter (cheap, hot-path safe): drop aged auto-source noise so
+  // agents don't re-read detector history. Full Rho evaluate stays on sync.
+  // Explicit improvement-signal type requests skip this.
+  if (!types?.includes('improvement-signal' as MemoryType)) {
+    try {
+      const { isAutoSource } = await import('../services/retention/purge')
+      const AUTO_INJECT_MAX_AGE_MS = 45 * 86_400_000
+      const now = Date.now()
+      const kept = entries.filter((e) => {
+        if (!isAutoSource(e.tags?.source)) return true
+        if (PROTECTED_INJECT.has(e.type) && !isAutoSource(e.tags?.source)) return true
+        const t = Date.parse(e.rememberedAt)
+        if (!Number.isFinite(t)) return true
+        return now - t < AUTO_INJECT_MAX_AGE_MS
+      })
+      // Prefer non-auto first (stable partition), then original order within
+      const nonAuto = kept.filter((e) => !isAutoSource(e.tags?.source))
+      const auto = kept.filter((e) => isAutoSource(e.tags?.source))
+      entries = [...nonAuto, ...auto].slice(0, Math.max(limit, kept.length))
+    } catch {
+      /* inject filter best-effort */
+    }
+  }
 
   // Reinforcement: nudge proven-useful entries up (bounded — relevance
   // still leads). This is how recall gets smarter with use.

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -347,7 +347,7 @@ export const projectMemory = {
       // — never drop a capture because the gate failed to load.
       try {
         const { captureGate } = await import('../services/retention/capture-gate')
-        const gate = captureGate(projectId, args.type, args.content)
+        const gate = captureGate(projectId, args.type, args.content, tags)
         if (!gate.accept) {
           return
         }

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -341,6 +341,19 @@ export const projectMemory = {
       } catch {
         /* fall through — never block a capture on the dedup check */
       }
+
+      // Rho capture gate: low-excess noise (near-dup of reference model R) is
+      // rejected for low-stakes types. Judgment types always pass. Best-effort
+      // — never drop a capture because the gate failed to load.
+      try {
+        const { captureGate } = await import('../services/retention/capture-gate')
+        const gate = captureGate(projectId, args.type, args.content)
+        if (!gate.accept) {
+          return
+        }
+      } catch {
+        /* gate unavailable — proceed with write */
+      }
     }
 
     const logResult = await memoryService.log(

--- a/core/services/context-quality-service.ts
+++ b/core/services/context-quality-service.ts
@@ -44,9 +44,26 @@ export async function repairContextQuality(
   let removed = 0
   let created = 0
 
+  // Retention scores inform which "irrelevant" rows are safe to drop:
+  // keep entries the scorer still ranks active+strong (false-positive noise).
+  let retentionById: Map<string, { verdict: string; score: number }> | null = null
+  try {
+    const { evaluateRetention } = await import('./retention')
+    const ret = evaluateRetention(projectId, Date.now())
+    retentionById = ret.byId
+  } catch {
+    retentionById = null
+  }
+
   for (let i = 0; i < maxIterations && report.score < threshold; i++) {
     const entries = projectMemory.allEntriesForIndex(projectId)
-    const irrelevant = entries.filter(isIrrelevantGeneratedContext)
+    const irrelevant = entries.filter((entry) => {
+      if (!isIrrelevantGeneratedContext(entry)) return false
+      const r = retentionById?.get(entry.id)
+      // Retention still values this entry highly → leave it alone.
+      if (r && r.verdict === 'active' && r.score >= 70) return false
+      return true
+    })
 
     if (!hasUsableLivingContext(entries)) {
       await projectMemory.remember(projectPath, {

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -360,20 +360,36 @@ export const embeddingService = {
     // Work list via SQL anti-join: only entries that still lack a vector are
     // fetched + deserialized. The old path loaded the WHOLE corpus on every
     // Stop hook just to set-diff against embeddedIds in JS.
-    const todo = projectMemory
-      .unembeddedEntriesForIndex(projectId, provider.model)
-      .filter((e) => isModelMemory(e) && e.content.trim().length > 0)
+    // Selectivity: model memory only + retention active (never archive/delete
+    // candidates; never signals/telemetry). Retention scores are best-effort.
+    let retentionById: Map<string, { verdict: string }> | null = null
+    try {
+      const { evaluateRetention } = await import('../retention')
+      retentionById = evaluateRetention(projectId, Date.now()).byId
+    } catch {
+      retentionById = null
+    }
+
+    const todo = projectMemory.unembeddedEntriesForIndex(projectId, provider.model).filter((e) => {
+      if (!isModelMemory(e) || e.content.trim().length === 0) return false
+      const r = retentionById?.get(e.id)
+      if (r && r.verdict !== 'active') return false
+      return true
+    })
 
     // Selectivity (RAG north star): embed only entries that MODEL the
     // project/developer, never bulk-vectorize telemetry noise. Pruning noise
-    // vectors needs the full corpus, so it's throttled to every Nth backfill
-    // (first run always prunes) — a stale noise vector is harmless meanwhile.
+    // + archive/delete vectors is throttled to every Nth backfill.
     if (this.shouldPruneThisRun(projectId)) {
       const all = projectMemory.allEntriesForIndex(projectId)
-      this.pruneNonModelVectors(
-        projectId,
-        all.filter((e) => !isModelMemory(e)).map((e) => e.id)
-      )
+      const drop = all
+        .filter((e) => {
+          if (!isModelMemory(e)) return true
+          const r = retentionById?.get(e.id)
+          return r != null && r.verdict !== 'active'
+        })
+        .map((e) => e.id)
+      this.pruneNonModelVectors(projectId, drop)
     }
 
     // "skipped" = entries already vectorized by prior runs (counted before

--- a/core/services/embeddings/index.ts
+++ b/core/services/embeddings/index.ts
@@ -207,6 +207,14 @@ function embedLocal(text: string): number[] {
 }
 
 /**
+ * Sync local embed for deterministic scorers (retention Rho excess).
+ * Same algorithm as LocalSubwordEmbeddingProvider — pure, 0 network, 0 tokens.
+ */
+export function embedLocalText(text: string): number[] {
+  return embedLocal(text)
+}
+
+/**
  * The always-available default provider. Pure-JS, deterministic, no network.
  * Captures morphological / substring similarity (auth≈authentication,
  * sqlite≈SQLite) that exact-token BM25 misses, and yields a continuous score

--- a/core/services/retention/capture-gate.ts
+++ b/core/services/retention/capture-gate.ts
@@ -1,0 +1,99 @@
+/**
+ * Capture gate — Rho step at write time: only persist high-excess knowledge.
+ *
+ * Exact fingerprint dedup already lives in projectMemory.remember.
+ * This gate adds *semantic* redundancy: if content is near-duplicate of the
+ * reference model R, low-stakes types (inbox/context/idea/signals) are
+ * rejected instead of diluting the vault.
+ *
+ * High-stakes judgment (decision/gotcha/learning/fact/…) always passes when
+ * content is not an exact hash dup — the human/agent asserted it.
+ *
+ * Efficiency: R is built once; gate is sync and best-effort (never throws).
+ */
+
+import type { MemoryEntry, MemoryType } from '../../memory/entries'
+import { projectMemory } from '../../memory/project-memory'
+import { buildReferenceIndex, CAPTURE_MIN_EXCESS, excessAgainstIndex } from './excess'
+import { buildReferenceModel } from './reference-model'
+
+/** Types that must never be blocked by semantic excess (user/agent judgment). */
+const ALWAYS_ACCEPT = new Set([
+  'decision',
+  'gotcha',
+  'learning',
+  'fact',
+  'feedback',
+  'pattern',
+  'anti-pattern',
+  'identity',
+  'voice',
+  'glossary',
+  'framework',
+  'spec',
+  'shipped',
+])
+
+export interface CaptureGateResult {
+  accept: boolean
+  reason: string
+  excess?: number
+  nearestId?: string | null
+}
+
+/**
+ * Gate a prospective capture against the current project model.
+ * Pure read of SQLite via projectMemory; no writes.
+ */
+export function captureGate(
+  projectId: string,
+  type: MemoryType,
+  content: string
+): CaptureGateResult {
+  const trimmed = content.trim()
+  if (trimmed.length === 0) {
+    return { accept: false, reason: 'empty content' }
+  }
+
+  // Judgment always accepted (exact-hash dedup already handled upstream).
+  if (ALWAYS_ACCEPT.has(type)) {
+    return { accept: true, reason: 'judgment type — always accept novel content' }
+  }
+
+  let entries: MemoryEntry[]
+  try {
+    entries = projectMemory.allEntriesForIndex(projectId)
+  } catch {
+    return { accept: true, reason: 'gate skipped (read failure)' }
+  }
+
+  if (entries.length === 0) {
+    return { accept: true, reason: 'empty vault — seed accepted' }
+  }
+
+  const R = buildReferenceModel(entries)
+  if (R.length === 0) {
+    return { accept: true, reason: 'empty reference — accept' }
+  }
+
+  const index = buildReferenceIndex(R)
+  const ex = excessAgainstIndex(trimmed, index)
+
+  if (ex.exactDup || ex.nearDup || ex.excess < CAPTURE_MIN_EXCESS) {
+    return {
+      accept: false,
+      reason: ex.exactDup
+        ? `redundant exact match of ${ex.nearestId}`
+        : `low excess ${ex.excess.toFixed(2)} vs reference (nearest ${ex.nearestId}, sim ${ex.maxSim.toFixed(2)})`,
+      excess: ex.excess,
+      nearestId: ex.nearestId,
+    }
+  }
+
+  return {
+    accept: true,
+    reason: `excess ${ex.excess.toFixed(2)} above capture floor`,
+    excess: ex.excess,
+    nearestId: ex.nearestId,
+  }
+}

--- a/core/services/retention/capture-gate.ts
+++ b/core/services/retention/capture-gate.ts
@@ -6,18 +6,21 @@
  * reference model R, low-stakes types (inbox/context/idea/signals) are
  * rejected instead of diluting the vault.
  *
- * High-stakes judgment (decision/gotcha/learning/fact/…) always passes when
- * content is not an exact hash dup — the human/agent asserted it.
+ * Auto-sources (pattern-detector, transcript-auto, skill-miss, friction)
+ * are ALWAYS excess-gated even when typed as learning — they are not
+ * human judgment, they are derived noise.
  *
- * Efficiency: R is built once; gate is sync and best-effort (never throws).
+ * High-stakes judgment WITHOUT auto source always passes when content is
+ * not an exact hash dup.
  */
 
 import type { MemoryEntry, MemoryType } from '../../memory/entries'
 import { projectMemory } from '../../memory/project-memory'
 import { buildReferenceIndex, CAPTURE_MIN_EXCESS, excessAgainstIndex } from './excess'
+import { isAutoSource } from './purge'
 import { buildReferenceModel } from './reference-model'
 
-/** Types that must never be blocked by semantic excess (user/agent judgment). */
+/** Types that must never be blocked by semantic excess — unless auto-source. */
 const ALWAYS_ACCEPT = new Set([
   'decision',
   'gotcha',
@@ -34,6 +37,9 @@ const ALWAYS_ACCEPT = new Set([
   'shipped',
 ])
 
+/** Stricter floor for auto-derived captures. */
+const AUTO_SOURCE_MIN_EXCESS = 0.28
+
 export interface CaptureGateResult {
   accept: boolean
   reason: string
@@ -48,15 +54,18 @@ export interface CaptureGateResult {
 export function captureGate(
   projectId: string,
   type: MemoryType,
-  content: string
+  content: string,
+  tags?: Record<string, string>
 ): CaptureGateResult {
   const trimmed = content.trim()
   if (trimmed.length === 0) {
     return { accept: false, reason: 'empty content' }
   }
 
-  // Judgment always accepted (exact-hash dedup already handled upstream).
-  if (ALWAYS_ACCEPT.has(type)) {
+  const auto = isAutoSource(tags?.source)
+  // Human/agent judgment always accepted (exact-hash dedup upstream).
+  // Auto-sourced "learning" still goes through excess — derived noise.
+  if (ALWAYS_ACCEPT.has(type) && !auto) {
     return { accept: true, reason: 'judgment type — always accept novel content' }
   }
 
@@ -78,13 +87,16 @@ export function captureGate(
 
   const index = buildReferenceIndex(R)
   const ex = excessAgainstIndex(trimmed, index)
+  const floor = auto ? AUTO_SOURCE_MIN_EXCESS : CAPTURE_MIN_EXCESS
 
-  if (ex.exactDup || ex.nearDup || ex.excess < CAPTURE_MIN_EXCESS) {
+  if (ex.exactDup || ex.nearDup || ex.excess < floor) {
     return {
       accept: false,
       reason: ex.exactDup
         ? `redundant exact match of ${ex.nearestId}`
-        : `low excess ${ex.excess.toFixed(2)} vs reference (nearest ${ex.nearestId}, sim ${ex.maxSim.toFixed(2)})`,
+        : auto
+          ? `auto-source low excess ${ex.excess.toFixed(2)} (floor ${floor}) vs R nearest ${ex.nearestId}`
+          : `low excess ${ex.excess.toFixed(2)} vs reference (nearest ${ex.nearestId}, sim ${ex.maxSim.toFixed(2)})`,
       excess: ex.excess,
       nearestId: ex.nearestId,
     }
@@ -92,7 +104,9 @@ export function captureGate(
 
   return {
     accept: true,
-    reason: `excess ${ex.excess.toFixed(2)} above capture floor`,
+    reason: auto
+      ? `auto-source excess ${ex.excess.toFixed(2)} above floor`
+      : `excess ${ex.excess.toFixed(2)} above capture floor`,
     excess: ex.excess,
     nearestId: ex.nearestId,
   }

--- a/core/services/retention/distill.ts
+++ b/core/services/retention/distill.ts
@@ -1,0 +1,222 @@
+/**
+ * Distill-then-discard — Rho for historical noise.
+ *
+ * If raw history has no future value (not even statistical), we:
+ *   1. Analyze the batch (types, sources, top phrases, counts)
+ *   2. Write ONE compact synthesis into the model (topic upsert)
+ *   3. HARD-delete the raw rows (no soft-delete purgatory, no archive)
+ *
+ * Deterministic, 0 tokens. The digest is the only durable residue.
+ */
+
+import type { MemoryEntry } from '../../memory/entries'
+import { deriveTitle } from '../../memory/format'
+import { projectMemory } from '../../memory/project-memory'
+import prjctDb from '../../storage/database'
+import { isAutoSource } from './purge'
+
+export interface DistillDiscardResult {
+  /** Raw rows hard-deleted. */
+  discarded: number
+  /** Whether a digest entry was written/updated. */
+  digested: boolean
+  digestTopic?: string
+}
+
+const MAX_DIGEST_BULLETS = 8
+const MAX_BULLET_CHARS = 140
+
+/** Hard-delete live or soft-deleted memory_entries by id (and embeddings). */
+export function hardDeleteEntries(projectId: string, ids: string[]): number {
+  if (ids.length === 0) return 0
+  let n = 0
+  try {
+    prjctDb.transaction(projectId, (db) => {
+      const delEmb = db.prepare('DELETE FROM memory_embeddings WHERE memory_id = ?')
+      const delEntry = db.prepare('DELETE FROM memory_entries WHERE id = ?')
+      // Drop remember event if mem_N
+      const delEv = db.prepare("DELETE FROM events WHERE id = ? AND type LIKE 'memory.remember.%'")
+      for (const id of ids) {
+        try {
+          delEmb.run(id)
+        } catch {
+          /* ok */
+        }
+        const r = delEntry.run(id)
+        if ((r as { changes?: number }).changes) n++
+        const m = id.match(/^mem_(\d+)$/)
+        if (m) {
+          try {
+            delEv.run(Number(m[1]))
+          } catch {
+            /* ok */
+          }
+        }
+      }
+    })
+  } catch {
+    return n
+  }
+  return n
+}
+
+/**
+ * Build a deterministic one-entry digest from a batch of low-value rows.
+ * Captures counts + a few title cues — enough for a human/agent later,
+ * not a second copy of the noise.
+ */
+export function buildDistillContent(
+  sourceKey: string,
+  batch: MemoryEntry[],
+  nowIso: string
+): string {
+  const byType = new Map<string, number>()
+  for (const e of batch) {
+    byType.set(e.type, (byType.get(e.type) ?? 0) + 1)
+  }
+  const typeLine = [...byType.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([t, c]) => `${t}×${c}`)
+    .join(', ')
+
+  // Prefer longer / more structured titles as bullets
+  const bullets = batch
+    .map((e) => deriveTitle(e).replace(/\s+/g, ' ').trim())
+    .filter((t) => t.length > 20)
+    .slice(0, MAX_DIGEST_BULLETS)
+    .map((t) => `- ${t.length > MAX_BULLET_CHARS ? `${t.slice(0, MAX_BULLET_CHARS - 1)}…` : t}`)
+
+  const parts = [
+    `Distill of discarded auto-history (${sourceKey}).`,
+    `Context synthesis: ${batch.length} low-value rows collapsed — raw history deleted; only this digest remains for the project model.`,
+    `Key data: source=retention-distill; discarded=${batch.length}; types=${typeLine}; at=${nowIso}`,
+    `What happened: purged auto-generated / redundant captures that added no excess vs the reference model.`,
+    `Why it mattered: prevent vault bloat; agents must not re-read detector noise.`,
+    `Outcome: ${batch.length} raw entries hard-deleted after distillation.`,
+    `Next implication: prefer high-excess judgment; re-run detectors only when code/model changes.`,
+  ]
+  if (bullets.length > 0) {
+    parts.push(`Sample cues (not full bodies):\n${bullets.join('\n')}`)
+  }
+  return parts.join(' ')
+}
+
+/**
+ * For one auto-source bucket: keep at most `keep` newest, distill the rest
+ * into a single topic entry, hard-delete overflow (no archive).
+ */
+export async function distillAndDiscardAutoSource(
+  projectPath: string,
+  projectId: string,
+  source: string,
+  entries: MemoryEntry[],
+  keep: number
+): Promise<DistillDiscardResult> {
+  if (entries.length <= keep) {
+    return { discarded: 0, digested: false }
+  }
+
+  const sorted = [...entries].sort((a, b) => b.rememberedAt.localeCompare(a.rememberedAt))
+  const overflow = sorted.slice(keep)
+  if (overflow.length === 0) return { discarded: 0, digested: false }
+
+  const nowIso = new Date().toISOString()
+  const topic = `auto-distill:${source}`
+  const content = buildDistillContent(source, overflow, nowIso)
+
+  let digested = false
+  try {
+    await projectMemory.remember(projectPath, {
+      type: 'learning',
+      content,
+      tags: {
+        source: 'retention-distill',
+        topic,
+        capture: 'distill-discard-v1',
+        context_schema: 'living-v2',
+        synthesis: 'deterministic',
+        discarded_count: String(overflow.length),
+        auto_source: source,
+      },
+      provenance: 'inferred',
+      projectId,
+    })
+    digested = true
+  } catch {
+    digested = false
+  }
+
+  // Hard-delete overflow — no soft-delete, no archives table.
+  // Exclude the digest if remember re-used an id (won't be in overflow).
+  const ids = overflow.map((e) => e.id)
+  const discarded = hardDeleteEntries(projectId, ids)
+
+  return { discarded, digested, digestTopic: topic }
+}
+
+/**
+ * Distill all auto-source groups over `maxLive`, then hard-delete excess.
+ */
+export async function distillAndDiscardAllAutoSources(
+  projectPath: string,
+  projectId: string,
+  maxLive: number
+): Promise<{ discarded: number; digests: number }> {
+  const all = projectMemory.allEntriesForIndex(projectId)
+  const bySource = new Map<string, MemoryEntry[]>()
+  for (const e of all) {
+    const src = e.tags?.source
+    if (!isAutoSource(src)) continue
+    // Never distill the distill digests themselves
+    if (src === 'retention-distill' || e.tags?.source === 'retention-distill') continue
+    const list = bySource.get(src!) ?? []
+    list.push(e)
+    bySource.set(src!, list)
+  }
+
+  let discarded = 0
+  let digests = 0
+  for (const [source, list] of bySource) {
+    if (list.length <= maxLive) continue
+    const r = await distillAndDiscardAutoSource(projectPath, projectId, source, list, maxLive)
+    discarded += r.discarded
+    if (r.digested) digests++
+  }
+  return { discarded, digests }
+}
+
+/**
+ * Soft-deleted rows with no future value: hard-delete immediately when
+ * already past grace, without re-summarizing (they were already judged
+ * low-value by retention/forget). Optional mini-digest when batch is large.
+ */
+export function eliminateSoftDeletedNoValue(
+  projectId: string,
+  olderThanDays: number,
+  maxRows: number = 1000
+): { purged: number; digested: boolean } {
+  const cutoff = Date.now() - olderThanDays * 86_400_000
+  try {
+    const rows = prjctDb.query<{ id: string; type: string; content: string }>(
+      projectId,
+      `SELECT id, type, content FROM memory_entries
+       WHERE deleted_at IS NOT NULL AND deleted_at < ?
+       ORDER BY deleted_at ASC
+       LIMIT ?`,
+      cutoff,
+      maxRows
+    )
+    if (rows.length === 0) return { purged: 0, digested: false }
+
+    // No statistical residue: hard delete. Digests already exist from
+    // retention-distill when auto-source was the path; soft-deleted judgment
+    // clones need no second essay.
+    const n = hardDeleteEntries(
+      projectId,
+      rows.map((r) => r.id)
+    )
+    return { purged: n, digested: false }
+  } catch {
+    return { purged: 0, digested: false }
+  }
+}

--- a/core/services/retention/excess.ts
+++ b/core/services/retention/excess.ts
@@ -1,0 +1,121 @@
+/**
+ * Excess information vs reference model R — the Rho core for project memory.
+ *
+ * Rho: excess_loss(token) = loss_train - loss_reference
+ *   → keep tokens the reference does not already "know"
+ *
+ * prjct: excess(entry) = 1 - max_similarity(entry, R \ {entry})
+ *   → high excess = novel contribution to the project model
+ *   → low excess  = redundant with R (derivable / already stored)
+ *
+ * Implementation is pure + deterministic + 0 tokens:
+ *   1. Exact content fingerprint match against R → excess = 0
+ *   2. Local subword embedding cosine vs every R vector → max sim
+ *   3. excess = clamp(1 - maxSim, 0, 1)
+ *
+ * Efficiency: vectors for R are computed once (O(|R|·L)); each candidate is
+ * one embed + |R| cosines of dim 256. For |R|≤150 and n≤2k this is fine on
+ * the sync path (single-digit ms on typical machines).
+ */
+
+import { memoryFingerprint } from '../../memory/content-fingerprint'
+import type { MemoryEntry } from '../../memory/entries'
+import { cosineSimilarity, embedLocalText } from '../embeddings'
+
+/** Near-duplicate threshold: sim ≥ this ⇒ excess treated as ~0. */
+export const NEAR_DUP_SIM = 0.92
+
+/** Capture gate: below this excess, low-stakes types are rejected as redundant. */
+export const CAPTURE_MIN_EXCESS = 0.18
+
+export interface ExcessResult {
+  /** 0 = fully known by R, 1 = totally novel. */
+  excess: number
+  /** Max cosine similarity to any reference member (0 if R empty). */
+  maxSim: number
+  /** Reference entry id that matched best (if any). */
+  nearestId: string | null
+  /** Exact fingerprint collision with R. */
+  exactDup: boolean
+  /** Near-dup by embedding (maxSim ≥ NEAR_DUP_SIM). */
+  nearDup: boolean
+}
+
+export interface ReferenceIndex {
+  entries: MemoryEntry[]
+  fingerprints: Map<string, string> // fingerprint → entry id
+  /** L2-normalized local vectors, parallel to entries. */
+  vectors: Float64Array[]
+}
+
+/**
+ * Precompute fingerprints + local vectors for R. Call once per evaluate.
+ */
+export function buildReferenceIndex(reference: MemoryEntry[]): ReferenceIndex {
+  const fingerprints = new Map<string, string>()
+  const vectors: Float64Array[] = []
+  for (const e of reference) {
+    fingerprints.set(memoryFingerprint(e.content), e.id)
+    const v = embedLocalText(e.content)
+    vectors.push(Float64Array.from(v))
+  }
+  return { entries: reference, fingerprints, vectors }
+}
+
+/**
+ * Excess of `content` (and optional id) vs a prebuilt reference index.
+ * Pass `excludeId` when the candidate is already in R.
+ */
+export function excessAgainstIndex(
+  content: string,
+  index: ReferenceIndex | null | undefined,
+  excludeId?: string
+): ExcessResult {
+  if (!index || index.entries.length === 0) {
+    return { excess: 1, maxSim: 0, nearestId: null, exactDup: false, nearDup: false }
+  }
+
+  const print = memoryFingerprint(content)
+  const fpHit = index.fingerprints.get(print)
+  if (fpHit && fpHit !== excludeId) {
+    return {
+      excess: 0,
+      maxSim: 1,
+      nearestId: fpHit,
+      exactDup: true,
+      nearDup: true,
+    }
+  }
+
+  const cand = embedLocalText(content)
+  let maxSim = 0
+  let nearestId: string | null = null
+
+  for (let i = 0; i < index.entries.length; i++) {
+    const ref = index.entries[i]!
+    if (excludeId && ref.id === excludeId) continue
+    const sim = cosineSimilarity(cand, index.vectors[i]!)
+    if (sim > maxSim) {
+      maxSim = sim
+      nearestId = ref.id
+    }
+  }
+
+  // Numerical safety
+  maxSim = Math.max(0, Math.min(1, maxSim))
+  const nearDup = maxSim >= NEAR_DUP_SIM
+  const excess = nearDup ? 0 : Math.max(0, Math.min(1, 1 - maxSim))
+
+  return { excess, maxSim, nearestId, exactDup: false, nearDup }
+}
+
+/**
+ * Convenience: build index from R and score one content string.
+ */
+export function computeExcess(
+  content: string,
+  reference: MemoryEntry[],
+  excludeId?: string
+): ExcessResult {
+  return excessAgainstIndex(content, buildReferenceIndex(reference), excludeId)
+}

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -1,25 +1,18 @@
 /**
- * Retention score — value-based cleanup verdicts for memory entries.
+ * Retention — Rho-inspired selective memory for prjct.
  *
- * Replaces "oldest-first" knowledge thinning with a single per-entry
- * evaluation against what the project actually knows and uses:
+ * microsoft/rho (Selective Language Modeling):
+ *   1. Build a reference model on high-quality data
+ *   2. Score candidates by excess loss vs reference
+ *   3. Keep / train only high-excess signal
  *
- *   1. Real usage    — decayed `memory_usefulness` score (ship credits,
- *                      references, corrections). The strongest signal.
- *   2. Groundedness  — cited file paths still exist in the code index (HEAD)?
- *                      Superseded or corrected by a later entry?
- *   3. Excess signal — fingerprint duplicates + generated noise
- *                      (improvement-signal, hot-file, low-value legacy context).
- *                      Proxy for "adds nothing beyond synthesis/code" until a
- *                      deeper synthesis-diff lands.
- *   4. Type floor    — judgment knowledge is never hard-deleted: worst case
- *                      archive (soft-delete from recall, recoverable).
- *   5. Idle age      — unused knowledge past 90d gradually loses score so
- *                      dead entries can leave `active` without dramatic strikes.
+ * prjct mapping (deterministic, 0 tokens, no new tables):
+ *   1. R = judgment + living-v2 synthesis (reference-model.ts)
+ *   2. excess(entry) = 1 - max_sim(entry, R\{entry}) via local embeddings (excess.ts)
+ *   3. Verdict active|archive|delete from excess + usage + groundedness + floor
  *
- * Deterministic, 0 tokens, no new tables. `evaluateRetention` is read-only;
- * `applyRetention` archives/deletes according to verdicts (soft-delete via
- * `projectMemory.forget` + optional archives table row for recoverability).
+ * Capture gate (capture-gate.ts) rejects low-excess noise at write time.
+ * applyRetention soft-deletes according to verdicts (capped).
  */
 
 import { loadIndex as loadBm25Index } from '../../domain/bm25'
@@ -30,6 +23,13 @@ import { archiveStorage } from '../../storage/archive-storage'
 import prjctDb from '../../storage/database'
 import { isIrrelevantGeneratedContext } from '../context-quality-service'
 import { extractCorrectionIds, usefulnessService } from '../usefulness'
+import {
+  buildReferenceIndex,
+  type ExcessResult,
+  excessAgainstIndex,
+  type ReferenceIndex,
+} from './excess'
+import { buildReferenceModel } from './reference-model'
 
 export type RetentionVerdict = 'active' | 'archive' | 'delete'
 
@@ -37,9 +37,13 @@ export interface RetentionResult {
   id: string
   type: string
   verdict: RetentionVerdict
-  /** 0–100; higher = more worth keeping. Used to rank within a verdict. */
+  /** 0–100; higher = more worth keeping. */
   score: number
   reasons: string[]
+  /** Rho excess ∈ [0,1]; high = novel vs R. */
+  excess?: number
+  maxSim?: number
+  nearestId?: string | null
 }
 
 export interface RetentionReport {
@@ -47,18 +51,15 @@ export interface RetentionReport {
   active: number
   archive: number
   delete: number
-  /** Non-active results only — the actionable set, worst score first. */
+  /** |R| used for this evaluation. */
+  referenceSize: number
   flagged: RetentionResult[]
-  /** All results by id (for callers that need per-entry lookup). */
   byId: Map<string, RetentionResult>
 }
 
 export interface ApplyRetentionOptions {
-  /** When true, score only — no mutations. Default false. */
   dryRun?: boolean
-  /** Cap how many archive actions run this pass (default 100). */
   maxArchive?: number
-  /** Cap how many delete actions run this pass (default 50). */
   maxDelete?: number
   nowMs?: number
 }
@@ -73,9 +74,9 @@ export interface ApplyRetentionResult {
   skipped: number
   dryRun: boolean
   samples: RetentionResult[]
+  referenceSize?: number
 }
 
-/** Entry types whose worst-case verdict is `archive` (tombstone), never `delete`. */
 export const PROTECTED_TYPES = new Set([
   'decision',
   'gotcha',
@@ -86,40 +87,38 @@ export const PROTECTED_TYPES = new Set([
   'spec',
 ])
 
-/** Entries newer than this stay `active` unless duplicated or superseded. */
 const GRACE_DAYS = 30
-
-/** Verdict thresholds over the 0–100 score. */
 const ACTIVE_MIN = 50
 const ARCHIVE_MIN = 20
 
 /**
- * Base below ACTIVE_MIN so unused knowledge is not permanently active.
- * Usefulness / recency push above the line; idle age + strikes pull below.
+ * Score composition (0–100), Rho-first:
+ *   excess contribution up to 45  — THE signal (novelty vs R)
+ *   usefulness up to 25
+ *   recency up to 15
+ *   penalties: superseded/corrected/noise/ungrounded/idle/low-excess
  */
-const BASE_SCORE = 40
-const USEFULNESS_MAX_BONUS = 30
-const RECENCY_MAX_BONUS = 20
+const EXCESS_MAX = 45
+const USEFULNESS_MAX_BONUS = 25
+const RECENCY_MAX_BONUS = 15
 const RECENCY_WINDOW_DAYS = 180
-/** After this many days with zero usefulness, apply idle penalty. */
 const IDLE_AFTER_DAYS = 90
-const IDLE_MAX_PENALTY = 30
-const IDLE_PENALTY_PER_DAY = 0.15
+const IDLE_MAX_PENALTY = 25
+const IDLE_PENALTY_PER_DAY = 0.12
 const SUPERSEDED_PENALTY = 40
 const CORRECTED_PENALTY = 40
-const DUPLICATE_PENALTY = 35
-const NOISE_PENALTY = 35
-const UNGROUNDED_PENALTY = 25
+const NOISE_PENALTY = 30
+const UNGROUNDED_PENALTY = 20
+/** When excess is near-zero, push hard toward archive (redundant with R). */
+const LOW_EXCESS_PENALTY = 35
+const LOW_EXCESS_CUTOFF = 0.12
 
 const MS_PER_DAY = 86_400_000
-
 const DEFAULT_MAX_ARCHIVE = 100
 const DEFAULT_MAX_DELETE = 50
-/** Smaller budget for per-done incremental passes. */
 const INCREMENTAL_MAX_ARCHIVE = 25
 const INCREMENTAL_MAX_DELETE = 15
 
-/** Path-like references in entry content (e.g. `core/services/foo.ts`). */
 const PATH_RE = /\b[\w.-]+(?:\/[\w.-]+)+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|sh|toml|yml|yaml)\b/g
 
 export interface RetentionInputs {
@@ -127,12 +126,12 @@ export interface RetentionInputs {
   usefulness: Map<string, number>
   supersededIds: Set<string>
   correctedIds: Set<string>
-  /** Indexed file paths at HEAD; null when no code index exists yet. */
   indexedPaths: Set<string> | null
   nowMs: number
+  /** Prebuilt reference index (required for Rho excess). */
+  refIndex: ReferenceIndex
 }
 
-/** Gather every input the scorer needs from storage. Read-only. */
 export function collectRetentionInputs(projectId: string, nowMs: number): RetentionInputs {
   const entries = projectMemory.allEntriesForIndex(projectId)
 
@@ -146,8 +145,11 @@ export function collectRetentionInputs(projectId: string, nowMs: number): Retent
     const index = loadBm25Index(projectId)
     if (index) indexedPaths = new Set(Object.keys(index.documents))
   } catch {
-    // No code index (first run) — groundedness is skipped, not failed.
+    /* first run */
   }
+
+  const R = buildReferenceModel(entries)
+  const refIndex = buildReferenceIndex(R)
 
   return {
     entries,
@@ -156,13 +158,10 @@ export function collectRetentionInputs(projectId: string, nowMs: number): Retent
     correctedIds,
     indexedPaths,
     nowMs,
+    refIndex,
   }
 }
 
-/**
- * Older entries whose content fingerprint matches a newer entry exactly.
- * Newest copy survives; the rest are duplicates (backstop for pre-dedup data).
- */
 export function collectDuplicateIds(entries: MemoryEntry[]): Set<string> {
   const newestByPrint = new Map<string, MemoryEntry>()
   const duplicates = new Set<string>()
@@ -175,7 +174,6 @@ export function collectDuplicateIds(entries: MemoryEntry[]): Set<string> {
   return duplicates
 }
 
-/** True when the entry cites concrete files and NONE of them exist at HEAD. */
 function isUngrounded(entry: MemoryEntry, indexedPaths: Set<string>): boolean {
   const cited = entry.content.match(PATH_RE)
   if (!cited || cited.length === 0) return false
@@ -188,11 +186,34 @@ export function scoreEntry(
   duplicateIds: Set<string>
 ): RetentionResult {
   const reasons: string[] = []
-  let score = BASE_SCORE
 
+  // ── Rho core: excess vs R ──────────────────────────────────────────
+  const ex: ExcessResult = excessAgainstIndex(entry.content, inputs.refIndex, entry.id)
+  // Exact/near fingerprint dups among full corpus still count
+  const corpusDup = duplicateIds.has(entry.id)
+  if (corpusDup && !ex.exactDup) {
+    reasons.push('duplicate of newer entry')
+  }
+
+  // Start from excess — high novelty is the keep signal (Rho).
+  let score = ex.excess * EXCESS_MAX
+  reasons.push(`excess ${ex.excess.toFixed(2)} (sim ${ex.maxSim.toFixed(2)})`)
+
+  if (ex.exactDup || ex.nearDup || ex.excess < LOW_EXCESS_CUTOFF) {
+    score -= LOW_EXCESS_PENALTY
+    reasons.push(
+      ex.exactDup
+        ? `exact dup of ${ex.nearestId}`
+        : ex.nearDup
+          ? `near-dup of ${ex.nearestId}`
+          : 'low excess vs reference'
+    )
+  }
+
+  // ── Real usage ─────────────────────────────────────────────────────
   const usefulness = inputs.usefulness.get(entry.id) ?? 0
   if (usefulness > 0) {
-    const bonus = Math.min(USEFULNESS_MAX_BONUS, usefulness * 10)
+    const bonus = Math.min(USEFULNESS_MAX_BONUS, usefulness * 8)
     score += bonus
     reasons.push(`used (+${Math.round(bonus)})`)
   }
@@ -203,7 +224,6 @@ export function scoreEntry(
     score += recency
   }
 
-  // Idle: unused knowledge past IDLE_AFTER_DAYS gradually falls out of active.
   if (usefulness <= 0 && Number.isFinite(ageDays) && ageDays > IDLE_AFTER_DAYS) {
     const idle = Math.min(IDLE_MAX_PENALTY, (ageDays - IDLE_AFTER_DAYS) * IDLE_PENALTY_PER_DAY)
     if (idle > 0) {
@@ -212,6 +232,7 @@ export function scoreEntry(
     }
   }
 
+  // ── Groundedness / refutation ──────────────────────────────────────
   const superseded = inputs.supersededIds.has(entry.id)
   if (superseded) {
     score -= SUPERSEDED_PENALTY
@@ -222,13 +243,6 @@ export function scoreEntry(
     reasons.push('corrected')
   }
 
-  const duplicate = duplicateIds.has(entry.id)
-  if (duplicate) {
-    score -= DUPLICATE_PENALTY
-    reasons.push('duplicate of newer entry')
-  }
-
-  // Excess-signal proxy: non-model types + low-value generated/legacy context.
   const noise = !isModelMemory(entry) || isIrrelevantGeneratedContext(entry)
   if (noise) {
     score -= NOISE_PENALTY
@@ -240,27 +254,41 @@ export function scoreEntry(
     reasons.push('cites files missing at HEAD')
   }
 
+  // Corpus-level exact older dup
+  if (corpusDup) {
+    score -= 20
+  }
+
   score = Math.max(0, Math.min(100, score))
 
   let verdict: RetentionVerdict =
     score >= ACTIVE_MIN ? 'active' : score >= ARCHIVE_MIN ? 'archive' : 'delete'
 
-  // Grace: fresh knowledge stays active unless already known-dead.
-  if (verdict !== 'active' && ageDays < GRACE_DAYS && !duplicate && !superseded) {
+  // Grace: brand-new high-stakes knowledge gets time to be used —
+  // unless already known-dead (dup/superseded/near-dup of R).
+  const knownDead = corpusDup || ex.exactDup || ex.nearDup || superseded
+  if (verdict !== 'active' && ageDays < GRACE_DAYS && !knownDead) {
     verdict = 'active'
     reasons.push('grace period')
   }
 
-  // Type floor: judgment knowledge is never hard-deleted.
   if (verdict === 'delete' && PROTECTED_TYPES.has(entry.type)) {
     verdict = 'archive'
     reasons.push('protected type')
   }
 
-  return { id: entry.id, type: entry.type, verdict, score: Math.round(score), reasons }
+  return {
+    id: entry.id,
+    type: entry.type,
+    verdict,
+    score: Math.round(score),
+    reasons,
+    excess: ex.excess,
+    maxSim: ex.maxSim,
+    nearestId: ex.nearestId,
+  }
 }
 
-/** Score every memory entry. Read-only; callers act on the verdicts. */
 export function evaluateRetention(projectId: string, nowMs: number): RetentionReport {
   const inputs = collectRetentionInputs(projectId, nowMs)
   const duplicateIds = collectDuplicateIds(inputs.entries)
@@ -270,6 +298,7 @@ export function evaluateRetention(projectId: string, nowMs: number): RetentionRe
     active: 0,
     archive: 0,
     delete: 0,
+    referenceSize: inputs.refIndex.entries.length,
     flagged: [],
     byId: new Map(),
   }
@@ -285,21 +314,17 @@ export function evaluateRetention(projectId: string, nowMs: number): RetentionRe
   return report
 }
 
-/**
- * Whether an entry should receive an embedding (selective vectorization).
- * Never embed signals/telemetry; never embed entries that score archive/delete.
- */
 export function shouldEmbedEntry(entry: MemoryEntry, retention?: RetentionResult | null): boolean {
   if (!isModelMemory(entry)) return false
   if (entry.content.trim().length === 0) return false
   if (retention && retention.verdict !== 'active') return false
+  // Rho: do not embed zero-excess near-dups of R
+  if (retention && retention.excess !== undefined && retention.excess < 0.05) return false
   return true
 }
 
 function forgetEntry(projectId: string, id: string): boolean {
-  // projectMemory.forget only handles mem_N numeric ids.
   if (projectMemory.forget(projectId, id)) return true
-  // ship_* and other ids: soft-delete memory_entries row if present.
   try {
     const r = prjctDb.run(
       projectId,
@@ -313,12 +338,6 @@ function forgetEntry(projectId: string, id: string): boolean {
   }
 }
 
-/**
- * Act on retention verdicts:
- *   - archive → row in archives table + soft-delete from active recall
- *   - delete  → soft-delete from active recall (no archives row; refuted/noise)
- * Caps prevent a single sync from emptying a large vault.
- */
 export function applyRetention(
   projectId: string,
   options: ApplyRetentionOptions = {}
@@ -348,14 +367,15 @@ export function applyRetention(
             id: r.id,
             type: r.type,
             score: r.score,
+            excess: r.excess,
             reasons: r.reasons,
             verdict: r.verdict,
           },
-          summary: `retention archive [${r.type}] score=${r.score}`,
+          summary: `retention archive [${r.type}] excess=${r.excess?.toFixed(2) ?? '?'} score=${r.score}`,
           reason: 'retention-archive',
         })
       } catch {
-        /* archive row best-effort */
+        /* best-effort */
       }
       if (forgetEntry(projectId, r.id)) archived++
       else skipped++
@@ -365,7 +385,6 @@ export function applyRetention(
     skipped += Math.max(0, toDelete.length - deleteBatch.length)
     for (const r of deleteBatch) {
       if (PROTECTED_TYPES.has(r.type)) {
-        // Double-check floor — never hard-delete protected types.
         skipped++
         continue
       }
@@ -384,10 +403,10 @@ export function applyRetention(
     skipped,
     dryRun,
     samples: report.flagged.slice(0, 10),
+    referenceSize: report.referenceSize,
   }
 }
 
-/** Smaller best-effort pass for `prjct status done` / task close. */
 export function applyRetentionIncremental(projectId: string): ApplyRetentionResult {
   return applyRetention(projectId, {
     maxArchive: INCREMENTAL_MAX_ARCHIVE,
@@ -395,39 +414,28 @@ export function applyRetentionIncremental(projectId: string): ApplyRetentionResu
   })
 }
 
-/**
- * Inbox triage: soft-delete inbox items that are fingerprint-duplicates of
- * newer non-inbox knowledge, or that score archive/delete under retention.
- */
 export function triageInbox(
   projectId: string,
   nowMs: number = Date.now()
-): {
-  merged: number
-  archived: number
-} {
+): { merged: number; archived: number } {
   const entries = projectMemory.allEntriesForIndex(projectId)
   const inbox = entries.filter((e) => e.type === 'inbox')
   if (inbox.length === 0) return { merged: 0, archived: 0 }
 
-  const nonInbox = entries.filter((e) => e.type !== 'inbox')
-  const nonInboxPrints = new Set(nonInbox.map((e) => memoryFingerprint(e.content)))
-  const dups = collectDuplicateIds(entries)
+  const R = buildReferenceModel(entries)
+  const refIndex = buildReferenceIndex(R)
   const report = evaluateRetention(projectId, nowMs)
 
   let merged = 0
   let archived = 0
 
   for (const item of inbox) {
-    const print = memoryFingerprint(item.content)
-    const isDupOfKnowledge = nonInboxPrints.has(print)
-    const isOlderDup = dups.has(item.id)
-    const verdict = report.byId.get(item.id)
-
-    if (isDupOfKnowledge || isOlderDup) {
+    const ex = excessAgainstIndex(item.content, refIndex)
+    if (ex.exactDup || ex.nearDup || ex.excess < 0.15) {
       if (forgetEntry(projectId, item.id)) merged++
       continue
     }
+    const verdict = report.byId.get(item.id)
     if (verdict && verdict.verdict !== 'active') {
       try {
         archiveStorage.archive(projectId, {
@@ -437,9 +445,10 @@ export function triageInbox(
             id: item.id,
             type: 'inbox',
             score: verdict.score,
+            excess: verdict.excess,
             reasons: verdict.reasons,
           },
-          summary: `inbox triage score=${verdict.score}`,
+          summary: `inbox triage excess=${verdict.excess?.toFixed(2) ?? '?'}`,
           reason: 'retention-inbox',
         })
       } catch {
@@ -451,3 +460,10 @@ export function triageInbox(
 
   return { merged, archived }
 }
+
+export type { CaptureGateResult } from './capture-gate'
+// Re-exports for tests and capture path
+export { captureGate } from './capture-gate'
+export type { ExcessResult } from './excess'
+export { CAPTURE_MIN_EXCESS, computeExcess, NEAR_DUP_SIM } from './excess'
+export { buildReferenceModel, isReferenceEligible, REFERENCE_CAP } from './reference-model'

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -23,6 +23,7 @@ import { archiveStorage } from '../../storage/archive-storage'
 import prjctDb from '../../storage/database'
 import { isIrrelevantGeneratedContext } from '../context-quality-service'
 import { extractCorrectionIds, usefulnessService } from '../usefulness'
+import { hardDeleteEntries } from './distill'
 import {
   buildReferenceIndex,
   type ExcessResult,
@@ -381,15 +382,21 @@ export function applyRetention(
       else skipped++
     }
 
+    // Delete verdict = no future value (not even statistical): HARD-delete.
+    // Protected types never reach here (floored to archive).
     const deleteBatch = toDelete.slice(0, maxDelete)
     skipped += Math.max(0, toDelete.length - deleteBatch.length)
+    const hardIds: string[] = []
     for (const r of deleteBatch) {
       if (PROTECTED_TYPES.has(r.type)) {
         skipped++
         continue
       }
-      if (forgetEntry(projectId, r.id)) deleted++
-      else skipped++
+      hardIds.push(r.id)
+    }
+    if (hardIds.length > 0) {
+      deleted = hardDeleteEntries(projectId, hardIds)
+      skipped += hardIds.length - deleted
     }
   }
 

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -466,4 +466,14 @@ export type { CaptureGateResult } from './capture-gate'
 export { captureGate } from './capture-gate'
 export type { ExcessResult } from './excess'
 export { CAPTURE_MIN_EXCESS, computeExcess, NEAR_DUP_SIM } from './excess'
+export type { PurgeResult, VaultHealth } from './purge'
+export {
+  DEFAULT_SOFT_DELETED_PURGE_DAYS,
+  isAutoSource,
+  purgeOrphanRememberEvents,
+  purgeSoftDeleted,
+  runVaultPurge,
+  trimAutoSourceCap,
+  vaultHealth,
+} from './purge'
 export { buildReferenceModel, isReferenceEligible, REFERENCE_CAP } from './reference-model'

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -1,30 +1,33 @@
 /**
  * Retention score — value-based cleanup verdicts for memory entries.
  *
- * Replaces "oldest-first" and "shape-only" cleanup criteria with a single
- * per-entry evaluation against what the project actually knows and uses:
+ * Replaces "oldest-first" knowledge thinning with a single per-entry
+ * evaluation against what the project actually knows and uses:
  *
  *   1. Real usage    — decayed `memory_usefulness` score (ship credits,
  *                      references, corrections). The strongest signal.
- *   2. Groundedness  — do the file paths the entry cites still exist in the
- *                      code index (HEAD)? Was it superseded or corrected by a
- *                      later entry?
- *   3. Excess signal — exact-fingerprint duplicates and non-model telemetry
- *                      add nothing beyond what is already stored.
- *   4. Type floor    — judgment knowledge (decisions, gotchas, learnings,
- *                      feedback, shipped) is never hard-deleted: worst case
- *                      it is archived with its record intact. Raw context
- *                      and generated signals may be deleted.
+ *   2. Groundedness  — cited file paths still exist in the code index (HEAD)?
+ *                      Superseded or corrected by a later entry?
+ *   3. Excess signal — fingerprint duplicates + generated noise
+ *                      (improvement-signal, hot-file, low-value legacy context).
+ *                      Proxy for "adds nothing beyond synthesis/code" until a
+ *                      deeper synthesis-diff lands.
+ *   4. Type floor    — judgment knowledge is never hard-deleted: worst case
+ *                      archive (soft-delete from recall, recoverable).
+ *   5. Idle age      — unused knowledge past 90d gradually loses score so
+ *                      dead entries can leave `active` without dramatic strikes.
  *
- * Deterministic and read-only: 0 tokens, no new tables — every input already
- * lives in SQLite. Callers decide what to DO with a verdict; this module only
- * scores. The sync dry-run phase reports verdicts without mutating anything.
+ * Deterministic, 0 tokens, no new tables. `evaluateRetention` is read-only;
+ * `applyRetention` archives/deletes according to verdicts (soft-delete via
+ * `projectMemory.forget` + optional archives table row for recoverability).
  */
 
 import { loadIndex as loadBm25Index } from '../../domain/bm25'
 import { memoryFingerprint } from '../../memory/content-fingerprint'
 import { collectSupersededIds, isModelMemory, type MemoryEntry } from '../../memory/entries'
 import { projectMemory } from '../../memory/project-memory'
+import { archiveStorage } from '../../storage/archive-storage'
+import prjctDb from '../../storage/database'
 import { isIrrelevantGeneratedContext } from '../context-quality-service'
 import { extractCorrectionIds, usefulnessService } from '../usefulness'
 
@@ -46,10 +49,34 @@ export interface RetentionReport {
   delete: number
   /** Non-active results only — the actionable set, worst score first. */
   flagged: RetentionResult[]
+  /** All results by id (for callers that need per-entry lookup). */
+  byId: Map<string, RetentionResult>
+}
+
+export interface ApplyRetentionOptions {
+  /** When true, score only — no mutations. Default false. */
+  dryRun?: boolean
+  /** Cap how many archive actions run this pass (default 100). */
+  maxArchive?: number
+  /** Cap how many delete actions run this pass (default 50). */
+  maxDelete?: number
+  nowMs?: number
+}
+
+export interface ApplyRetentionResult {
+  evaluated: number
+  active: number
+  wouldArchive: number
+  wouldDelete: number
+  archived: number
+  deleted: number
+  skipped: number
+  dryRun: boolean
+  samples: RetentionResult[]
 }
 
 /** Entry types whose worst-case verdict is `archive` (tombstone), never `delete`. */
-const PROTECTED_TYPES = new Set([
+export const PROTECTED_TYPES = new Set([
   'decision',
   'gotcha',
   'learning',
@@ -59,18 +86,25 @@ const PROTECTED_TYPES = new Set([
   'spec',
 ])
 
-/** Entries newer than this stay `active` unless duplicated or superseded —
- *  fresh knowledge must get a chance to be used before it can be judged. */
+/** Entries newer than this stay `active` unless duplicated or superseded. */
 const GRACE_DAYS = 30
 
 /** Verdict thresholds over the 0–100 score. */
 const ACTIVE_MIN = 50
 const ARCHIVE_MIN = 20
 
-const BASE_SCORE = 50
+/**
+ * Base below ACTIVE_MIN so unused knowledge is not permanently active.
+ * Usefulness / recency push above the line; idle age + strikes pull below.
+ */
+const BASE_SCORE = 40
 const USEFULNESS_MAX_BONUS = 30
 const RECENCY_MAX_BONUS = 20
 const RECENCY_WINDOW_DAYS = 180
+/** After this many days with zero usefulness, apply idle penalty. */
+const IDLE_AFTER_DAYS = 90
+const IDLE_MAX_PENALTY = 30
+const IDLE_PENALTY_PER_DAY = 0.15
 const SUPERSEDED_PENALTY = 40
 const CORRECTED_PENALTY = 40
 const DUPLICATE_PENALTY = 35
@@ -79,9 +113,13 @@ const UNGROUNDED_PENALTY = 25
 
 const MS_PER_DAY = 86_400_000
 
-/** Path-like references in entry content (e.g. `core/services/foo.ts`).
- *  Requires a directory segment + a source-ish extension so prose with
- *  dots ("v3.44.0", "Node.js") never counts as a citation. */
+const DEFAULT_MAX_ARCHIVE = 100
+const DEFAULT_MAX_DELETE = 50
+/** Smaller budget for per-done incremental passes. */
+const INCREMENTAL_MAX_ARCHIVE = 25
+const INCREMENTAL_MAX_DELETE = 15
+
+/** Path-like references in entry content (e.g. `core/services/foo.ts`). */
 const PATH_RE = /\b[\w.-]+(?:\/[\w.-]+)+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|sh|toml|yml|yaml)\b/g
 
 export interface RetentionInputs {
@@ -123,9 +161,7 @@ export function collectRetentionInputs(projectId: string, nowMs: number): Retent
 
 /**
  * Older entries whose content fingerprint matches a newer entry exactly.
- * The newest copy of each fingerprint survives; the rest are duplicates.
- * Capture-time dedup already collapses verbatim repeats going forward —
- * this is the backstop for entries stored before that existed.
+ * Newest copy survives; the rest are duplicates (backstop for pre-dedup data).
  */
 export function collectDuplicateIds(entries: MemoryEntry[]): Set<string> {
   const newestByPrint = new Map<string, MemoryEntry>()
@@ -167,6 +203,15 @@ export function scoreEntry(
     score += recency
   }
 
+  // Idle: unused knowledge past IDLE_AFTER_DAYS gradually falls out of active.
+  if (usefulness <= 0 && Number.isFinite(ageDays) && ageDays > IDLE_AFTER_DAYS) {
+    const idle = Math.min(IDLE_MAX_PENALTY, (ageDays - IDLE_AFTER_DAYS) * IDLE_PENALTY_PER_DAY)
+    if (idle > 0) {
+      score -= idle
+      reasons.push(`idle ${Math.round(ageDays)}d`)
+    }
+  }
+
   const superseded = inputs.supersededIds.has(entry.id)
   if (superseded) {
     score -= SUPERSEDED_PENALTY
@@ -183,6 +228,7 @@ export function scoreEntry(
     reasons.push('duplicate of newer entry')
   }
 
+  // Excess-signal proxy: non-model types + low-value generated/legacy context.
   const noise = !isModelMemory(entry) || isIrrelevantGeneratedContext(entry)
   if (noise) {
     score -= NOISE_PENALTY
@@ -199,8 +245,7 @@ export function scoreEntry(
   let verdict: RetentionVerdict =
     score >= ACTIVE_MIN ? 'active' : score >= ARCHIVE_MIN ? 'archive' : 'delete'
 
-  // Grace: fresh knowledge stays active until it has had a chance to be
-  // used — unless it is already known-dead (duplicate/superseded).
+  // Grace: fresh knowledge stays active unless already known-dead.
   if (verdict !== 'active' && ageDays < GRACE_DAYS && !duplicate && !superseded) {
     verdict = 'active'
     reasons.push('grace period')
@@ -226,14 +271,183 @@ export function evaluateRetention(projectId: string, nowMs: number): RetentionRe
     archive: 0,
     delete: 0,
     flagged: [],
+    byId: new Map(),
   }
 
   for (const entry of inputs.entries) {
     const result = scoreEntry(entry, inputs, duplicateIds)
     report[result.verdict]++
+    report.byId.set(result.id, result)
     if (result.verdict !== 'active') report.flagged.push(result)
   }
 
   report.flagged.sort((a, b) => a.score - b.score)
   return report
+}
+
+/**
+ * Whether an entry should receive an embedding (selective vectorization).
+ * Never embed signals/telemetry; never embed entries that score archive/delete.
+ */
+export function shouldEmbedEntry(entry: MemoryEntry, retention?: RetentionResult | null): boolean {
+  if (!isModelMemory(entry)) return false
+  if (entry.content.trim().length === 0) return false
+  if (retention && retention.verdict !== 'active') return false
+  return true
+}
+
+function forgetEntry(projectId: string, id: string): boolean {
+  // projectMemory.forget only handles mem_N numeric ids.
+  if (projectMemory.forget(projectId, id)) return true
+  // ship_* and other ids: soft-delete memory_entries row if present.
+  try {
+    const r = prjctDb.run(
+      projectId,
+      'UPDATE memory_entries SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL',
+      Date.now(),
+      id
+    )
+    return (r.changes ?? 0) > 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Act on retention verdicts:
+ *   - archive → row in archives table + soft-delete from active recall
+ *   - delete  → soft-delete from active recall (no archives row; refuted/noise)
+ * Caps prevent a single sync from emptying a large vault.
+ */
+export function applyRetention(
+  projectId: string,
+  options: ApplyRetentionOptions = {}
+): ApplyRetentionResult {
+  const dryRun = options.dryRun === true
+  const nowMs = options.nowMs ?? Date.now()
+  const maxArchive = options.maxArchive ?? DEFAULT_MAX_ARCHIVE
+  const maxDelete = options.maxDelete ?? DEFAULT_MAX_DELETE
+
+  const report = evaluateRetention(projectId, nowMs)
+  const toArchive = report.flagged.filter((r) => r.verdict === 'archive')
+  const toDelete = report.flagged.filter((r) => r.verdict === 'delete')
+
+  let archived = 0
+  let deleted = 0
+  let skipped = 0
+
+  if (!dryRun) {
+    const archiveBatch = toArchive.slice(0, maxArchive)
+    skipped += Math.max(0, toArchive.length - archiveBatch.length)
+    for (const r of archiveBatch) {
+      try {
+        archiveStorage.archive(projectId, {
+          entityType: 'memory_entry',
+          entityId: r.id,
+          entityData: {
+            id: r.id,
+            type: r.type,
+            score: r.score,
+            reasons: r.reasons,
+            verdict: r.verdict,
+          },
+          summary: `retention archive [${r.type}] score=${r.score}`,
+          reason: 'retention-archive',
+        })
+      } catch {
+        /* archive row best-effort */
+      }
+      if (forgetEntry(projectId, r.id)) archived++
+      else skipped++
+    }
+
+    const deleteBatch = toDelete.slice(0, maxDelete)
+    skipped += Math.max(0, toDelete.length - deleteBatch.length)
+    for (const r of deleteBatch) {
+      if (PROTECTED_TYPES.has(r.type)) {
+        // Double-check floor — never hard-delete protected types.
+        skipped++
+        continue
+      }
+      if (forgetEntry(projectId, r.id)) deleted++
+      else skipped++
+    }
+  }
+
+  return {
+    evaluated: report.evaluated,
+    active: report.active,
+    wouldArchive: toArchive.length,
+    wouldDelete: toDelete.length,
+    archived: dryRun ? 0 : archived,
+    deleted: dryRun ? 0 : deleted,
+    skipped,
+    dryRun,
+    samples: report.flagged.slice(0, 10),
+  }
+}
+
+/** Smaller best-effort pass for `prjct status done` / task close. */
+export function applyRetentionIncremental(projectId: string): ApplyRetentionResult {
+  return applyRetention(projectId, {
+    maxArchive: INCREMENTAL_MAX_ARCHIVE,
+    maxDelete: INCREMENTAL_MAX_DELETE,
+  })
+}
+
+/**
+ * Inbox triage: soft-delete inbox items that are fingerprint-duplicates of
+ * newer non-inbox knowledge, or that score archive/delete under retention.
+ */
+export function triageInbox(
+  projectId: string,
+  nowMs: number = Date.now()
+): {
+  merged: number
+  archived: number
+} {
+  const entries = projectMemory.allEntriesForIndex(projectId)
+  const inbox = entries.filter((e) => e.type === 'inbox')
+  if (inbox.length === 0) return { merged: 0, archived: 0 }
+
+  const nonInbox = entries.filter((e) => e.type !== 'inbox')
+  const nonInboxPrints = new Set(nonInbox.map((e) => memoryFingerprint(e.content)))
+  const dups = collectDuplicateIds(entries)
+  const report = evaluateRetention(projectId, nowMs)
+
+  let merged = 0
+  let archived = 0
+
+  for (const item of inbox) {
+    const print = memoryFingerprint(item.content)
+    const isDupOfKnowledge = nonInboxPrints.has(print)
+    const isOlderDup = dups.has(item.id)
+    const verdict = report.byId.get(item.id)
+
+    if (isDupOfKnowledge || isOlderDup) {
+      if (forgetEntry(projectId, item.id)) merged++
+      continue
+    }
+    if (verdict && verdict.verdict !== 'active') {
+      try {
+        archiveStorage.archive(projectId, {
+          entityType: 'memory_entry',
+          entityId: item.id,
+          entityData: {
+            id: item.id,
+            type: 'inbox',
+            score: verdict.score,
+            reasons: verdict.reasons,
+          },
+          summary: `inbox triage score=${verdict.score}`,
+          reason: 'retention-inbox',
+        })
+      } catch {
+        /* best-effort */
+      }
+      if (forgetEntry(projectId, item.id)) archived++
+    }
+  }
+
+  return { merged, archived }
 }

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -1,0 +1,239 @@
+/**
+ * Retention score — value-based cleanup verdicts for memory entries.
+ *
+ * Replaces "oldest-first" and "shape-only" cleanup criteria with a single
+ * per-entry evaluation against what the project actually knows and uses:
+ *
+ *   1. Real usage    — decayed `memory_usefulness` score (ship credits,
+ *                      references, corrections). The strongest signal.
+ *   2. Groundedness  — do the file paths the entry cites still exist in the
+ *                      code index (HEAD)? Was it superseded or corrected by a
+ *                      later entry?
+ *   3. Excess signal — exact-fingerprint duplicates and non-model telemetry
+ *                      add nothing beyond what is already stored.
+ *   4. Type floor    — judgment knowledge (decisions, gotchas, learnings,
+ *                      feedback, shipped) is never hard-deleted: worst case
+ *                      it is archived with its record intact. Raw context
+ *                      and generated signals may be deleted.
+ *
+ * Deterministic and read-only: 0 tokens, no new tables — every input already
+ * lives in SQLite. Callers decide what to DO with a verdict; this module only
+ * scores. The sync dry-run phase reports verdicts without mutating anything.
+ */
+
+import { loadIndex as loadBm25Index } from '../../domain/bm25'
+import { memoryFingerprint } from '../../memory/content-fingerprint'
+import { collectSupersededIds, isModelMemory, type MemoryEntry } from '../../memory/entries'
+import { projectMemory } from '../../memory/project-memory'
+import { isIrrelevantGeneratedContext } from '../context-quality-service'
+import { extractCorrectionIds, usefulnessService } from '../usefulness'
+
+export type RetentionVerdict = 'active' | 'archive' | 'delete'
+
+export interface RetentionResult {
+  id: string
+  type: string
+  verdict: RetentionVerdict
+  /** 0–100; higher = more worth keeping. Used to rank within a verdict. */
+  score: number
+  reasons: string[]
+}
+
+export interface RetentionReport {
+  evaluated: number
+  active: number
+  archive: number
+  delete: number
+  /** Non-active results only — the actionable set, worst score first. */
+  flagged: RetentionResult[]
+}
+
+/** Entry types whose worst-case verdict is `archive` (tombstone), never `delete`. */
+const PROTECTED_TYPES = new Set([
+  'decision',
+  'gotcha',
+  'learning',
+  'feedback',
+  'fact',
+  'shipped',
+  'spec',
+])
+
+/** Entries newer than this stay `active` unless duplicated or superseded —
+ *  fresh knowledge must get a chance to be used before it can be judged. */
+const GRACE_DAYS = 30
+
+/** Verdict thresholds over the 0–100 score. */
+const ACTIVE_MIN = 50
+const ARCHIVE_MIN = 20
+
+const BASE_SCORE = 50
+const USEFULNESS_MAX_BONUS = 30
+const RECENCY_MAX_BONUS = 20
+const RECENCY_WINDOW_DAYS = 180
+const SUPERSEDED_PENALTY = 40
+const CORRECTED_PENALTY = 40
+const DUPLICATE_PENALTY = 35
+const NOISE_PENALTY = 35
+const UNGROUNDED_PENALTY = 25
+
+const MS_PER_DAY = 86_400_000
+
+/** Path-like references in entry content (e.g. `core/services/foo.ts`).
+ *  Requires a directory segment + a source-ish extension so prose with
+ *  dots ("v3.44.0", "Node.js") never counts as a citation. */
+const PATH_RE = /\b[\w.-]+(?:\/[\w.-]+)+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|sh|toml|yml|yaml)\b/g
+
+export interface RetentionInputs {
+  entries: MemoryEntry[]
+  usefulness: Map<string, number>
+  supersededIds: Set<string>
+  correctedIds: Set<string>
+  /** Indexed file paths at HEAD; null when no code index exists yet. */
+  indexedPaths: Set<string> | null
+  nowMs: number
+}
+
+/** Gather every input the scorer needs from storage. Read-only. */
+export function collectRetentionInputs(projectId: string, nowMs: number): RetentionInputs {
+  const entries = projectMemory.allEntriesForIndex(projectId)
+
+  const correctedIds = new Set<string>()
+  for (const entry of entries) {
+    for (const id of extractCorrectionIds(entry.tags)) correctedIds.add(id)
+  }
+
+  let indexedPaths: Set<string> | null = null
+  try {
+    const index = loadBm25Index(projectId)
+    if (index) indexedPaths = new Set(Object.keys(index.documents))
+  } catch {
+    // No code index (first run) — groundedness is skipped, not failed.
+  }
+
+  return {
+    entries,
+    usefulness: usefulnessService.decayedScores(projectId, nowMs),
+    supersededIds: collectSupersededIds(entries),
+    correctedIds,
+    indexedPaths,
+    nowMs,
+  }
+}
+
+/**
+ * Older entries whose content fingerprint matches a newer entry exactly.
+ * The newest copy of each fingerprint survives; the rest are duplicates.
+ * Capture-time dedup already collapses verbatim repeats going forward —
+ * this is the backstop for entries stored before that existed.
+ */
+export function collectDuplicateIds(entries: MemoryEntry[]): Set<string> {
+  const newestByPrint = new Map<string, MemoryEntry>()
+  const duplicates = new Set<string>()
+  const byNewest = [...entries].sort((a, b) => b.rememberedAt.localeCompare(a.rememberedAt))
+  for (const entry of byNewest) {
+    const print = memoryFingerprint(entry.content)
+    if (newestByPrint.has(print)) duplicates.add(entry.id)
+    else newestByPrint.set(print, entry)
+  }
+  return duplicates
+}
+
+/** True when the entry cites concrete files and NONE of them exist at HEAD. */
+function isUngrounded(entry: MemoryEntry, indexedPaths: Set<string>): boolean {
+  const cited = entry.content.match(PATH_RE)
+  if (!cited || cited.length === 0) return false
+  return !cited.some((p) => indexedPaths.has(p))
+}
+
+export function scoreEntry(
+  entry: MemoryEntry,
+  inputs: RetentionInputs,
+  duplicateIds: Set<string>
+): RetentionResult {
+  const reasons: string[] = []
+  let score = BASE_SCORE
+
+  const usefulness = inputs.usefulness.get(entry.id) ?? 0
+  if (usefulness > 0) {
+    const bonus = Math.min(USEFULNESS_MAX_BONUS, usefulness * 10)
+    score += bonus
+    reasons.push(`used (+${Math.round(bonus)})`)
+  }
+
+  const ageDays = Math.max(0, (inputs.nowMs - Date.parse(entry.rememberedAt)) / MS_PER_DAY)
+  if (Number.isFinite(ageDays)) {
+    const recency = Math.max(0, RECENCY_MAX_BONUS * (1 - ageDays / RECENCY_WINDOW_DAYS))
+    score += recency
+  }
+
+  const superseded = inputs.supersededIds.has(entry.id)
+  if (superseded) {
+    score -= SUPERSEDED_PENALTY
+    reasons.push('superseded')
+  }
+  if (inputs.correctedIds.has(entry.id)) {
+    score -= CORRECTED_PENALTY
+    reasons.push('corrected')
+  }
+
+  const duplicate = duplicateIds.has(entry.id)
+  if (duplicate) {
+    score -= DUPLICATE_PENALTY
+    reasons.push('duplicate of newer entry')
+  }
+
+  const noise = !isModelMemory(entry) || isIrrelevantGeneratedContext(entry)
+  if (noise) {
+    score -= NOISE_PENALTY
+    reasons.push('generated noise')
+  }
+
+  if (inputs.indexedPaths && isUngrounded(entry, inputs.indexedPaths)) {
+    score -= UNGROUNDED_PENALTY
+    reasons.push('cites files missing at HEAD')
+  }
+
+  score = Math.max(0, Math.min(100, score))
+
+  let verdict: RetentionVerdict =
+    score >= ACTIVE_MIN ? 'active' : score >= ARCHIVE_MIN ? 'archive' : 'delete'
+
+  // Grace: fresh knowledge stays active until it has had a chance to be
+  // used — unless it is already known-dead (duplicate/superseded).
+  if (verdict !== 'active' && ageDays < GRACE_DAYS && !duplicate && !superseded) {
+    verdict = 'active'
+    reasons.push('grace period')
+  }
+
+  // Type floor: judgment knowledge is never hard-deleted.
+  if (verdict === 'delete' && PROTECTED_TYPES.has(entry.type)) {
+    verdict = 'archive'
+    reasons.push('protected type')
+  }
+
+  return { id: entry.id, type: entry.type, verdict, score: Math.round(score), reasons }
+}
+
+/** Score every memory entry. Read-only; callers act on the verdicts. */
+export function evaluateRetention(projectId: string, nowMs: number): RetentionReport {
+  const inputs = collectRetentionInputs(projectId, nowMs)
+  const duplicateIds = collectDuplicateIds(inputs.entries)
+
+  const report: RetentionReport = {
+    evaluated: inputs.entries.length,
+    active: 0,
+    archive: 0,
+    delete: 0,
+    flagged: [],
+  }
+
+  for (const entry of inputs.entries) {
+    const result = scoreEntry(entry, inputs, duplicateIds)
+    report[result.verdict]++
+    if (result.verdict !== 'active') report.flagged.push(result)
+  }
+
+  report.flagged.sort((a, b) => a.score - b.score)
+  return report
+}

--- a/core/services/retention/purge.ts
+++ b/core/services/retention/purge.ts
@@ -14,7 +14,8 @@ import { projectMemory } from '../../memory/project-memory'
 import { archiveStorage } from '../../storage/archive-storage'
 import prjctDb from '../../storage/database'
 
-export const DEFAULT_SOFT_DELETED_PURGE_DAYS = 30
+/** Soft-deleted rows have no future/statistical value — purge quickly. */
+export const DEFAULT_SOFT_DELETED_PURGE_DAYS = 7
 export const DEFAULT_ARCHIVE_PRUNE_DAYS = 90
 export const DEFAULT_AUTO_SOURCE_MAX_LIVE = 20
 /** Sources that are auto-generated (not human judgment). */
@@ -32,6 +33,9 @@ export interface PurgeResult {
   orphanEventsPurged: number
   archivesPruned: number
   autoSourceTrimmed: number
+  /** Hard-deleted after distill (auto-source noise). */
+  distilledDiscarded?: number
+  digestsWritten?: number
 }
 
 export interface VaultHealth {
@@ -212,16 +216,20 @@ export function vaultHealth(projectId: string): VaultHealth {
 
 /**
  * Full cold purge pass for sync. Best-effort; never throws.
+ *
+ * Policy (user): if rows have no future value — not even statistical —
+ * distill a one-line residue when useful, then HARD-delete. No purgatory.
  */
-export function runVaultPurge(
+export async function runVaultPurge(
   projectId: string,
   opts: {
+    projectPath?: string
     softDeletedPurgeDays?: number
     archivePruneDays?: number
     autoSourceMaxLive?: number
     dryRun?: boolean
   } = {}
-): PurgeResult {
+): Promise<PurgeResult> {
   const softDays = opts.softDeletedPurgeDays ?? DEFAULT_SOFT_DELETED_PURGE_DAYS
   const archDays = opts.archivePruneDays ?? DEFAULT_ARCHIVE_PRUNE_DAYS
   const autoMax = opts.autoSourceMaxLive ?? DEFAULT_AUTO_SOURCE_MAX_LIVE
@@ -233,11 +241,33 @@ export function runVaultPurge(
       orphanEventsPurged: 0,
       archivesPruned: 0,
       autoSourceTrimmed: 0,
+      distilledDiscarded: 0,
+      digestsWritten: 0,
     }
   }
 
-  const autoSourceTrimmed = trimAutoSourceCap(projectId, autoMax)
-  const softDeletedPurged = purgeSoftDeleted(projectId, softDays)
+  let distilledDiscarded = 0
+  let digestsWritten = 0
+  // Distill-then-hard-delete auto-source overflow (preferred over soft-delete).
+  if (opts.projectPath) {
+    try {
+      const { distillAndDiscardAllAutoSources } = await import('./distill')
+      const d = await distillAndDiscardAllAutoSources(opts.projectPath, projectId, autoMax)
+      distilledDiscarded = d.discarded
+      digestsWritten = d.digests
+    } catch {
+      // Fallback: soft-trim if distill fails
+      trimAutoSourceCap(projectId, autoMax)
+    }
+  } else {
+    trimAutoSourceCap(projectId, autoMax)
+  }
+
+  // Soft-deleted = already judged worthless → hard eliminate (no second archive).
+  const { eliminateSoftDeletedNoValue } = await import('./distill')
+  const elim = eliminateSoftDeletedNoValue(projectId, softDays)
+  const softDeletedPurged = elim.purged || purgeSoftDeleted(projectId, softDays)
+
   const orphanEventsPurged = purgeOrphanRememberEvents(projectId, softDays)
   let archivesPruned = 0
   try {
@@ -250,7 +280,9 @@ export function runVaultPurge(
     softDeletedPurged,
     orphanEventsPurged,
     archivesPruned,
-    autoSourceTrimmed,
+    autoSourceTrimmed: distilledDiscarded,
+    distilledDiscarded,
+    digestsWritten,
   }
 }
 

--- a/core/services/retention/purge.ts
+++ b/core/services/retention/purge.ts
@@ -1,0 +1,257 @@
+/**
+ * Cold-store purge — make soft-delete and archives actually die.
+ *
+ * Soft-delete (deleted_at set) removes rows from recall but leaves them on
+ * disk forever without this module. Archives accumulate every retention wave.
+ * Both are purged on `prjct sync` (the maintenance pass).
+ *
+ * Deterministic, capped, best-effort. Never touches live (deleted_at IS NULL)
+ * judgment without going through retention first.
+ */
+
+import type { MemoryEntry } from '../../memory/entries'
+import { projectMemory } from '../../memory/project-memory'
+import { archiveStorage } from '../../storage/archive-storage'
+import prjctDb from '../../storage/database'
+
+export const DEFAULT_SOFT_DELETED_PURGE_DAYS = 30
+export const DEFAULT_ARCHIVE_PRUNE_DAYS = 90
+export const DEFAULT_AUTO_SOURCE_MAX_LIVE = 20
+/** Sources that are auto-generated (not human judgment). */
+export const AUTO_SOURCE_PREFIXES = [
+  'pattern-detector',
+  'transcript-auto',
+  'skill-miss',
+  'friction',
+  'land-auto',
+  'sync-context-quality',
+] as const
+
+export interface PurgeResult {
+  softDeletedPurged: number
+  orphanEventsPurged: number
+  archivesPruned: number
+  autoSourceTrimmed: number
+}
+
+export interface VaultHealth {
+  live: number
+  softDeleted: number
+  archives: number
+  rememberEvents: number
+  autoSourceLive: number
+}
+
+function isAutoSource(source: string | undefined): boolean {
+  if (!source) return false
+  return AUTO_SOURCE_PREFIXES.some(
+    (p) => source === p || source.startsWith(`${p}-`) || source.startsWith(p)
+  )
+}
+
+/**
+ * Hard-delete memory_entries rows soft-deleted more than `olderThanDays` ago.
+ * Also drops their tags (CASCADE) and embeddings.
+ */
+export function purgeSoftDeleted(
+  projectId: string,
+  olderThanDays: number = DEFAULT_SOFT_DELETED_PURGE_DAYS,
+  maxRows: number = 500
+): number {
+  const cutoff = Date.now() - olderThanDays * 86_400_000
+  try {
+    const rows = prjctDb.query<{ id: string }>(
+      projectId,
+      `SELECT id FROM memory_entries
+       WHERE deleted_at IS NOT NULL AND deleted_at < ?
+       ORDER BY deleted_at ASC
+       LIMIT ?`,
+      cutoff,
+      maxRows
+    )
+    if (rows.length === 0) return 0
+
+    prjctDb.transaction(projectId, (db) => {
+      const delEmb = db.prepare('DELETE FROM memory_embeddings WHERE memory_id = ?')
+      const delEntry = db.prepare('DELETE FROM memory_entries WHERE id = ?')
+      for (const r of rows) {
+        try {
+          delEmb.run(r.id)
+        } catch {
+          /* embeddings table may be empty */
+        }
+        delEntry.run(r.id)
+      }
+    })
+    return rows.length
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Delete remember-events whose memory_entries row is gone or soft-deleted
+ * past cutoff (orphan audit rows that no longer map to live knowledge).
+ */
+export function purgeOrphanRememberEvents(
+  projectId: string,
+  olderThanDays: number = DEFAULT_SOFT_DELETED_PURGE_DAYS,
+  maxRows: number = 500
+): number {
+  const cutoffIso = new Date(Date.now() - olderThanDays * 86_400_000).toISOString()
+  try {
+    // Events whose id has no live memory_entries mem_<id>
+    const rows = prjctDb.query<{ id: number }>(
+      projectId,
+      `SELECT e.id FROM events e
+       WHERE e.type LIKE 'memory.remember.%'
+         AND e.timestamp < ?
+         AND NOT EXISTS (
+           SELECT 1 FROM memory_entries m
+           WHERE m.id = 'mem_' || e.id AND m.deleted_at IS NULL
+         )
+       ORDER BY e.id ASC
+       LIMIT ?`,
+      cutoffIso,
+      maxRows
+    )
+    if (rows.length === 0) return 0
+    prjctDb.transaction(projectId, (db) => {
+      const del = db.prepare('DELETE FROM events WHERE id = ?')
+      for (const r of rows) del.run(r.id)
+    })
+    return rows.length
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * If more than `maxLive` entries share an auto source, soft-delete the oldest
+ * excess (FIFO). Keeps auto-noise from unbounded growth between syncs.
+ */
+export function trimAutoSourceCap(
+  projectId: string,
+  maxLive: number = DEFAULT_AUTO_SOURCE_MAX_LIVE
+): number {
+  if (maxLive <= 0) return 0
+  let trimmed = 0
+  try {
+    const entries = projectMemory.allEntriesForIndex(projectId)
+    const bySource = new Map<string, MemoryEntry[]>()
+    for (const e of entries) {
+      const src = e.tags?.source
+      if (!isAutoSource(src)) continue
+      const key = src!
+      const list = bySource.get(key) ?? []
+      list.push(e)
+      bySource.set(key, list)
+    }
+    for (const [, list] of bySource) {
+      if (list.length <= maxLive) continue
+      // Oldest first
+      list.sort((a, b) => a.rememberedAt.localeCompare(b.rememberedAt))
+      const overflow = list.slice(0, list.length - maxLive)
+      for (const e of overflow) {
+        try {
+          archiveStorage.archive(projectId, {
+            entityType: 'memory_entry',
+            entityId: e.id,
+            entityData: {
+              id: e.id,
+              type: e.type,
+              content: e.content,
+              tags: e.tags,
+              rememberedAt: e.rememberedAt,
+            },
+            summary: e.content.slice(0, 80),
+            reason: `auto-source-cap (>${maxLive})`,
+          })
+        } catch {
+          /* best-effort */
+        }
+        if (projectMemory.forget(projectId, e.id)) trimmed++
+      }
+    }
+  } catch {
+    return trimmed
+  }
+  return trimmed
+}
+
+/** Snapshot for sync --md vault health line. */
+export function vaultHealth(projectId: string): VaultHealth {
+  const live =
+    prjctDb.get<{ c: number }>(
+      projectId,
+      'SELECT COUNT(*) AS c FROM memory_entries WHERE deleted_at IS NULL'
+    )?.c ?? 0
+  const softDeleted =
+    prjctDb.get<{ c: number }>(
+      projectId,
+      'SELECT COUNT(*) AS c FROM memory_entries WHERE deleted_at IS NOT NULL'
+    )?.c ?? 0
+  const archives =
+    prjctDb.get<{ c: number }>(projectId, 'SELECT COUNT(*) AS c FROM archives')?.c ?? 0
+  const rememberEvents =
+    prjctDb.get<{ c: number }>(
+      projectId,
+      "SELECT COUNT(*) AS c FROM events WHERE type LIKE 'memory.remember.%'"
+    )?.c ?? 0
+
+  let autoSourceLive = 0
+  try {
+    const entries = projectMemory.allEntriesForIndex(projectId)
+    autoSourceLive = entries.filter((e) => isAutoSource(e.tags?.source)).length
+  } catch {
+    autoSourceLive = 0
+  }
+
+  return { live, softDeleted, archives, rememberEvents, autoSourceLive }
+}
+
+/**
+ * Full cold purge pass for sync. Best-effort; never throws.
+ */
+export function runVaultPurge(
+  projectId: string,
+  opts: {
+    softDeletedPurgeDays?: number
+    archivePruneDays?: number
+    autoSourceMaxLive?: number
+    dryRun?: boolean
+  } = {}
+): PurgeResult {
+  const softDays = opts.softDeletedPurgeDays ?? DEFAULT_SOFT_DELETED_PURGE_DAYS
+  const archDays = opts.archivePruneDays ?? DEFAULT_ARCHIVE_PRUNE_DAYS
+  const autoMax = opts.autoSourceMaxLive ?? DEFAULT_AUTO_SOURCE_MAX_LIVE
+  const dryRun = opts.dryRun === true
+
+  if (dryRun) {
+    return {
+      softDeletedPurged: 0,
+      orphanEventsPurged: 0,
+      archivesPruned: 0,
+      autoSourceTrimmed: 0,
+    }
+  }
+
+  const autoSourceTrimmed = trimAutoSourceCap(projectId, autoMax)
+  const softDeletedPurged = purgeSoftDeleted(projectId, softDays)
+  const orphanEventsPurged = purgeOrphanRememberEvents(projectId, softDays)
+  let archivesPruned = 0
+  try {
+    archivesPruned = archiveStorage.pruneOldArchives(projectId, archDays)
+  } catch {
+    archivesPruned = 0
+  }
+
+  return {
+    softDeletedPurged,
+    orphanEventsPurged,
+    archivesPruned,
+    autoSourceTrimmed,
+  }
+}
+
+export { isAutoSource }

--- a/core/services/retention/reference-model.ts
+++ b/core/services/retention/reference-model.ts
@@ -1,0 +1,102 @@
+/**
+ * Reference model R — the Rho "high-quality distribution" for project memory.
+ *
+ * Rho trains a reference LM on clean data, then scores corpus tokens by excess
+ * loss vs that reference. In prjct the analogous R is the durable project
+ * model already in SQLite: judgment knowledge + living-v2 synthesis. No LLM
+ * call, no new tables — pure selection over existing entries.
+ *
+ * Efficiency: R is capped and built once per evaluate/capture-gate call.
+ * Vectors for excess scoring are computed lazily by the excess module.
+ */
+
+import type { MemoryEntry } from '../../memory/entries'
+import { isModelMemory } from '../../memory/entries'
+
+/** Types that form the project's reference model (judgment + synthesis). */
+export const REFERENCE_TYPES = new Set([
+  'decision',
+  'gotcha',
+  'learning',
+  'fact',
+  'feedback',
+  'pattern',
+  'anti-pattern',
+  'identity',
+  'voice',
+  'glossary',
+  'framework',
+  'spec',
+  // living-v2 context is synthesis of the project model; included when tagged
+  'context',
+])
+
+/** Hard cap on |R| — keeps excess scoring O(n·|R|) sub-millisecond for typical vaults. */
+export const REFERENCE_CAP = 150
+
+const PROVENANCE_RANK: Record<string, number> = {
+  declared: 3,
+  extracted: 2,
+  ambiguous: 1,
+  inferred: 0,
+}
+
+function isLivingV2(entry: MemoryEntry): boolean {
+  if (entry.tags?.context_schema === 'living-v2') return true
+  if (entry.tags?.synthesis === 'model-authored' || entry.tags?.synthesis === 'deterministic') {
+    return true
+  }
+  // Heuristic: land-auto session close is model-relevant synthesis
+  if (entry.tags?.source === 'land-auto' || entry.tags?.capture === 'land-v2') return true
+  return false
+}
+
+/**
+ * Is this entry eligible to sit in the reference set R?
+ * Noise, inbox, raw signals, and empty content never define the model.
+ */
+export function isReferenceEligible(entry: MemoryEntry): boolean {
+  if (!isModelMemory(entry)) return false
+  if (entry.content.trim().length < 40) return false
+  if (!REFERENCE_TYPES.has(entry.type)) return false
+  if (entry.type === 'context' && !isLivingV2(entry)) return false
+  if (entry.type === 'inbox' || entry.type === 'todo' || entry.type === 'idea') return false
+  return true
+}
+
+/**
+ * Rank for selection into R (higher = more authoritative).
+ * Prefer declared judgment, then recency.
+ */
+function referenceRank(entry: MemoryEntry): number {
+  const prov = PROVENANCE_RANK[entry.provenance] ?? 1
+  const typeBoost =
+    entry.type === 'decision' || entry.type === 'gotcha'
+      ? 100
+      : entry.type === 'learning' || entry.type === 'fact'
+        ? 50
+        : entry.type === 'context'
+          ? 30
+          : 20
+  const t = Date.parse(entry.rememberedAt)
+  const recency = Number.isFinite(t) ? t / 1e13 : 0 // small tie-break
+  return typeBoost * 10 + prov * 3 + recency
+}
+
+/**
+ * Build the reference set R from the live entry list.
+ * Deterministic: same entries → same R (sorted by rank, capped).
+ */
+export function buildReferenceModel(entries: MemoryEntry[]): MemoryEntry[] {
+  const eligible = entries.filter(isReferenceEligible)
+  eligible.sort((a, b) => referenceRank(b) - referenceRank(a))
+  return eligible.slice(0, REFERENCE_CAP)
+}
+
+/**
+ * R without `excludeId` — used when scoring an entry that is itself in R
+ * so it is not compared to itself (would force excess → 0).
+ */
+export function referenceWithout(r: MemoryEntry[], excludeId: string): MemoryEntry[] {
+  return r.filter((e) => e.id !== excludeId)
+}

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -41,7 +41,6 @@ import log from '../utils/logger'
 import { repairContextQuality } from './context-quality-service'
 import context7Service from './context7-service'
 import { writeProjectAgentSurfaces } from './project-agent-surfaces'
-import { evaluateRetention } from './retention'
 import { skillGenerator } from './skill-generator'
 import { emptyCommands, emptyGitData, emptyStack, emptyStats } from './sync/defaults'
 import { detectIncrementalChanges } from './sync/incremental'
@@ -460,22 +459,44 @@ class SyncService {
         repairContextQuality(this.projectPath, this.projectId!)
       )
 
-      // 9d. Retention dry-run (PR1 of retention-score): report which entries
-      // the value-based criterion would archive/delete. READ-ONLY — nothing
-      // is mutated until the verdicts are validated against real projects.
-      const retentionDryRun = await phase('retention-dryrun', async () => {
+      // 9d. Value-based retention (score → archive/delete). Default applies
+      // capped actions; config.retention.mode = dry-run|off for observe/skip.
+      // 9e. Inbox triage merges fingerprint duplicates + archives stale inbox.
+      const retentionDryRun = await phase('retention', async () => {
         try {
-          const report = evaluateRetention(this.projectId!, Date.now())
+          const cfg = await configManager.readConfig(this.projectPath).catch(() => null)
+          const mode = cfg?.retention?.mode ?? 'apply'
+          if (mode === 'off') return undefined
+
+          const dryRun = mode === 'dry-run'
+          const { applyRetention, triageInbox } = await import('./retention')
+          const applied = applyRetention(this.projectId!, {
+            dryRun,
+            maxArchive: cfg?.retention?.maxArchive,
+            maxDelete: cfg?.retention?.maxDelete,
+          })
+          let inboxMerged = 0
+          let inboxArchived = 0
+          if (!dryRun) {
+            const triaged = triageInbox(this.projectId!)
+            inboxMerged = triaged.merged
+            inboxArchived = triaged.archived
+          }
           return {
-            evaluated: report.evaluated,
-            active: report.active,
-            archive: report.archive,
-            delete: report.delete,
-            samples: report.flagged.slice(0, 10),
+            evaluated: applied.evaluated,
+            active: applied.active,
+            archive: applied.wouldArchive,
+            delete: applied.wouldDelete,
+            archived: applied.archived,
+            deleted: applied.deleted,
+            inboxMerged,
+            inboxArchived,
+            dryRun,
+            samples: applied.samples,
           }
         } catch (error) {
-          // Best-effort: a scoring failure must never break sync.
-          log.debug('retention dry-run failed', { error: getErrorMessage(error) })
+          // Best-effort: a scoring/apply failure must never break sync.
+          log.debug('retention phase failed', { error: getErrorMessage(error) })
           return undefined
         }
       })

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -486,7 +486,8 @@ class SyncService {
           // Cold purge: vacuum soft-deleted, orphan events, old archives,
           // auto-source caps. This is where historical bloat actually dies.
           const { runVaultPurge, vaultHealth } = await import('./retention/purge')
-          const purged = runVaultPurge(this.projectId!, {
+          const purged = await runVaultPurge(this.projectId!, {
+            projectPath: this.projectPath,
             dryRun,
             softDeletedPurgeDays: cfg?.retention?.softDeletedPurgeDays,
             archivePruneDays: cfg?.retention?.archivePruneDays,
@@ -519,6 +520,8 @@ class SyncService {
               orphanEventsPurged: purged.orphanEventsPurged,
               archivesPruned: purged.archivesPruned,
               autoSourceTrimmed: purged.autoSourceTrimmed,
+              distilledDiscarded: purged.distilledDiscarded,
+              digestsWritten: purged.digestsWritten,
             },
           }
         } catch (error) {

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -41,6 +41,7 @@ import log from '../utils/logger'
 import { repairContextQuality } from './context-quality-service'
 import context7Service from './context7-service'
 import { writeProjectAgentSurfaces } from './project-agent-surfaces'
+import { evaluateRetention } from './retention'
 import { skillGenerator } from './skill-generator'
 import { emptyCommands, emptyGitData, emptyStack, emptyStats } from './sync/defaults'
 import { detectIncrementalChanges } from './sync/incremental'
@@ -459,6 +460,26 @@ class SyncService {
         repairContextQuality(this.projectPath, this.projectId!)
       )
 
+      // 9d. Retention dry-run (PR1 of retention-score): report which entries
+      // the value-based criterion would archive/delete. READ-ONLY — nothing
+      // is mutated until the verdicts are validated against real projects.
+      const retentionDryRun = await phase('retention-dryrun', async () => {
+        try {
+          const report = evaluateRetention(this.projectId!, Date.now())
+          return {
+            evaluated: report.evaluated,
+            active: report.active,
+            archive: report.archive,
+            delete: report.delete,
+            samples: report.flagged.slice(0, 10),
+          }
+        } catch (error) {
+          // Best-effort: a scoring failure must never break sync.
+          log.debug('retention dry-run failed', { error: getErrorMessage(error) })
+          return undefined
+        }
+      })
+
       // 10. Update global config and commands (CLI does EVERYTHING)
       // This ensures `prjct sync` from terminal updates global CLAUDE.md and commands
       await phase('install-global', async () => {
@@ -500,6 +521,7 @@ class SyncService {
         },
         analysisSummary,
         contextQuality,
+        retentionDryRun,
         syncMetrics,
         workCost,
         verification,

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -492,7 +492,15 @@ class SyncService {
             inboxMerged,
             inboxArchived,
             dryRun,
-            samples: applied.samples,
+            samples: applied.samples.map((s) => ({
+              id: s.id,
+              type: s.type,
+              verdict: s.verdict,
+              score: s.score,
+              reasons: s.reasons,
+              excess: s.excess,
+            })),
+            referenceSize: applied.referenceSize,
           }
         } catch (error) {
           // Best-effort: a scoring/apply failure must never break sync.

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -482,6 +482,18 @@ class SyncService {
             inboxMerged = triaged.merged
             inboxArchived = triaged.archived
           }
+
+          // Cold purge: vacuum soft-deleted, orphan events, old archives,
+          // auto-source caps. This is where historical bloat actually dies.
+          const { runVaultPurge, vaultHealth } = await import('./retention/purge')
+          const purged = runVaultPurge(this.projectId!, {
+            dryRun,
+            softDeletedPurgeDays: cfg?.retention?.softDeletedPurgeDays,
+            archivePruneDays: cfg?.retention?.archivePruneDays,
+            autoSourceMaxLive: cfg?.retention?.autoSourceMaxLive,
+          })
+          const health = vaultHealth(this.projectId!)
+
           return {
             evaluated: applied.evaluated,
             active: applied.active,
@@ -501,6 +513,13 @@ class SyncService {
               excess: s.excess,
             })),
             referenceSize: applied.referenceSize,
+            vault: {
+              ...health,
+              softDeletedPurged: purged.softDeletedPurged,
+              orphanEventsPurged: purged.orphanEventsPurged,
+              archivesPruned: purged.archivesPruned,
+              autoSourceTrimmed: purged.autoSourceTrimmed,
+            },
           }
         } catch (error) {
           // Best-effort: a scoring/apply failure must never break sync.

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -670,6 +670,13 @@ export async function setTaskStatus(
       } catch {
         /* best-effort usefulness credit */
       }
+      // Phase 3: incremental retention cleanup on task done (capped, best-effort).
+      try {
+        const { applyRetentionIncremental } = await import('./retention')
+        applyRetentionIncremental(projectId)
+      } catch {
+        /* never block done on cleanup */
+      }
       return {
         ok: true,
         taskId: wsTask.id,
@@ -736,6 +743,13 @@ export async function setTaskStatus(
         usefulnessService.creditShippedTask(projectId, active.id)
       } catch {
         /* best-effort usefulness credit */
+      }
+      // Phase 3: incremental retention cleanup on task done (capped, best-effort).
+      try {
+        const { applyRetentionIncremental } = await import('./retention')
+        applyRetentionIncremental(projectId)
+      } catch {
+        /* never block done on cleanup */
       }
     } else if (normalized === 'paused' || normalized === 'pause') {
       await stateStorage.pauseTask(projectId)

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -148,6 +148,19 @@ export interface LocalConfig {
   notify?: { mode: 'on' | 'off' }
 
   /**
+   * Value-based memory retention (score → active|archive|delete).
+   * Unset / `apply` runs archive+delete on sync (capped). `dry-run` only
+   * reports. `off` skips the retention phase entirely.
+   */
+  retention?: {
+    mode?: 'off' | 'dry-run' | 'apply'
+    /** Max archive actions per full sync (default 100). */
+    maxArchive?: number
+    /** Max delete actions per full sync (default 50). */
+    maxDelete?: number
+  }
+
+  /**
    * Multi-agent coordination (worktree isolation + switch/accept handoff).
    * Unset ⇒ owner stamping always on; isolation defaults to `auto` when a
    * foreign cycle occupies the workspace; switch does not spawn target CLIs

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -158,6 +158,12 @@ export interface LocalConfig {
     maxArchive?: number
     /** Max delete actions per full sync (default 50). */
     maxDelete?: number
+    /** Hard-delete soft-deleted rows older than N days on sync (default 30). */
+    softDeletedPurgeDays?: number
+    /** Prune archives older than N days on sync (default 90). */
+    archivePruneDays?: number
+    /** Max live entries per auto source prefix (default 20). */
+    autoSourceMaxLive?: number
   }
 
   /**

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -158,7 +158,7 @@ export interface LocalConfig {
     maxArchive?: number
     /** Max delete actions per full sync (default 50). */
     maxDelete?: number
-    /** Hard-delete soft-deleted rows older than N days on sync (default 30). */
+    /** Hard-delete soft-deleted rows older than N days on sync (default 7 — no statistical value). */
     softDeletedPurgeDays?: number
     /** Prune archives older than N days on sync (default 90). */
     archivePruneDays?: number

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -131,6 +131,18 @@ export interface RetentionDryRunSummary {
     excess?: number
   }>
   referenceSize?: number
+  /** Cold purge + vault inventory (sync maintenance). */
+  vault?: {
+    live: number
+    softDeleted: number
+    archives: number
+    rememberEvents: number
+    autoSourceLive: number
+    softDeletedPurged?: number
+    orphanEventsPurged?: number
+    archivesPruned?: number
+    autoSourceTrimmed?: number
+  }
 }
 
 // Sync Result & Context Generator Config

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -142,6 +142,8 @@ export interface RetentionDryRunSummary {
     orphanEventsPurged?: number
     archivesPruned?: number
     autoSourceTrimmed?: number
+    distilledDiscarded?: number
+    digestsWritten?: number
   }
 }
 

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -109,6 +109,16 @@ export interface ContextQualitySummary {
   issues: string[]
 }
 
+/** Dry-run retention verdict counts (nothing is mutated; see core/services/retention). */
+export interface RetentionDryRunSummary {
+  evaluated: number
+  active: number
+  archive: number
+  delete: number
+  /** Worst-scored flagged entries, capped for the sync report. */
+  samples: Array<{ id: string; type: string; verdict: string; score: number; reasons: string[] }>
+}
+
 // Sync Result & Context Generator Config
 
 export interface IncrementalInfo {
@@ -135,6 +145,7 @@ export interface ProjectSyncResult {
   context7?: SyncContext7Status
   analysisSummary?: SyncAnalysisSummary
   contextQuality?: ContextQualitySummary
+  retentionDryRun?: RetentionDryRunSummary
   syncMetrics?: SyncMetrics
   workCost?: WorkCostSnapshot[]
   verification?: VerificationReport

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -109,12 +109,18 @@ export interface ContextQualitySummary {
   issues: string[]
 }
 
-/** Dry-run retention verdict counts (nothing is mutated; see core/services/retention). */
+/** Retention phase summary (dry-run or applied). See core/services/retention. */
 export interface RetentionDryRunSummary {
   evaluated: number
   active: number
   archive: number
   delete: number
+  /** Actions actually performed this pass (0 when dry-run). */
+  archived?: number
+  deleted?: number
+  inboxMerged?: number
+  inboxArchived?: number
+  dryRun?: boolean
   /** Worst-scored flagged entries, capped for the sync report. */
   samples: Array<{ id: string; type: string; verdict: string; score: number; reasons: string[] }>
 }

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -122,7 +122,15 @@ export interface RetentionDryRunSummary {
   inboxArchived?: number
   dryRun?: boolean
   /** Worst-scored flagged entries, capped for the sync report. */
-  samples: Array<{ id: string; type: string; verdict: string; score: number; reasons: string[] }>
+  samples: Array<{
+    id: string
+    type: string
+    verdict: string
+    score: number
+    reasons: string[]
+    excess?: number
+  }>
+  referenceSize?: number
 }
 
 // Sync Result & Context Generator Config


### PR DESCRIPTION
## Summary
- `prjct connect` aliases `prjct cloud link` (matches web/email activation copy)
- Client for `GET /sync/account` + `prjct cloud status` shows plan/trial/canSync
- `prjct cloud billing` prints/opens billing URL
- Login success prints trial blurb + next step

## Deploy order
1. **prjct-cli-api** (`GET /sync/account`) first
2. This CLI release
3. prjct-cli-app setup/canSync polish

## Test plan
- [x] `bun test core/__tests__/sync/cloud-command.test.ts`
- [ ] Manual: login → status shows trial → connect links → billing opens URL
- [ ] Against old API: status degrades if `/sync/account` 404