### PR TITLE
fix: security P0 (no shell spawns) + cold afterEmit detach

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-The latest minor on `main` plus the previous minor receive security fixes. Older releases are not patched — upgrade with `bun install -g prjct-cli@latest` (or your installer of choice).
+The latest minor on `main` plus the previous minor receive security fixes. Older releases are not patched — upgrade with `npm install -g prjct-cli@latest` (or your installer of choice).
 
 | Version | Supported |
 | ------- | --------- |
-| Latest 2.x | :white_check_mark: |
-| Previous 2.x minor | :white_check_mark: |
-| 1.x and older | :x: |
+| Latest 3.x minor | :white_check_mark: |
+| Previous 3.x minor | :white_check_mark: |
+| 2.x and older | :x: |
 
 ## Security Model
 
@@ -16,22 +16,38 @@ The latest minor on `main` plus the previous minor receive security fixes. Older
 
 prjct-cli is designed with privacy and security as core principles:
 
-- **All data stored locally** in `~/.prjct-cli/` - never transmitted externally
-- **No telemetry or analytics** - we don't track usage
-- **No cloud sync** - your productivity data stays on your machine
-- **No external servers** - works entirely offline (except Claude integration)
+- **Project data lives locally** in `~/.prjct-cli/projects/{id}/` (SQLite) and `.prjct/prjct.config.json` in the repo
+- **No telemetry or analytics** — we don't track usage
+- **Offline by default** — core CLI, hooks, MCP, and SQLite work with no network
+- **Optional cloud sync** — only when the user signs in (`prjct login` / cloud link). Tokens never go in plaintext config files; they use the OS credential store (macOS Keychain, libsecret, Windows Credential Manager). Login fails closed if no secure store is available
+- **Agent host integration** — context is injected into Claude Code / Gemini / Cursor / etc. via local hooks and MCP; those hosts have their own network paths to model providers
+
+### Threat Model (summary)
+
+| Surface | Control |
+| ------- | ------- |
+| Credential material in tool args | PreToolUse `pre-secrets` MUST — deny on pattern match (multi-host, no fragile env) |
+| Secrets in `remember` / capture | Refuse by default unless `--force` |
+| Imported workflow templates | Shell / verify / script rules with `trustSource: imported` are refused |
+| Local workflow `script:` paths | Resolved under `.prjct/workflows/` only (`path.relative` + `realpath`, no shell) |
+| Subprocess spawn | Prefer `execFile` / `spawn(..., { shell: false })`; no free-form `shell: true` on product paths |
+| Daemon IPC | Unix socket mode `0600` (named pipe on Windows) |
+| npm package | Minimal runtime deps, `npm audit` in CI, pinned versions + overrides |
+
+**User-authored local workflow rules** may run shell commands the user (or their agent) defined. That is intentional project automation — treat workflow rules like code you review before enabling. Imported/shared rules cannot shell out without local re-creation.
 
 ### Data Policy
 
-We store: project config (`.prjct/prjct.config.json`), task history (`~/.prjct-cli/projects/{id}/`), and session activity in SQLite. We do **not** store credentials, API keys, source code bodies (only paths for analysis), or personal info beyond the git author name/email already in your commits. `prjct remember` and `prjct capture` refuse content that looks like a secret or like a prompt-injection payload unless invoked with `--force`.
+We store: project config (`.prjct/prjct.config.json`), task history and memory in SQLite under `~/.prjct-cli/`, and session activity. We do **not** store API keys in the project tree. Source code bodies are not bulk-uploaded; analysis keeps paths and derived signals. `prjct remember` and `prjct capture` refuse content that looks like a secret or like a prompt-injection payload unless invoked with `--force`.
+
+When cloud sync is enabled, only entities the user links are exchanged with the prjct cloud API over authenticated channels. Review cloud product docs for retention if you enable it.
 
 ### Dependencies
 
-We use minimal dependencies and audit them regularly:
-
+- Minimal runtime dependency set
 - `npm audit` runs in CI on every push
-- Dependencies are pinned to specific versions
-- No dependencies with known critical vulnerabilities
+- Dependencies pinned; transitive overrides applied when needed
+- No known critical vulnerabilities in the published dependency tree at release time
 
 ## Reporting a Vulnerability
 
@@ -68,16 +84,18 @@ We use minimal dependencies and audit them regularly:
 
 ## Security Best Practices for Users
 
-1. **Keep prjct-cli updated** - Run `npm update -g prjct-cli` regularly
-2. **Review before committing** - Check `.prjct/prjct.config.json` before pushing to public repos
-3. **Avoid storing secrets** - Don't put API keys or passwords in `now.md` or `ideas.md`
-4. **Use .gitignore** - The `.prjct/` directory should be in your `.gitignore` (auto-added by `prjct init`)
+1. **Keep prjct-cli updated** — `npm update -g prjct-cli` (or `prjct upgrade`)
+2. **Review before committing** — Check `.prjct/prjct.config.json` and workflow rules under `.prjct/workflows/` before pushing to public repos
+3. **Avoid storing secrets** — Don't put API keys or passwords in memory captures, specs, or workflow scripts
+4. **Use .gitignore** — `.prjct/` local state should stay out of public remotes when it holds machine-local paths (init helps)
+5. **Treat local shell workflow rules as code** — only enable rules you trust
+6. **Cloud optional** — leave cloud signed out if you want a fully offline install
 
-## Claude Integration Security
+## Agent Host Integration Security
 
-When using prjct-cli with Claude Code or Claude Desktop:
+When using prjct-cli with Claude Code, Gemini CLI, Cursor, Codex, or similar:
 
-- Commands execute locally on your machine
-- Claude only sees the context you provide via slash commands
-- No data is stored on Anthropic's servers beyond standard Claude usage
-- Review [Anthropic's privacy policy](https://www.anthropic.com/privacy) for Claude-specific details
+- Commands and hooks execute **locally** on your machine
+- Hosts only see context prjct injects (hooks / MCP / skill files)
+- Model providers receive whatever the host sends under that host's privacy policy
+- Review your host vendor's privacy policy for model traffic details

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -141,7 +141,35 @@ if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
           pending.push(fn)
         },
       })
-      for (const fn of pending) await fn().catch(() => undefined)
+      // Detach afterEmit so cold Stop/SessionStart do not block the host.
+      // Prefer a detached self-spawn when we have a script path (mirrors
+      // cold-entry); otherwise await in-process (dev / missing argv[1]).
+      if (pending.length > 0) {
+        const entry = process.argv[1]
+        if (entry && subcommand) {
+          try {
+            const { spawn } = await import('node:child_process')
+            const child = spawn(process.execPath, [entry, 'hook', subcommand], {
+              detached: true,
+              stdio: ['pipe', 'ignore', 'ignore'],
+              cwd: process.cwd(),
+              env: {
+                ...process.env,
+                PRJCT_HOOK_AFTER_EMIT: '1',
+                PRJCT_NO_DAEMON: '1',
+              },
+              shell: false,
+            })
+            child.stdin?.write(stdinPayload)
+            child.stdin?.end()
+            child.unref()
+          } catch {
+            for (const fn of pending) await fn().catch(() => undefined)
+          }
+        } else {
+          for (const fn of pending) await fn().catch(() => undefined)
+        }
+      }
       process.exit(0)
     } catch {
       process.stdout.write('{}\n')

--- a/core/commands/update/cleanup-installs.ts
+++ b/core/commands/update/cleanup-installs.ts
@@ -13,7 +13,7 @@
  * multi-install footgun without shelling out to real package managers.
  */
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { realpathSync } from 'node:fs'
 import path from 'node:path'
 import readline from 'node:readline'
@@ -28,12 +28,12 @@ import {
 /** How aggressively `prjct update` consolidates parallel installs. */
 export type CleanupMode = 'auto' | 'force' | 'off'
 
-/** PM-native global uninstall (preferred over rm — keeps PM metadata sane). */
-const UNINSTALL_ARGS: Record<PkgManagerName, string> = {
-  npm: 'npm uninstall -g prjct-cli',
-  pnpm: 'pnpm remove -g prjct-cli',
-  bun: 'bun remove -g prjct-cli',
-  yarn: 'yarn global remove prjct-cli',
+/** PM-native global uninstall argv (execFile — no shell). */
+const UNINSTALL_ARGV: Record<PkgManagerName, [string, ...string[]]> = {
+  npm: ['npm', 'uninstall', '-g', 'prjct-cli'],
+  pnpm: ['pnpm', 'remove', '-g', 'prjct-cli'],
+  bun: ['bun', 'remove', '-g', 'prjct-cli'],
+  yarn: ['yarn', 'global', 'remove', 'prjct-cli'],
 }
 
 export interface CleanupPlan {
@@ -267,9 +267,10 @@ export function planCleanup(): CleanupPlan {
 }
 
 function removeOne(pm: PkgManagerName | 'brew'): { ok: boolean; error?: string } {
-  const cmd = pm === 'brew' ? 'brew uninstall prjct-cli' : UNINSTALL_ARGS[pm]
+  const argv: [string, ...string[]] =
+    pm === 'brew' ? ['brew', 'uninstall', 'prjct-cli'] : UNINSTALL_ARGV[pm]
   try {
-    execSync(cmd, { stdio: 'pipe', shell: '/bin/sh' })
+    execFileSync(argv[0], argv.slice(1), { stdio: 'pipe' })
     return { ok: true }
   } catch (e) {
     return { ok: false, error: `${pm}: ${(e as Error).message.split('\n')[0]}` }

--- a/core/hooks/_runner.ts
+++ b/core/hooks/_runner.ts
@@ -15,16 +15,17 @@
  *   3. Output is JSON-validated against the event's schema by
  *      `buildHookOutput` (e.g. SessionStart accepts hookSpecificOutput,
  *      Stop only accepts systemMessage).
- *   4. After-effects run AFTER `emit` so the host parser doesn't wait
- *      on side-effect work.
+ *   4. After-effects run AFTER `emit` (never before the host-visible line).
  *
  * Two execution modes share ALL of the above:
- *   - Process mode (`io` omitted): the cold path Claude Code spawns —
- *     reads `process.stdin`, writes `process.stdout`, awaits `afterEmit`.
- *   - Daemon mode (`io` supplied): the warm path — input comes pre-parsed
- *     from the wire request, output goes to a sink (returned to the
- *     client), and `afterEmit` is DETACHED so it never blocks the daemon's
- *     serialized request chain. Same build + same fail-soft contract.
+ *   - Process mode (`io` omitted): tests + direct callers — reads
+ *     `process.stdin`, writes `process.stdout`, awaits `afterEmit` so work is
+ *     not lost when the process is about to exit. Production cold path uses
+ *     HookIo via `cold-entry` (detached afterEmit worker) instead.
+ *   - Daemon / HookIo mode (`io` supplied): warm path or cold-entry bridge —
+ *     input pre-parsed, output to a sink, and `afterEmit` is DETACHED via
+ *     `detachAfterEmit` so it never blocks the host response. Same build +
+ *     same fail-soft contract.
  */
 
 import {

--- a/core/hooks/cold-entry.ts
+++ b/core/hooks/cold-entry.ts
@@ -14,11 +14,12 @@
  *   hook logic). esbuild bundles THIS entry on its own into
  *   `dist/bin/prjct-hooks.mjs`, so the cold path parses only the hook closure.
  *
- * CONTRACT (must stay byte-identical to the old cold path in bin/prjct.ts):
- *   - emit the hook's JSON line to stdout, then AWAIT every `afterEmit`
- *     side-effect (vault regen, transcript ingest) before exit — cold mode has
- *     no daemon to detach them onto, and skipping them is what made the vault
- *     go stale. afterEmit is awaited here exactly as bin/prjct.ts did.
+ * CONTRACT:
+ *   - emit the hook's JSON line to stdout immediately (host-visible response)
+ *   - afterEmit side-effects (transcript ingest, vault regen, patterns) run in
+ *     a DETACHED child (`PRJCT_HOOK_AFTER_EMIT=1`) so Stop/SessionStart no longer
+ *     block the host on cold path for 1–2s. The child re-runs the same hook with
+ *     a noop sink and awaits afterEmit — work is preserved, response is fast.
  *   - fail-soft: any throw degrades to `{}` + exit 0; a hook must never disturb
  *     the host session.
  *
@@ -26,7 +27,11 @@
  * dev/source path (`bun bin/prjct.ts hook`) are unchanged.
  */
 
+import { spawn } from 'node:child_process'
 import { getHookRunner } from './registry'
+
+/** Env flag: this process only exists to finish afterEmit (parent already responded). */
+const AFTER_EMIT_ENV = 'PRJCT_HOOK_AFTER_EMIT'
 
 /** Read all of stdin (the hook event JSON) with a timeout safety net.
  *  Mirrors bin/prjct.ts `readAllStdin`. */
@@ -47,14 +52,45 @@ async function readAllStdin(timeoutMs: number): Promise<string> {
   })
 }
 
+/**
+ * Re-invoke this entry as a detached worker that only runs afterEmit.
+ * Parent exits as soon as the host-visible JSON is written.
+ * @returns true when a worker was spawned successfully.
+ */
+function trySpawnAfterEmitWorker(subcommand: string | undefined, stdinPayload: string): boolean {
+  const entry = process.argv[1]
+  if (!entry || !subcommand) return false
+  try {
+    const child = spawn(process.execPath, [entry, 'hook', subcommand], {
+      detached: true,
+      stdio: ['pipe', 'ignore', 'ignore'],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        [AFTER_EMIT_ENV]: '1',
+        // Worker must not try the daemon — it only finishes local afterEmit.
+        PRJCT_NO_DAEMON: '1',
+      },
+      shell: false,
+    })
+    child.stdin?.write(stdinPayload)
+    child.stdin?.end()
+    child.unref()
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function main(): Promise<void> {
   // argv after the runtime + script: ["hook", "<subcommand>", ...].
   const args = process.argv.slice(2)
   const subcommand = args[1]
+  const isAfterEmitWorker = process.env[AFTER_EMIT_ENV] === '1'
   try {
     const runner = getHookRunner(subcommand)
     if (!runner) {
-      process.stdout.write('{}\n')
+      if (!isAfterEmitWorker) process.stdout.write('{}\n')
       process.exit(0)
     }
     const stdinPayload = await readAllStdin(1000)
@@ -68,16 +104,32 @@ async function main(): Promise<void> {
     await runner(process.cwd(), {
       input,
       sink: (chunk: string) => {
-        process.stdout.write(chunk)
+        // Worker: parent already answered the host — never write again.
+        if (!isAfterEmitWorker) process.stdout.write(chunk)
       },
       detachAfterEmit: (fn: () => Promise<void>) => {
         pending.push(fn)
       },
     })
-    for (const fn of pending) await fn().catch(() => undefined)
+
+    if (isAfterEmitWorker) {
+      // This process exists solely to finish afterEmit.
+      for (const fn of pending) await fn().catch(() => undefined)
+      process.exit(0)
+    }
+
+    // Parent: response already on stdout. Detach afterEmit so Stop (~1–2s of
+    // transcript/pattern work) does not block host process exit. If the
+    // spawn fails, fall back to in-process await so work is not lost.
+    if (pending.length > 0) {
+      const detached = trySpawnAfterEmitWorker(subcommand, stdinPayload)
+      if (!detached) {
+        for (const fn of pending) await fn().catch(() => undefined)
+      }
+    }
     process.exit(0)
   } catch {
-    process.stdout.write('{}\n')
+    if (!isAfterEmitWorker) process.stdout.write('{}\n')
     process.exit(0)
   }
 }

--- a/core/services/drift-refresh.ts
+++ b/core/services/drift-refresh.ts
@@ -135,23 +135,27 @@ export function maybeDetachDriftRefresh(input: {
     // Hint to sync that this is continuous-understanding refresh (world model).
     PRJCT_WORLD_MODEL_REFRESH: '1',
   }
+  // Never enable shell mode — PATH/Windows injection surface. Prefer the
+  // running runtime + resolved bin path; fall back to argv-only `prjct`
+  // via execFile semantics (spawn with shell disabled).
   try {
     const child = spawn(process.execPath, [bin, 'sync', '--project', input.projectPath], {
       detached: true,
       stdio: 'ignore',
       cwd: input.projectPath,
       env,
+      shell: false,
     })
     child.unref()
     return true
   } catch {
     try {
-      const child = spawn('prjct', ['sync'], {
+      const child = spawn('prjct', ['sync', '--project', input.projectPath], {
         detached: true,
         stdio: 'ignore',
         cwd: input.projectPath,
         env,
-        shell: true,
+        shell: false,
       })
       child.unref()
       return true

--- a/core/utils/which.ts
+++ b/core/utils/which.ts
@@ -7,7 +7,7 @@
  * Always returns the PATH-winning path (first hit), never throws.
  */
 
-import { execFileSync, execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { execFileAsync } from './exec'
 
 function firstNonEmptyLine(stdout: string): string | null {
@@ -40,11 +40,12 @@ export function whichSync(command: string): string | null {
       })
       return firstNonEmptyLine(stdout)
     } catch {
-      // Busybox / stripped PATH: command -v via sh.
-      const stdout = execSync(`command -v ${JSON.stringify(command)}`, {
+      // Busybox / stripped PATH: `command -v` via /bin/sh -c with a single
+      // argv payload. JSON.stringify keeps the token shell-safe (no injection).
+      // Prefer execFile over execSync({shell}) so we never inherit a free-form shell.
+      const stdout = execFileSync('/bin/sh', ['-c', `command -v ${JSON.stringify(command)}`], {
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'ignore'],
-        shell: '/bin/sh',
       })
       return firstNonEmptyLine(stdout)
     }

--- a/core/workflow-engine/workflow-engine.ts
+++ b/core/workflow-engine/workflow-engine.ts
@@ -163,21 +163,38 @@ async function runScriptAction(
   }
   const relativePath = rule.action.slice(SCRIPT_ACTION_PREFIX.length).trim()
   if (!relativePath) throw new Error(`Empty script path in action '${rule.action}'`)
-
-  const scriptPath = path.resolve(projectPath, '.prjct/workflows', relativePath)
-  // Security: keep scripts inside the project's workflows dir. No
-  // traversal via `../..` or absolute paths pointing elsewhere.
-  const workflowsRoot = path.resolve(projectPath, '.prjct/workflows')
-  if (!scriptPath.startsWith(`${workflowsRoot}${path.sep}`) && scriptPath !== workflowsRoot) {
+  // Reject absolute paths and null bytes before resolve — no host-root scripts.
+  if (path.isAbsolute(relativePath) || relativePath.includes('\0')) {
     throw new Error(`Script path escapes workflows dir: ${relativePath}`)
   }
+
+  const workflowsRoot = path.resolve(projectPath, '.prjct/workflows')
+  const candidate = path.resolve(workflowsRoot, relativePath)
+  // relative() + ".." is robust against startsWith prefix tricks; realpath
+  // collapses symlinks that would otherwise jump outside the workflows tree.
+  const relToRoot = path.relative(workflowsRoot, candidate)
+  if (relToRoot.startsWith('..') || path.isAbsolute(relToRoot)) {
+    throw new Error(`Script path escapes workflows dir: ${relativePath}`)
+  }
+  let scriptPath = candidate
   try {
-    await fs.access(scriptPath)
+    scriptPath = await fs.realpath(candidate)
   } catch {
     throw new Error(`Script not found: .prjct/workflows/${relativePath}`)
   }
+  let resolvedRoot = workflowsRoot
+  try {
+    resolvedRoot = await fs.realpath(workflowsRoot)
+  } catch {
+    /* workflows dir missing — realpath of script already failed or will */
+  }
+  const relAfterReal = path.relative(resolvedRoot, scriptPath)
+  if (relAfterReal.startsWith('..') || path.isAbsolute(relAfterReal)) {
+    throw new Error(`Script path escapes workflows dir: ${relativePath}`)
+  }
 
-  await execAsync(`bash ${JSON.stringify(scriptPath)}`, {
+  // execFile — no shell, argv only (script path is a single resolved file).
+  await execFileAsync('bash', [scriptPath], {
     timeout: rule.timeoutMs,
     cwd: projectPath,
     env: {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -303,8 +303,8 @@ if(cmd==="hook"){
     if(process.stdin.isTTY){sendHook(sub,"")}else{let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>sendHook(sub,d));process.stdin.on("error",()=>sendHook(sub,d));setTimeout(()=>sendHook(sub,d),1000)}
   }else{
     // Cold path (daemon disabled/unreachable): run the hook from the dedicated
-    // ~136KB hooks bundle, NOT the ~936KB core. cold-entry reads argv+stdin and
-    // exits, awaiting afterEmit (byte-identical output to the old core path).
+    // hooks bundle, NOT the full core. cold-entry emits host JSON then detaches
+    // afterEmit into a worker (PRJCT_HOOK_AFTER_EMIT) so Stop does not block.
     import("./prjct-hooks.mjs").catch(()=>{process.stdout.write("{}\\n");process.exit(0)})
   }
 }else if(cmd&&!skip.has(cmd)&&process.env.PRJCT_NO_DAEMON!=="1"&&hasEndpoint()){


### PR DESCRIPTION
## Summary

Separate from hygiene (#545). Closes the P0 findings from the security/perf audit on v3.47.0:

1. **Security** — eliminate free-form shell spawns on product paths; harden workflow `script:` path lock; refresh SECURITY.md for 3.x + optional cloud.
2. **Perf** — cold-path hooks emit host-visible JSON then run `afterEmit` in a detached worker (`PRJCT_HOOK_AFTER_EMIT`) so Stop does not block the host for ~1–2s.

## Security

| Change | Why |
|--------|-----|
| `drift-refresh` spawn with shell disabled | PATH/Windows injection surface |
| `cleanup-installs` → `execFile` + fixed argv | no shell uninstall |
| `which` busybox fallback → `execFile('/bin/sh', ['-c', …])` | no `execSync({ shell })` |
| `script:` → `path.relative` + `realpath` + `execFile('bash', [path])` | no traversal / symlink escape; no shell |
| `SECURITY.md` | support 3.x, cloud opt-in, threat model table |

## Performance

- `core/hooks/cold-entry.ts`: after host JSON is written, spawn detached worker for pending `afterEmit`; parent exits immediately (fallback: await in-process if spawn fails).
- `bin/prjct.ts` daemon-miss fallback: same pattern.
- **Measured (cold, `PRJCT_NO_DAEMON=1`)**: Stop p50 **~1.7–2.2s → ~220ms**.

Daemon path already detached `afterEmit` via `setImmediate`; this aligns cold path latency with that contract without dropping work.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test core/__tests__/hooks/fail-soft.test.ts`
- [x] `bun test core/__tests__/workflow/step-types.test.ts` (script escape + exec)
- [x] `bun test core/__tests__/services/drift-refresh.test.ts`
- [ ] CI green
- [ ] Optional: `node scripts/build.js` then bench `hook stop` under `PRJCT_NO_DAEMON=1`

## Relation to #545

#545 = repo hygiene / licensing / product-only tree.  
This PR = runtime security + cold-hook latency. No intentional overlap; both target `main` independently.