### PR TITLE
fix(daemon): performance + stability hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Daemon performance + stability**: spawn single-flight lock kills concurrent bind races (`Failed to listen` / `chmod ENOENT`); hook vs command request lanes (no HOL-block of Claude hooks); graceful drain on shutdown; absorb uncaught errors with capped respawn; hook client timeout 5s (shim parity); version drift only when global is strictly newer semver; self-respawn only on code mtime reload; richer `daemon status` (version, RSS, active, absorbed errors)
+
 ## [3.49.0] - 2026-07-12
 
 ### Features

--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -94,15 +94,20 @@ if (_fastCommand === 'hook' && process.env.PRJCT_NO_DAEMON !== '1') {
     const stdinPayload = await readAllStdin(1000)
     try {
       const { sendRequest } = await import('../core/daemon/client')
+      const { HOOK_REQUEST_TIMEOUT_MS } = await import('../core/daemon/protocol')
       const crypto = await import('node:crypto')
-      const response = await sendRequest({
-        id: crypto.randomUUID(),
-        command: 'hook',
-        args: subcommand ? [subcommand] : [],
-        options: {},
-        cwd: process.cwd(),
-        stdin: stdinPayload,
-      })
+      // 5s fail-soft — matches production shim; never stall Claude for 30s.
+      const response = await sendRequest(
+        {
+          id: crypto.randomUUID(),
+          command: 'hook',
+          args: subcommand ? [subcommand] : [],
+          options: {},
+          cwd: process.cwd(),
+          stdin: stdinPayload,
+        },
+        { timeoutMs: HOOK_REQUEST_TIMEOUT_MS }
+      )
       // `retry` = daemon code is stale; the hook did NOT run there. Fall
       // through to in-process execution below so the hook always runs on the
       // fresh code (this was the original "stale daemon caches old hook code"

--- a/core/__tests__/daemon/request-lanes.test.ts
+++ b/core/__tests__/daemon/request-lanes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { RequestLanes } from '../../daemon/request-lanes'
+
+describe('RequestLanes', () => {
+  test('serializes work within the same lane', async () => {
+    const lanes = new RequestLanes()
+    const order: string[] = []
+    let release!: () => void
+    const gate = new Promise<void>((r) => {
+      release = r
+    })
+
+    const first = lanes.run('command', async () => {
+      order.push('first-start')
+      await gate
+      order.push('first-end')
+      return 1
+    })
+    const second = lanes.run('command', async () => {
+      order.push('second')
+      return 2
+    })
+
+    // Give the microtask queue a turn so first has started and second is queued.
+    await Promise.resolve()
+    expect(order).toEqual(['first-start'])
+
+    release()
+    expect(await first).toBe(1)
+    expect(await second).toBe(2)
+    expect(order).toEqual(['first-start', 'first-end', 'second'])
+  })
+
+  test('hook lane does not wait for a long command', async () => {
+    const lanes = new RequestLanes()
+    const order: string[] = []
+    let releaseCmd!: () => void
+    const cmdGate = new Promise<void>((r) => {
+      releaseCmd = r
+    })
+
+    const cmd = lanes.run('command', async () => {
+      order.push('cmd-start')
+      await cmdGate
+      order.push('cmd-end')
+    })
+
+    // Hook scheduled while command is mid-flight — must still run.
+    const hook = lanes.run('hook', async () => {
+      order.push('hook')
+      return 'ok'
+    })
+
+    await Promise.resolve()
+    // Hook may complete before we release the command.
+    expect(await hook).toBe('ok')
+    expect(order).toContain('hook')
+    expect(order).toContain('cmd-start')
+    expect(order).not.toContain('cmd-end')
+
+    releaseCmd()
+    await cmd
+    expect(order).toEqual(['cmd-start', 'hook', 'cmd-end'])
+  })
+
+  test('a rejected lane job does not kill the chain', async () => {
+    const lanes = new RequestLanes()
+    await expect(
+      lanes.run('command', async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+
+    const next = await lanes.run('command', async () => 'recovered')
+    expect(next).toBe('recovered')
+  })
+})

--- a/core/__tests__/daemon/staleness-decision.test.ts
+++ b/core/__tests__/daemon/staleness-decision.test.ts
@@ -7,7 +7,19 @@
  */
 
 import { describe, expect, test } from 'bun:test'
-import { decideRestart } from '../../daemon/staleness'
+import { decideRestart, isStrictlyNewerVersion } from '../../daemon/staleness'
+
+describe('isStrictlyNewerVersion', () => {
+  test('detects upgrades and ignores equal/older/non-semver', () => {
+    expect(isStrictlyNewerVersion('3.49.0', '3.48.0')).toBe(true)
+    expect(isStrictlyNewerVersion('3.48.1', '3.48.0')).toBe(true)
+    expect(isStrictlyNewerVersion('4.0.0', '3.99.99')).toBe(true)
+    expect(isStrictlyNewerVersion('3.48.0', '3.48.0')).toBe(false)
+    expect(isStrictlyNewerVersion('3.47.0', '3.48.0')).toBe(false)
+    expect(isStrictlyNewerVersion('not-a-version', '3.48.0')).toBe(false)
+    expect(isStrictlyNewerVersion('v3.50.0', '3.49.0')).toBe(true)
+  })
+})
 
 const NEVER = () => false
 const ALWAYS = () => true

--- a/core/__tests__/daemon/startup-lock.test.ts
+++ b/core/__tests__/daemon/startup-lock.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  decideListenFailure,
+  releaseSpawnLock,
+  spawnLockPath,
+  tryAcquireSpawnLock,
+} from '../../daemon/startup-lock'
+
+describe('decideListenFailure', () => {
+  test('lost race with healthy peer exits 0', () => {
+    expect(
+      decideListenFailure({
+        errorCode: 'EADDRINUSE',
+        errorMessage: 'listen EADDRINUSE',
+        peerHealthy: true,
+      })
+    ).toEqual({ exitCode: 0, reason: 'lost-spawn-race-peer-healthy' })
+  })
+
+  test('listen fail without peer is fatal', () => {
+    const d = decideListenFailure({
+      errorCode: 'EADDRINUSE',
+      errorMessage: 'Failed to listen at /tmp/daemon.sock',
+      peerHealthy: false,
+    })
+    expect(d.exitCode).toBe(1)
+    expect(d.reason).toBe('listen-failed-no-peer')
+  })
+
+  test('other errors are fatal', () => {
+    expect(
+      decideListenFailure({
+        errorMessage: 'permission denied',
+        peerHealthy: true,
+      }).exitCode
+    ).toBe(1)
+  })
+})
+
+describe('tryAcquireSpawnLock', () => {
+  let tmp: string
+
+  afterEach(() => {
+    if (tmp && fs.existsSync(tmp)) {
+      try {
+        fs.rmSync(tmp, { recursive: true, force: true })
+      } catch {
+        /* ignore */
+      }
+    }
+  })
+
+  test('first acquirer wins; second yields while holder is live', () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-spawn-lock-'))
+    const a = tryAcquireSpawnLock(tmp, process.pid)
+    expect(a).not.toBeNull()
+    expect(fs.existsSync(spawnLockPath(tmp))).toBe(true)
+
+    const b = tryAcquireSpawnLock(tmp, process.pid + 99999)
+    expect(b).toBeNull()
+
+    releaseSpawnLock(a)
+    const c = tryAcquireSpawnLock(tmp, process.pid)
+    expect(c).not.toBeNull()
+    releaseSpawnLock(c)
+  })
+
+  test('stale lock from dead pid is reclaimed', () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-spawn-lock-'))
+    const lockPath = spawnLockPath(tmp)
+    fs.mkdirSync(tmp, { recursive: true })
+    // PID 1 on macOS is launchd and is always "running" — use an absurd pid.
+    const deadPid = 2_147_483_646
+    fs.writeFileSync(lockPath, `${deadPid}\n`)
+
+    const handle = tryAcquireSpawnLock(tmp, process.pid)
+    expect(handle).not.toBeNull()
+    releaseSpawnLock(handle)
+  })
+})

--- a/core/cli/bin-commands.ts
+++ b/core/cli/bin-commands.ts
@@ -73,10 +73,24 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
         const uptime = status.uptime ? Math.round(status.uptime / 1000) : 0
         const stale = (status as unknown as Record<string, unknown>).stale
         console.log(`Daemon running (PID ${status.pid})${stale ? ' ⚠ STALE' : ''}`)
+        if (status.version) console.log(`  Version: ${status.version}`)
         console.log(`  Uptime: ${uptime}s`)
         console.log(`  Commands served: ${status.commandsServed ?? 0}`)
+        if (typeof status.activeRequests === 'number') {
+          console.log(`  Active requests: ${status.activeRequests}`)
+        }
+        if (typeof status.memoryRss === 'number') {
+          const mb = Math.round(status.memoryRss / 1024 / 1024)
+          console.log(`  Memory (RSS): ${mb} MB`)
+        }
         if (status.lastActivity) {
           console.log(`  Last activity: ${status.lastActivity}`)
+        }
+        if (status.restartPending) {
+          console.log(`  ${chalk.yellow(`Restart pending (${status.restartReason ?? 'unknown'})`)}`)
+        }
+        if (typeof status.absorbedErrors === 'number' && status.absorbedErrors > 0) {
+          console.log(`  Absorbed errors: ${status.absorbedErrors}`)
         }
         if (stale) {
           console.log(

--- a/core/daemon/client.ts
+++ b/core/daemon/client.ts
@@ -14,7 +14,14 @@ import { connect } from 'node:net'
 import path from 'node:path'
 import type { DaemonRequest, DaemonResponse, DaemonStatus } from '../types/daemon'
 import { isBunAvailable } from '../utils/runtime'
-import { DAEMON_PATHS, encodeMessage, isDaemonNamedPipe } from './protocol'
+import {
+  COMMAND_REQUEST_TIMEOUT_MS,
+  DAEMON_PATHS,
+  encodeMessage,
+  HOOK_REQUEST_TIMEOUT_MS,
+  isDaemonNamedPipe,
+} from './protocol'
+import { releaseSpawnLock, tryAcquireSpawnLock } from './startup-lock'
 
 /**
  * Check if the daemon is running (socket file exists + responds to ping)
@@ -28,14 +35,18 @@ export async function isDaemonRunning(): Promise<boolean> {
   if (!namedPipe && !fs.existsSync(socketPath)) return false
 
   // Verify: can we actually connect and get a response?
+  // Short timeout — a hung daemon must not stall spawn/health for 30s.
   try {
-    const response = await sendRequest({
-      id: crypto.randomUUID(),
-      command: '__ping',
-      args: [],
-      options: {},
-      cwd: process.cwd(),
-    })
+    const response = await sendRequest(
+      {
+        id: crypto.randomUUID(),
+        command: '__ping',
+        args: [],
+        options: {},
+        cwd: process.cwd(),
+      },
+      { timeoutMs: 1_000 }
+    )
     return response.success
   } catch {
     // Socket exists but daemon is dead — stale socket. Named pipes are not unlinkable files.
@@ -88,10 +99,25 @@ export async function getDaemonStatus(): Promise<DaemonStatus> {
   return { running: false }
 }
 
+export interface SendRequestOptions {
+  /** Override the default timeout (commands 30s, hooks should pass HOOK_REQUEST_TIMEOUT_MS). */
+  timeoutMs?: number
+}
+
 /**
- * Send a command to the daemon and return the response
+ * Send a command to the daemon and return the response.
+ * Default timeout is 30s for CLI commands. Callers serving hooks MUST pass
+ * `timeoutMs: HOOK_REQUEST_TIMEOUT_MS` (5s) so a hung daemon cannot stall
+ * the host agent for half a minute.
  */
-export function sendRequest(request: DaemonRequest): Promise<DaemonResponse> {
+export function sendRequest(
+  request: DaemonRequest,
+  options: SendRequestOptions = {}
+): Promise<DaemonResponse> {
+  const timeoutMs =
+    options.timeoutMs ??
+    (request.command === 'hook' ? HOOK_REQUEST_TIMEOUT_MS : COMMAND_REQUEST_TIMEOUT_MS)
+
   return new Promise((resolve, reject) => {
     const socketPath = DAEMON_PATHS.socket()
     const socket = connect(socketPath)
@@ -104,7 +130,7 @@ export function sendRequest(request: DaemonRequest): Promise<DaemonResponse> {
         socket.destroy()
         reject(new Error('Daemon request timed out'))
       }
-    }, 30_000) // 30s timeout for command execution
+    }, timeoutMs)
 
     socket.on('connect', () => {
       socket.write(encodeMessage(request))
@@ -112,6 +138,17 @@ export function sendRequest(request: DaemonRequest): Promise<DaemonResponse> {
 
     socket.on('data', (chunk) => {
       buffer += chunk.toString()
+
+      // Guard against a runaway response (malformed / hostile peer).
+      if (buffer.length > 8 * 1024 * 1024) {
+        if (!resolved) {
+          resolved = true
+          clearTimeout(timeout)
+          socket.destroy()
+          reject(new Error('Daemon response too large'))
+        }
+        return
+      }
 
       const newlineIdx = buffer.indexOf('\n')
       if (newlineIdx !== -1) {
@@ -263,62 +300,102 @@ export function forceKillDaemon(): boolean {
  * - Dev mode: raw TypeScript via bun (core/daemon/entry.ts exists)
  * - Production (from dist/bin/): compiled JS adjacent (../daemon/entry.mjs)
  * - Production (from bin/): compiled JS in dist/ (dist/daemon/entry.mjs)
+ *
+ * Single-flight: in-process promise coalesce + exclusive spawn lock file so
+ * concurrent hooks/CLI clients never race the Unix socket bind (production
+ * symptom: "Failed to listen" / "chmod ENOENT" storms in daemon.log).
  */
+/** In-process single-flight so one CLI process never double-spawns. */
+let _spawnInFlight: Promise<boolean> | null = null
+
 export async function spawnDaemon(): Promise<boolean> {
-  const { spawn } = await import('node:child_process')
-
-  // Resolve daemon entry: prefer source (dev) → compiled (production)
-  const srcPath = path.join(__dirname, 'entry.ts')
-  // When running from dist/bin/, the daemon is at ../daemon/entry.mjs
-  const distPathAdjacent = path.join(__dirname, '..', 'daemon', 'entry.mjs')
-  // When running from bin/, the daemon is at dist/daemon/entry.mjs
-  const distPath = path.join(__dirname, '..', 'dist', 'daemon', 'entry.mjs')
-
-  let entryPath: string
-  let runtime: string
-  const preferBun = process.platform !== 'win32' && isBunAvailable()
-
-  if (fs.existsSync(srcPath)) {
-    // Dev mode: use raw TypeScript with bun
-    entryPath = srcPath
-    runtime = 'bun'
-  } else if (fs.existsSync(distPathAdjacent)) {
-    // Production (running from dist/): prefer bun if available
-    entryPath = distPathAdjacent
-    runtime = preferBun ? 'bun' : 'node'
-  } else if (fs.existsSync(distPath)) {
-    // Production (running from bin/): prefer bun if available
-    entryPath = distPath
-    runtime = preferBun ? 'bun' : 'node'
-  } else {
-    return false
-  }
-
-  const runDir = DAEMON_PATHS.runDir()
-  fs.mkdirSync(runDir, { recursive: true })
-
-  const logPath = DAEMON_PATHS.log()
-  const logFd = fs.openSync(logPath, 'a')
-
-  const child = spawn(runtime, [entryPath], {
-    detached: true,
-    stdio: ['ignore', logFd, logFd],
-    // The daemon entry sets PRJCT_IN_DAEMON itself before any consumer
-    // code runs, so we just inherit the parent env.
-    env: process.env,
+  if (_spawnInFlight) return _spawnInFlight
+  _spawnInFlight = spawnDaemonExclusive().finally(() => {
+    _spawnInFlight = null
   })
+  return _spawnInFlight
+}
 
-  child.unref()
-  fs.closeSync(logFd)
+async function spawnDaemonExclusive(): Promise<boolean> {
+  // Already up — nothing to do (cheap; avoids the lock entirely).
+  if (await isDaemonRunning()) return true
 
-  // Poll until daemon is live (up to 3s, especially important after updates)
-  const deadline = Date.now() + 3000
-  while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 300))
-    if (await isDaemonRunning()) return true
+  const lock = tryAcquireSpawnLock()
+  if (!lock) {
+    // Another process is mid-spawn — wait for it to come up instead of
+    // racing the socket (production logs: Failed to listen / chmod ENOENT).
+    return await waitUntilDaemonRunning(3_000)
   }
 
-  return false
+  try {
+    // Re-check under the lock: the winner of a prior race may already be live.
+    if (await isDaemonRunning()) return true
+
+    const { spawn } = await import('node:child_process')
+
+    // Resolve daemon entry: prefer source (dev) → compiled (production)
+    const srcPath = path.join(__dirname, 'entry.ts')
+    // When running from dist/bin/, the daemon is at ../daemon/entry.mjs
+    const distPathAdjacent = path.join(__dirname, '..', 'daemon', 'entry.mjs')
+    // When running from bin/, the daemon is at dist/daemon/entry.mjs
+    const distPath = path.join(__dirname, '..', 'dist', 'daemon', 'entry.mjs')
+
+    let entryPath: string
+    let runtime: string
+    const preferBun = process.platform !== 'win32' && isBunAvailable()
+
+    if (fs.existsSync(srcPath)) {
+      // Dev mode: use raw TypeScript with bun
+      entryPath = srcPath
+      runtime = 'bun'
+    } else if (fs.existsSync(distPathAdjacent)) {
+      // Production (running from dist/): prefer bun if available
+      entryPath = distPathAdjacent
+      runtime = preferBun ? 'bun' : 'node'
+    } else if (fs.existsSync(distPath)) {
+      // Production (running from bin/): prefer bun if available
+      entryPath = distPath
+      runtime = preferBun ? 'bun' : 'node'
+    } else {
+      return false
+    }
+
+    const runDir = DAEMON_PATHS.runDir()
+    fs.mkdirSync(runDir, { recursive: true })
+
+    const logPath = DAEMON_PATHS.log()
+    const logFd = fs.openSync(logPath, 'a')
+
+    const child = spawn(runtime, [entryPath], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      // The daemon entry sets PRJCT_IN_DAEMON itself before any consumer
+      // code runs, so we just inherit the parent env.
+      env: process.env,
+    })
+
+    child.unref()
+    fs.closeSync(logFd)
+
+    return await waitUntilDaemonRunning(3_000)
+  } finally {
+    releaseSpawnLock(lock)
+  }
+}
+
+/**
+ * Poll for a live daemon with short early intervals (hooks care about the
+ * first ~100ms) then back off. Caps at `budgetMs`.
+ */
+async function waitUntilDaemonRunning(budgetMs: number): Promise<boolean> {
+  const deadline = Date.now() + budgetMs
+  let delay = 40
+  while (Date.now() < deadline) {
+    if (await isDaemonRunning()) return true
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    delay = Math.min(delay * 2, 250)
+  }
+  return isDaemonRunning()
 }
 
 /**

--- a/core/daemon/daemon.ts
+++ b/core/daemon/daemon.ts
@@ -11,9 +11,10 @@
  * - Single process for CLI + HTTP API
  */
 
+import { spawn as spawnProcess } from 'node:child_process'
 import fs from 'node:fs'
 import type { Server, Socket } from 'node:net'
-import { createServer as createNetServer } from 'node:net'
+import { createServer as createNetServer, connect as netConnect } from 'node:net'
 import { PrjctCommands } from '../commands/commands'
 import { resetGroupLoaders } from '../commands/register'
 import { commandRegistry } from '../commands/registry'
@@ -30,8 +31,10 @@ import {
   IDLE_TIMEOUT_MS,
   isDaemonNamedPipe,
   MAX_BUFFER_SIZE,
+  SHUTDOWN_DRAIN_MS,
 } from './protocol'
 import { daemonRequestJournal } from './request-journal'
+import { daemonRequestLanes } from './request-lanes'
 import {
   decideRestart,
   isCodeStale as detectStaleCode,
@@ -41,6 +44,7 @@ import {
   resolveEntryPath,
   rotateLog,
 } from './staleness'
+import { decideListenFailure } from './startup-lock'
 
 /** Run WAL checkpoint every N requests to reclaim disk space */
 const WAL_CHECKPOINT_INTERVAL = 50
@@ -57,22 +61,16 @@ const VERSION_DRIFT_CHECK_MIN_MS = 1000
 /** How often the daemon re-checks npm for a newer published version. */
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000
 
+/** Cap absorbed crash handlers so a tight loop cannot pin the process forever. */
+const MAX_ABSORBED_ERRORS = 50
+
 let ipcServer: Server | null = null
 let commands: PrjctCommands | null = null
 let state: DaemonState | null = null
 let ownVersion: string | null = null
 let lastDriftCheckMs = 0
 let updateTimer: ReturnType<typeof setInterval> | null = null
-
-// Serializes command execution. handleRequestInner patches the GLOBAL
-// console.log/error to capture a command's output; with concurrent socket
-// connections (state.activeRequests can exceed 1) two requests would
-// cross-capture each other's output and whichever finishes first would
-// restore the real console while the other is still mid-command. Chaining
-// through one promise makes command execution strictly one-at-a-time —
-// SQLite is single-writer anyway and commands are short, so the throughput
-// cost is negligible next to the correctness win.
-let _requestChain: Promise<unknown> = Promise.resolve()
+let shuttingDown = false
 
 export async function startDaemon(options: { foreground?: boolean }): Promise<void> {
   // Flag child services can check to know they're running under the
@@ -87,18 +85,37 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
 
   fs.mkdirSync(runDir, { recursive: true })
 
-  // Check if daemon is already running
+  // Cross-process single-flight lives in spawnDaemon() (client-side lock).
+  // Here we only refuse if a live PID already owns the endpoint; lost listen
+  // races exit 0 via decideListenFailure when a peer is healthy.
   if (fs.existsSync(pidPath)) {
     const existingPid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10)
     if (isProcessRunning(existingPid)) {
-      console.error(`Daemon already running (PID ${existingPid})`)
-      process.exit(1)
+      console.log(`Daemon already running (PID ${existingPid})`)
+      process.exit(0)
     }
-    fs.unlinkSync(pidPath)
+    try {
+      fs.unlinkSync(pidPath)
+    } catch {
+      /* ignore */
+    }
   }
 
   // Clean up stale Unix socket. Windows named pipes are not filesystem entries.
-  if (!namedPipe && fs.existsSync(socketPath)) fs.unlinkSync(socketPath)
+  // Never unlink if a live peer is already serving (protects against the
+  // classic "steal the Unix socket under a live listener" race).
+  if (!namedPipe && fs.existsSync(socketPath)) {
+    const peerAlive = await peerDaemonHealthy(socketPath, pidPath)
+    if (peerAlive) {
+      console.log('Daemon already serving — yielding')
+      process.exit(0)
+    }
+    try {
+      fs.unlinkSync(socketPath)
+    } catch {
+      /* ignore */
+    }
+  }
 
   rotateLog()
 
@@ -124,7 +141,11 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
     entryMtime,
     activeRequests: 0,
     restartPending: false,
+    restartReason: null,
+    absorbedErrors: 0,
   }
+
+  installCrashHandlers()
 
   // Self-heal hooks + global CLAUDE.md when the binary moved past the
   // last sync. Best-effort: failures must never block daemon startup.
@@ -158,8 +179,18 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
   ipcServer = createNetServer((socket) => handleConnection(socket))
 
   ipcServer.listen(socketPath, () => {
-    if (!namedPipe) fs.chmodSync(socketPath, 0o600)
-    fs.writeFileSync(pidPath, String(process.pid))
+    if (!namedPipe) {
+      try {
+        if (fs.existsSync(socketPath)) fs.chmodSync(socketPath, 0o600)
+      } catch {
+        // Race with a dying peer unlinking the socket — non-fatal if we still listen.
+      }
+    }
+    try {
+      fs.writeFileSync(pidPath, String(process.pid))
+    } catch (err) {
+      console.error('Failed to write daemon pid file:', (err as Error).message)
+    }
 
     console.log(`prjct daemon started (PID ${process.pid})`)
     console.log(`  Socket: ${socketPath}`)
@@ -173,12 +204,30 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
   })
 
   ipcServer.on('error', (err) => {
-    console.error('Daemon socket error:', err.message)
-    shutdown(1)
+    const code = (err as NodeJS.ErrnoException).code
+    void (async () => {
+      const peerHealthy = await peerDaemonHealthy(socketPath, pidPath)
+      const decision = decideListenFailure({
+        errorCode: code,
+        errorMessage: err.message,
+        peerHealthy,
+      })
+      console.error(
+        decision.exitCode === 0
+          ? `Daemon listen race lost (${decision.reason}) — peer is healthy`
+          : `Daemon socket error: ${err.message}`
+      )
+      // Don't call full shutdown (would unlink a peer's socket). Just exit.
+      process.exit(decision.exitCode)
+    })()
   })
 
-  process.on('SIGTERM', () => shutdown(0))
-  process.on('SIGINT', () => shutdown(0))
+  process.on('SIGTERM', () => {
+    void shutdown(0)
+  })
+  process.on('SIGINT', () => {
+    void shutdown(0)
+  })
   process.on('SIGHUP', () => {
     // Refresh BOTH dispatch paths: the explicit-case instance below AND the
     // registry's lazy group memos (schema-covered commands kept pre-reload
@@ -196,6 +245,93 @@ export async function startDaemon(options: { foreground?: boolean }): Promise<vo
       // Not available in all runtimes (e.g. Bun)
     }
   }
+}
+
+/**
+ * Best-effort check that another daemon is already serving (or a live PID
+ * owns the endpoint). Used to exit 0 on lost spawn races instead of
+ * cascading fatal errors.
+ */
+async function peerDaemonHealthy(socketPath: string, pidPath: string): Promise<boolean> {
+  const namedPipe = isDaemonNamedPipe(socketPath)
+  if (!namedPipe && !fs.existsSync(socketPath)) {
+    if (fs.existsSync(pidPath)) {
+      const pid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10)
+      return !Number.isNaN(pid) && isProcessRunning(pid)
+    }
+    return false
+  }
+
+  // Light connect + ping without importing the full client (avoids cycles).
+  return await new Promise<boolean>((resolve) => {
+    const sock = netConnect(socketPath)
+    let done = false
+    const finish = (ok: boolean) => {
+      if (done) return
+      done = true
+      try {
+        sock.destroy()
+      } catch {
+        /* ignore */
+      }
+      resolve(ok)
+    }
+    const t = setTimeout(() => finish(false), 400)
+    sock.on('connect', () => {
+      sock.write(
+        encodeMessage({
+          id: 'startup-peer-check',
+          command: '__ping',
+          args: [],
+          options: {},
+          cwd: process.cwd(),
+        })
+      )
+    })
+    sock.on('data', (chunk: Buffer) => {
+      try {
+        const line = chunk.toString().split('\n')[0]
+        const msg = JSON.parse(line) as DaemonResponse
+        clearTimeout(t)
+        finish(msg.success === true)
+      } catch {
+        clearTimeout(t)
+        finish(false)
+      }
+    })
+    sock.on('error', () => {
+      clearTimeout(t)
+      finish(false)
+    })
+  })
+}
+
+function installCrashHandlers(): void {
+  process.on('unhandledRejection', (reason) => {
+    if (!state) return
+    state.absorbedErrors++
+    console.error(
+      `Daemon absorbed unhandledRejection (${state.absorbedErrors}):`,
+      reason instanceof Error ? reason.message : String(reason)
+    )
+    if (state.absorbedErrors >= MAX_ABSORBED_ERRORS) {
+      console.error('Daemon absorbed-error cap reached — shutting down for clean respawn')
+      void shutdown(1, { respawn: true })
+    }
+  })
+
+  process.on('uncaughtException', (err) => {
+    if (!state) {
+      console.error('Daemon uncaughtException before init:', err.message)
+      process.exit(1)
+      return
+    }
+    state.absorbedErrors++
+    console.error(`Daemon absorbed uncaughtException (${state.absorbedErrors}):`, err.message)
+    // A true uncaughtException can leave the process in an undefined state.
+    // Drain + exit (and self-respawn for warm recovery) rather than keep serving.
+    void shutdown(1, { respawn: true })
+  })
 }
 
 function handleConnection(socket: Socket): void {
@@ -273,6 +409,10 @@ function markStaleIfNeeded(command: string): void {
 
   if (decision.restart) {
     state.restartPending = true
+    // Local rebuild → safe to self-respawn the same entry path.
+    // Global version drift → must NOT self-respawn (this binary is the stale
+    // one); the fresh client falls through and spawns the new install.
+    state.restartReason = codeStale ? 'code' : 'drift'
     console.log(
       codeStale
         ? 'Build change detected — daemon will restart; request runs on fresh code.'
@@ -291,6 +431,16 @@ async function handleRequest(request: DaemonRequest): Promise<DaemonResponse> {
     }
   }
 
+  if (shuttingDown && request.command !== 'daemon' && request.command !== '__ping') {
+    return {
+      id: request.id,
+      success: false,
+      exitCode: 1,
+      retry: true,
+      stderr: 'daemon is shutting down — running directly',
+    }
+  }
+
   // Detect staleness BEFORE serving so no request is ever answered by an
   // outdated build.
   markStaleIfNeeded(request.command)
@@ -303,7 +453,9 @@ async function handleRequest(request: DaemonRequest): Promise<DaemonResponse> {
   if (state.restartPending && request.command !== 'daemon' && request.command !== '__ping') {
     if (state.activeRequests === 0) {
       console.log('Daemon shutting down for code reload...')
-      setImmediate(() => shutdown(0))
+      setImmediate(() => {
+        void shutdown(0, { respawn: state?.restartReason === 'code' })
+      })
     }
     return {
       id: request.id,
@@ -317,23 +469,19 @@ async function handleRequest(request: DaemonRequest): Promise<DaemonResponse> {
   return daemonRequestJournal.run(request, async () => {
     state!.activeRequests++
     try {
-      // Run strictly after any in-flight command (see _requestChain). The
-      // catch arms keep the chain alive if a prior request rejected.
-      const run = _requestChain.then(
-        () => handleRequestInner(request),
-        () => handleRequestInner(request)
-      )
-      _requestChain = run.then(
-        () => undefined,
-        () => undefined
-      )
-      return await run
+      // Hooks use a separate lane so a long CLI command cannot head-of-line
+      // block Claude Code's Prompt/Stop path. Commands stay exclusive because
+      // they patch global console.log/error for output capture.
+      const lane = request.command === 'hook' ? 'hook' : 'command'
+      return await daemonRequestLanes.run(lane, () => handleRequestInner(request))
     } finally {
       state!.activeRequests--
       if (state!.restartPending && state!.activeRequests === 0) {
         console.log('Daemon shutting down for code reload...')
         // Defer to next tick so the response finishes flushing to the client.
-        setImmediate(() => shutdown(0))
+        setImmediate(() => {
+          void shutdown(0, { respawn: state?.restartReason === 'code' })
+        })
       }
     }
   })
@@ -463,6 +611,12 @@ function handleDaemonCommand(request: DaemonRequest): DaemonResponse {
   const subcommand = request.args[0]
 
   if (subcommand === 'status') {
+    let memoryRss: number | undefined
+    try {
+      memoryRss = process.memoryUsage().rss
+    } catch {
+      memoryRss = undefined
+    }
     return {
       id: request.id,
       success: true,
@@ -476,6 +630,12 @@ function handleDaemonCommand(request: DaemonRequest): DaemonResponse {
         lastActivity: state ? new Date(state.lastActivity).toISOString() : null,
         registeredCommands: commandRegistry.list().length,
         stale: state ? detectStaleCode(state.entryPath, state.entryMtime) : false,
+        version: ownVersion,
+        memoryRss,
+        activeRequests: state?.activeRequests ?? 0,
+        restartPending: state?.restartPending ?? false,
+        restartReason: state?.restartReason ?? null,
+        absorbedErrors: state?.absorbedErrors ?? 0,
       },
     }
   }
@@ -487,7 +647,9 @@ function handleDaemonCommand(request: DaemonRequest): DaemonResponse {
       exitCode: 0,
       stdout: 'Daemon stopping...',
     }
-    setTimeout(() => shutdown(0), 100)
+    setTimeout(() => {
+      void shutdown(0)
+    }, 100)
     return response
   }
 
@@ -500,21 +662,52 @@ function handleDaemonCommand(request: DaemonRequest): DaemonResponse {
 }
 
 function resetIdleTimer(): void {
-  if (!state) return
+  if (!state || shuttingDown) return
 
   if (state.idleTimer) clearTimeout(state.idleTimer)
 
   state.idleTimer = setTimeout(() => {
     console.log(`Daemon idle for ${state!.idleTimeoutMs / 1000 / 60} minutes, shutting down`)
-    shutdown(0)
+    void shutdown(0)
   }, state.idleTimeoutMs)
 
   // Don't keep the process alive just for the timer
   if (state.idleTimer.unref) state.idleTimer.unref()
 }
 
-function shutdown(exitCode: number): void {
+/**
+ * Graceful shutdown: stop accepting work, wait briefly for in-flight
+ * requests to finish, then tear down. Optionally self-respawn (only safe
+ * for local rebuild reloads — never for version drift).
+ */
+async function shutdown(exitCode: number, opts: { respawn?: boolean } = {}): Promise<void> {
+  if (shuttingDown) return
+  shuttingDown = true
   console.log('Daemon shutting down...')
+
+  // Stop accepting new connections immediately.
+  if (ipcServer) {
+    try {
+      ipcServer.close()
+    } catch {
+      /* ignore */
+    }
+    ipcServer = null
+  }
+
+  // Drain in-flight work so a mid-command exit doesn't leave partial state
+  // without a response. Cap the wait so a stuck request cannot pin us forever.
+  if (state && state.activeRequests > 0) {
+    const deadline = Date.now() + SHUTDOWN_DRAIN_MS
+    while (state.activeRequests > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 25))
+    }
+    if (state.activeRequests > 0) {
+      console.log(
+        `Daemon drain timeout with ${state.activeRequests} active request(s) — forcing exit`
+      )
+    }
+  }
 
   // Close realtime connections before tearing down storage.
   try {
@@ -529,12 +722,11 @@ function shutdown(exitCode: number): void {
     updateTimer = null
   }
 
-  if (ipcServer) {
-    ipcServer.close()
-    ipcServer = null
+  try {
+    prjctDb.close()
+  } catch {
+    /* ignore */
   }
-
-  prjctDb.close()
 
   const socketPath = DAEMON_PATHS.socket()
   const pidPath = DAEMON_PATHS.pid()
@@ -553,5 +745,51 @@ function shutdown(exitCode: number): void {
     /* ignore */
   }
 
+  // Self-respawn only when the same entry path now has fresher code (local
+  // rebuild). Version drift must leave the process down so a client running
+  // the NEW binary can spawn the correct install.
+  if (opts.respawn && state?.restartReason !== 'drift') {
+    scheduleSelfRespawn()
+  }
+
   process.exit(exitCode)
+}
+
+/**
+ * Detach a sibling daemon process from the same entry we were started with.
+ * Best-effort: failures leave the daemon down (clients cold-fall-through and
+ * will spawn on the next command).
+ */
+function scheduleSelfRespawn(): void {
+  try {
+    const entry = process.argv[1]
+    if (!entry || !fs.existsSync(entry)) return
+    const logPath = DAEMON_PATHS.log()
+    let logFd: number | undefined
+    try {
+      logFd = fs.openSync(logPath, 'a')
+    } catch {
+      logFd = undefined
+    }
+    const stdio: ['ignore', number | 'ignore', number | 'ignore'] = logFd
+      ? ['ignore', logFd, logFd]
+      : ['ignore', 'ignore', 'ignore']
+    // Must be synchronous before process.exit — an async spawn would never run.
+    const child = spawnProcess(process.execPath, [entry], {
+      detached: true,
+      stdio,
+      env: process.env,
+    })
+    child.unref()
+    if (logFd !== undefined) {
+      try {
+        fs.closeSync(logFd)
+      } catch {
+        /* ignore */
+      }
+    }
+    console.log('Daemon scheduled self-respawn after code reload')
+  } catch (err) {
+    console.error('Daemon self-respawn failed:', (err as Error).message)
+  }
 }

--- a/core/daemon/protocol.ts
+++ b/core/daemon/protocol.ts
@@ -52,6 +52,26 @@ export const IDLE_TIMEOUT_MS = 30 * 60 * 1000
 /** Maximum buffer size per connection before rejecting (1 MB) */
 export const MAX_BUFFER_SIZE = 1024 * 1024
 
+/**
+ * Client timeout for normal CLI commands routed through the daemon.
+ * Must stay in lockstep with the production shim in scripts/build.js.
+ */
+export const COMMAND_REQUEST_TIMEOUT_MS = 30_000
+
+/**
+ * Client timeout for hook requests. Hooks are fail-soft and latency-critical
+ * (Claude Code waits). A hung daemon must not block the host for 30s — the
+ * production shim already uses 5s; keep the source path identical.
+ */
+export const HOOK_REQUEST_TIMEOUT_MS = 5_000
+
+/**
+ * How long shutdown waits for in-flight requests before force-exit.
+ * Long enough for a normal command to finish; short enough that a stuck
+ * request cannot pin a stale daemon forever.
+ */
+export const SHUTDOWN_DRAIN_MS = 2_000
+
 /** Encode a message for sending over socket */
 export function encodeMessage(msg: DaemonRequest | DaemonResponse): Buffer {
   return Buffer.from(`${JSON.stringify(msg)}\n`)

--- a/core/daemon/request-lanes.ts
+++ b/core/daemon/request-lanes.ts
@@ -1,0 +1,38 @@
+/**
+ * Serialized request lanes for the daemon.
+ *
+ * Commands patch the GLOBAL console.log/error to capture output, so they
+ * must never run concurrently with each other. Hooks use HookIo (not console
+ * capture) and are the latency-critical path for Claude Code — a long
+ * `prjct sync` must not head-of-line-block Prompt/Stop.
+ *
+ * Two lanes:
+ *   - command: exclusive, one-at-a-time
+ *   - hook: exclusive among hooks, independent of the command lane
+ *
+ * SQLite remains single-writer at the C boundary (better-sqlite3 is sync);
+ * interleaving at await points already happens across MCP processes (see
+ * concurrent-MCP gotcha). Hook afterEmit is detached, so the hook lane stays
+ * short.
+ */
+
+export type LaneName = 'command' | 'hook'
+
+export class RequestLanes {
+  private commandChain: Promise<unknown> = Promise.resolve()
+  private hookChain: Promise<unknown> = Promise.resolve()
+
+  run<T>(lane: LaneName, work: () => Promise<T>): Promise<T> {
+    const chain = lane === 'hook' ? this.hookChain : this.commandChain
+    const run = chain.then(work, work)
+    const settled = run.then(
+      () => undefined,
+      () => undefined
+    )
+    if (lane === 'hook') this.hookChain = settled
+    else this.commandChain = settled
+    return run
+  }
+}
+
+export const daemonRequestLanes = new RequestLanes()

--- a/core/daemon/staleness.ts
+++ b/core/daemon/staleness.ts
@@ -110,10 +110,37 @@ export function readOwnPackageVersion(): string | null {
 }
 
 /**
- * Best-effort detection that a newer `prjct-cli` has been installed globally
- * while this daemon is still running. Returns `true` only when we can
- * positively identify a mismatch — on any lookup failure we return `false`
- * (daemon keeps running; no false positives).
+ * True when `candidate` is a strictly greater semver than `baseline`.
+ * Pre-release / build metadata are ignored; non-semver strings compare equal
+ * (no drift) so we never false-positive restart on weird labels.
+ */
+export function isStrictlyNewerVersion(candidate: string, baseline: string): boolean {
+  const parse = (v: string): number[] | null => {
+    const core = v.trim().replace(/^v/i, '').split('-')[0].split('+')[0]
+    const parts = core.split('.').map((p) => Number.parseInt(p, 10))
+    if (parts.length < 1 || parts.some((n) => Number.isNaN(n))) return null
+    while (parts.length < 3) parts.push(0)
+    return parts.slice(0, 3)
+  }
+  const a = parse(candidate)
+  const b = parse(baseline)
+  if (!a || !b) return false
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true
+    if (a[i] < b[i]) return false
+  }
+  return false
+}
+
+/**
+ * Best-effort detection that a *newer* `prjct-cli` has been installed globally
+ * while this daemon is still running. Returns `true` only when the global
+ * install is strictly greater than our own version — on any lookup failure we
+ * return `false` (daemon keeps running; no false positives).
+ *
+ * Equality → fine. Global older than own (monorepo ahead of published, or a
+ * local build) → not drift; thrashing a 3.49 monorepo daemon because the
+ * machine still has 3.48 on PATH was a production-log footgun in reverse.
  */
 export function isGlobalVersionDrifted(ownVersion: string | null): boolean {
   if (!ownVersion) return false
@@ -144,7 +171,7 @@ export function isGlobalVersionDrifted(ownVersion: string | null): boolean {
       try {
         const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
         if (pkg?.name === 'prjct-cli' && typeof pkg.version === 'string') {
-          return pkg.version !== ownVersion
+          return isStrictlyNewerVersion(pkg.version, ownVersion)
         }
       } catch {
         /* keep walking */

--- a/core/daemon/startup-lock.ts
+++ b/core/daemon/startup-lock.ts
@@ -1,0 +1,127 @@
+/**
+ * Single-flight spawn lock for the prjct daemon.
+ *
+ * Concurrent clients (hooks + CLI + post-upgrade) all call spawnDaemon()
+ * when the socket is missing. Without a lock, two processes both unlink the
+ * socket, both bind, and the loser (or worse: a stolen Unix socket) leaves
+ * "Failed to listen" / "chmod ENOENT" noise in daemon.log — observed in
+ * production under session storms.
+ *
+ * Exclusive create (O_EXCL / 'wx') is the mutex. Stale locks from a killed
+ * spawner are reclaimed when the holder PID is no longer alive.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { DAEMON_PATHS } from './protocol'
+import { isProcessRunning } from './staleness'
+
+export function spawnLockPath(runDir: string = DAEMON_PATHS.runDir()): string {
+  return path.join(runDir, 'daemon.spawn.lock')
+}
+
+export interface SpawnLockHandle {
+  fd: number
+  path: string
+}
+
+/**
+ * Try to acquire the exclusive spawn lock.
+ * Returns a handle on success, null if another live process holds it.
+ */
+export function tryAcquireSpawnLock(
+  runDir: string = DAEMON_PATHS.runDir(),
+  pid: number = process.pid
+): SpawnLockHandle | null {
+  fs.mkdirSync(runDir, { recursive: true })
+  const lockPath = spawnLockPath(runDir)
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx')
+      try {
+        fs.writeFileSync(fd, `${pid}\n`)
+      } catch {
+        try {
+          fs.closeSync(fd)
+        } catch {
+          /* ignore */
+        }
+        try {
+          fs.unlinkSync(lockPath)
+        } catch {
+          /* ignore */
+        }
+        return null
+      }
+      return { fd, path: lockPath }
+    } catch {
+      // Lock exists — reclaim if the holder is dead, otherwise yield.
+      let holderPid: number | null = null
+      try {
+        holderPid = parseInt(fs.readFileSync(lockPath, 'utf-8').trim(), 10)
+      } catch {
+        holderPid = null
+      }
+
+      if (holderPid && !Number.isNaN(holderPid) && isProcessRunning(holderPid)) {
+        return null
+      }
+
+      // Stale lock (dead holder or unreadable) — remove and retry once.
+      try {
+        fs.unlinkSync(lockPath)
+      } catch {
+        return null
+      }
+    }
+  }
+
+  return null
+}
+
+export function releaseSpawnLock(handle: SpawnLockHandle | null): void {
+  if (!handle) return
+  try {
+    fs.closeSync(handle.fd)
+  } catch {
+    /* ignore */
+  }
+  try {
+    if (fs.existsSync(handle.path)) {
+      const content = fs.readFileSync(handle.path, 'utf-8').trim()
+      // Only unlink if we still own it (another process shouldn't, but be safe).
+      if (content === String(process.pid) || content === `${process.pid}`) {
+        fs.unlinkSync(handle.path)
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Pure decision for a listen failure: if the endpoint is already serving
+ * (we lost the race), exit cleanly as success; otherwise treat as fatal.
+ */
+export function decideListenFailure(opts: {
+  errorCode?: string
+  errorMessage: string
+  peerHealthy: boolean
+}): { exitCode: number; reason: string } {
+  const code = opts.errorCode ?? ''
+  const msg = opts.errorMessage
+  const addrInUse =
+    code === 'EADDRINUSE' ||
+    msg.includes('EADDRINUSE') ||
+    msg.includes('address already in use') ||
+    msg.includes('Failed to listen')
+
+  if (addrInUse && opts.peerHealthy) {
+    return { exitCode: 0, reason: 'lost-spawn-race-peer-healthy' }
+  }
+  if (addrInUse) {
+    return { exitCode: 1, reason: 'listen-failed-no-peer' }
+  }
+  return { exitCode: 1, reason: 'listen-error' }
+}

--- a/core/types/daemon.ts
+++ b/core/types/daemon.ts
@@ -55,6 +55,18 @@ export interface DaemonStatus {
   uptime?: number
   commandsServed?: number
   lastActivity?: string
+  /** Installed package version this daemon process loaded */
+  version?: string | null
+  /** Resident set size in bytes (process.memoryUsage().rss) */
+  memoryRss?: number
+  /** In-flight requests (commands + hooks) */
+  activeRequests?: number
+  /** True when a reload/restart has been scheduled */
+  restartPending?: boolean
+  /** Why a restart was scheduled, if any */
+  restartReason?: 'code' | 'drift' | null
+  /** Uncaught/unhandled errors absorbed since start (crash resilience counter) */
+  absorbedErrors?: number
 }
 
 /** Internal daemon state */
@@ -72,4 +84,12 @@ export interface DaemonState {
   activeRequests: number
   /** True once the daemon has decided to restart; new requests are refused. */
   restartPending: boolean
+  /**
+   * Why restart is pending. `code` = local rebuild (safe to self-respawn the
+   * same entry path). `drift` = global install moved (must NOT self-respawn
+   * from this process — the fresh client spawns the new binary).
+   */
+  restartReason: 'code' | 'drift' | null
+  /** Count of absorbed uncaught/unhandled errors (diagnostics). */
+  absorbedErrors: number
 }


### PR DESCRIPTION
## Summary

Hardens the warm prjct daemon for production performance and stability — the path every Claude hook and CLI command should take.

- **Spawn races fixed**: client-side exclusive spawn lock + in-process single-flight kill concurrent bind storms (`Failed to listen` / `chmod ENOENT` in daemon.log)
- **Hook lane isolation**: hooks no longer head-of-line-block behind long CLI commands (separate request lanes; commands still serialize for console capture)
- **Graceful drain** on shutdown; absorb uncaught errors with capped respawn
- **Hook timeout 5s** (parity with production shim — never stall the host for 30s)
- **Drift only when global is strictly newer semver** (monorepo-ahead no longer thrash-kills warm daemons)
- **Self-respawn only on code mtime reload**, never on version drift
- **Richer `daemon status`**: version, RSS, active requests, restart reason, absorbed errors

## Test plan

- [x] `bun test core/__tests__/daemon/` — 30/30
- [x] `bun test core/__tests__/infrastructure/daemon-shim-sync.test.ts` — 8/8
- [x] Isolated smoke: 8 concurrent pings ~1ms, cold concurrent spawn×4 ~130ms, clean stop/start, no listen races in log
- [ ] CI green
- [ ] After merge: patch release + `prjct restart` so warm daemon picks up new code