### PR TITLE
fix(test): realign skill-generator L0 assertions after skill compression (v3.56.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
+## [3.56.0] - 2026-07-13
+
+### Added
+- skill generator l0 test assertions
+
 <<<<<<< HEAD
+
 ## [3.39.0] - 2026-07-09
 
 ### Added

--- a/core/__tests__/services/skill-generator.test.ts
+++ b/core/__tests__/services/skill-generator.test.ts
@@ -97,11 +97,21 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('surfaces the opt-in tdd + sdd verbs in the always-loaded body', async () => {
-      const content = await readClaudeSkill()
+      // L0 only lists the verbs (token budget). Methodology (test-first /
+      // intent-first intensity) lives in the pulled workflows.md reference.
+      const result = await generator.generateAndInstall()
+      const claude = result.generated.find((g) => g.path.includes('.claude/skills/prjct/SKILL.md'))
+      const content = await fs.readFile(claude!.path, 'utf-8')
+      const ref = await fs.readFile(path.join(path.dirname(claude!.path), 'workflows.md'), 'utf-8')
+
       expect(content).toContain('`prjct tdd`')
-      expect(content).toMatch(/test-first|TDD/)
-      expect(content).toContain('`prjct sdd`')
-      expect(content).toMatch(/intent-first|SDD/)
+      expect(content).toMatch(/tdd\/sdd|`sdd`/)
+      expect(content).not.toMatch(/test-first|intent-first/)
+
+      expect(ref).toMatch(/test-first|TDD/)
+      expect(ref).toContain('`prjct tdd`')
+      expect(ref).toContain('`prjct sdd`')
+      expect(ref).toMatch(/intent-first|SDD/)
     })
 
     it('teaches the sovereign knowledge base so agents pull it, never inject it', async () => {
@@ -117,11 +127,13 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('frames work as the single entrypoint for transparent AI Agile orchestration', async () => {
+      // Lean L0: single-entrypoint contract only. Spec/test-first pipeline
+      // detail stays in workflows.md (not always-on prose).
       const content = await readClaudeSkill()
       expect(content).toContain('`prjct work` is the single normal entrypoint')
-      expect(content).toContain('Trivial work proceeds directly')
-      expect(content).toMatch(/persisted intent|tests before implementation/)
+      expect(content).toContain('Full map in `workflows.md`')
       expect(content).not.toContain('**NO spec, NO audit-spec, NO subagents, NO fan-out.**')
+      expect(content).not.toContain('Trivial work proceeds directly')
     })
 
     it('keeps loop-discipline triggers + model quick-ref in the pulled reference', async () => {
@@ -155,13 +167,15 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
     })
 
     it('exposes v3 primitives (work, intent, remember, context, workflow, seed)', async () => {
+      // Compact core table: paired verbs use `/ \`seed\`` shorthand (not
+      // the full `prjct seed` string) to stay inside the L0 token budget.
       const content = await readClaudeSkill()
       expect(content).toContain('prjct work')
       expect(content).toContain('prjct intent')
       expect(content).toContain('prjct remember')
       expect(content).toContain('prjct context memory')
       expect(content).toContain('prjct workflow')
-      expect(content).toContain('prjct seed')
+      expect(content).toMatch(/`prjct workflow`\s*\/\s*`seed`/)
     })
 
     it('points knowledge access at tools, not the vault', async () => {

--- a/core/workflow-engine/workflow-engine.ts
+++ b/core/workflow-engine/workflow-engine.ts
@@ -333,6 +333,7 @@ async function runGitPush(projectPath: string): Promise<void> {
   })
     .then((r) => r.stdout.trim())
     .catch(() => '')
+
   const upstream = await execFileAsync(
     'git',
     ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
@@ -342,7 +343,17 @@ async function runGitPush(projectPath: string): Promise<void> {
     .catch(() => '')
 
   const args = decideGitPushArgs(currentBranch, upstream)
-  await execFileAsync('git', args, { cwd: projectPath })
+
+  try {
+    await execFileAsync('git', args, {
+      cwd: projectPath,
+      timeout: 30000,
+    })
+  } catch (error) {
+    const message = getErrorMessage(error)
+    // Surface real git error (no remote, permission, etc.) instead of generic failure
+    throw new Error(`git push failed: ${message}`)
+  }
 }
 
 async function runRuleAction(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.55.0",
+  "version": "3.56.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Realigns three `skill-generator` unit tests to the lean L0 skill contract after the post-analysis compression (v3.54/3.55). Those tests still expected pre-compression always-on prose and failed CI shard **core-b** (3 fails / 1110 pass).
- Also includes `runGitPush` error-propagation fix already staged on this line.
- Ships as **v3.56.0**.

## Test plan
- [x] `bun test core/__tests__/services/skill-generator.test.ts` — 39 pass
- [x] `bun run test:unit` — 2360 pass, 0 fail
- [ ] CI green on this PR (core-a/b/c + e2e)