### PR TITLE
ci: one-shot npm publish for registry metadata (temp)

### DIFF
--- a/.github/workflows/oneshot-publish.yml
+++ b/.github/workflows/oneshot-publish.yml
@@ -1,0 +1,54 @@
+# Temporary one-shot: publish current package.json version to npm with NPM_TOKEN.
+# Removes the jlopezlira repository URL stuck on the last published tarball (3.52.0).
+# Delete this workflow after a successful run.
+name: One-shot npm publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install + build
+        run: |
+          npm install
+          npm run build
+
+      - name: Show package identity
+        run: |
+          node -e "const p=require('./package.json'); console.log({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage})"
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "prjct-cli@$VERSION" version >/dev/null 2>&1; then
+            echo "prjct-cli@$VERSION already on npm — nothing to publish."
+            exit 0
+          fi
+          npm publish --access public
+          echo "Published prjct-cli@$VERSION"
+
+      - name: Verify registry metadata
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          for i in 1 2 3 4 5 6; do
+            if npm view "prjct-cli@$VERSION" version >/dev/null 2>&1; then
+              npm view prjct-cli version repository bugs homepage
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Version not visible yet" >&2
+          exit 1


### PR DESCRIPTION
## Summary
Temporary workflow to publish **3.56.0** with correct `repository: prjct-app/cli` so npmjs.com no longer shows jlopezlira.

Uses existing `NPM_TOKEN` secret (OIDC Trusted Publisher still misconfigured after org/rename).

## After success
Delete this workflow in a follow-up commit.