### PR TITLE
chore(release): v3.50.0 — Claude ecosystem adopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.50.0] - 2026-07-12
+
+### Added
+- Claude ecosystem adopt — trust, tiers, session, packs
+
 ### Features
 
 - **Claude ecosystem adopt (patterns, not products)** — model-agnostic harness organs:
@@ -22,7 +27,6 @@
 
 - performance + stability hardening (#550)
 
-
 ## [3.49.0] - 2026-07-12
 
 ### Features
@@ -32,7 +36,6 @@
 ### Bug Fixes
 
 - project pattern supremacy + mechanical review FP refute (v3.48.0) (#549)
-
 
 ## [3.48.0] - 2026-07-11
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.49.1",
+  "version": "3.50.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v3.50.0** of Claude ecosystem adopt harness organs (merged via #551).

## Includes
- Trust boundary, alignment card, context tiers L0–L3
- Safe artifacts, managed session continuity (land→prime)
- Pack marketplace-lite (catalog/verify)

## Test plan
- [x] Feature PR #551 CI green + merged
- [x] Ship workflow version bump + push
- [ ] Merge this release PR
- [ ] npm publish (if automated) / upgrade + gate:dominance