### PR TITLE
fix(harness): portable multi-LLM L0 skill isolation (v3.51.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.51.0] - 2026-07-13
+
+### Added
+- portable multi-LLM L0 skill isolation — no global project stamp
+
 ## [3.50.2] - 2026-07-12
 
 ### Added
@@ -27,7 +32,6 @@
 ### Performance
 
 - slim core ListTools 19→10 tools (#554)
-
 
 ## [3.50.1] - 2026-07-12
 

--- a/core/__tests__/hooks/session-start-staleness.test.ts
+++ b/core/__tests__/hooks/session-start-staleness.test.ts
@@ -66,7 +66,7 @@ describe('SessionStart — understanding staleness', () => {
     expect(r).toContain('12 commits')
   })
 
-  it('stays silent when the sync is current (no drift → no nag)', async () => {
+  it('stays silent on drift when the sync is current (identity still ok)', async () => {
     const head = git('rev-parse --short HEAD')
     prjctDb.setDoc(projectId, 'project', {
       name: 'x',
@@ -74,7 +74,10 @@ describe('SessionStart — understanding staleness', () => {
       lastSyncCommit: head, // synced AT head → zero commits since
     })
     const r = await buildSessionContext(repo, cfg, { digest: false })
-    // No persona, no digest, no drift → the block is silent.
-    expect(r).toBeNull()
+    // No persona, no digest, no drift → identity only (L1 cwd), no staleness nag.
+    expect(r).not.toBeNull()
+    expect(r).toContain('## Project identity (cwd)')
+    expect(r).not.toContain('Understanding may be stale')
+    expect(r).not.toContain('commits since')
   })
 })

--- a/core/__tests__/hooks/session-start.test.ts
+++ b/core/__tests__/hooks/session-start.test.ts
@@ -12,8 +12,8 @@
  *
  * Locked invariants:
  *   1. No projectId in config → returns null (skip injection).
- *   2. No persona → returns null. Per-turn topical recall is the
- *      prompt hook's job; SessionStart is persona-only.
+ *   2. With projectId → always emit cwd project identity (L1; skill is
+ *      portable L0 and must not carry project stamp).
  *   3. Persona present → injects persona section verbatim.
  *   4. Output is "describe state" — never "do this".
  *   5. Output bytes do NOT depend on memory state (cache stability).
@@ -71,20 +71,25 @@ describe('SessionStart hook — buildSessionContext', () => {
     expect(ctx).toBeNull()
   })
 
-  test('returns null when no persona is configured', async () => {
+  test('emits cwd project identity even without persona (L1 isolation)', async () => {
     await freshProject()
     const ctx = await buildSessionContext(projectPath)
-    expect(ctx).toBeNull()
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('## Project identity (cwd)')
+    expect(ctx).toContain('Skill is portable L0')
+    expect(ctx).not.toContain('Your role in this project')
   })
 
-  test('returns null when persona is missing even if memory exists', async () => {
+  test('without persona still omits memory content (cache stability)', async () => {
     // Prior versions injected a "Recent memory" section in this case.
-    // That broke cache stability and is no longer surfaced from this
-    // hook (UserPromptSubmit handles per-turn recall).
+    // That broke cache stability; UserPromptSubmit handles per-turn recall.
     await freshProject()
     insertMemory('decision', 'we picked SQLite for local-first')
     const ctx = await buildSessionContext(projectPath)
-    expect(ctx).toBeNull()
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('## Project identity (cwd)')
+    expect(ctx).not.toContain('SQLite for local-first')
+    expect(ctx).not.toContain('## Recent memory')
   })
 
   test('injects persona block with role/focus/MCPs/packs', async () => {
@@ -97,6 +102,7 @@ describe('SessionStart hook — buildSessionContext', () => {
     const ctx = await buildSessionContext(projectPath)
     expect(ctx).not.toBeNull()
     expect(ctx).toContain('# prjct: project context')
+    expect(ctx).toContain('## Project identity (cwd)')
     expect(ctx).toContain('Your role in this project: **PM**')
     expect(ctx).toContain('Focus: B2B onboarding')
     expect(ctx).toContain('Available MCPs this project expects: linear, posthog')
@@ -172,10 +178,12 @@ describe('SessionStart hook — knowledge digest (cold-start only)', () => {
     expect(ctx).toContain('What this project already knows')
   })
 
-  test('digest ON with no memory and no persona → still null (no noise)', async () => {
+  test('digest ON with no memory and no persona → identity only (no digest noise)', async () => {
     await freshProject()
     const ctx = await buildSessionContext(projectPath, null, { digest: true })
-    expect(ctx).toBeNull()
+    expect(ctx).not.toBeNull()
+    expect(ctx).toContain('## Project identity (cwd)')
+    expect(ctx).not.toContain('What this project already knows')
   })
 
   test('digest surfaces an entry skill-missed ≥2× (feedback loop read side)', async () => {

--- a/core/__tests__/services/doctor-heal.test.ts
+++ b/core/__tests__/services/doctor-heal.test.ts
@@ -45,4 +45,30 @@ describe('doctor-heal plan', () => {
     })
     expect(p.actions.find((a) => a.id === 'claude-hooks')?.needed).toBe(false)
   })
+
+  it('needs portable-skills heal when skill is project-stamped', () => {
+    const p = planDoctorHeal({
+      hooksInstalled: 12,
+      hooksExpected: 12,
+      liveCount: 4,
+      detectedCount: 4,
+      organicPct: 100,
+      hasProject: true,
+      skillPoisoned: true,
+    })
+    expect(p.actions.find((a) => a.id === 'portable-skills')?.needed).toBe(true)
+  })
+
+  it('skips portable-skills when skill is clean', () => {
+    const p = planDoctorHeal({
+      hooksInstalled: 12,
+      hooksExpected: 12,
+      liveCount: 4,
+      detectedCount: 4,
+      organicPct: 100,
+      hasProject: true,
+      skillPoisoned: false,
+    })
+    expect(p.actions.find((a) => a.id === 'portable-skills')?.needed).toBe(false)
+  })
 })

--- a/core/__tests__/services/skill-generator.test.ts
+++ b/core/__tests__/services/skill-generator.test.ts
@@ -151,28 +151,35 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
   })
 
   describe('generateAndInstall', () => {
-    it('generates the `prjct` skill', async () => {
+    it('generates the `prjct` skill (Claude full + compact fan-out)', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      expect(result.generated).toHaveLength(1)
-      expect(result.generated[0].name).toBe('prjct')
+      expect(result.generated.some((g) => g.name === 'prjct')).toBe(true)
+      expect(result.generated.some((g) => g.path.includes('.claude/skills/prjct'))).toBe(true)
       expect(result.skipped).toHaveLength(0)
     })
 
     it('writes SKILL.md at the expected path', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const skill = result.generated[0]
-      expect(skill.path).toContain('.claude/skills/')
-      expect(skill.path).toEndWith('/SKILL.md')
+      const skill = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      expect(skill).toBeDefined()
+      expect(skill!.path).toContain('.claude/skills/')
+      expect(skill!.path).toEndWith('/SKILL.md')
       const exists = await fs
-        .access(skill.path)
+        .access(skill!.path)
         .then(() => true)
         .catch(() => false)
       expect(exists).toBe(true)
     })
 
-    it('skill body includes the canonical anti-harness sections', async () => {
+    async function readClaudeSkill(): Promise<string> {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      expect(claude).toBeDefined()
+      return fs.readFile(claude!.path, 'utf-8')
+    }
+
+    it('skill body includes the canonical anti-harness sections', async () => {
+      const content = await readClaudeSkill()
       expect(content).toContain('## Use when')
       expect(content).toContain("## What's here")
       expect(content).toContain('### Agent contract')
@@ -180,8 +187,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('surfaces the opt-in tdd + sdd verbs in the always-loaded body', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaudeSkill()
       expect(content).toContain('`prjct tdd`')
       expect(content).toMatch(/test-first|TDD/)
       expect(content).toContain('`prjct sdd`')
@@ -189,8 +195,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('teaches the sovereign knowledge base so agents pull it, never inject it', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaudeSkill()
       // KB facets are first-class, capturable, and discoverable to any rig.
       for (const facet of ['identity', 'voice', 'glossary', 'framework']) {
         expect(content).toContain(facet)
@@ -202,8 +207,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('frames work as the single entrypoint for transparent AI Agile orchestration', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaudeSkill()
       expect(content).toContain('`prjct work` is the single normal entrypoint')
       expect(content).toContain('Trivial work proceeds directly')
       expect(content).toMatch(/persisted intent|tests before implementation/)
@@ -212,8 +216,9 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
 
     it('keeps loop-discipline triggers + model quick-ref in the pulled reference', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      const dir = path.dirname(result.generated[0].path)
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
+      const dir = path.dirname(claude!.path)
       const ref = await fs.readFile(path.join(dir, 'workflows.md'), 'utf-8')
 
       expect(content).toContain('workflows.md')
@@ -229,19 +234,18 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
       expect(ref).toContain('commit / push / open a PR')
       expect(ref).toContain('worktree/git accident')
       expect(ref).toContain('`model: "sonnet"`')
+      expect(ref).toMatch(/capability class|host vocabulary|Claude Code/i)
     })
 
     it('states the portable agent contract for Claude and GPT', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaudeSkill()
       expect(content).toContain('prjct remembers project state and shows the path')
       expect(content).toContain('Agents decide HOW with native tools and judgment')
       expect(content).toContain('Treat prjct output as durable signals')
     })
 
     it('exposes v3 primitives (work, intent, remember, context, workflow, seed)', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaudeSkill()
       expect(content).toContain('prjct work')
       expect(content).toContain('prjct intent')
       expect(content).toContain('prjct remember')
@@ -251,25 +255,29 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('points knowledge access at tools, not the vault', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaudeSkill()
       // Vault retired as a default read surface — the skill routes to tools.
       expect(content).not.toContain('.prjct/wiki/_generated/')
       expect(content).toContain('prjct context memory')
       expect(content).toContain('.prjct/prjct.config.json')
     })
 
-    it('includes project name, stack, and branch in the body', async () => {
+    it('is project-agnostic — never embeds project name/stack/branch (multi-project isolation)', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      expect(content).toContain('my-app')
-      expect(content).toContain('TypeScript')
-      expect(content).toContain('feat/alpha11')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      expect(claude).toBeDefined()
+      const content = await fs.readFile(claude!.path, 'utf-8')
+      expect(content).not.toContain('my-app')
+      expect(content).not.toContain('feat/alpha11')
+      expect(content).not.toMatch(/^\s*# my-app/m)
+      expect(content).toMatch(/portable|cwd-scoped/i)
+      expect(content).toContain('Skill ≠ project identity')
     })
 
     it('frontmatter has valid Claude Code native format', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
       expect(content).toStartWith('---\n')
       expect(content).toContain('description:')
       expect(content).toContain('allowed-tools:')
@@ -278,58 +286,88 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
       expect(secondDash).toBeGreaterThan(0)
     })
 
-    it('regenerates on every call (picks up new branch)', async () => {
-      await generator.generateAndInstall(makeSyncResult())
-      const result2 = await generator.generateAndInstall(
+    it('multi-project sync isolation: project A then B never stamps either name into L0', async () => {
+      await generator.generateAndInstall(
         makeSyncResult({
+          stats: {
+            fileCount: 10,
+            version: '1.0.0',
+            name: 'project-alpha',
+            ecosystem: 'Python',
+            projectType: 'app',
+            languages: ['Python'],
+            frameworks: [],
+          },
+        })
+      )
+      await generator.generateAndInstall(
+        makeSyncResult({
+          stats: {
+            fileCount: 99,
+            version: '0.0.0',
+            name: 'project-beta',
+            ecosystem: 'TypeScript',
+            projectType: 'cli',
+            languages: ['TypeScript'],
+            frameworks: ['Hono'],
+          },
           git: {
-            branch: 'fix/different',
-            commits: 100,
-            contributors: 3,
+            branch: 'fix/pins-account-products-state',
+            commits: 1,
+            contributors: 1,
             hasChanges: false,
             stagedFiles: [],
             modifiedFiles: [],
             untrackedFiles: [],
             recentCommits: [],
-            weeklyCommits: 5,
+            weeklyCommits: 0,
           },
         })
       )
-      const content = await fs.readFile(result2.generated[0].path, 'utf-8')
-      expect(content).toContain('fix/different')
-      expect(content).not.toContain('feat/alpha11')
+      const skillPath = path.join(tmpHome, '.claude', 'skills', 'prjct', 'SKILL.md')
+      const content = await fs.readFile(skillPath, 'utf-8')
+      expect(content).not.toContain('project-alpha')
+      expect(content).not.toContain('project-beta')
+      expect(content).not.toContain('fix/pins-account-products-state')
+      expect(content).not.toContain('## Recent Deliveries')
+      const { skillBodyHasProjectStamp } = await import('../../services/skill-generator')
+      expect(skillBodyHasProjectStamp(content)).toBe(false)
+    })
+
+    it('fans out compact portable skill to Codex/Gemini host dirs', async () => {
+      const result = await generator.generateAndInstall(makeSyncResult())
+      const compactPaths = result.generated
+        .filter((g) => g.name === 'prjct-compact')
+        .map((g) => g.path)
+      expect(compactPaths.length).toBeGreaterThanOrEqual(1)
+      expect(compactPaths.some((p) => p.includes('.codex/skills'))).toBe(true)
+      const sample = await fs.readFile(compactPaths[0], 'utf-8')
+      expect(sample).toContain('RAG-backed')
+      expect(sample).toMatch(/portable|context --md/i)
+      expect(sample).not.toContain('my-app')
     })
   })
 
-  describe('rich context injection', () => {
-    it('includes patterns from analysis', async () => {
+  describe('rich context isolation (never in L0)', () => {
+    it('ignores richContext — patterns/ships stay out of global skill', async () => {
       const result = await generator.generateAndInstall(
         makeSyncResult(),
         makeConditionContext(),
         makeRichContext()
       )
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      expect(content).toContain('Storage Layer Abstraction')
-    })
-
-    it('State is counts-only — no task description text (token diet R3)', async () => {
-      const result = await generator.generateAndInstall(
-        makeSyncResult(),
-        makeConditionContext(),
-        makeRichContext()
-      )
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      // Task DESCRIPTIONS are stale by the next sync and duplicated by the
-      // per-turn prompt hook — the body must never bake them in.
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
+      expect(content).not.toContain('Storage Layer Abstraction')
+      expect(content).not.toContain('## Patterns')
+      expect(content).not.toContain('## Velocity')
+      expect(content).not.toContain('## Recent Deliveries')
       expect(content).not.toContain('Wire alpha.11 hooks')
-      expect(content).toContain('## State')
-      expect(content).toContain('detail via `prjct context --md`')
     })
 
-    it('omits rich sections gracefully when empty', async () => {
+    it('omits rich sections when empty (and when rich is provided)', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      // Empty project → no Patterns / Anti-Patterns / Velocity blocks
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
       expect(content).not.toContain('## Patterns')
       expect(content).not.toContain('## Anti-Patterns')
       expect(content).not.toContain('## Velocity')
@@ -337,9 +375,14 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
   })
 
   describe('anti-harness enforcement', () => {
-    it('contains no numbered "do X then Y" steps', async () => {
+    async function readClaude(): Promise<string> {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      return fs.readFile(claude!.path, 'utf-8')
+    }
+
+    it('contains no numbered "do X then Y" steps', async () => {
+      const content = await readClaude()
       // No "1. ", "2. ", "3. " in the body (outside the frontmatter /
       // data blocks). Keep the check conservative — just look for the
       // numbered-step pattern with a verb that suggests prescription.
@@ -349,16 +392,14 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('contains no BLOCKING / MANDATORY directives', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaude()
       expect(content).not.toContain('BLOCKING')
       expect(content).not.toContain('MANDATORY')
       expect(content).not.toContain('## Constraints')
     })
 
     it('contains no "Pre-flight" ceremony', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await readClaude()
       expect(content).not.toContain('Pre-flight')
     })
   })
@@ -372,13 +413,15 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
   describe('deep-methodology reference (workflows.md)', () => {
     async function readReference(): Promise<string> {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const dir = path.dirname(result.generated[0].path)
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const dir = path.dirname(claude!.path)
       return fs.readFile(path.join(dir, 'workflows.md'), 'utf-8')
     }
 
     it('writes workflows.md next to SKILL.md', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const dir = path.dirname(result.generated[0].path)
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const dir = path.dirname(claude!.path)
       const exists = await fs
         .access(path.join(dir, 'workflows.md'))
         .then(() => true)
@@ -388,7 +431,8 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
 
     it('keeps SKILL.md lean — points at the reference, does not inline it', async () => {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
       expect(content).toContain('workflows.md')
       // Heavy methodology must NOT sit in the always-in-context body.
       expect(content).not.toContain('### Subagent dispatch')
@@ -402,7 +446,8 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
         makeConditionContext(),
         makeRichContext()
       )
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
       // ≤1500 tok always-on. Full verb map + methodology live in workflows.md.
       expect(countTokens(content)).toBeLessThanOrEqual(1500)
     })
@@ -471,11 +516,16 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
 
   // Verb intent map — always-on carries a CORE table; full map in workflows.md.
   describe('verb intent map (UX phase 1)', () => {
-    it('declares a compact core verb table always-on + full map in reference', async () => {
+    async function claudeSkillAndRef(): Promise<{ content: string; ref: string }> {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      const dir = path.dirname(result.generated[0].path)
-      const ref = await fs.readFile(path.join(dir, 'workflows.md'), 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
+      const ref = await fs.readFile(path.join(path.dirname(claude!.path), 'workflows.md'), 'utf-8')
+      return { content, ref }
+    }
+
+    it('declares a compact core verb table always-on + full map in reference', async () => {
+      const { content, ref } = await claudeSkillAndRef()
       expect(content).toContain('### Core verbs')
       expect(content).toMatch(/you run the verb|never types/)
       expect(content).toContain('| Signal | Verb | T |')
@@ -494,8 +544,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('explicitly tells the model NOT to make the user type commands', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const { content } = await claudeSkillAndRef()
       expect(content).toMatch(/never types|run the verb/i)
       // Skill description carries the same contract.
       const description = content.split('description:')[1]?.split('\n')[0] ?? ''
@@ -503,10 +552,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('teaches living context synthesis via pull reference (not always-on dump)', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
-      const dir = path.dirname(result.generated[0].path)
-      const ref = await fs.readFile(path.join(dir, 'workflows.md'), 'utf-8')
+      const { content, ref } = await claudeSkillAndRef()
       expect(content).toMatch(/living context|Session close/i)
       expect(ref).toContain('Living context synthesis')
       expect(ref).toContain('same model that just executed the task')
@@ -524,9 +570,14 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
   // Routing protocol — three tiers based on blast radius (condensed from
   // the old per-tier sections into a tight list in the lean body).
   describe('routing protocol (UX phase 2)', () => {
-    it('declares the three-tier routing protocol by blast radius', async () => {
+    async function claudeBody(): Promise<string> {
       const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      return fs.readFile(claude!.path, 'utf-8')
+    }
+
+    it('declares the three-tier routing protocol by blast radius', async () => {
+      const content = await claudeBody()
       expect(content).toContain('### Routing')
       expect(content).toContain('Tier 1 — auto-execute')
       expect(content).toContain('Tier 2 — confirm')
@@ -534,8 +585,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('groups memory / guard / insights / performance into Tier 1', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await claudeBody()
       const tier1 = content.split('Tier 1 — auto-execute')[1]?.split('Tier 2 —')[0] ?? ''
       expect(tier1).toContain('search')
       expect(tier1).toContain('remember')
@@ -545,8 +595,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('groups work / intent / ship into Tier 2 (confirm once)', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await claudeBody()
       const tier2 = content.split('Tier 2 — confirm')[1]?.split('Tier 3 —')[0] ?? ''
       expect(tier2).toContain('work')
       expect(tier2).toContain('intent')
@@ -554,8 +603,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('refuses pausing on routine captures and shipping without user OK', async () => {
-      const result = await generator.generateAndInstall(makeSyncResult())
-      const content = await fs.readFile(result.generated[0].path, 'utf-8')
+      const content = await claudeBody()
       expect(content).toMatch(/do not ask permission to save|auto-execute/i)
       expect(content).toMatch(/Never ship without user OK/)
     })

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -143,8 +143,14 @@ export async function buildSessionContext(
     }
   }
 
-  // Nothing to say (no persona, no knowledge, no drift) → stay silent.
+  // L1 cwd identity — NEVER from the global skill (multi-project poison).
+  // Always emit when we have projectId so the model never trusts a foreign
+  // skill stamp over this cwd (branch can change; acceptable on resume).
+  const identity = await buildProjectIdentityLine(projectPath, config.projectId)
+
+  // Nothing to say (no identity, persona, knowledge, drift) → stay silent.
   if (
+    !identity &&
     !persona &&
     !digest &&
     !staleness &&
@@ -158,6 +164,11 @@ export async function buildSessionContext(
   }
 
   const sections: string[] = ['# prjct: project context', '']
+
+  if (identity) {
+    sections.push(identity, '')
+  }
+
   if (persona) {
     // One advisory line only — the recall verbs already live in the skill's
     // Primitives section; repeating them here cost tokens on every cold
@@ -484,6 +495,39 @@ function formatPersona(persona: ProjectPersona): string {
     lines.push(`Active packs: ${persona.packs.join(', ')}`)
   }
   return lines.join('\n')
+}
+
+/**
+ * Cwd-scoped project identity for L1 inject. Global skills stay portable;
+ * this is the only place agents should learn "which repo am I in?".
+ */
+export async function buildProjectIdentityLine(
+  projectPath: string,
+  projectId: string
+): Promise<string | null> {
+  try {
+    const path = await import('node:path')
+    const { execFileAsync } = await import('../utils/exec')
+    const name = path.basename(projectPath)
+    let branch = ''
+    try {
+      const { stdout } = await execFileAsync('git', ['branch', '--show-current'], {
+        cwd: projectPath,
+      })
+      branch = stdout.trim()
+    } catch {
+      branch = ''
+    }
+    const shortId = projectId.length > 12 ? `${projectId.slice(0, 8)}…` : projectId
+    const parts = [`## Project identity (cwd)`, `- **${name}** · id \`${shortId}\``]
+    if (branch) parts.push(`- Branch: \`${branch}\``)
+    parts.push(
+      '- Skill is portable L0 — if skill text names another project, ignore it; trust this block + `prjct context --md`.'
+    )
+    return parts.join('\n')
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/core/infrastructure/command-installer/global-config.ts
+++ b/core/infrastructure/command-installer/global-config.ts
@@ -36,6 +36,8 @@ Before reading source code or running broad searches for ANY question about the 
 
 Only fall through to source/repo reading when prjct does not contain the answer.
 
+**Skill ≠ project identity.** The prjct skill is a portable multi-LLM contract (L0). Live name/stack/branch come from SessionStart + \`prjct context --md\` for **this cwd**. If skill text and the tree disagree, trust the cwd and the tree.
+
 ## Capture analyses BACK to prjct
 
 When you complete substantive work — analysis, decision, learning, gotcha — persist it: \`prjct remember <decision|learning|gotcha|fact> "..."\` or \`prjct capture "<text>" --tags k:v\`. **Author every entry in ENGLISH**, whatever language the user speaks. **Default to capturing — under-capture is the failure mode that makes prjct useless.** The full verb map and task workflow live in the \`prjct\` skill.

--- a/core/services/doctor-heal.ts
+++ b/core/services/doctor-heal.ts
@@ -15,6 +15,7 @@ export type HealActionId =
   | 'claude-hooks'
   | 'multi-runtime-wire'
   | 'agent-surfaces'
+  | 'portable-skills'
   | 'organic-board'
 
 export interface HealAction {
@@ -51,6 +52,8 @@ export function planDoctorHeal(input: {
   detectedCount: number
   organicPct: number
   hasProject: boolean
+  /** True when global Claude skill embeds project identity (poison). */
+  skillPoisoned?: boolean
 }): HealPlan {
   const actions: HealAction[] = [
     {
@@ -80,6 +83,15 @@ export function planDoctorHeal(input: {
       reason: input.hasProject
         ? 'explicit surface refresh (clean-repo opt-in)'
         : 'no project — skip surfaces',
+    },
+    {
+      id: 'portable-skills',
+      label: 'Rewrite portable multi-host skills (clear project stamp)',
+      needed: input.skillPoisoned === true,
+      reason:
+        input.skillPoisoned === true
+          ? 'global skill has project identity (multi-project poison)'
+          : 'skills portable',
     },
     {
       id: 'organic-board',
@@ -116,6 +128,20 @@ export async function applyDoctorHeal(
 
   let coverage = await probeHarnessCoverage(projectPath).catch(() => null)
   const projectId = await configManager.getProjectId(projectPath).catch(() => null)
+
+  let skillPoisoned = false
+  try {
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    const os = await import('node:os')
+    const { skillBodyHasProjectStamp } = await import('./skill-generator')
+    const skillPath = path.join(os.homedir(), '.claude', 'skills', 'prjct', 'SKILL.md')
+    const body = await fs.readFile(skillPath, 'utf-8').catch(() => null)
+    skillPoisoned = body ? skillBodyHasProjectStamp(body) : false
+  } catch {
+    skillPoisoned = false
+  }
+
   const plan = planDoctorHeal({
     hooksInstalled,
     hooksExpected,
@@ -123,6 +149,7 @@ export async function applyDoctorHeal(
     detectedCount: coverage?.detectedCount ?? 0,
     organicPct: coverage?.organicPct ?? 0,
     hasProject: Boolean(projectId),
+    skillPoisoned,
   })
 
   for (const action of plan.actions) {
@@ -133,6 +160,10 @@ export async function applyDoctorHeal(
     try {
       if (action.id === 'claude-hooks') {
         await installHooks()
+        applied.push(action.id)
+      } else if (action.id === 'portable-skills') {
+        const { skillGenerator } = await import('./skill-generator')
+        await skillGenerator.generateAndInstall()
         applied.push(action.id)
       } else if (action.id === 'multi-runtime-wire') {
         // Mirror install.ts: wire every detected host

--- a/core/services/harness-score.ts
+++ b/core/services/harness-score.ts
@@ -192,6 +192,23 @@ export function computeHarnessScore(
       'MCP core default + skill budget in code',
       `tier=${DEFAULT_MCP_TOOL_TIER}; skillMax=${WORLD_CLASS.skillTokensMax}`
     ),
+    (() => {
+      // Multi-project isolation: L0 skill must never carry project identity.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { skillBodyHasProjectStamp } =
+        require('./skill-generator') as typeof import('./skill-generator')
+      const portable = !skillBodyHasProjectStamp(skill)
+      const hasBaseline =
+        skill.includes('cwd-scoped') || skill.includes('Portable L0') || skill.includes('portable')
+      const score = portable && hasBaseline ? 5 : portable ? 3 : 1
+      return criterion(
+        'skill-isolation',
+        'Multi-project skill isolation',
+        score,
+        'global L0 skill project-agnostic',
+        portable ? 'portable L0 (no project stamp)' : 'PROJECT-STAMPED (poison risk)'
+      )
+    })(),
   ]
 
   // Optional: live organic multi-runtime board (probed by harness score / install).

--- a/core/services/multi-runtime-signals.ts
+++ b/core/services/multi-runtime-signals.ts
@@ -12,7 +12,9 @@
 
 import { BENCHMARK_HARNESS_SURFACES } from '../infrastructure/harness-surfaces'
 import { PRJCT_HOOKS } from './settings-installer'
+import { skillBodyHasProjectStamp } from './skill-generator'
 import { buildCodexSkill, buildGeminiConfig, CONTRACT } from './skill-generator/editor-surfaces'
+import { buildPrjctSkill, emptySkillContext } from './skill-generator/prjct-skill-body'
 
 export const CORE_SUPERIORITY_RUNTIMES = ['claude', 'codex', 'gemini', 'cursor', 'grok'] as const
 
@@ -88,10 +90,20 @@ export function multiRuntimeInstallParityReport(): {
 
   const codexSkill = buildCodexSkill()
   const geminiCfg = buildGeminiConfig()
+  const claudeSkill = buildPrjctSkill(emptySkillContext())
   const codexHasLoop = codexSkill.includes(CONTRACT.loop)
   const geminiHasLoop = geminiCfg.includes(CONTRACT.loop)
   if (!codexHasLoop) missing.push('codex skill missing CONTRACT.loop')
   if (!geminiHasLoop) missing.push('gemini config missing CONTRACT.loop')
+  if (!codexSkill.includes(CONTRACT.identity)) {
+    missing.push('codex skill missing CONTRACT.identity')
+  }
+  if (skillBodyHasProjectStamp(claudeSkill)) {
+    missing.push('claude L0 skill is project-stamped (multi-project poison)')
+  }
+  if (!claudeSkill.includes('cwd-scoped') && !claudeSkill.includes('portable')) {
+    missing.push('claude L0 skill missing portable baseline')
+  }
 
   const grok = BENCHMARK_HARNESS_SURFACES.find((s) => s.runtimeId === 'grok')
   const grokInheritsClaude =

--- a/core/services/skill-generator.ts
+++ b/core/services/skill-generator.ts
@@ -1,19 +1,11 @@
 /**
- * Skill Generator — Auto-generates Native Claude Code Skills from sync results.
+ * Portable multi-host skill installer.
  *
- * During `prjct sync`, generates workflow SKILL.md files installed to ~/.claude/skills/.
- * These are project-management skills with RICH project context baked in:
- * - Real patterns, anti-patterns, velocity, shipped features, known gotchas
- * - Embedded workflow that wraps CLI commands (heavy lifting in JS)
+ * L0 skill is project-agnostic (agentskills progressive disclosure).
+ * Project identity never lands in global skills — last-writer-wins poison.
+ * One content SSOT → N host paths (Claude full skill; Codex/Gemini compact).
  *
- * Design principles:
- * - Progressive disclosure: SKILL.md is concise, `prjct <cmd> --md` for details
- * - Data real embebida: Each skill includes relevant project data inline
- * - Pushy descriptions: Say WHEN to use, not just WHAT it does
- * - Context economy: Only include what Claude doesn't know. Every token justified
- * - Rich context lives in prjct-context (non-invocable): patterns, anti-patterns,
- *   velocity, gotchas, shipped, commands — workflow skills do NOT duplicate this
- *
+ * Live project facts = L1 SessionStart / prompt hooks + pull tools (MCP/CLI).
  */
 
 import fs from 'node:fs/promises'
@@ -23,23 +15,23 @@ import { getErrorMessage } from '../errors'
 import type { ProjectSyncResult } from '../types/project-sync'
 import type { SkillGenerationResult } from '../types/services.js'
 import log from '../utils/logger'
+import { buildCompactSkill } from './skill-generator/editor-surfaces'
 import {
   buildPrjctSkillBody,
   buildPrjctSkillReference,
+  emptySkillContext,
   PRJCT_SKILL_ALLOWED_TOOLS,
   PRJCT_SKILL_DESCRIPTION,
   PRJCT_SKILL_REFERENCE_FILE,
 } from './skill-generator/prjct-skill-body'
 import type { ConditionContext, SkillContext, SkillDefinition } from './skill-generator/types'
 
-// SKILL DEFINITIONS
-
 /**
  * Anti-harness skill template (canonical Anthropic shape).
  *
  * The body is `Use when` + `What's here` + `Gotchas` — zero numbered
- * steps, zero "first X then Y", zero "pre-flight BLOCKING" language.
- * prjct describes state; Claude decides HOW.
+ * steps. prjct describes state; the agent decides HOW.
+ * Body is always portable (emptySkillContext) — never project-stamped.
  */
 const SKILL_DEFINITIONS: SkillDefinition[] = [
   {
@@ -53,16 +45,9 @@ const SKILL_DEFINITIONS: SkillDefinition[] = [
   },
 ]
 
-// HELPERS
-
-// CRITICAL — cache stability: the description appears verbatim in the
-// host model's system prompt. Project-specific suffixes like
-// `(${name}, ${stack})` change every time `prjct sync` runs in a
-// different cwd, busting the entire system-prompt prefix and forcing
-// a full re-tokenization on the next turn. The frontmatter therefore
-// takes NO project context — it must stay static by construction.
-// Project metadata still ships in the skill body (loaded on skill
-// invocation), so Claude sees it when it actually needs it.
+// CRITICAL — cache stability + multi-project isolation: description and
+// body take NO project context. Project facts ship via SessionStart /
+// prompt hooks (cwd-scoped) and pull tools.
 function buildFrontmatter(skill: SkillDefinition): string {
   const isUserInvocable = skill.userInvocable !== false
   return `---
@@ -80,51 +65,61 @@ function homeDir(): string {
   return process.env.HOME || os.homedir()
 }
 
-// SKILL GENERATOR
+/** Hosts that install the full Claude-format skill + workflows.md reference. */
+function claudeSkillsRoot(): string {
+  return path.join(homeDir(), '.claude', 'skills')
+}
+
+/**
+ * Hosts that install the compact CONTRACT skill (agentskills-compatible,
+ * Codex hard ~1024B including metadata when installed via codex-skill).
+ */
+function compactSkillRoots(): string[] {
+  const home = homeDir()
+  return [
+    path.join(home, '.codex', 'skills'),
+    path.join(home, '.gemini', 'skills'),
+    path.join(home, '.gemini', 'antigravity', 'global_skills'),
+  ]
+}
+
+/**
+ * True when skill body embeds project identity (multi-project poison).
+ * Portable skill uses baseline "What's here" only — no `# name` + stack line.
+ */
+export function skillBodyHasProjectStamp(content: string): boolean {
+  // Pattern from formatProjectHeader when projectName is set:
+  //   # my-app
+  //   TypeScript/Hono | 200 files | v2.0.0 | Branch: feat/x
+  if (/^# [^\n]+\n[^\n]*\|\s*\d+\s+files\s*\|/m.test(content)) return true
+  if (/## Recent Deliveries/m.test(content)) return true
+  if (/## Velocity/m.test(content) && /pts\/sprint/m.test(content)) return true
+  return false
+}
 
 class SkillGenerator {
   /**
-   * Generate workflow skills from sync results and install to ~/.claude/skills/.
+   * Install portable L0 skills to all host skill dirs.
+   * syncResult / richContext are accepted for API stability but **ignored**
+   * for skill body content (project facts never enter global skills).
    */
   async generateAndInstall(
-    syncResult: ProjectSyncResult,
+    _syncResult?: ProjectSyncResult,
     conditionContext: ConditionContext = {
       backlogCount: 0,
       completedTaskCount: 0,
       pausedTaskCount: 0,
       hasActiveTask: false,
     },
-    richContext?: Partial<
+    _richContext?: Partial<
       Omit<SkillContext, 'projectName' | 'stack' | 'branch' | 'commands' | 'projectId'>
     >
   ): Promise<SkillGenerationResult> {
     const result: SkillGenerationResult = { generated: [], skipped: [] }
 
-    const ctx: SkillContext = {
-      projectName: syncResult.stats.name,
-      stack:
-        [...syncResult.stats.languages, ...syncResult.stats.frameworks].filter(Boolean).join('/') ||
-        syncResult.stats.ecosystem,
-      branch: syncResult.git.branch,
-      commands: syncResult.commands,
-      projectId: syncResult.projectId,
-
-      version: richContext?.version ?? syncResult.stats.version ?? '0.0.0',
-      fileCount: richContext?.fileCount ?? syncResult.stats.fileCount ?? 0,
-      patterns: richContext?.patterns ?? [],
-      antiPatterns: richContext?.antiPatterns ?? [],
-      recentShipped: richContext?.recentShipped ?? [],
-      velocity: richContext?.velocity ?? null,
-      backlogCount: richContext?.backlogCount ?? conditionContext.backlogCount,
-      knownGotchas: richContext?.knownGotchas ?? [],
-
-      pausedTasks: richContext?.pausedTasks ?? [],
-      ideasCount: richContext?.ideasCount ?? 0,
-      shippedCount: richContext?.shippedCount ?? 0,
-      userPatterns: richContext?.userPatterns ?? [],
-    }
-
-    const skillsDir = path.join(homeDir(), '.claude', 'skills')
+    // Always portable — multi-project isolation.
+    const ctx = emptySkillContext()
+    const skillsDir = claudeSkillsRoot()
 
     for (const def of SKILL_DEFINITIONS) {
       if (!def.condition(conditionContext)) {
@@ -137,14 +132,15 @@ class SkillGenerator {
 
       try {
         const content = buildSkillContent(def, ctx)
+        if (skillBodyHasProjectStamp(content)) {
+          throw new Error('refusing to install project-stamped skill body (isolation guard)')
+        }
         const skillDir = path.join(skillsDir, def.name)
         const skillPath = path.join(skillDir, 'SKILL.md')
 
         await fs.mkdir(skillDir, { recursive: true })
         await fs.writeFile(skillPath, content, 'utf-8')
 
-        // Deep-methodology reference (progressive disclosure): written next
-        // to SKILL.md and pulled on demand so it never sits in context.
         if (def.reference && def.referenceFile) {
           await fs.writeFile(path.join(skillDir, def.referenceFile), def.reference(), 'utf-8')
         }
@@ -154,6 +150,29 @@ class SkillGenerator {
         log.debug(`Failed to generate skill ${def.name}`, { error: getErrorMessage(error) })
         result.skipped.push({ name: def.name, reason: getErrorMessage(error) })
       }
+    }
+
+    // Compact CONTRACT skill → Codex / Gemini / Antigravity (same SSOT).
+    try {
+      const compact = buildCompactSkill()
+      for (const root of compactSkillRoots()) {
+        try {
+          const skillDir = path.join(root, 'prjct')
+          const skillPath = path.join(skillDir, 'SKILL.md')
+          await fs.mkdir(skillDir, { recursive: true })
+          await fs.writeFile(skillPath, compact, 'utf-8')
+          result.generated.push({ name: 'prjct-compact', path: skillPath })
+        } catch (error) {
+          log.debug('Compact skill install skipped', {
+            root,
+            error: getErrorMessage(error),
+          })
+        }
+      }
+    } catch (error) {
+      log.debug('Compact skill fan-out failed (non-critical)', {
+        error: getErrorMessage(error),
+      })
     }
 
     // Clean up stale prjct-* skill directories not in current definitions
@@ -172,13 +191,35 @@ class SkillGenerator {
     }
 
     if (result.generated.length > 0) {
-      log.info('Generated native workflow skills', {
+      log.info('Generated portable multi-host skills', {
         count: result.generated.length,
         skills: result.generated.map((s) => s.name),
       })
     }
 
     return result
+  }
+
+  /**
+   * Rewrite any poisoned global Claude skill to portable baseline.
+   * Safe to call from doctor / self-heal / sync.
+   */
+  async healPortableSkills(): Promise<{ healed: string[]; ok: boolean }> {
+    const healed: string[] = []
+    const claudePath = path.join(claudeSkillsRoot(), 'prjct', 'SKILL.md')
+    try {
+      const existing = await fs.readFile(claudePath, 'utf-8').catch(() => null)
+      if (existing && skillBodyHasProjectStamp(existing)) {
+        await this.generateAndInstall()
+        healed.push(claudePath)
+      } else if (!existing) {
+        await this.generateAndInstall()
+        healed.push(claudePath)
+      }
+    } catch {
+      /* best-effort */
+    }
+    return { healed, ok: true }
   }
 
   /** Get all skill definitions (for testing) */

--- a/core/services/skill-generator/editor-surfaces.ts
+++ b/core/services/skill-generator/editor-surfaces.ts
@@ -31,14 +31,16 @@ export const CONTRACT = {
   rag: 'prjct is a RAG-backed project memory harness; do not preload project history.',
   entrypoint:
     '`prjct work "<intent>" --md` is the single entrypoint — recognize intent and run the verb yourself.',
-  pull: 'Pull only what surfaces: `prjct search` / `prjct context memory <topic>` / `prjct guard <file>` / MCP `prjct_*` — not something to load wholesale.',
+  pull: 'Pull only what surfaces: `prjct search` / `context memory` / `guard` / MCP — not something to load wholesale.',
   remember:
     'Save synthesized memory in English: `prjct remember <decision|learning|gotcha|context> "<text>"`.',
-  kb: `KB facets (\`${KB}\`): \`prjct remember <facet>\` / \`prjct context memory <facet>\` — pulled on demand, never injected here.`,
-  ship: 'Ship only after the user OKs: `prjct ship --md`.',
+  kb: `KB (\`${KB}\`): \`remember <facet>\` / \`context memory <facet>\` — on demand, never injected here.`,
+  ship: 'Ship only after user OKs: `prjct ship --md`.',
   /** Loop-discipline parity across Claude/Codex/Gemini/Cursor/Grok (SUPERIOR multi-runtime). */
   // Kept short: Codex SKILL.md hard cap ~1024B including metadata marker.
   loop: 'Loop: land; H2+ intent; tip→user SoT; close.',
+  /** Multi-project isolation — skill is never project identity. Keep short (Codex ~1024B). */
+  identity: 'L0 portable; id=cwd.',
 } as const
 
 /**
@@ -63,6 +65,7 @@ export function buildCompactSkill(): string {
     `- ${CONTRACT.kb}`,
     `- ${CONTRACT.ship}`,
     `- ${CONTRACT.loop}`,
+    `- ${CONTRACT.identity}`,
     '',
     `Commit footer: \`${FOOTER}\``,
   ].join('\n')}\n`

--- a/core/services/skill-generator/formatters.ts
+++ b/core/services/skill-generator/formatters.ts
@@ -9,9 +9,18 @@
 import type { ProjectCommands } from '../../types/project-sync'
 import type { SkillContext } from './types'
 
+/**
+ * L0 skill header — **portable only**. Project identity must never enter
+ * the global skill (multi-project last-writer poison). Live name/stack/branch
+ * come from SessionStart (L1) and `prjct context --md`.
+ *
+ * When ctx.projectName is set (legacy callers / L1 helpers), still formats
+ * a header — but skill install always passes emptySkillContext().
+ */
 export function formatProjectHeader(ctx: SkillContext): string {
   if (!ctx.projectName) {
-    return 'Baseline skill (no project in cwd). On first real intent, suggest `prjct init` once — then run the verb. `prjct sync` regenerates this with project context.'
+    // Keep lean (L0 ≤900 tok). Identity lives in SessionStart + `prjct context --md`.
+    return 'Portable L0 — no project stamp. Identity is cwd-scoped (SessionStart / `prjct context --md`). Uninitialized tree: suggest `prjct init` once, then run the verb.'
   }
   return `# ${ctx.projectName}
 ${ctx.stack} | ${ctx.fileCount} files | v${ctx.version} | Branch: ${ctx.branch}`

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -5,7 +5,7 @@
  * (Dynasty D5); methodology and full verb map live in workflows.md.
  */
 
-import { formatProjectHeader, formatRichContext } from './formatters'
+import { formatProjectHeader } from './formatters'
 import type { SkillContext } from './types'
 
 export const PRJCT_SKILL_DESCRIPTION =
@@ -60,7 +60,13 @@ export function buildPrjctSkill(ctx: SkillContext): string {
 }
 
 export function buildPrjctSkillBody(ctx: SkillContext): string {
-  // Dynasty D5: always-on skill ≤900 tok (empty). Methodology → workflows.md.
+  // Dynasty D5: always-on skill ≤900 tok. Methodology → workflows.md.
+  // L0 is portable: install path always passes emptySkillContext so
+  // multi-project sync cannot poison the global skill. If a non-empty
+  // ctx is passed (tests/helpers), still prefer portable baseline for
+  // the always-on body — project facts belong in L1 SessionStart.
+  const portable = emptySkillContext()
+  const headerCtx = ctx.projectName ? portable : ctx
   return [
     '# prjct',
     '',
@@ -70,8 +76,9 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '',
     "## What's here",
     '',
-    formatProjectHeader(ctx),
-    formatRichContext(ctx),
+    formatProjectHeader(headerCtx),
+    // Never bake formatRichContext into L0 — ships/velocity/patterns are
+    // project-scoped and stale across syncs of different repos.
     '',
     '### Agent contract',
     '',
@@ -79,6 +86,7 @@ export function buildPrjctSkillBody(ctx: SkillContext): string {
     '- Agents decide HOW with native tools and judgment. Treat prjct output as durable signals: work, memory, intents, risks, performance.',
     '- Persist via `prjct remember` / `work` / `performance` / `ship`. Author every memory in **ENGLISH**.',
     '- **Pattern supremacy:** style source = THIS repo (neighbor + `search`/`context memory`/Work scope). Sound pattern → **match**. Shit pattern → **propose upgrade**, do not spread garbage or foreign linter taste. Never make the client tutor basics already in the tree.',
+    '- **Skill ≠ project identity.** If skill and cwd disagree, trust cwd + `prjct context --md`.',
     '',
     '### Cast + file scope (MUST)',
     '',
@@ -195,7 +203,7 @@ export function buildPrjctSkillReference(): string {
     '| **SoT / Live suggest / tip lines (terminal only — no web UI)** | **Surface them to the user in chat** as a short tip, then act. **SoT** = binding project truth (obey or supersede with `prjct remember`). **SUGGEST/tip** = propose the live change in the terminal and apply when editing. Never swallow tips silently. |',
     '| **Workspace owned by another agent (parallel work)** | `prjct work` auto-isolates to a sibling git worktree — `cd` there. Same-feature rescue uses `switch`, not a new worktree. |',
     '',
-    'Model on every dispatch: implementer that writes code → `model: "opus"`; reviewer/judge (`review`/`security`/`investigate`/`audit-spec`) → `model: "sonnet"`; pure routing/orchestration → `model: "haiku"`. A non-implementer inheriting the parent model burns tokens and latency.',
+    'Model policy is **capability class**, not a single host vocabulary. Implementer that writes code → max-tier model; reviewer/judge (`review`/`security`/`investigate`/`audit-spec`) → mid-tier; pure routing/orchestration → fast tier. Host mapping examples: Claude Code `opus` / `sonnet` / `haiku`; other hosts use their equivalent. A non-implementer inheriting the parent max model burns tokens and latency.',
     '',
     '## Spec pipeline — the stations (COMPLEX work only)',
     '',
@@ -269,15 +277,15 @@ export function buildPrjctSkillReference(): string {
     '',
     'Workflows that read many files (`review`, `security`, `investigate`, `audit`) MUST dispatch the read-and-analyze step as a subagent via the Agent tool with `subagent_type: "general-purpose"`. The subagent runs in a fresh context window and returns only the conclusion — the parent does not accumulate intermediate file reads. Without this, the parent\'s context fills with diffs, source files, and memory excerpts, leaving little budget for the user\'s actual conversation.',
     '',
-    "**Model policy (perf — non-negotiable).** A subagent inherits the parent's model + effort UNLESS you set `model:` in the Agent call. Orchestrators and reviewers do NOT implement — running them on the parent's max model is exactly why a single task used to crawl through every agent. Set the model explicitly on every dispatch:",
+    "**Model policy (perf — non-negotiable).** A subagent inherits the parent's model + effort UNLESS you set `model:` in the Agent call. Orchestrators and reviewers do NOT implement — running them on the parent's max model is exactly why a single task used to crawl through every agent. Set the model explicitly on every dispatch (host vocabulary may differ — Claude examples below):",
     '',
-    '- **Implementer** (the agent that writes code) → `model: "opus"`, full effort. ONLY this role gets max.',
-    '- **Reviewers / judgment** (`review`, `security`, `investigate`, and the `audit-spec` review specialists) → `model: "sonnet"`. Strong reasoning, ~no quality loss for judging a diff, far faster than Opus-max.',
-    '- **Pure orchestration / routing** (crew leader, any fan-out step that only routes) → `model: "haiku"`.',
+    '- **Implementer** (the agent that writes code) → max-tier (`model: "opus"` on Claude Code), full effort. ONLY this role gets max.',
+    '- **Reviewers / judgment** (`review`, `security`, `investigate`, and the `audit-spec` review specialists) → mid-tier (`model: "sonnet"` on Claude Code). Strong reasoning for judging a diff; far cheaper than max.',
+    '- **Pure orchestration / routing** (crew leader, any fan-out step that only routes) → fast tier (`model: "haiku"` on Claude Code).',
     '',
     'In every non-implementer subagent prompt, add one line: "Apply decent, not exhaustive, effort — you are reviewing/orchestrating: return the verdict, do not over-deliberate." Effort is prompt guidance (the Agent tool has no effort param); `model:` is the concrete lever — never omit it for a non-implementer.',
     '',
-    '**Fan out implementers when subtasks are independent.** One implementer is the floor, not a cap. When work splits into 2+ parts that touch DISJOINT files, dispatch one `implementer` per part IN THE SAME MESSAGE (one Agent block each) so they run in parallel — each `model: "opus"`, each handed its own non-overlapping file scope by you. If you cannot carve disjoint scopes (two parts would edit the same file), do NOT parallelize — run them sequentially; parallel writes to one file clobber each other. After the fan-out returns, compose the review specialists the combined diff raises (architecture + the lenses the change touches — the same set `prjct spec audit` selects), one specialist per concern over the whole diff, not one generic reviewer per implementer. Only fan out for genuine independence — parallel `opus` implementers are the most expensive spawn, so match the count to the work, never pad it.',
+    '**Fan out implementers when subtasks are independent.** One implementer is the floor, not a cap. When work splits into 2+ parts that touch DISJOINT files, dispatch one `implementer` per part IN THE SAME MESSAGE (one Agent block each) so they run in parallel — each max-tier model, each handed its own non-overlapping file scope by you. If you cannot carve disjoint scopes (two parts would edit the same file), do NOT parallelize — run them sequentially; parallel writes to one file clobber each other. After the fan-out returns, compose the review specialists the combined diff raises (architecture + the lenses the change touches — the same set `prjct spec audit` selects), one specialist per concern over the whole diff, not one generic reviewer per implementer. Only fan out for genuine independence — parallel max-tier implementers are the most expensive spawn, so match the count to the work, never pad it.',
     '',
     '**Crew mode reconciliation.** If this project has crew mode installed (`.claude/agents/leader.md` present, or a `prjct:crew` block in CLAUDE.md), the TRIAGE-FIRST "go direct" rule does NOT mean the main session writes code itself — it means triage happens INSIDE the leader: a trivial change is a 1-implementer dispatch (no spec), not a reason to skip the crew. In a crew project, ANY code/test work routes through the leader → implementer(s) → reviewer; the main session never edits source directly. "Go direct" still governs non-code turns (captures, memory, Q&A) — those need no subagent at all.',
     '',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.50.2",
+  "version": "3.51.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/scripts/generate-skill-template.ts
+++ b/scripts/generate-skill-template.ts
@@ -34,7 +34,7 @@ function emit(relParts: string[], content: string): void {
   console.log(`  → templates/${relParts.join('/')} (${Buffer.byteLength(content, 'utf-8')} bytes)`)
 }
 
-// Canonical Claude skill (full, project-aware at sync; baseline here).
+// Canonical Claude skill — always portable L0 (no project stamp; multi-LLM safe).
 emit(['skills', 'prjct', 'SKILL.md'], buildPrjctSkill(emptySkillContext()))
 
 // Compact non-Claude surfaces — generated from the same contract SSOT so they


### PR DESCRIPTION
## Summary

Claude looked broken because the **global** `~/.claude/skills/prjct/SKILL.md` was last-writer-wins project-stamped (wrong project identity). This ships a unified multi-LLM fix:

- **L0 skill is portable** for every host (Claude full + Codex/Gemini/Antigravity compact) — **no project name/stack/branch** in global skills
- **L1 cwd identity** via SessionStart (`## Project identity (cwd)`)
- **Doctor heal** rewrites poisoned skills; harness gains **skill-isolation** criterion
- CLAUDE.md: *Skill ≠ project identity*
- Multi-project isolation tests + release **v3.51.0**

## Test plan

- [x] `bun test` skill-generator / session-start / doctor-heal / harness-score / codex-skill / editor-surfaces / superiority-gates (110 pass)
- [x] Live heal: `~/.claude/skills/prjct/SKILL.md` no longer contains foreign project stamps
- [x] Harness score 5/5 including skill-isolation
- [ ] CI green on this PR
- [ ] After merge: npm publish via release workflow

Generated with [p/](https://www.prjct.app/)