### PR TITLE
perf(mcp): slim core ListTools 19→10 tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- **MCP schema slim (ListTools tax)**: default core surface **19 → 10 tools**; `projectPath` optional (cwd / `PRJCT_PROJECT_PATH`); typed record verbs + cost/signals/skills/developer/tiers/artifacts moved to `PRJCT_MCP_TOOLS=standard|all`; shorter server instructions. CLI parity unchanged.
+
 ### Bug Fixes
 
 - **Routing: `prjct harness score` no longer GTD-captures to inbox** — `harness` was implemented in bin-commands but missing from `BIN_ONLY_COMMANDS`, so multi-word GTD rewrote it to `capture` whenever the daemon path ran. Registered as bin-only + completeness test so handlers cannot outlive the allowlist again.

--- a/core/__tests__/mcp/tool-tiers.test.ts
+++ b/core/__tests__/mcp/tool-tiers.test.ts
@@ -22,6 +22,13 @@ describe('tiered MCP tool loading (PRJCT_MCP_TOOLS)', () => {
     expect(all).toBeGreaterThan(standard)
   })
 
+  it('core stays lean (schema-tax budget)', async () => {
+    const core = await toolCount('core')
+    // mem×5 + project×5 = 10 after slim (typed/cost/signals/skills off-core)
+    expect(core).toBeLessThanOrEqual(12)
+    expect(core).toBeGreaterThanOrEqual(8)
+  })
+
   it('unset and garbage default to core; all remains opt-in', async () => {
     const core = await toolCount('core')
     expect(await toolCount(undefined)).toBe(core)

--- a/core/mcp/resolve.ts
+++ b/core/mcp/resolve.ts
@@ -1,11 +1,31 @@
 /**
- * Project ID resolution for MCP tools.
+ * Project path/ID resolution for MCP tools.
  *
- * Resolves projectPath → projectId using configManager.
+ * Schema tax: every tool used to require `projectPath` in ListTools JSON.
+ * Path is now optional — defaults to PRJCT_PROJECT_PATH / MCP server cwd.
  */
 
+import { z } from 'zod'
 import configManager from '../infrastructure/config-manager'
 
-export async function resolveProjectId(projectPath: string): Promise<string> {
-  return configManager.getProjectId(projectPath)
+/** Shared schema field — omit on single-project MCP installs. */
+export const optionalProjectPath = z
+  .string()
+  .optional()
+  .describe('Project root. Omit to use PRJCT_PROJECT_PATH or the MCP server cwd.')
+
+/**
+ * Resolve filesystem project root for a tool call.
+ * Order: explicit arg → PRJCT_PROJECT_PATH → process.cwd().
+ */
+export function resolveProjectPath(explicit?: string | null): string {
+  const e = explicit?.trim()
+  if (e) return e
+  const env = process.env.PRJCT_PROJECT_PATH?.trim() || process.env.PRJCT_CWD?.trim()
+  if (env) return env
+  return process.cwd()
+}
+
+export async function resolveProjectId(projectPath?: string | null): Promise<string> {
+  return configManager.getProjectId(resolveProjectPath(projectPath))
 }

--- a/core/mcp/server.ts
+++ b/core/mcp/server.ts
@@ -4,6 +4,8 @@
  * Exposes project data via Model Context Protocol.
  * Wraps existing storage and context modules — no new logic.
  *
+ * Schema tax: every registered tool's name+description+JSON schema is
+ * loaded into the host model every session. Keep DEFAULT tier lean.
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -15,41 +17,26 @@ import { registerSpecTools } from './tools/spec'
 import { registerWorkflowTools } from './tools/workflow'
 
 /**
- * MCP server instructions — describe WHAT prjct holds, never prescribe
- * step-by-step HOW to use it. Deterministic pipelines (“first do X, then
- * Y”) are harness behavior; this template is the canonical anti-harness
- * shape (Anthropic skill docs): `Use when` + `What's here` + `Gotchas`.
- *
- * If you find yourself adding a numbered list of steps here, stop.
+ * Compact instructions — hosts already list tool names; avoid duplicating
+ * the tool laundry list here (token tax on every session).
  */
-const PRJCT_INSTRUCTIONS = `# prjct — AI Agile OS + project memory
+const PRJCT_INSTRUCTIONS = `# prjct — project memory + AI Agile work cycles
 
-Use when the user describes work, asks for project memory, or wants to improve developer/LLM execution. **Recognize intent — don't wait for the user to type prjct commands.** Default to a human-in-the-loop work cycle: clarify intent, retrieve focused context, run the right workflow/gates, execute with evidence, persist synthesized learning, and measure performance.
+Use when work needs durable project memory, intent, or harness gates. Prefer tools over Grep for recall.
 
 ## What's here
-
-- **Intent briefs** — durable goal/scope/risk artifacts for complex or high-stakes work. Tools: \`prjct_spec_*\`.
-- **Memory** (facts, decisions, learnings, gotchas, patterns, anti-patterns, insights, questions, sources, people, okrs, shipped work, inbox, **spec**). Save/recall via memory tools.
-- **Work-cycle state** via the session and project tools. The backing storage may still use task-shaped rows for compatibility.
-- **Workflows and gates** registered in this project (can be run, listed, edited). They are the quality engine of the work cycle, not a task board.
-- **Code intelligence** helpers (impact, related context) for navigating repos.
-- **Patterns and performance signals** detected by analysis.
-- **Managed session resume** (\`prjct_session_resume\` / \`prjct prime\`) — land stamps continuity; next window restores cycle + hand-off.
-- **Context tiers / safe artifacts** (MCP tier standard+) — \`prjct_context_tiers\`, \`prjct_safe_artifacts\`; also CLI \`prjct context tiers|artifacts --md\`.
+- Memory save/list/guard · work cycle status/start · analysis · session resume
+- Extended (PRJCT_MCP_TOOLS=standard|all): files, code-intel, typed record verbs, signals, skills, tiers, artifacts, workflows, specs
 
 ## Gotchas
-
-- Recognize intent in any language — the verbs are language-agnostic. But PERSIST in English only: every saved entry is authored in English regardless of the conversation language.
-- Memory is best-effort — never assume recall returned everything; it's a query, not a lookup.
-- Topic keys are free-form strings; don't invent new vocabularies when existing ones fit.
-- Not every project defines every memory type — if one is empty, that's fine.
-- Saving a secret-looking string is refused by default. Re-save with a scrubbed version.
-- Synthesize what happened and why. Raw transcript fragments are input, not final project context.`
+- Persist memories in ENGLISH. Secrets refused unless force=true.
+- projectPath is optional — defaults to MCP cwd / PRJCT_PROJECT_PATH.
+- Recall is ranked/best-effort, not a full dump.`
 
 /**
  * Tool surface tiers. Every registered tool costs schema tokens every session.
- *   core     — memory + project (default)
- *   standard — + files + code-intel
+ *   core     — high-signal only (default, ~10 tools)
+ *   standard — + files, code-intel, typed mem, cost, signals, skills, tiers, artifacts
  *   all      — + workflows + specs
  * Override with PRJCT_MCP_TOOLS=core|standard|all.
  */
@@ -70,9 +57,9 @@ export function createServer(): McpServer {
   )
 
   const tier = resolveTier()
-  registerMemoryTools(server)
-  // Core keeps a lean schema; extended project tools (tiers/artifacts) on standard+.
-  registerProjectTools(server, { extended: tier !== 'core' })
+  const extended = tier !== 'core'
+  registerMemoryTools(server, { extended })
+  registerProjectTools(server, { extended })
   if (tier === 'core') return server
 
   registerFileTools(server)

--- a/core/mcp/tools/code-intel.ts
+++ b/core/mcp/tools/code-intel.ts
@@ -14,7 +14,7 @@ import {
   loadMatrix,
 } from '../../domain/git-cochange'
 import { scoreFromSeeds as importScore, indexImports, loadGraph } from '../../domain/import-graph'
-import { resolveProjectId } from '../resolve'
+import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
 // MCP SDK TS2589 workaround: cast server to avoid deep type instantiation
@@ -28,7 +28,7 @@ export function registerCodeIntelTools(server: McpServer) {
     'prjct_impact_analysis',
     'Given changed files, find affected files via import graph + affected domains',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       changedFiles: z
         .array(z.string())
         .describe('List of changed file paths (relative to project root)'),
@@ -76,7 +76,7 @@ export function registerCodeIntelTools(server: McpServer) {
     'prjct_import_graph',
     'Import graph stats + file neighbors (imports/importers). Pass a file for its neighbors, omit for graph stats.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       file: z.string().optional().describe('File path to get neighbors for (omit for graph stats)'),
       rebuild: z.boolean().optional().default(false).describe('Force rebuild the import graph'),
     },
@@ -87,7 +87,7 @@ export function registerCodeIntelTools(server: McpServer) {
 
         let graph = args.rebuild ? null : loadGraph(projectId)
         if (!graph) {
-          graph = await indexImports(args.projectPath, projectId)
+          graph = await indexImports(resolveProjectPath(args.projectPath), projectId)
         }
 
         if (args.file) {
@@ -121,7 +121,7 @@ export function registerCodeIntelTools(server: McpServer) {
     'prjct_cochange',
     'Files that historically change together (Jaccard similarity from git history)',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       seedFiles: z.array(z.string()).describe('Seed files to find co-change partners for'),
       rebuild: z.boolean().optional().default(false).describe('Force rebuild the co-change matrix'),
       maxResults: z.number().optional().default(10).describe('Max results (default 10)'),
@@ -138,7 +138,7 @@ export function registerCodeIntelTools(server: McpServer) {
 
         let index = args.rebuild ? null : loadMatrix(projectId)
         if (!index) {
-          index = await indexCoChanges(args.projectPath, projectId)
+          index = await indexCoChanges(resolveProjectPath(args.projectPath), projectId)
         }
 
         const scores = cochangeScore(args.seedFiles, index).slice(0, args.maxResults)
@@ -167,7 +167,7 @@ export function registerCodeIntelTools(server: McpServer) {
     'prjct_related_context',
     'Combined: import neighbors + co-change partners for seed files',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       seedFiles: z.array(z.string()).describe('Seed files to find related context for'),
       maxResults: z.number().optional().default(15).describe('Max results (default 15)'),
     },

--- a/core/mcp/tools/files.ts
+++ b/core/mcp/tools/files.ts
@@ -9,7 +9,7 @@ import { z } from 'zod'
 import { stateStorage } from '../../storage/state-storage'
 import { findRelevantFiles } from '../../tools/context/files-tool'
 import { extractSignatures } from '../../tools/context/signatures-tool'
-import { resolveProjectId } from '../resolve'
+import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
 // MCP SDK TS2589 workaround: cast server to avoid deep type instantiation
@@ -23,7 +23,7 @@ export function registerFileTools(server: McpServer) {
     'prjct_relevant_files',
     'MUST call before Grep/Glob tree walks. Resolves a constrained work scope via prjct: memory (FTS + semantic embeddings when enabled) + code BM25 index + import graph + co-change. Prefer this over scanning the repo.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       query: z.string().describe('Task or query to find relevant files for'),
       maxFiles: z.number().optional().default(10).describe('Max files to return'),
     },
@@ -38,7 +38,7 @@ export function registerFileTools(server: McpServer) {
               '../../services/work-scope'
             )
             const scope = await resolveWorkScope(
-              args.projectPath,
+              resolveProjectPath(args.projectPath),
               projectId,
               args.query,
               args.maxFiles
@@ -66,7 +66,7 @@ export function registerFileTools(server: McpServer) {
         }
 
         // Fallback: live path scan (only when indexes/memory empty).
-        const result = await findRelevantFiles(args.query, args.projectPath, {
+        const result = await findRelevantFiles(args.query, resolveProjectPath(args.projectPath), {
           maxFiles: args.maxFiles,
           minScore: 0.1,
         })
@@ -95,7 +95,7 @@ export function registerFileTools(server: McpServer) {
     'prjct_signatures',
     'Function/class signatures of a file without bodies (~90% fewer tokens). Use to map an unfamiliar file before deciding whether to Read it fully.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       filePath: z.string().describe('Relative file path to extract signatures from'),
     },
     safeMcpCall('prjct_signatures', async (args: { projectPath: string; filePath: string }) => {
@@ -130,7 +130,7 @@ export function registerFileTools(server: McpServer) {
     'prjct_history',
     'Recently completed tasks and how they ended. Use to learn what was just done before continuing related work.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       limit: z.number().optional().default(10).describe('Max results'),
     },
     safeMcpCall('prjct_history', async (args: { projectPath: string; limit: number }) => {

--- a/core/mcp/tools/memory.ts
+++ b/core/mcp/tools/memory.ts
@@ -33,7 +33,7 @@ import { formatMemoryMd } from '../../memory/format'
 import { projectMemory } from '../../memory/project-memory'
 import { evaluateMemoryContent } from '../../services/trust-boundary'
 import { recordSurfacedForActiveTask } from '../../services/usefulness/surface-attribution'
-import { resolveProjectId } from '../resolve'
+import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
 // MCP SDK TS2589 workaround: cast server to any to avoid deep type
@@ -42,14 +42,18 @@ type S = any
 
 const TYPE_DESCRIPTIONS = `Base types: ${BASE_MEMORY_TYPES.join(', ')}. Any lowercase identifier is accepted (e.g. "recipe", "okr").`
 
-export function registerMemoryTools(server: McpServer) {
+/**
+ * @param options.extended — standard+ only: typed record verbs (decision/gotcha/…)
+ *   that alias mem_save. Keep them off core ListTools to cut schema tokens.
+ */
+export function registerMemoryTools(server: McpServer, options: { extended?: boolean } = {}) {
   const s: S = server
 
   s.tool(
     'prjct_mem_save',
     `Save a memory entry. Author content in ENGLISH regardless of the conversation language. ${TYPE_DESCRIPTIONS} Evolving topic? add tags.topic (stable key) — prjct UPSERTS by topic key, superseding prior versions instead of accumulating. Secret-like content is refused unless force=true.`,
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       type: z.string().describe('Memory type (fact/decision/learning/... or user-defined)'),
       content: z.string().describe('The memory content. Freeform text.'),
       tags: z
@@ -103,7 +107,8 @@ export function registerMemoryTools(server: McpServer) {
           }
         }
 
-        await projectMemory.remember(args.projectPath, {
+        const projectPath = resolveProjectPath(args.projectPath)
+        await projectMemory.remember(resolveProjectPath(projectPath), {
           type: typeStr,
           content: args.content,
           tags: args.tags ?? {},
@@ -117,134 +122,11 @@ export function registerMemoryTools(server: McpServer) {
     )
   )
 
-  // --- Narrow typed memory verbs (the "addCost not eval" principle) ---
-  // Each gives the model typed slots instead of one freeform `content` blob +
-  // open tags, so the entry's structure is unambiguous at the call site. They
-  // compose the typed fields into a single memory entry; `prjct_mem_save`
-  // remains the generic escape hatch for anything that doesn't fit.
-  async function saveTyped(
-    projectPath: string,
-    type: MemoryType,
-    content: string,
-    tags: Record<string, string> = {}
-  ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
-    await resolveProjectId(projectPath)
-    const trust = evaluateMemoryContent(content)
-    if (!trust.allow) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text:
-              trust.kind === 'secrets'
-                ? `Refused — content looks like a secret (${trust.hits.join(', ')}). Use prjct_mem_save with force=true if intentional.`
-                : trust.kind === 'prompt_injection'
-                  ? `Refused — content looks like prompt injection (${trust.hits.join(', ')}). Use prjct_mem_save with force=true if intentional.`
-                  : `Refused — ${trust.denyMessage}`,
-          },
-        ],
-      }
-    }
-    await projectMemory.remember(projectPath, { type, content, tags })
-    return { content: [{ type: 'text', text: `Saved ${type}: ${content.slice(0, 80)}` }] }
-  }
-
-  s.tool(
-    'prjct_record_decision',
-    'Record a DECISION: what was decided, why, and the alternatives considered. Author in ENGLISH.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-      decision: z.string().describe('What was decided (the choice itself)'),
-      rationale: z.string().optional().describe('Why this was chosen'),
-      alternatives: z.array(z.string()).optional().describe('Options considered and rejected'),
-    },
-    safeMcpCall(
-      'prjct_record_decision',
-      async (args: {
-        projectPath: string
-        decision: string
-        rationale?: string
-        alternatives?: string[]
-      }) => {
-        const parts = [args.decision]
-        if (args.rationale) parts.push(`\nWhy: ${args.rationale}`)
-        if (args.alternatives?.length)
-          parts.push(`\nAlternatives considered: ${args.alternatives.join('; ')}`)
-        return saveTyped(args.projectPath, 'decision', parts.join(''))
-      }
-    )
-  )
-
-  s.tool(
-    'prjct_record_gotcha',
-    'Record a GOTCHA: a trap/footgun, its symptom, and the fix. Tag the file so `prjct guard` surfaces it before edits.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-      symptom: z.string().describe('What goes wrong / how it manifests'),
-      fix: z.string().describe('How to avoid or fix it'),
-      file: z.string().optional().describe('File path this gotcha applies to (powers prjct guard)'),
-    },
-    safeMcpCall(
-      'prjct_record_gotcha',
-      async (args: { projectPath: string; symptom: string; fix: string; file?: string }) => {
-        const content = `${args.symptom}\nFix: ${args.fix}`
-        return saveTyped(args.projectPath, 'gotcha', content, args.file ? { file: args.file } : {})
-      }
-    )
-  )
-
-  s.tool(
-    'prjct_record_learning',
-    'Record a LEARNING: a claim discovered during the work and the evidence for it. Author in ENGLISH.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-      claim: z.string().describe('What was learned'),
-      evidence: z.string().optional().describe('What supports it (observation, file, result)'),
-    },
-    safeMcpCall(
-      'prjct_record_learning',
-      async (args: { projectPath: string; claim: string; evidence?: string }) => {
-        const content = args.evidence ? `${args.claim}\nEvidence: ${args.evidence}` : args.claim
-        return saveTyped(args.projectPath, 'learning', content)
-      }
-    )
-  )
-
-  s.tool(
-    'prjct_record_fact',
-    'Record a FACT: a stable statement about a subject in the project. Author in ENGLISH.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-      subject: z.string().describe('What the fact is about'),
-      statement: z.string().describe('The fact itself'),
-    },
-    safeMcpCall(
-      'prjct_record_fact',
-      async (args: { projectPath: string; subject: string; statement: string }) => {
-        return saveTyped(args.projectPath, 'fact', `${args.subject}: ${args.statement}`, {
-          subject: args.subject,
-        })
-      }
-    )
-  )
-
-  s.tool(
-    'prjct_capture_inbox',
-    'Capture a quick INBOX note (idea/bug/todo) for later triage. No structure required.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-      text: z.string().describe('The note to capture'),
-    },
-    safeMcpCall('prjct_capture_inbox', async (args: { projectPath: string; text: string }) => {
-      return saveTyped(args.projectPath, 'inbox', args.text)
-    })
-  )
-
   s.tool(
     'prjct_mem_list',
     'Recall memory entries as compact one-line cues (id + type + truncated body). Pull a full body on demand by id (`prjct context memory <id>`). Optional filters: topic (keyword across content + tag values), types, tags, limit.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       topic: z.string().optional().describe('Keyword to match over content + tag values'),
       types: z.array(z.string()).optional().describe('Restrict to these types'),
       tags: z
@@ -267,7 +149,7 @@ export function registerMemoryTools(server: McpServer) {
         // blend, usefulness rerank, link expansion, ship attribution).
         // Subagents reach memory through THIS tool — a plain recency
         // recall here gave them strictly worse retrieval than the CLI.
-        const entries = await enrichedRecall(args.projectPath, projectId, {
+        const entries = await enrichedRecall(resolveProjectPath(args.projectPath), projectId, {
           topic: args.topic,
           types: args.types as MemoryType[] | undefined,
           tags: args.tags,
@@ -286,7 +168,7 @@ export function registerMemoryTools(server: McpServer) {
     'prjct_mem_similar',
     'Find memory entries similar to a free-text description. Keyword-based, best-effort. Returns compact one-line cues; pull a full body by id on demand.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       description: z.string().describe('Free-text description to find similar memories for'),
       limit: z.number().optional().default(10).describe('Max results (default 10)'),
     },
@@ -298,7 +180,7 @@ export function registerMemoryTools(server: McpServer) {
         // beat the old shared-keyword `similar()` heuristic. Link
         // expansion off — similarity asks "does this exist?", not "give
         // me its whole neighborhood".
-        const entries = await enrichedRecall(args.projectPath, projectId, {
+        const entries = await enrichedRecall(resolveProjectPath(args.projectPath), projectId, {
           topic: args.description,
           limit: args.limit ?? 10,
           expandLinks: false,
@@ -319,7 +201,7 @@ export function registerMemoryTools(server: McpServer) {
     'prjct_guard',
     'Anticipation: before editing a file, get the preventive memory recorded against it — gotchas, anti-patterns, recurring bugs only. Empty result means clear to edit. Pull this instead of guessing what might break.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       file: z.string().describe('File to check (absolute or repo-relative)'),
       limit: z.number().optional().default(3).describe('Max preventive entries (default 3)'),
     },
@@ -349,10 +231,10 @@ export function registerMemoryTools(server: McpServer) {
     'prjct_mem_forget',
     'Remove a memory entry by id. Ids are stable — pull them from `prjct_mem_list`.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Memory id (e.g. "mem_42" or "ship_7")'),
     },
-    safeMcpCall('prjct_mem_forget', async (args: { projectPath: string; id: string }) => {
+    safeMcpCall('prjct_mem_forget', async (args: { projectPath?: string; id: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
       const removed = projectMemory.forget(projectId, args.id)
       return {
@@ -365,6 +247,132 @@ export function registerMemoryTools(server: McpServer) {
           },
         ],
       }
+    })
+  )
+
+  // --- Typed memory verbs (standard+) — alias mem_save; keep off core ListTools. ---
+  if (!options.extended) return
+
+  async function saveTyped(
+    projectPath: string | undefined,
+    type: MemoryType,
+    content: string,
+    tags: Record<string, string> = {}
+  ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+    const path = resolveProjectPath(projectPath)
+    await resolveProjectId(path)
+    const trust = evaluateMemoryContent(content)
+    if (!trust.allow) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              trust.kind === 'secrets'
+                ? `Refused — content looks like a secret (${trust.hits.join(', ')}). Use prjct_mem_save with force=true if intentional.`
+                : trust.kind === 'prompt_injection'
+                  ? `Refused — content looks like prompt injection (${trust.hits.join(', ')}). Use prjct_mem_save with force=true if intentional.`
+                  : `Refused — ${trust.denyMessage}`,
+          },
+        ],
+      }
+    }
+    await projectMemory.remember(path, { type, content, tags })
+    return { content: [{ type: 'text', text: `Saved ${type}: ${content.slice(0, 80)}` }] }
+  }
+
+  s.tool(
+    'prjct_record_decision',
+    'Record a DECISION: what was decided, why, and alternatives. Author in ENGLISH. (Or use prjct_mem_save type=decision.)',
+    {
+      projectPath: optionalProjectPath,
+      decision: z.string().describe('What was decided'),
+      rationale: z.string().optional().describe('Why'),
+      alternatives: z.array(z.string()).optional().describe('Rejected options'),
+    },
+    safeMcpCall(
+      'prjct_record_decision',
+      async (args: {
+        projectPath?: string
+        decision: string
+        rationale?: string
+        alternatives?: string[]
+      }) => {
+        const parts = [args.decision]
+        if (args.rationale) parts.push(`\nWhy: ${args.rationale}`)
+        if (args.alternatives?.length)
+          parts.push(`\nAlternatives considered: ${args.alternatives.join('; ')}`)
+        return saveTyped(args.projectPath, 'decision', parts.join(''))
+      }
+    )
+  )
+
+  s.tool(
+    'prjct_record_gotcha',
+    'Record a GOTCHA (trap + fix). Tag file for prjct_guard. (Or prjct_mem_save type=gotcha.)',
+    {
+      projectPath: optionalProjectPath,
+      symptom: z.string().describe('What goes wrong'),
+      fix: z.string().describe('How to avoid/fix'),
+      file: z.string().optional().describe('File path for guard'),
+    },
+    safeMcpCall(
+      'prjct_record_gotcha',
+      async (args: { projectPath?: string; symptom: string; fix: string; file?: string }) => {
+        return saveTyped(
+          args.projectPath,
+          'gotcha',
+          `${args.symptom}\nFix: ${args.fix}`,
+          args.file ? { file: args.file } : {}
+        )
+      }
+    )
+  )
+
+  s.tool(
+    'prjct_record_learning',
+    'Record a LEARNING + evidence. Author in ENGLISH. (Or prjct_mem_save type=learning.)',
+    {
+      projectPath: optionalProjectPath,
+      claim: z.string().describe('What was learned'),
+      evidence: z.string().optional().describe('Supporting observation'),
+    },
+    safeMcpCall(
+      'prjct_record_learning',
+      async (args: { projectPath?: string; claim: string; evidence?: string }) => {
+        const content = args.evidence ? `${args.claim}\nEvidence: ${args.evidence}` : args.claim
+        return saveTyped(args.projectPath, 'learning', content)
+      }
+    )
+  )
+
+  s.tool(
+    'prjct_record_fact',
+    'Record a FACT about a subject. Author in ENGLISH. (Or prjct_mem_save type=fact.)',
+    {
+      projectPath: optionalProjectPath,
+      subject: z.string().describe('Subject'),
+      statement: z.string().describe('The fact'),
+    },
+    safeMcpCall(
+      'prjct_record_fact',
+      async (args: { projectPath?: string; subject: string; statement: string }) => {
+        return saveTyped(args.projectPath, 'fact', `${args.subject}: ${args.statement}`, {
+          subject: args.subject,
+        })
+      }
+    )
+  )
+
+  s.tool(
+    'prjct_capture_inbox',
+    'Quick INBOX capture for later triage. (Or prjct_mem_save type=inbox.)',
+    {
+      projectPath: optionalProjectPath,
+      text: z.string().describe('Note text'),
+    },
+    safeMcpCall('prjct_capture_inbox', async (args: { projectPath?: string; text: string }) => {
+      return saveTyped(args.projectPath, 'inbox', args.text)
     })
   )
 }

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -17,7 +17,7 @@ import { formatRelatedContextForAgent, setTaskStatus, startTask } from '../../se
 import { recordTaskTokenUsage } from '../../services/work-cost-service'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
 import { queueStorage } from '../../storage/queue-storage'
-import { resolveProjectId } from '../resolve'
+import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
 // MCP SDK TS2589 workaround: cast server to avoid deep type instantiation
@@ -36,11 +36,11 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     'prjct_session_resume',
     'Managed session resume card (land→prime continuity): last land stamp, open cycle, session-close hand-off, next actions. Prefer this after a fresh window instead of re-discovering from chat.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
     },
     safeMcpCall('prjct_session_resume', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
-      const overview = await collectActiveTasks(projectId, args.projectPath)
+      const overview = await collectActiveTasks(projectId, resolveProjectPath(args.projectPath))
       const { loadSessionContinuity, loadLastSessionCloseContent, formatSessionResumeCard } =
         await import('../../services/session-continuity')
       const stamp = loadSessionContinuity(projectId)
@@ -79,11 +79,11 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     'prjct_task_status',
     'The active AI Agile work cycle (description, branch, when it started) plus queued work. Read this to see what is in progress before starting new work.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
     },
     safeMcpCall('prjct_task_status', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
-      const overview = await collectActiveTasks(projectId, args.projectPath)
+      const overview = await collectActiveTasks(projectId, resolveProjectPath(args.projectPath))
       const queue = await queueStorage.getActiveTasks(projectId)
 
       const parts: string[] = []
@@ -118,7 +118,7 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     'prjct_task_start',
     'Start an AI Agile work cycle. Fires before/after workflow gates and memory logging through the compatibility task backend; a gate may block the start. Pass linked_spec_id only when a durable intent/spec brief is required. Use when the user begins concrete work.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       description: z.string().describe('What the work cycle is — a short intent phrase'),
       linked_spec_id: z
         .string()
@@ -138,10 +138,15 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
         skip_hooks?: boolean
       }) => {
         const projectId = await resolveProjectId(args.projectPath)
-        const outcome = await startTask(projectId, args.projectPath, args.description, {
-          spec: args.linked_spec_id,
-          skipHooks: args.skip_hooks,
-        })
+        const outcome = await startTask(
+          projectId,
+          resolveProjectPath(args.projectPath),
+          args.description,
+          {
+            spec: args.linked_spec_id,
+            skipHooks: args.skip_hooks,
+          }
+        )
         if (!outcome.ok) {
           return { content: [{ type: 'text', text: outcome.blocked ?? 'Work start was blocked.' }] }
         }
@@ -193,14 +198,18 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     'prjct_task_set_status',
     'Change the active work cycle status. Records the transition and drives the workflow state machine. "active"/"resume" promotes paused work back to focus. To report token usage use the dedicated prjct_cost_add tool — this verb only transitions state.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       status: z
         .enum(['done', 'completed', 'paused', 'active', 'resume', 'in_progress'])
         .describe('New status'),
     },
     safeMcpCall('prjct_task_set_status', async (args: { projectPath: string; status: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
-      const outcome = await setTaskStatus(projectId, args.projectPath, args.status)
+      const outcome = await setTaskStatus(
+        projectId,
+        resolveProjectPath(args.projectPath),
+        args.status
+      )
       if (!outcome.ok) {
         const text =
           outcome.reason === 'unsupported'
@@ -222,77 +231,10 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
   )
 
   s.tool(
-    'prjct_cost_add',
-    "Report a work cycle's token usage so prjct can measure cost/ROI. A narrow, typed verb — any agent (Claude, Codex, Gemini, …) passes its own counts. Pass model/runtime when known; mark isEstimated=true if the counts are not exact provider usage.",
-    {
-      projectPath: z.string().describe('Project directory path'),
-      tokensIn: z.number().describe('Total input tokens this cycle consumed'),
-      tokensOut: z.number().describe('Total output tokens this cycle produced'),
-      model: z
-        .string()
-        .optional()
-        .describe('Model id when the runtime exposes it (e.g. claude-opus-4-8)'),
-      runtime: z.string().optional().describe('Runtime/host: claude | codex | gemini | …'),
-      isEstimated: z
-        .boolean()
-        .optional()
-        .describe('True when the counts are an estimate, not exact provider usage. Default false.'),
-      workCycleId: z
-        .string()
-        .optional()
-        .describe('Work cycle/task id; defaults to the active cycle when omitted'),
-    },
-    safeMcpCall(
-      'prjct_cost_add',
-      async (args: {
-        projectPath: string
-        tokensIn: number
-        tokensOut: number
-        model?: string
-        runtime?: string
-        isEstimated?: boolean
-        workCycleId?: string
-      }) => {
-        const projectId = await resolveProjectId(args.projectPath)
-        let taskId = args.workCycleId
-        if (!taskId) {
-          const { resolveActiveTask } = await import('../../services/task-service')
-          const active = await resolveActiveTask(projectId, args.projectPath)
-          taskId = active?.id
-        }
-        if (!taskId) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: 'No work cycle to attribute cost to (pass workCycleId or start a cycle).',
-              },
-            ],
-          }
-        }
-        recordTaskTokenUsage(projectId, taskId, args.tokensIn, args.tokensOut, {
-          model: args.model,
-          runtime: args.runtime,
-          isEstimated: args.isEstimated ?? false,
-          source: 'mcp',
-        })
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Recorded ${args.tokensIn} in / ${args.tokensOut} out${args.model ? ` (${args.model})` : ''} for ${taskId}.`,
-            },
-          ],
-        }
-      }
-    )
-  )
-
-  s.tool(
     'prjct_analysis',
     'The stored project analysis: architecture, stack, patterns, anti-patterns, conventions, tech-debt, and insights. Read this instead of re-deriving the architecture from source. Pass mode:"archive" for the history of superseded analyses.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       mode: z
         .enum(['active', 'archive'])
         .optional()
@@ -421,88 +363,124 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     )
   )
 
-  // `prjct_patterns` was removed — it was a strict subset of `prjct_mem_list`
-  // (recall with types=[decision, pattern, anti-pattern, gotcha]). One fewer
-  // tool schema in the client's context every turn; callers pass the `types`
-  // filter to `prjct_mem_list` for the same result.
-
-  // `prjct_developer` + `prjct_signals` replace the vault-only `developer.md`
-  // and `signals.md` read surfaces (WS-A: vault is off by default, so this
-  // synthesis must be queryable through a tool, not Read/Glob over markdown).
-  s.tool(
-    'prjct_developer',
-    'The synthesized developer profile — stated preferences (feedback) + friction lessons. Read this to act as the developer would without being told each time.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-    },
-    safeMcpCall('prjct_developer', async (args: { projectPath: string }) => {
-      const projectId = await resolveProjectId(args.projectPath)
-      const { projectMemory } = await import('../../memory/project-memory')
-      const { buildDeveloperProfile } = await import('../../services/developer-profile')
-      const { renderDeveloperEvolution } = await import('../../services/developer-evolution')
-      const entries = projectMemory.allEntriesForIndex(projectId)
-      const body = buildDeveloperProfile(entries)
-      // Weekly typed snapshots: how the profile + delivery velocity have
-      // evolved over time (developer_profile_snapshots).
-      const evolution = renderDeveloperEvolution(projectId)
-      const text =
-        [body, evolution].filter(Boolean).join('\n\n') ||
-        'No developer profile yet — capture `feedback` memories as preferences emerge.'
-      return {
-        content: [{ type: 'text', text }],
-      }
-    })
-  )
-
-  s.tool(
-    'prjct_signals',
-    'Machine signals dashboard — hot files, recurring patterns, skill-misses, friction. Transient telemetry to act on, then let expire (not durable knowledge).',
-    {
-      projectPath: z.string().describe('Project directory path'),
-    },
-    safeMcpCall('prjct_signals', async (args: { projectPath: string }) => {
-      const projectId = await resolveProjectId(args.projectPath)
-      const { projectMemory } = await import('../../memory/project-memory')
-      const { buildSignalsFile, isSignalEntry } = await import('../../services/signals-digest')
-      const signals = projectMemory.allEntriesForIndex(projectId).filter(isSignalEntry)
-      const body = buildSignalsFile(signals, { boundary: 'llm' })
-      return {
-        content: [{ type: 'text', text: body ?? 'No active signals.' }],
-      }
-    })
-  )
-
-  // Cross-rig skill discovery ("index of paths, not summaries"): agents on
-  // MCP-only rigs (Cursor, Windsurf, ...) resolve the catalog here and pass
-  // EXACT SKILL.md paths to their subagents — never a generated digest.
-  s.tool(
-    'prjct_skills',
-    'Skill index: every available agent skill (project + global roots) with name, description, and the EXACT SKILL.md path. Resolve once, pass paths to subagents — they read the originals.',
-    {
-      projectPath: z.string().describe('Project directory path'),
-    },
-    safeMcpCall('prjct_skills', async (args: { projectPath: string }) => {
-      const projectId = await resolveProjectId(args.projectPath)
-      const { refreshSkillIndex, renderSkillIndex } = await import('../../services/skill-index')
-      await refreshSkillIndex(projectId, args.projectPath)
-      const body = renderSkillIndex(projectId)
-      return {
-        content: [
-          { type: 'text', text: body ?? 'No skills found in project or global skill roots.' },
-        ],
-      }
-    })
-  )
-
-  // Standard+ only — keep default core MCP schema lean (≤20 tools).
+  // Standard+ only — cut ListTools token tax on default core (≤12 tools).
+  // CLI parity: prjct cost, prjct context, prjct seed skills, etc.
   if (options.extended) {
     s.tool(
-      'prjct_context_tiers',
-      'Context cache tiers L0–L3 contract: what loads always vs session vs pull vs cold. Never stuff L2/L3 into L0. Includes live L0 skill/routing budget.',
+      'prjct_cost_add',
+      'Record cycle token usage (cost/ROI). Pass model/runtime when known.',
       {
-        projectPath: z.string().describe('Project directory path'),
+        projectPath: optionalProjectPath,
+        tokensIn: z.number().describe('Input tokens'),
+        tokensOut: z.number().describe('Output tokens'),
+        model: z.string().optional().describe('Model id'),
+        runtime: z.string().optional().describe('Host: claude | codex | gemini | …'),
+        isEstimated: z.boolean().optional().describe('True if estimated. Default false.'),
+        workCycleId: z.string().optional().describe('Task id; defaults to active cycle'),
       },
-      safeMcpCall('prjct_context_tiers', async (_args: { projectPath: string }) => {
+      safeMcpCall(
+        'prjct_cost_add',
+        async (args: {
+          projectPath?: string
+          tokensIn: number
+          tokensOut: number
+          model?: string
+          runtime?: string
+          isEstimated?: boolean
+          workCycleId?: string
+        }) => {
+          const path = resolveProjectPath(args.projectPath)
+          const projectId = await resolveProjectId(path)
+          let taskId = args.workCycleId
+          if (!taskId) {
+            const { resolveActiveTask } = await import('../../services/task-service')
+            const active = await resolveActiveTask(projectId, path)
+            taskId = active?.id
+          }
+          if (!taskId) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: 'No work cycle to attribute cost to (pass workCycleId or start a cycle).',
+                },
+              ],
+            }
+          }
+          recordTaskTokenUsage(projectId, taskId, args.tokensIn, args.tokensOut, {
+            model: args.model,
+            runtime: args.runtime,
+            isEstimated: args.isEstimated ?? false,
+            source: 'mcp',
+          })
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Recorded ${args.tokensIn} in / ${args.tokensOut} out${args.model ? ` (${args.model})` : ''} for ${taskId}.`,
+              },
+            ],
+          }
+        }
+      )
+    )
+
+    s.tool(
+      'prjct_developer',
+      'Synthesized developer profile (feedback + friction). Act as this developer would.',
+      { projectPath: optionalProjectPath },
+      safeMcpCall('prjct_developer', async (args: { projectPath?: string }) => {
+        const projectId = await resolveProjectId(args.projectPath)
+        const { projectMemory } = await import('../../memory/project-memory')
+        const { buildDeveloperProfile } = await import('../../services/developer-profile')
+        const { renderDeveloperEvolution } = await import('../../services/developer-evolution')
+        const entries = projectMemory.allEntriesForIndex(projectId)
+        const body = buildDeveloperProfile(entries)
+        const evolution = renderDeveloperEvolution(projectId)
+        const text =
+          [body, evolution].filter(Boolean).join('\n\n') ||
+          'No developer profile yet — capture `feedback` memories as preferences emerge.'
+        return { content: [{ type: 'text', text }] }
+      })
+    )
+
+    s.tool(
+      'prjct_signals',
+      'Machine signals: hot files, skill-misses, friction (transient telemetry).',
+      { projectPath: optionalProjectPath },
+      safeMcpCall('prjct_signals', async (args: { projectPath?: string }) => {
+        const projectId = await resolveProjectId(args.projectPath)
+        const { projectMemory } = await import('../../memory/project-memory')
+        const { buildSignalsFile, isSignalEntry } = await import('../../services/signals-digest')
+        const signals = projectMemory.allEntriesForIndex(projectId).filter(isSignalEntry)
+        const body = buildSignalsFile(signals, { boundary: 'llm' })
+        return { content: [{ type: 'text', text: body ?? 'No active signals.' }] }
+      })
+    )
+
+    s.tool(
+      'prjct_skills',
+      'Skill index: name + description + EXACT SKILL.md path for subagent dispatch.',
+      { projectPath: optionalProjectPath },
+      safeMcpCall('prjct_skills', async (args: { projectPath?: string }) => {
+        const path = resolveProjectPath(args.projectPath)
+        const projectId = await resolveProjectId(path)
+        const { refreshSkillIndex, renderSkillIndex } = await import('../../services/skill-index')
+        await refreshSkillIndex(projectId, path)
+        const body = renderSkillIndex(projectId)
+        return {
+          content: [
+            { type: 'text', text: body ?? 'No skills found in project or global skill roots.' },
+          ],
+        }
+      })
+    )
+
+    s.tool(
+      'prjct_context_tiers',
+      'Context cache tiers L0–L3 + live L0 budget. Never stuff L2 into L0.',
+      { projectPath: optionalProjectPath },
+      safeMcpCall('prjct_context_tiers', async () => {
         const { formatContextTiersMd } = await import('../../services/context-tiers')
         return { content: [{ type: 'text', text: formatContextTiersMd() }] }
       })
@@ -510,19 +488,22 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
 
     s.tool(
       'prjct_safe_artifacts',
-      'List controlled agent-output artifacts: judgment ledger, ship receipts, pending handoffs, context checkpoints, session continuity stamp. Audit surface — not a markdown vault.',
+      'Audit agent outputs: judgment, ships, handoffs, checkpoints, session stamp.',
       {
-        projectPath: z.string().describe('Project directory path'),
+        projectPath: optionalProjectPath,
         limit: z.number().int().min(1).max(20).optional().describe('Max per kind (default 5)'),
       },
-      safeMcpCall('prjct_safe_artifacts', async (args: { projectPath: string; limit?: number }) => {
-        const projectId = await resolveProjectId(args.projectPath)
-        const { listSafeArtifacts, formatSafeArtifactsMd } = await import(
-          '../../services/safe-artifacts'
-        )
-        const report = await listSafeArtifacts(projectId, { limit: args.limit })
-        return { content: [{ type: 'text', text: formatSafeArtifactsMd(report) }] }
-      })
+      safeMcpCall(
+        'prjct_safe_artifacts',
+        async (args: { projectPath?: string; limit?: number }) => {
+          const projectId = await resolveProjectId(args.projectPath)
+          const { listSafeArtifacts, formatSafeArtifactsMd } = await import(
+            '../../services/safe-artifacts'
+          )
+          const report = await listSafeArtifacts(projectId, { limit: args.limit })
+          return { content: [{ type: 'text', text: formatSafeArtifactsMd(report) }] }
+        }
+      )
     )
   }
 }

--- a/core/mcp/tools/spec.ts
+++ b/core/mcp/tools/spec.ts
@@ -25,7 +25,7 @@ import {
   SpecContentSchema,
   type SpecStatus,
 } from '../../types/spec'
-import { resolveProjectId } from '../resolve'
+import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
 // MCP SDK TS2589 workaround: cast server to any to avoid deep type
@@ -40,7 +40,7 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_create',
     'Draft a spec when the user frames a feature/fix/initiative WITH goals or stakes (e.g. "rate limiting on auth", "fix onboarding"). Fields default empty — fill them via `prjct_spec_update`. Skip for routine work (single-file fix, doc tweak, capture); use `prjct_mem_save` with type="inbox" or the CLI `prjct capture` instead.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       title: z.string().describe("One-line title (what you'd say to a coworker walking by)"),
       goal: z.string().describe('What success looks like, 1-3 sentences. Concrete, observable.'),
       eli10: z.string().optional().describe('Plain English a 16-year-old follows, 2-4 sentences'),
@@ -76,7 +76,7 @@ export function registerSpecTools(server: McpServer) {
         test_plan?: string[]
         tags?: Record<string, string>
       }) => {
-        const spec = await specService.create(args.projectPath, {
+        const spec = await specService.create(resolveProjectPath(args.projectPath), {
           title: args.title,
           content: {
             goal: args.goal,
@@ -109,7 +109,7 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_list',
     'List specs in this project. Use to check what specs exist before drafting a new one (avoid duplicates) or to find the right spec to link a task to.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       status: z
         .enum(SPEC_STATUSES)
         .optional()
@@ -152,11 +152,11 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_get',
     'Fetch one spec by id, including all structured fields (goal, acceptance criteria, scope, risks, reviews, linked tasks).',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Spec id'),
     },
     safeMcpCall('prjct_spec_get', async (args: { projectPath: string; id: string }) => {
-      const spec = await specService.get(args.projectPath, args.id)
+      const spec = await specService.get(resolveProjectPath(args.projectPath), args.id)
       if (!spec) {
         return { content: [{ type: 'text', text: `_Spec not found: ${args.id}_` }] }
       }
@@ -170,7 +170,7 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_update',
     "Replace a spec's structured content. Pass the FULL content object (this is a replace, not a merge) — when filling in acceptance_criteria for the first time, fetch with `prjct_spec_get` first and merge in your changes.",
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Spec id'),
       content: z
         .object({
@@ -196,7 +196,7 @@ export function registerSpecTools(server: McpServer) {
       }) => {
         const validated = SpecContentSchema.parse(args.content)
         const updated = await specService.update(
-          args.projectPath,
+          resolveProjectPath(args.projectPath),
           args.id,
           validated as SpecContent
         )
@@ -214,14 +214,18 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_set_status',
     'Promote/demote a spec lifecycle state: `in_progress` when work starts, `archived` when superseded. (draft → reviewed auto-promotes when reviewers pass; for first ship use `prjct_spec_ship` so the PR is recorded.)',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Spec id'),
       status: z.enum(SPEC_STATUSES).describe('Target status'),
     },
     safeMcpCall(
       'prjct_spec_set_status',
       async (args: { projectPath: string; id: string; status: SpecStatus }) => {
-        const next = await specService.setStatus(args.projectPath, args.id, args.status)
+        const next = await specService.setStatus(
+          resolveProjectPath(args.projectPath),
+          args.id,
+          args.status
+        )
         if (!next) {
           return { content: [{ type: 'text', text: `_Spec not found: ${args.id}_` }] }
         }
@@ -236,11 +240,11 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_audit',
     'Call before implementing a spec. Returns a dispatch prompt for the review specialists the spec raises — a DYNAMIC set (architecture is the floor; security/data/performance/design/strategic + any project DOMAIN experts join when the spec signals them). Run them IN PARALLEL (one Agent block per reviewer, same message). Persist each verdict via `prjct_spec_record_review`; all pass → spec auto-promotes draft → reviewed.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Spec id to audit'),
     },
     safeMcpCall('prjct_spec_audit', async (args: { projectPath: string; id: string }) => {
-      const spec = await specService.get(args.projectPath, args.id)
+      const spec = await specService.get(resolveProjectPath(args.projectPath), args.id)
       if (!spec) {
         return { content: [{ type: 'text', text: `_Spec not found: ${args.id}_` }] }
       }
@@ -252,7 +256,7 @@ export function registerSpecTools(server: McpServer) {
         ? (indexStorage.readDomainsSync(auditProjectId)?.domains ?? [])
         : []
       const lenses = selectReviewers(spec.content, domains)
-      await specService.setSelectedReviewers(args.projectPath, args.id, lenses)
+      await specService.setSelectedReviewers(resolveProjectPath(args.projectPath), args.id, lenses)
       return {
         content: [
           {
@@ -275,7 +279,7 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_record_review',
     "Persist one reviewer's verdict from `prjct_spec_audit` dispatch. Call once per reviewer (strategic, architecture, design). When all three are recorded with verdict=pass, the spec auto-promotes draft → reviewed.",
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Spec id'),
       reviewer: z.string().min(1).describe('Which lens (e.g. architecture, security, data)'),
       verdict: z.enum(['pass', 'fail']).describe('Verdict'),
@@ -290,10 +294,15 @@ export function registerSpecTools(server: McpServer) {
         verdict: 'pass' | 'fail'
         notes: string
       }) => {
-        const updated = await specService.recordReview(args.projectPath, args.id, args.reviewer, {
-          verdict: args.verdict,
-          notes: args.notes,
-        })
+        const updated = await specService.recordReview(
+          resolveProjectPath(args.projectPath),
+          args.id,
+          args.reviewer,
+          {
+            verdict: args.verdict,
+            notes: args.notes,
+          }
+        )
         if (!updated) {
           return { content: [{ type: 'text', text: `_Spec not found: ${args.id}_` }] }
         }
@@ -310,14 +319,18 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_link_task',
     'Link a task to its spec (call after starting the task) so `prjct_ship` knows which spec to gate against. Idempotent.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       specId: z.string().describe('Spec id'),
       taskId: z.string().describe('Task id (from `prjct_task_start` or stateStorage)'),
     },
     safeMcpCall(
       'prjct_spec_link_task',
       async (args: { projectPath: string; specId: string; taskId: string }) => {
-        const updated = await specService.linkTask(args.projectPath, args.specId, args.taskId)
+        const updated = await specService.linkTask(
+          resolveProjectPath(args.projectPath),
+          args.specId,
+          args.taskId
+        )
         if (!updated) {
           return { content: [{ type: 'text', text: `_Spec not found: ${args.specId}_` }] }
         }
@@ -332,14 +345,14 @@ export function registerSpecTools(server: McpServer) {
     'prjct_spec_ship',
     'Mark a spec as shipped (after the linked PR merges). Records the PR number on the spec for provenance.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       id: z.string().describe('Spec id'),
       pr: z.number().optional().describe('PR / MR number that delivered the spec'),
     },
     safeMcpCall(
       'prjct_spec_ship',
       async (args: { projectPath: string; id: string; pr?: number }) => {
-        const next = await specService.ship(args.projectPath, args.id, args.pr)
+        const next = await specService.ship(resolveProjectPath(args.projectPath), args.id, args.pr)
         if (!next) {
           return { content: [{ type: 'text', text: `_Spec not found: ${args.id}_` }] }
         }

--- a/core/mcp/tools/workflow.ts
+++ b/core/mcp/tools/workflow.ts
@@ -8,7 +8,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { customWorkflowStorage } from '../../storage/custom-workflow-storage'
 import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
-import { resolveProjectId } from '../resolve'
+import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
 // MCP SDK TS2589 workaround: cast server to avoid deep type instantiation
@@ -22,7 +22,7 @@ export function registerWorkflowTools(server: McpServer) {
     'prjct_workflow_rules',
     'The gates/hooks/steps registered for a command (task, ship, …). Check before running a lifecycle verb so a gate never surprises you mid-action.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
       command: z.string().describe('Command name (task, done, ship, sync, etc.)'),
     },
     safeMcpCall('prjct_workflow_rules', async (args: { projectPath: string; command: string }) => {
@@ -59,7 +59,7 @@ export function registerWorkflowTools(server: McpServer) {
     'prjct_workflow_list',
     'Every workflow this project registered (built-in + custom). Use to discover what `prjct workflow run <name>` can execute here.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
     },
     safeMcpCall('prjct_workflow_list', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -87,14 +87,14 @@ export function registerWorkflowTools(server: McpServer) {
     'prjct_workflow_status',
     'Where the active work cycle sits in its workflow/gates (state + rules currently in force). Read when deciding whether done/ship is allowed next.',
     {
-      projectPath: z.string().describe('Project directory path'),
+      projectPath: optionalProjectPath,
     },
     safeMcpCall('prjct_workflow_status', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
       // Workspace-aware: surface THIS worktree's task (main → currentTask,
       // child worktree → its activeTasks[] slot), not just the main slot.
       const { resolveActiveTask } = await import('../../services/task-service')
-      const currentTask = await resolveActiveTask(projectId, args.projectPath)
+      const currentTask = await resolveActiveTask(projectId, resolveProjectPath(args.projectPath))
       const allRules = workflowRuleStorage.getAllRules(projectId)
 
       const parts: string[] = ['## Workflow Status']

--- a/core/services/context-tiers.ts
+++ b/core/services/context-tiers.ts
@@ -26,6 +26,8 @@ import type { SkillContext } from './skill-generator/types'
  */
 export const L0_SKILL_TOKENS_MAX = 900
 export const L0_ROUTING_BYTES_MAX = 400
+/** Default MCP ListTools surface (core tier) — schema tokens every session. */
+export const MCP_TOOLS_CORE_MAX = 12
 
 export type ContextTierId = 'L0' | 'L1' | 'L2' | 'L3'
 

--- a/core/services/harness-score.ts
+++ b/core/services/harness-score.ts
@@ -12,6 +12,7 @@ import {
   CONTEXT_TIERS,
   L0_ROUTING_BYTES_MAX,
   L0_SKILL_TOKENS_MAX,
+  MCP_TOOLS_CORE_MAX,
   measureL0Budget,
 } from './context-tiers'
 import { MINIMAL_ROUTING_BODY } from './routing-block'
@@ -49,7 +50,8 @@ export const WORLD_CLASS = {
   routingBodyBytesMax: L0_ROUTING_BYTES_MAX,
   routingBodyBytesAmber: 600,
   mcpDefaultTier: 'core' as const,
-  mcpToolsCoreMax: 20,
+  /** Core ListTools budget after MCP schema slim (was 20). */
+  mcpToolsCoreMax: MCP_TOOLS_CORE_MAX,
   providerMapsMin: 6,
   meanGreen: 4.5,
   minCriterionGreen: 4,


### PR DESCRIPTION
## Summary

Cut **session schema tax** for every MCP host (Claude/Codex/Cursor/Grok):

| Tier | Tools (approx) |
|------|----------------|
| **core (default)** | **10** (was 19) |
| standard | 28 |
| all | 40 |

### Changes
1. **`projectPath` optional** on all tools — defaults to `PRJCT_PROJECT_PATH` or MCP cwd (less schema + fewer args every call).
2. **Core keep only high-signal tools:** mem save/list/similar/forget/guard · session_resume · task status/start/set_status · analysis.
3. **Moved to standard+:** typed record verbs, cost_add, developer, signals, skills, context_tiers, safe_artifacts (+ files/code-intel already).
4. **Shorter MCP `instructions`** (no tool laundry list).
5. **SLO** `mcpToolsCoreMax` 20 → 12 (measured core = 10).

CLI parity unchanged (`prjct remember`, `prjct cost`, etc.).

## Test plan
- [x] tool-tiers: core ≤12 and core < standard < all
- [x] weak-model bench: MCP 10 tools PASS
- [x] typecheck
- [ ] CI green