### PR TITLE
feat(judgment): freeze review scope from git (gentle-ai v1.49)

### DIFF
--- a/core/__tests__/services/precision-judgment.test.ts
+++ b/core/__tests__/services/precision-judgment.test.ts
@@ -10,6 +10,8 @@ import {
   applyBatchRefutation,
   applyEvidenceTax,
   applyGhostFilter,
+  applyScopeFreeze,
+  applyScopeFreezeAll,
   applySeverityFloor,
   applySeverityFloorAll,
   blastRank,
@@ -26,9 +28,13 @@ import {
   isActionableSeverity,
   isHotPath,
   judgmentShipVerdict,
+  markFindings,
+  markFindingsSkippedByScope,
   markGhost,
   markLeftoversOpen,
   mergeDualJudges,
+  normalizeScopePath,
+  pathInScope,
   rankFindingsForFix,
   refutePanelSize,
   resolveRefuteVotes,
@@ -497,5 +503,143 @@ describe('protocol card', () => {
     expect(p.evidenceTax).toMatch(/file:line/i)
     expect(p.maxFixRounds).toBe(2)
     expect(p.redCharter).toMatch(/attack/i)
+  })
+})
+
+describe('scope freeze (gentle-ai v1.49)', () => {
+  it('normalizeScopePath strips ./ and backslashes', () => {
+    expect(normalizeScopePath('./core/foo.ts')).toBe('core/foo.ts')
+    expect(normalizeScopePath('core\\foo.ts')).toBe('core/foo.ts')
+  })
+
+  it('pathInScope: empty scope = everything allowed', () => {
+    expect(pathInScope('evil/other.ts', undefined)).toBe(true)
+    expect(pathInScope('evil/other.ts', [])).toBe(true)
+  })
+
+  it('pathInScope: exact + prefix membership', () => {
+    const scope = ['core/services/precision-judgment.ts', 'core/schemas']
+    expect(pathInScope('core/services/precision-judgment.ts', scope)).toBe(true)
+    expect(pathInScope('core/schemas/judgment.ts', scope)).toBe(true)
+    expect(pathInScope('scripts/release.js', scope)).toBe(false)
+  })
+
+  it('createLedger freezes deduped scopePaths', () => {
+    const ledger = createLedger({
+      target: 't',
+      intensity: 'full',
+      now: 't0',
+      scopePaths: ['./core/a.ts', 'core/a.ts', 'core/b.ts'],
+    })
+    expect(ledger.scopePaths).toEqual(['core/a.ts', 'core/b.ts'])
+    expect(ledger.scopeFrozenAt).toBe('t0')
+  })
+
+  it('applyScopeFreeze demotes out-of-scope blocker → info follow-up', () => {
+    const f = applyScopeFreeze(
+      finding({
+        id: 'a',
+        severity: 'blocker',
+        title: 'leak',
+        status: 'candidate',
+        file: 'scripts/evil.ts',
+        line: 1,
+        evidence: 'repro steps here',
+      }),
+      ['core/services/x.ts']
+    )
+    expect(f.status).toBe('info')
+    expect(f.evidence).toMatch(/out of frozen review scope/i)
+  })
+
+  it('in-scope findings stay candidates', () => {
+    const f = applyScopeFreeze(
+      finding({
+        id: 'a',
+        severity: 'blocker',
+        title: 'leak',
+        status: 'candidate',
+        file: 'core/services/x.ts',
+        line: 1,
+        evidence: 'repro steps here',
+      }),
+      ['core/services/x.ts']
+    )
+    expect(f.status).toBe('candidate')
+  })
+
+  it('rankFindingsForFix excludes out-of-scope stands', () => {
+    const ranked = rankFindingsForFix(
+      [
+        finding({
+          id: 'in',
+          severity: 'blocker',
+          title: 'in',
+          status: 'stands',
+          file: 'core/a.ts',
+          line: 1,
+          evidence: 'repro steps here',
+        }),
+        finding({
+          id: 'out',
+          severity: 'blocker',
+          title: 'out',
+          status: 'stands',
+          file: 'scripts/b.ts',
+          line: 1,
+          evidence: 'repro steps here',
+        }),
+      ],
+      ['core/a.ts']
+    )
+    expect(ranked.map((f) => f.id)).toEqual(['in'])
+  })
+
+  it('markFindings refuses fixed on out-of-scope findings', () => {
+    let ledger = createLedger({
+      target: 't',
+      intensity: 'standard',
+      now: 't0',
+      scopePaths: ['core/a.ts'],
+    })
+    ledger.findings = [
+      finding({
+        id: 'out',
+        severity: 'blocker',
+        title: 'x',
+        status: 'stands',
+        file: 'scripts/b.ts',
+        line: 1,
+        evidence: 'repro steps here',
+      }),
+    ]
+    // Force stands despite freeze (simulates pre-freeze legacy row)
+    expect(markFindingsSkippedByScope(ledger, ['out'], 'fixed')).toEqual(['out'])
+    ledger = markFindings(ledger, ['out'], 'fixed', 't1')
+    expect(ledger.findings[0]!.status).toBe('stands')
+  })
+
+  it('applyScopeFreezeAll batch demotes', () => {
+    const out = applyScopeFreezeAll(
+      [
+        finding({
+          id: 'a',
+          severity: 'critical',
+          title: 'a',
+          file: 'core/a.ts',
+          status: 'candidate',
+        }),
+        finding({
+          id: 'b',
+          severity: 'critical',
+          title: 'b',
+          file: 'other/b.ts',
+          status: 'candidate',
+        }),
+      ],
+      ['core/a.ts']
+    )
+    expect(out[0]!.status).toBe('candidate')
+    expect(out[1]!.status).toBe('info')
   })
 })

--- a/core/commands/judgment.ts
+++ b/core/commands/judgment.ts
@@ -15,6 +15,7 @@ import {
   advanceFixRound,
   applyBatchRefutation,
   applyGhostFilter,
+  applyScopeFreeze,
   applySeverityFloor,
   buildNextAction,
   buildReReviewBrief,
@@ -25,6 +26,7 @@ import {
   intensityFromChangeset,
   intensityProtocol,
   markFindings,
+  markFindingsSkippedByScope,
   markLeftoversOpen,
   mergeDualJudges,
   newFindingId,
@@ -162,20 +164,28 @@ export class JudgmentCommands extends PrjctCommandsBase {
     const target =
       targetRaw.trim() || (await defaultTarget(projectPath)) || `changeset-${cs?.base ?? 'local'}`
 
+    // Immutable review scope from git (gentle-ai v1.49) — not caller-authored paths.
+    const scopePaths = await changesetPaths(projectPath, cs?.dirs)
+
     const ledger = createLedger({
       target,
       intensity,
       deliveryTier: tier as DeliveryTier,
       baseSha: cs?.base,
       now: getTimestamp(),
+      scopePaths,
     })
     judgmentLedgerStorage.set(proj.value, ledger)
 
     const protocol = intensityProtocol(intensity)
     const next = buildNextAction(ledger, intensity)
+    const scopeN = ledger.scopePaths?.length ?? 0
     const lines = [
       `Opened ledger \`${ledger.id}\` → intensity **${intensity}** (tier ${tier})`,
       `Target: ${target}`,
+      scopeN > 0
+        ? `Scope freeze: **${scopeN}** path(s) from git (findings outside → follow-up only)`
+        : 'Scope freeze: _none_ (no git paths — freeze inactive until open has a changeset)',
       `Reviewers: ${protocol.reviewers}`,
       `Evidence tax: ${protocol.evidenceTax}`,
       `Max fix rounds: ${ledger.maxFixRounds}`,
@@ -230,7 +240,9 @@ export class JudgmentCommands extends PrjctCommandsBase {
     // Ghost filter — annotate known FPs (never auto-kill)
     const book = judgmentLedgerStorage.getGhosts(proj.value)
     const [tagged] = applyGhostFilter([rawFinding], book)
-    const { findings, finding, deduped } = upsertFinding(ledger.findings, tagged!)
+    // Scope freeze: file outside frozen git path set → non-blocking follow-up.
+    const scoped = applyScopeFreeze(tagged!, ledger.scopePaths)
+    const { findings, finding, deduped } = upsertFinding(ledger.findings, scoped)
     ledger.findings = findings
     ledger.updatedAt = getTimestamp()
     ledger.verdict = 'in_progress'
@@ -240,8 +252,12 @@ export class JudgmentCommands extends PrjctCommandsBase {
       finding.severity !== (sevParsed.data as FindingSeverity)
         ? ` · evidence tax: ${sevParsed.data} → ${finding.severity}`
         : ''
+    const scopeNote =
+      scoped.status === 'info' && tagged!.status !== 'info'
+        ? ' · **out of frozen scope** (follow-up only)'
+        : ''
     const lines = [
-      `${deduped ? 'Merged (DNA dedup)' : 'Added'} ${finding.severity} [${finding.status}] \`${finding.id}\`: ${finding.title}${taxNote}`,
+      `${deduped ? 'Merged (DNA dedup)' : 'Added'} ${finding.severity} [${finding.status}] \`${finding.id}\`: ${finding.title}${taxNote}${scopeNote}`,
       `DNA \`${finding.dna}\` · evidence=${finding.evidenceScore ?? 0}/3 · blast=${finding.blast ?? 0}`,
       finding.knownFalsePositive
         ? '👻 GHOST — previously refuted in this project; challenge hard'
@@ -324,7 +340,9 @@ export class JudgmentCommands extends PrjctCommandsBase {
     )
 
     const book = judgmentLedgerStorage.getGhosts(proj.value)
-    let findings = applyGhostFilter(merged.findings, book)
+    let findings = applyGhostFilter(merged.findings, book).map((f) =>
+      applyScopeFreeze(f, ledger.scopePaths)
+    )
     // Fold into existing ledger via DNA upsert
     for (const f of findings) {
       const r = upsertFinding(ledger.findings, f)
@@ -461,13 +479,13 @@ export class JudgmentCommands extends PrjctCommandsBase {
     const next = advanceFixRound(ledger, getTimestamp())
     judgmentLedgerStorage.set(proj.value, next)
     const brief = buildReReviewBrief(next)
-    const ranked = rankFindingsForFix(next.findings)
+    const ranked = rankFindingsForFix(next.findings, next.scopePaths)
     print(
       options,
       '## Judgment fix-round',
       [
         `Round ${next.fixRound}/${next.maxFixRounds} started.`,
-        `Blast-ranked fix order: ${ranked.map((f) => f.id).join(' → ') || '—'}`,
+        `Blast-ranked fix order (in-scope only): ${ranked.map((f) => f.id).join(' → ') || '—'}`,
         'After fixes: `prjct judgment fixed <ids…>` → `brief` → `verify <ids…>`.',
       ].join('\n')
     )
@@ -486,22 +504,27 @@ export class JudgmentCommands extends PrjctCommandsBase {
     if (!ledger) return failWith('No active ledger — `prjct judgment open` first.', options)
     if (ids.length === 0) return failWith(`${status} requires at least one finding id.`, options)
 
+    const skipped = markFindingsSkippedByScope(ledger, ids, status)
     const next = markFindings(ledger, ids, status, getTimestamp())
     const finalized = finalizeLedger(next, getTimestamp())
     judgmentLedgerStorage.set(proj.value, finalized)
     const card = buildNextAction(finalized, finalized.intensity)
+    const marked = ids.filter((id) => !skipped.includes(id)).length
     print(
       options,
       `## Judgment ${status}`,
       [
-        `Marked ${ids.length} → ${status}. verdict=${finalized.verdict}` +
+        `Marked ${marked} → ${status}. verdict=${finalized.verdict}` +
           (finalized.precisionHint !== undefined
             ? ` precision≈${Math.round(finalized.precisionHint * 100)}%`
             : ''),
+        skipped.length > 0 ? `Skipped out-of-scope (follow-up only): ${skipped.join(', ')}` : '',
         `### Next → \`${card.kind}\`: ${card.directive}`,
-      ].join('\n')
+      ]
+        .filter(Boolean)
+        .join('\n')
     )
-    return { success: true, ledger: finalized, next: card }
+    return { success: true, ledger: finalized, next: card, skippedScope: skipped }
   }
 
   private async brief(projectPath: string, options: MdOption): Promise<CommandResult> {
@@ -798,6 +821,7 @@ function formatLedger(ledger: {
   maxFixRounds: number
   verdict: string
   precisionHint?: number
+  scopePaths?: string[]
   findings: Array<{
     id: string
     severity: string
@@ -818,6 +842,11 @@ function formatLedger(ledger: {
   ]
   if (ledger.precisionHint !== undefined) {
     lines.push(`- **precision**: ~${Math.round(ledger.precisionHint * 100)}%`)
+  }
+  if (ledger.scopePaths && ledger.scopePaths.length > 0) {
+    lines.push(
+      `- **scope freeze**: ${ledger.scopePaths.length} path(s) — ${ledger.scopePaths.slice(0, 8).join(', ')}${ledger.scopePaths.length > 8 ? '…' : ''}`
+    )
   }
   if (ledger.escalateReason) lines.push(`- **escalate**: ${ledger.escalateReason}`)
   if (ledger.merge) {

--- a/core/schemas/judgment.ts
+++ b/core/schemas/judgment.ts
@@ -104,6 +104,14 @@ export const JudgmentLedgerSchema = z.object({
     .optional(),
   /** Running precision: verified / (verified + refuted) when enough signal. */
   precisionHint: z.number().min(0).max(1).optional(),
+  /**
+   * Frozen review path set from git at ledger open (gentle-ai v1.49 scope freeze).
+   * Corrections / fix-loop findings outside this set demote to non-blocking follow-up.
+   * Empty/omitted = no freeze (legacy ledgers + non-git workspaces).
+   */
+  scopePaths: z.array(z.string().min(1)).optional(),
+  /** ISO timestamp when scopePaths was frozen (open). */
+  scopeFrozenAt: z.string().optional(),
 })
 export type JudgmentLedger = z.infer<typeof JudgmentLedgerSchema>
 

--- a/core/services/judgment-orchestrator.ts
+++ b/core/services/judgment-orchestrator.ts
@@ -125,11 +125,32 @@ export async function ensureJudgmentLedger(input: {
     deliveryTier = undefined
   }
 
+  let scopePaths: string[] | undefined
+  try {
+    const { computeCommittedChangeset } = await import('./delivery-geometry')
+    const cs = await computeCommittedChangeset(input.projectPath)
+    const { execFileAsync } = await import('../utils/exec')
+    if (cs?.base) {
+      const { stdout } = await execFileAsync('git', ['diff', '--name-only', `${cs.base}..HEAD`], {
+        cwd: input.projectPath,
+      })
+      scopePaths = stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    } else if (cs?.dirs?.length) {
+      scopePaths = [...cs.dirs]
+    }
+  } catch {
+    scopePaths = undefined
+  }
+
   const ledger = createLedger({
     target,
     intensity,
     deliveryTier,
     now: getTimestamp(),
+    scopePaths,
   })
   judgmentLedgerStorage.set(input.projectId, ledger)
   const next = buildNextAction(ledger, intensity)

--- a/core/services/precision-judgment.ts
+++ b/core/services/precision-judgment.ts
@@ -174,7 +174,10 @@ export function blastRank(
   return n
 }
 
-export function rankFindingsForFix(findings: JudgmentFinding[]): JudgmentFinding[] {
+export function rankFindingsForFix(
+  findings: JudgmentFinding[],
+  scopePaths?: readonly string[] | undefined
+): JudgmentFinding[] {
   return [...findings]
     .filter(
       (f) =>
@@ -182,7 +185,9 @@ export function rankFindingsForFix(findings: JudgmentFinding[]): JudgmentFinding
         (f.status === 'stands' ||
           f.status === 'candidate' ||
           f.status === 'open' ||
-          f.status === 'fixed')
+          f.status === 'fixed') &&
+        // When scope freeze is set, out-of-scope findings never enter fix order.
+        pathInScope(f.file, scopePaths)
     )
     .sort((a, b) => (b.blast ?? blastRank(b)) - (a.blast ?? blastRank(a)))
 }
@@ -519,13 +524,33 @@ export function markFindings(
   now: string
 ): JudgmentLedger {
   const idSet = new Set(ids)
-  const findings = ledger.findings.map((f) => (idSet.has(f.id) ? { ...f, status } : f))
+  const findings = ledger.findings.map((f) => {
+    if (!idSet.has(f.id)) return f
+    // Scope freeze: never mark fixed/verified on out-of-scope follow-ups.
+    if ((status === 'fixed' || status === 'verified') && !findingInFixScope(f, ledger.scopePaths)) {
+      return f
+    }
+    return { ...f, status }
+  })
   return {
     ...ledger,
     findings,
     updatedAt: now,
     precisionHint: computePrecisionHint(findings),
   }
+}
+
+/** Ids that were requested for fixed/verified but skipped by scope freeze. */
+export function markFindingsSkippedByScope(
+  ledger: JudgmentLedger,
+  ids: string[],
+  status: Extract<FindingStatus, 'fixed' | 'verified'>
+): string[] {
+  if (status !== 'fixed' && status !== 'verified') return []
+  const idSet = new Set(ids)
+  return ledger.findings
+    .filter((f) => idSet.has(f.id) && !findingInFixScope(f, ledger.scopePaths))
+    .map((f) => f.id)
 }
 
 /** Precision = verified / (verified + refuted). null-ish when no signal → undefined. */
@@ -593,7 +618,8 @@ export function buildReReviewBrief(ledger: JudgmentLedger): ReReviewBrief {
       (f) =>
         isActionableSeverity(f.severity) &&
         (f.status === 'fixed' || f.status === 'stands' || f.status === 'open')
-    )
+    ),
+    ledger.scopePaths
   )
   const findings = ranked.map(({ id, severity, status, title, file, line, blast, dna }) => ({
     id,
@@ -612,13 +638,22 @@ export function buildReReviewBrief(ledger: JudgmentLedger): ReReviewBrief {
     maxFixRounds: ledger.maxFixRounds,
     findings,
     fixOrder: findings.map((f) => f.id),
-    scope:
-      'Re-judge ONLY the persisted ledger findings below plus the fix-diff for those items. ' +
-      'Confirm each fixed finding is actually resolved; report regressions on those lines only. ' +
-      'Fix order is blast-ranked — do not reorder by preference.',
+    scope: (() => {
+      const paths = ledger.scopePaths ?? []
+      const pathHint =
+        paths.length > 0
+          ? ` Frozen scope (${paths.length} paths): ${paths.slice(0, 12).join(', ')}${paths.length > 12 ? '…' : ''}.`
+          : ''
+      return (
+        'Re-judge ONLY the persisted ledger findings below plus the fix-diff for those items. ' +
+        'Confirm each fixed finding is actually resolved; report regressions on those lines only. ' +
+        `Fix order is blast-ranked — do not reorder by preference.${pathHint}`
+      )
+    })(),
     outOfScope:
       'Do NOT reopen the original full PR diff. Do NOT invent new WARNING/SUGGESTION loops. ' +
-      'New BLOCKER/CRITICAL on the fix-diff may be added as candidates (evidence tax + severity floor + challenge still apply).',
+      'Findings whose file is outside the frozen git scope are follow-up only (info) — they do not enter fix loops. ' +
+      'New BLOCKER/CRITICAL on in-scope fix-diff may be added as candidates (evidence tax + severity floor + challenge still apply).',
   }
 }
 
@@ -1041,6 +1076,72 @@ export function upsertFinding(
   return { findings: out, finding: merged, deduped: true }
 }
 
+// ── Scope freeze (gentle-ai v1.49 — immutable git path set) ─────────────────
+
+/** Normalize repo-relative paths for scope membership (posix, no leading ./). */
+export function normalizeScopePath(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/').replace(/\/$/, '').trim()
+}
+
+/**
+ * True when `file` is inside the frozen scope.
+ * Empty/undefined scope → no freeze (everything in-scope) for backward compat.
+ * Findings without a file stay in-scope (evidence tax already demotes vibes blockers).
+ */
+export function pathInScope(
+  file: string | undefined,
+  scopePaths: readonly string[] | undefined
+): boolean {
+  if (!scopePaths || scopePaths.length === 0) return true
+  if (!file || !file.trim()) return true
+  const f = normalizeScopePath(file)
+  if (!f) return true
+  for (const raw of scopePaths) {
+    const s = normalizeScopePath(raw)
+    if (!s) continue
+    if (f === s || f.startsWith(`${s}/`)) return true
+  }
+  return false
+}
+
+/**
+ * Demote out-of-scope findings to non-blocking follow-up (`info`).
+ * Does not invent new severities — preserves title/file for the follow-up trail.
+ */
+export function applyScopeFreeze(
+  finding: JudgmentFinding,
+  scopePaths: readonly string[] | undefined
+): JudgmentFinding {
+  if (pathInScope(finding.file, scopePaths)) return finding
+  if (finding.status === 'info' || finding.status === 'refuted') return finding
+  return {
+    ...finding,
+    status: 'info',
+    evidence:
+      (finding.evidence ? `${finding.evidence} · ` : '') +
+      'out of frozen review scope (follow-up only; does not enter fix loops or block ship)',
+  }
+}
+
+export function applyScopeFreezeAll(
+  findings: JudgmentFinding[],
+  scopePaths: readonly string[] | undefined
+): JudgmentFinding[] {
+  return findings.map((f) => applyScopeFreeze(f, scopePaths))
+}
+
+/**
+ * Whether a finding may enter fix rounds / be marked fixed under the freeze.
+ * In-scope (or no freeze) only.
+ */
+export function findingInFixScope(
+  finding: Pick<JudgmentFinding, 'file' | 'status'>,
+  scopePaths: readonly string[] | undefined
+): boolean {
+  if (finding.status === 'info' || finding.status === 'refuted') return false
+  return pathInScope(finding.file, scopePaths)
+}
+
 // ── Factory ─────────────────────────────────────────────────────────────────
 
 export function newFindingId(): string {
@@ -1058,7 +1159,13 @@ export function createLedger(input: {
   baseSha?: string
   headSha?: string
   now: string
+  /** Git path set frozen at open — empty/omit = no freeze. */
+  scopePaths?: string[]
 }): JudgmentLedger {
+  const scope =
+    input.scopePaths && input.scopePaths.length > 0
+      ? [...new Set(input.scopePaths.map(normalizeScopePath).filter(Boolean))]
+      : undefined
   return {
     id: newLedgerId(),
     target: input.target,
@@ -1072,5 +1179,7 @@ export function createLedger(input: {
     baseSha: input.baseSha,
     headSha: input.headSha,
     deliveryTier: input.deliveryTier,
+    scopePaths: scope,
+    scopeFrozenAt: scope ? input.now : undefined,
   }
 }


### PR DESCRIPTION
## Summary

Steals the **one** useful product move from [gentle-ai v1.49.0](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v1.49.0): **immutable review scope** — without cloning OpenCode/Pi adapters or a second review OS.

- `judgment open` freezes `scopePaths` from the git changeset (not caller-authored paths)
- `add` / `merge`: file outside scope → status `info` (follow-up only; no fix loop / no ship block)
- `fix-round` / `rankFindingsForFix`: in-scope only
- `fixed` / `verify`: skips out-of-scope ids (reports which)
- Empty/missing scope = no freeze (legacy ledgers + non-git)

## Test plan

- [x] `bun test core/__tests__/services/precision-judgment.test.ts` (9 new scope freeze cases)
- [x] `bun test core/__tests__/services/judgment-orchestrator.test.ts`
- [x] `bun run typecheck`
- [ ] CI green