### PR TITLE
perf(routing): fix harness GTD capture + hot-path efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Routing: `prjct harness score` no longer GTD-captures to inbox** — `harness` was implemented in bin-commands but missing from `BIN_ONLY_COMMANDS`, so multi-word GTD rewrote it to `capture` whenever the daemon path ran. Registered as bin-only + completeness test so handlers cannot outlive the allowlist again.
+
+### Performance
+
+- **Lazy hook runners** — Stop/embeddings/transcript graph no longer loads for prompt/pre-edit cold spawns (`hooks/registry.ts` dynamic import per event).
+- **UserPromptSubmit hot path** — `bumpTurnCount` returns post-bump task (one write, no second read); owner from task; parallel queue/ship/inbox/handoff/git; parallel alignment imports.
+- **Usefulness rerank** — `decayedScores` accepts candidate IDs so FTS rerank no longer full-scans `memory_usefulness`.
+- **Typo suggestions** — `findClosestCommand` uses full COMMANDS manifest (bin-only verbs included) + length early-exit.
+
 ## [3.50.0] - 2026-07-12
 
 ### Added

--- a/core/__tests__/commands/manifest-completeness.test.ts
+++ b/core/__tests__/commands/manifest-completeness.test.ts
@@ -52,6 +52,34 @@ describe('command manifest — completeness', () => {
     expect(REGISTERED_VERBS_SET.has('upgrade')).toBe(true)
   })
 
+  test('every bin-commands handler is allowlisted (no GTD capture fallthrough)', async () => {
+    // Handlers live as `args[0] === 'verb'` branches. If a verb is handled but
+    // missing from BIN_ONLY_COMMANDS, multi-word GTD rewrites it to capture
+    // before the cold path can run (harness score → inbox bug class).
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    // process.cwd() is the package root under `bun test` from repo root.
+    const src = await fs.readFile(path.join(process.cwd(), 'core/cli/bin-commands.ts'), 'utf-8')
+    const handlers = new Set<string>()
+    for (const m of src.matchAll(/args\[0\]\s*===\s*'([a-z][a-z0-9:-]*)'/g)) {
+      handlers.add(m[1]!)
+    }
+    // Flag aliases handled in the same file
+    for (const m of src.matchAll(/args\[0\]\s*===\s*'(-{1,2}[a-z]+)'/g)) {
+      handlers.add(m[1]!)
+    }
+    const missing = [...handlers].filter(
+      (v) => !BIN_COMMANDS_SET.has(v) && !REGISTERED_VERBS_SET.has(v)
+    )
+    expect(missing).toEqual([])
+  })
+
+  test('harness is bin-only so GTD never captures "harness score"', () => {
+    expect(BIN_COMMANDS_SET.has('harness')).toBe(true)
+    const meta = COMMANDS.find((c) => c.name === 'harness')
+    expect(meta?.routingMode).toBe('bin-only')
+  })
+
   test('schema-covered commands declare routing (the generic path needs a handler)', () => {
     const broken = COMMANDS.filter((c) => c.optionSchema && !c.routing).map((c) => c.name)
     expect(broken).toEqual([])

--- a/core/__tests__/hooks/prompt.test.ts
+++ b/core/__tests__/hooks/prompt.test.ts
@@ -118,9 +118,11 @@ describe('UserPromptSubmit — project state', () => {
       startedAt: new Date().toISOString(),
       sessionId: 's',
     } as Parameters<typeof stateStorage.startTask>[1])
-    expect(await stateStorage.bumpTurnCount(projectId)).toBe(1)
-    expect(await stateStorage.bumpTurnCount(projectId)).toBe(2)
-    expect(await stateStorage.bumpTurnCount(projectId)).toBe(3)
+    expect((await stateStorage.bumpTurnCount(projectId)).count).toBe(1)
+    expect((await stateStorage.bumpTurnCount(projectId)).count).toBe(2)
+    const third = await stateStorage.bumpTurnCount(projectId)
+    expect(third.count).toBe(3)
+    expect(third.task?.turnCount).toBe(3)
   })
 
   it('surfaces dirty working tree counts', async () => {

--- a/core/commands/closest-command.ts
+++ b/core/commands/closest-command.ts
@@ -11,18 +11,27 @@
  * catch fat-finger typos, far enough to not match unrelated short words.
  */
 
-import { commandRegistry } from './registry'
+import { COMMANDS } from './command-data'
 
+/**
+ * Closest match across the FULL command manifest (including bin-only verbs
+ * like health/crew/harness). Registry-only matching missed pure bin-only
+ * names, so typos never suggested them.
+ */
 export function findClosestCommand(input: string): string | null {
-  const allNames = commandRegistry.getAll().map((c) => c.name)
+  const needle = input.toLowerCase()
   let best: string | null = null
   let bestDist = Infinity
 
-  for (const name of allNames) {
-    const dist = editDistance(input.toLowerCase(), name.toLowerCase())
+  for (const cmd of COMMANDS) {
+    const name = cmd.name
+    // Early exit: length delta > threshold cannot be within edit distance 2.
+    if (Math.abs(name.length - needle.length) > 2) continue
+    const dist = editDistance(needle, name.toLowerCase())
     if (dist < bestDist) {
       bestDist = dist
       best = name
+      if (dist === 0) break
     }
   }
 
@@ -32,16 +41,17 @@ export function findClosestCommand(input: string): string | null {
 function editDistance(a: string, b: string): number {
   const m = a.length
   const n = b.length
+  if (Math.abs(m - n) > 2) return 3
   const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0))
-  for (let i = 0; i <= m; i++) dp[i][0] = i
-  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 0; i <= m; i++) dp[i]![0] = i
+  for (let j = 0; j <= n; j++) dp[0]![j] = j
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
-      dp[i][j] =
+      dp[i]![j] =
         a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+          ? dp[i - 1]![j - 1]!
+          : 1 + Math.min(dp[i - 1]![j]!, dp[i]![j - 1]!, dp[i - 1]![j - 1]!)
     }
   }
-  return dp[m][n]
+  return dp[m]![n]!
 }

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -1326,6 +1326,7 @@ export const COMMANDS: CommandMeta[] = [
       ['hooks', 'Inspect or reinstall the Claude Code hooks'],
       ['claude', 'Claude Code integration management (install/uninstall)'],
       ['crew', 'Run a crew (multi-subagent) workflow'],
+      ['harness', 'Harness scorecard + Body/rig adoption (score · learn-from · list · use)'],
       ['doctor', 'Diagnose the local prjct installation'],
       ['watch', 'Watch project files and react to changes'],
       ['version', 'Print the installed prjct version + provider status'],

--- a/core/hooks/prompt.ts
+++ b/core/hooks/prompt.ts
@@ -87,33 +87,30 @@ export async function buildProjectState(
           '  ↳ Before session end: `prjct land` · hand-off `prjct remember context "Session close: …"`'
         )
       }
-      // Loop control — count turns; hard signals feed the alignment card
-      // (Claude ZT / constitutional mid-cycle). Soft goal discipline stays here.
+      // Loop control — one write returns post-bump task (no second getCurrentTask).
       let turns = 0
       let loopVerdict: ReturnType<typeof loopGuardVerdict> | null = null
       let currentTask: Awaited<ReturnType<typeof stateStorage.getCurrentTask>> = null
       try {
-        turns = await stateStorage.bumpTurnCount(config.projectId)
-        currentTask = await stateStorage.getCurrentTask(config.projectId)
-        // Hard guard (config.maxTurnsPerCycle) — SAME verdict as edit-deny.
+        const bumped = await stateStorage.bumpTurnCount(config.projectId)
+        turns = bumped.count
+        currentTask = bumped.task
         loopVerdict = loopGuardVerdict(config, currentTask)
       } catch {
         /* best-effort — never block the state block on the counter */
       }
       if (!loopVerdict?.stopped && turns < STUCK_TURN_THRESHOLD) {
-        // Goal discipline — frontier self-control, given to weaker rigs every turn.
         lines.push(
           '  ↳ Stay on this goal. Each turn, before acting: is this step ADVANCING it? If you have hit the same wall twice, or you are exploring rather than progressing, STOP — re-plan, split the cycle, or ask the user. Do not loop; finish the cycle, then `prjct status done`.'
         )
       }
       hasContent = true
 
-      // Token budget (opt-in via config.maxTokensPerCycle): soft twin of turn budget.
+      // Token budget — uses post-bump task (no extra SQLite read).
       try {
         const budget = config.maxTokensPerCycle ?? 0
-        if (budget > 0) {
-          const task = currentTask ?? (await stateStorage.getCurrentTask(config.projectId))
-          const spent = (task?.tokensIn ?? 0) + (task?.tokensOut ?? 0)
+        if (budget > 0 && currentTask) {
+          const spent = (currentTask.tokensIn ?? 0) + (currentTask.tokensOut ?? 0)
           if (spent >= budget) {
             lines.push(
               `  ⚠ Token budget: ${spent.toLocaleString()} of ${budget.toLocaleString()} spent on this cycle. STOP growing it — ship the working slice, split the remainder into a new cycle, or check in with the user.`
@@ -128,7 +125,7 @@ export async function buildProjectState(
         /* budget is advisory — never block the state block */
       }
 
-      // Delegation trigger — multi-file write rule (advisory count).
+      // Delegation + alignment in parallel with static imports where possible.
       try {
         const startedIso = overview.current.startedAt
         if (startedIso) {
@@ -143,17 +140,17 @@ export async function buildProjectState(
           if (trigger) lines.push(`  ${trigger}`)
         }
       } catch {
-        /* best-effort — the trigger is advisory context, never a blocker */
+        /* best-effort */
       }
 
-      // Alignment card — unified MUST mid-cycle checks (loop / pressure / quality /
-      // stuck). One named block agents treat as constitutional, not scattered cues.
       try {
-        const { contextPressureVerdict } = await import('../services/context-pressure')
-        const { buildAlignmentCard } = await import('../services/alignment-card')
-        const { qualityInjectForProject } = await import('../services/judgment-orchestrator')
-        const task = currentTask ?? (await stateStorage.getCurrentTask(config.projectId))
-        const pressure = contextPressureVerdict(config, task)
+        const [{ contextPressureVerdict }, { buildAlignmentCard }, { qualityInjectForProject }] =
+          await Promise.all([
+            import('../services/context-pressure'),
+            import('../services/alignment-card'),
+            import('../services/judgment-orchestrator'),
+          ])
+        const pressure = contextPressureVerdict(config, currentTask)
         const qualityInject = qualityInjectForProject(config.projectId)
         const card = buildAlignmentCard({
           loop: loopVerdict,
@@ -168,7 +165,15 @@ export async function buildProjectState(
           hasContent = true
         }
       } catch {
-        /* advisory — never brick the state block */
+        /* advisory */
+      }
+
+      // Owner from post-bump task — skip resolveActiveTask (second workspace walk).
+      if (currentTask?.ownerAgent) {
+        lines.push(
+          `- Owner: ${currentTask.ownerAgent}${currentTask.ownerIdentity ? `/${currentTask.ownerIdentity}` : ''}${currentTask.yieldStatus === 'yielded' ? ' (yielded — awaiting accept)' : ''}`
+        )
+        hasContent = true
       }
     }
     const others = overview.all.filter((v) => !v.isCurrent)
@@ -176,23 +181,7 @@ export async function buildProjectState(
       lines.push(`- ${others.length} task(s) active in other workspace(s)`)
       hasContent = true
     }
-    // Foreign occupant on THIS workspace without being the current task owner
-    // (rare mid-session) — cue isolation / switch.
-    if (overview.current) {
-      // Owner line when present on the live cycle
-      try {
-        const { resolveActiveTask } = await import('../services/task-service')
-        const t = await resolveActiveTask(config.projectId, projectPath)
-        if (t?.ownerAgent) {
-          lines.push(
-            `- Owner: ${t.ownerAgent}${t.ownerIdentity ? `/${t.ownerIdentity}` : ''}${t.yieldStatus === 'yielded' ? ' (yielded — awaiting accept)' : ''}`
-          )
-          hasContent = true
-        }
-      } catch {
-        /* best-effort */
-      }
-    } else if (others.length > 0) {
+    if (!overview.current && others.length > 0) {
       lines.push(
         '- This workspace idle but siblings busy — `prjct work` auto-isolates to a worktree when needed'
       )
@@ -202,76 +191,70 @@ export async function buildProjectState(
     /* best-effort */
   }
 
-  // Pending multi-agent handoffs addressed to this runtime (or any if unknown).
-  try {
-    const { formatPendingHandoffCue } = await import('../services/agent-switch')
-    const cue = formatPendingHandoffCue(config.projectId)
-    if (cue) {
-      lines.push(`- ${cue.replace(/\n/g, '\n- ')}`)
-      hasContent = true
-    }
-  } catch {
-    /* best-effort */
-  }
+  // Parallel secondary signals (queue / ship / inbox / handoff / git) — was serial.
+  const secondary = await Promise.all([
+    (async (): Promise<string | null> => {
+      try {
+        const { formatPendingHandoffCue } = await import('../services/agent-switch')
+        const cue = formatPendingHandoffCue(config.projectId)
+        return cue ? `- ${cue.replace(/\n/g, '\n- ')}` : null
+      } catch {
+        return null
+      }
+    })(),
+    (async (): Promise<string | null> => {
+      try {
+        const pending = await queueStorage.getActiveTasks(config.projectId)
+        return pending.length > 0
+          ? `- Pending: ${pending.length} · Next: "${pending[0]!.description}"`
+          : null
+      } catch {
+        return null
+      }
+    })(),
+    (async (): Promise<string | null> => {
+      try {
+        if (!(await fileExists(path.join(projectPath, '.git')))) return null
+        const git = await captureGit(projectPath)
+        if (!git.branch) return null
+        const wtBits: string[] = []
+        if (git.modified > 0) wtBits.push(`${git.modified} modified`)
+        if (git.staged > 0) wtBits.push(`${git.staged} staged`)
+        if (git.untracked > 0) wtBits.push(`${git.untracked} untracked`)
+        const wt = wtBits.length > 0 ? ` — working tree ${wtBits.join(', ')}` : ''
+        const ahead = git.ahead > 0 ? `${wt ? ',' : ' —'} ${git.ahead} unpushed` : ''
+        return `- Branch: ${git.branch}${wt}${ahead}`
+      } catch {
+        return null
+      }
+    })(),
+    (async (): Promise<string | null> => {
+      try {
+        const recent = await shippedStorage.getRecent(config.projectId, 1)
+        if (recent.length === 0) return null
+        const last = recent[0]!
+        const ago = formatRelative(last.shippedAt ?? '')
+        const label = last.version ? `v${last.version}` : last.name
+        return `- Last ship: ${label} (${ago})`
+      } catch {
+        return null
+      }
+    })(),
+    (async (): Promise<string | null> => {
+      try {
+        const inboxCount = projectMemory.countByType(config.projectId, 'inbox')
+        return inboxCount > 0 ? `- Inbox: ${inboxCount} items pending` : null
+      } catch {
+        return null
+      }
+    })(),
+  ])
 
-  // Queue — what's pending + what's next, so "what's left / what's next" is
-  // always visible without asking. Active-section tasks only; backlog stays
-  // quiet. Omitted when the queue is empty (no noise).
-  try {
-    const pending = await queueStorage.getActiveTasks(config.projectId)
-    if (pending.length > 0) {
-      lines.push(`- Pending: ${pending.length} · Next: "${pending[0]!.description}"`)
+  for (const line of secondary) {
+    if (line) {
+      lines.push(line)
       hasContent = true
     }
-  } catch {
-    /* best-effort */
-  }
-
-  // Git state — branch, working tree summary, ahead-of-origin count.
-  // Each git call is wrapped — empty repo / missing git / network all
-  // become "no signal" rather than errors.
-  if (await fileExists(path.join(projectPath, '.git'))) {
-    const git = await captureGit(projectPath)
-    if (git.branch) {
-      const wtBits: string[] = []
-      if (git.modified > 0) wtBits.push(`${git.modified} modified`)
-      if (git.staged > 0) wtBits.push(`${git.staged} staged`)
-      if (git.untracked > 0) wtBits.push(`${git.untracked} untracked`)
-      // A clean tree with nothing unpushed carries no signal — emit just
-      // the branch. Repeating "working tree clean" every turn was pure
-      // token noise (token-cache audit R2).
-      const wt = wtBits.length > 0 ? ` — working tree ${wtBits.join(', ')}` : ''
-      const ahead = git.ahead > 0 ? `${wt ? ',' : ' —'} ${git.ahead} unpushed` : ''
-      lines.push(`- Branch: ${git.branch}${wt}${ahead}`)
-      hasContent = true
-    }
-  }
-
-  // Last shipped — useful for "what's the diff since last release?" intuition.
-  try {
-    const recent = await shippedStorage.getRecent(config.projectId, 1)
-    if (recent.length > 0) {
-      const last = recent[0]!
-      const ago = formatRelative(last.shippedAt ?? '')
-      const label = last.version ? `v${last.version}` : last.name
-      lines.push(`- Last ship: ${label} (${ago})`)
-      hasContent = true
-    }
-  } catch {
-    /* best-effort */
-  }
-
-  // Inbox depth — pure count, signals "you have things to triage". A direct
-  // COUNT (not a 200-row overfetch + deserialize just to read `.length`), and
-  // it reports the true count instead of capping at the old limit of 50.
-  try {
-    const inboxCount = projectMemory.countByType(config.projectId, 'inbox')
-    if (inboxCount > 0) {
-      lines.push(`- Inbox: ${inboxCount} items pending`)
-      hasContent = true
-    }
-  } catch {
-    /* best-effort */
   }
 
   if (!hasContent) return null

--- a/core/hooks/registry.ts
+++ b/core/hooks/registry.ts
@@ -7,46 +7,108 @@
  *   - the warm path (the daemon, which runs the same runner with a
  *     `HookIo` bridge so the hook body never touches process stdin/stdout).
  *
- * Keeping the mapping here (instead of a switch duplicated in both places)
- * means adding a hook is a one-line change that both paths pick up — the
- * same drift-killer applied to spec routing in `core/commands/route-spec.ts`.
+ * Runners load LAZILY per event. Stop (and its embeddings/transcript graph)
+ * must not be parsed for a prompt/pre-edit cold spawn — that was pure tax.
+ * After first load the module is cached by the runtime import map.
  */
 
 import type { HookIo } from './_runner'
-import { runCwdChangedHook } from './cwd-changed'
-import { runNotificationHook } from './notification'
-import { runPostEditHook } from './post-edit'
-import { runPreCommitHook } from './pre-commit'
-import { runPreEditHook } from './pre-edit'
-import { runPrePackageHook } from './pre-package'
-import { runPreSecretsHook } from './pre-secrets'
-import { runPromptHook } from './prompt'
-import { runSessionStartHook } from './session-start'
-import { runStopHook } from './stop'
-import { runSubagentStartHook } from './subagent-start'
-import { runSubagentStopHook } from './subagent-stop'
 
 /** A hook runner: runs the hook for `projectPath`. With `io` it runs in
  *  daemon (warm) mode; without, in process (cold) mode. */
 export type HookRunner = (projectPath: string, io?: HookIo) => Promise<void>
 
-export const HOOK_RUNNERS: Record<string, HookRunner> = {
-  'session-start': runSessionStartHook,
-  prompt: runPromptHook,
-  'pre-commit': runPreCommitHook,
-  // Credential MUST — registered before pre-edit so security decide runs early.
-  'pre-secrets': runPreSecretsHook,
-  // Package legitimacy PreToolUse — unknown deps before install (SUPERIOR vs ship-only).
-  'pre-package': runPrePackageHook,
-  'pre-edit': runPreEditHook,
-  'post-edit': runPostEditHook,
-  stop: runStopHook,
-  'subagent-start': runSubagentStartHook,
-  'subagent-stop': runSubagentStopHook,
-  notification: runNotificationHook,
-  'cwd-changed': runCwdChangedHook,
+type HookLoader = () => Promise<{ default?: HookRunner } | Record<string, HookRunner | unknown>>
+
+/**
+ * Map subcommand → dynamic import of the runner module + export name.
+ * Keep export names stable so cold-entry and daemon never diverge.
+ */
+const HOOK_LOADERS: Record<string, { load: HookLoader; exportName: string }> = {
+  'session-start': {
+    load: () => import('./session-start'),
+    exportName: 'runSessionStartHook',
+  },
+  prompt: {
+    load: () => import('./prompt'),
+    exportName: 'runPromptHook',
+  },
+  'pre-commit': {
+    load: () => import('./pre-commit'),
+    exportName: 'runPreCommitHook',
+  },
+  'pre-secrets': {
+    load: () => import('./pre-secrets'),
+    exportName: 'runPreSecretsHook',
+  },
+  'pre-package': {
+    load: () => import('./pre-package'),
+    exportName: 'runPrePackageHook',
+  },
+  'pre-edit': {
+    load: () => import('./pre-edit'),
+    exportName: 'runPreEditHook',
+  },
+  'post-edit': {
+    load: () => import('./post-edit'),
+    exportName: 'runPostEditHook',
+  },
+  stop: {
+    load: () => import('./stop'),
+    exportName: 'runStopHook',
+  },
+  'subagent-start': {
+    load: () => import('./subagent-start'),
+    exportName: 'runSubagentStartHook',
+  },
+  'subagent-stop': {
+    load: () => import('./subagent-stop'),
+    exportName: 'runSubagentStopHook',
+  },
+  notification: {
+    load: () => import('./notification'),
+    exportName: 'runNotificationHook',
+  },
+  'cwd-changed': {
+    load: () => import('./cwd-changed'),
+    exportName: 'runCwdChangedHook',
+  },
 }
 
+const runnerCache = new Map<string, HookRunner>()
+
+async function resolveRunner(name: string): Promise<HookRunner | undefined> {
+  const cached = runnerCache.get(name)
+  if (cached) return cached
+  const entry = HOOK_LOADERS[name]
+  if (!entry) return undefined
+  const mod = (await entry.load()) as Record<string, HookRunner>
+  const runner = mod[entry.exportName]
+  if (typeof runner !== 'function') return undefined
+  runnerCache.set(name, runner)
+  return runner
+}
+
+/**
+ * Synchronous map for callers that only need *names* (help, installers).
+ * Values are thin wrappers that lazy-load on first invoke.
+ */
+export const HOOK_RUNNERS: Record<string, HookRunner> = Object.fromEntries(
+  Object.keys(HOOK_LOADERS).map((name) => [
+    name,
+    async (projectPath: string, io?: HookIo) => {
+      const runner = await resolveRunner(name)
+      if (!runner) throw new Error(`Hook runner missing export for '${name}'`)
+      return runner(projectPath, io)
+    },
+  ])
+)
+
 export function getHookRunner(name: string | undefined): HookRunner | undefined {
-  return name ? HOOK_RUNNERS[name] : undefined
+  return name && HOOK_LOADERS[name] ? HOOK_RUNNERS[name] : undefined
+}
+
+/** Test helper — clear lazy cache between cases. */
+export function _resetHookRunnerCacheForTests(): void {
+  runnerCache.clear()
 }

--- a/core/services/usefulness/index.ts
+++ b/core/services/usefulness/index.ts
@@ -318,14 +318,35 @@ export const usefulnessService = {
    * Current time-decayed usefulness per memory id. A score recorded `age`
    * days ago is worth `score * 0.5^(age / HALF_LIFE_DAYS)` today.
    */
-  decayedScores(projectId: string, nowMs: number = Date.now()): Map<string, number> {
+  /**
+   * Time-decayed usefulness scores. When `ids` is provided (the common
+   * FTS/rerank path), only those rows are loaded — full-table scans were
+   * pure tax as vaults grew.
+   */
+  decayedScores(
+    projectId: string,
+    nowMs: number = Date.now(),
+    ids?: readonly string[]
+  ): Map<string, number> {
     const out = new Map<string, number>()
     let rows: UsefulnessRow[]
     try {
-      rows = prjctDb.query<UsefulnessRow>(
-        projectId,
-        'SELECT memory_id, score, last_used_at FROM memory_usefulness'
-      )
+      if (ids && ids.length > 0) {
+        const unique = [...new Set(ids)].slice(0, 200)
+        const placeholders = unique.map(() => '?').join(',')
+        rows = prjctDb.query<UsefulnessRow>(
+          projectId,
+          `SELECT memory_id, score, last_used_at FROM memory_usefulness WHERE memory_id IN (${placeholders})`,
+          ...unique
+        )
+      } else if (ids && ids.length === 0) {
+        return out
+      } else {
+        rows = prjctDb.query<UsefulnessRow>(
+          projectId,
+          'SELECT memory_id, score, last_used_at FROM memory_usefulness'
+        )
+      }
     } catch {
       return out
     }
@@ -349,7 +370,12 @@ export const usefulnessService = {
     if (entries.length < 2) return entries
     let scores: Map<string, number>
     try {
-      scores = this.decayedScores(projectId, nowMs)
+      // Only load usefulness for candidates being reranked (not full table).
+      scores = this.decayedScores(
+        projectId,
+        nowMs,
+        entries.map((e) => e.id)
+      )
     } catch {
       return entries
     }

--- a/core/storage/state-storage.ts
+++ b/core/storage/state-storage.ts
@@ -109,15 +109,24 @@ class StateStorage extends StorageManager<StateJson> {
    * UserPromptSubmit hook so the state block can escalate a stuck loop. A new
    * cycle starts with no turnCount, so it resets naturally.
    */
-  async bumpTurnCount(projectId: string): Promise<number> {
-    const resultRef: { count: number } = { count: 0 }
+  /**
+   * Bump turn counter and return count + the post-bump task (avoids a second
+   * read on the UserPromptSubmit hot path).
+   */
+  async bumpTurnCount(projectId: string): Promise<{ count: number; task: CurrentTask | null }> {
+    const resultRef: { count: number; task: CurrentTask | null } = {
+      count: 0,
+      task: null,
+    }
     await this.update(projectId, (state) => {
       if (!state.currentTask) return state
       const next = (state.currentTask.turnCount ?? 0) + 1
+      const task = { ...state.currentTask, turnCount: next }
       resultRef.count = next
-      return { ...state, currentTask: { ...state.currentTask, turnCount: next } }
+      resultRef.task = task
+      return { ...state, currentTask: task }
     })
-    return resultRef.count
+    return resultRef
   }
 
   /**


### PR DESCRIPTION
## Summary

Real routing + performance work — not scorecard theater.

### Routing (bug fix)
- **`prjct harness score` was GTD-captured to inbox** whenever the daemon path ran: handler existed in `bin-commands` but `harness` was missing from `BIN_ONLY_COMMANDS`.
- Registered as bin-only + **completeness test**: every `args[0] === 'verb'` handler must be allowlisted (prevents class recurrence).

### Efficiency
1. **Lazy hook registry** — Stop/embeddings graph not loaded for prompt/pre-edit cold spawns.
2. **UserPromptSubmit coalesce** — one `bumpTurnCount` write returns task; parallel secondary signals; no second workspace resolve for owner.
3. **Usefulness** — `decayedScores(ids?)` so FTS rerank does not full-scan usefulness table.
4. **Typo match** — closest command uses full COMMANDS (incl. bin-only) + length early-exit.

## Test plan
- [x] `BIN_COMMANDS_SET.has('harness')` + allowlist completeness
- [x] prompt / usefulness / manifest tests green
- [x] typecheck pre-push
- [ ] CI green
- [ ] After merge: `prjct harness score` via global install no longer says "✓ captured"