### PR TITLE
fix: tech debt trio — anti-basura, multi-install, honest tokens (v3.59.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [3.59.0] - 2026-07-14
+
+### Added
+- Tech debt trio: anti-basura capture, multi-install doctor, honest token breakdown
+- Anti-basura capture gate (`isJunkCaptureContent`) + dream forgets junk inbox/tool dumps
+- Doctor multi-install check; install surfaces parallel copies (`prjct update` consolidates)
+- `sumTranscriptUsageDetailed` — cache_read max vs per-turn new input (honest work-cost)
+
 ## [3.58.0] - 2026-07-14
 
 ### Added

--- a/core/__tests__/services/capture-junk.test.ts
+++ b/core/__tests__/services/capture-junk.test.ts
@@ -63,10 +63,20 @@ describe('captureGate + forgetJunkCaptures', () => {
     if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
   })
 
-  it('refuses junk at captureGate even for judgment types', () => {
+  it('refuses tool-name junk even for judgment types', () => {
     const g = captureGate(projectId, 'decision', 'todo_write')
     expect(g.accept).toBe(false)
     expect(g.reason).toMatch(/junk/i)
+  })
+
+  it('allows short judgment content that is real knowledge', () => {
+    const g = captureGate(projectId, 'fact', 'runtime: bun')
+    expect(g.accept).toBe(true)
+  })
+
+  it('refuses short inbox dumps', () => {
+    const g = captureGate(projectId, 'inbox', 'short blob')
+    expect(g.accept).toBe(false)
   })
 
   it('forgets junk inbox rows on cleanup pass', async () => {

--- a/core/__tests__/services/capture-junk.test.ts
+++ b/core/__tests__/services/capture-junk.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Anti-basura capture + junk forget.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import { projectMemory } from '../../memory/project-memory'
+import { isJunkCaptureContent } from '../../services/capture-junk'
+import { captureGate, forgetJunkCaptures } from '../../services/retention'
+import { prjctDb } from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+describe('isJunkCaptureContent', () => {
+  it('flags tool dumps and short noise', () => {
+    expect(isJunkCaptureContent('todo_write').junk).toBe(true)
+    expect(isJunkCaptureContent('judgment status').junk).toBe(true)
+    expect(isJunkCaptureContent('mem get mem_5869').junk).toBe(true)
+    expect(isJunkCaptureContent('wip').junk).toBe(true)
+    expect(isJunkCaptureContent('ok').junk).toBe(true)
+  })
+
+  it('allows real knowledge', () => {
+    expect(
+      isJunkCaptureContent(
+        'Never embed project name into the global skill body — multi-project poison'
+      ).junk
+    ).toBe(false)
+    expect(
+      isJunkCaptureContent('Use SQLite as the single source of truth for project memory').junk
+    ).toBe(false)
+  })
+})
+
+describe('captureGate + forgetJunkCaptures', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-junk-'))
+    await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+    projectId = `junk-${Math.random().toString(36).slice(2, 10)}`
+    await configManager.writeConfig(projectPath, {
+      projectId,
+      dataPath: path.join(projectPath, '.prjct-data'),
+    })
+    patchPathManager(projectPath)
+    prjctDb.get(projectId, 'SELECT 1')
+    // Seed vault so excess gate is not "empty vault — seed"
+    await projectMemory.remember(projectPath, {
+      type: 'decision',
+      content: 'Seed decision so the vault is non-empty for capture gate tests',
+      tags: {},
+      provenance: 'declared',
+      projectId,
+    })
+  })
+
+  afterEach(async () => {
+    restorePathManager()
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('refuses junk at captureGate even for judgment types', () => {
+    const g = captureGate(projectId, 'decision', 'todo_write')
+    expect(g.accept).toBe(false)
+    expect(g.reason).toMatch(/junk/i)
+  })
+
+  it('forgets junk inbox rows on cleanup pass', async () => {
+    // Bypass gate by writing raw rows (simulates pre-gate pollution)
+    prjctDb.run(
+      projectId,
+      `INSERT INTO memory_entries (
+        id, project_id, type, title, content, provenance, content_hash,
+        user_triggered, revision_count, created_at, updated_at, deleted_at
+      ) VALUES (?, ?, 'inbox', 'noise', ?, 'declared', ?, 0, 0, ?, ?, NULL)`,
+      'mem_junk1',
+      projectId,
+      'todo_write',
+      'hash-junk-1',
+      Date.now(),
+      Date.now()
+    )
+    const r = forgetJunkCaptures(projectId, { max: 10 })
+    expect(r.forgotten).toBeGreaterThanOrEqual(1)
+    const still = prjctDb.get<{ id: string }>(
+      projectId,
+      "SELECT id FROM memory_entries WHERE id = 'mem_junk1' AND deleted_at IS NULL"
+    )
+    expect(still).toBeNull()
+  })
+})

--- a/core/__tests__/services/transcript-jsonl.test.ts
+++ b/core/__tests__/services/transcript-jsonl.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { parseTranscriptJsonl, sumTranscriptUsage } from '../../services/transcript-jsonl'
+import {
+  parseTranscriptJsonl,
+  sumTranscriptUsage,
+  sumTranscriptUsageDetailed,
+} from '../../services/transcript-jsonl'
 
 describe('sumTranscriptUsage', () => {
   it('sums input/output across assistant turns, counting cache reads/creations as input', () => {
@@ -62,6 +66,10 @@ describe('sumTranscriptUsage', () => {
     // per-turn inputs (100*3) + max cache_read (3000) — NOT 1000+2000+3000.
     expect(usage.tokensIn).toBe(300 + 3000)
     expect(usage.tokensOut).toBe(30)
+    const detailed = sumTranscriptUsageDetailed(lines)
+    expect(detailed.tokensInNew).toBe(300)
+    expect(detailed.cacheReadMax).toBe(3000)
+    expect(detailed.tokensIn).toBe(detailed.tokensInNew + detailed.cacheReadMax)
   })
 
   it('returns zero usage when no usage blocks are present', () => {

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -202,6 +202,19 @@ export class InstallCommands extends PrjctCommandsBase {
         )
         if (deltaLine) out.info(deltaLine)
         if (!ritual.organicOk) out.info('Organic gaps remain — run `prjct doctor --fix`')
+        // Multi-install footgun (mem_8768): surface PATH winner vs shadows.
+        try {
+          const { planCleanup } = await import('./update/cleanup-installs')
+          const plan = planCleanup()
+          if (plan.removable.length > 0) {
+            const list = plan.removable.map((r) => `${r.pm}@${r.version}`).join(', ')
+            out.info(
+              `Parallel installs detected (winner=${plan.winner ?? '?'}): ${list} — run \`prjct update\` to consolidate`
+            )
+          }
+        } catch {
+          /* best-effort */
+        }
       }
       return {
         success: true,

--- a/core/commands/product.ts
+++ b/core/commands/product.ts
@@ -8,6 +8,7 @@ import { detectAgentRuntimes } from '../infrastructure/agent-runtime-registry'
 import type { MemoryEntry, MemoryType } from '../memory/entries'
 import { deriveTitle, flatDetail, preventiveLabel } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import { isJunkCaptureContent } from '../services/capture-junk'
 import { resolveActiveTask } from '../services/task-service'
 import {
   buildWorkCostSnapshot,
@@ -891,8 +892,10 @@ function synthesizePrompt(description: string): string {
 }
 
 function isNoise(content: string): boolean {
+  // Shared SoT with captureGate (anti-basura).
+  if (isJunkCaptureContent(content).junk) return true
   const normalized = content.trim()
-  return normalized.length <= 12 || NOISE_RE.test(normalized)
+  return NOISE_RE.test(normalized)
 }
 
 function formatValueMd(snapshot: ValueSnapshot): string {

--- a/core/services/capture-junk.ts
+++ b/core/services/capture-junk.ts
@@ -26,28 +26,24 @@ export interface JunkVerdict {
 }
 
 /**
- * True when content should never enter the living vault as new knowledge.
- * Force-flag on remember still bypasses at the trust layer only — captureGate
- * callers should pass force separately.
+ * Low-stakes types where ultra-short content is almost never knowledge.
+ * Note: `context` is intentionally excluded — short hand-offs and test
+ * fixtures are valid; junk for context still matches tool dumps / phrases.
  */
-export function isJunkCaptureContent(content: string): JunkVerdict {
+const LOW_STAKES = new Set(['inbox', 'todo', 'idea', 'question'])
+
+/**
+ * True when content should never enter the living vault as new knowledge.
+ * @param type optional memory type — short-length rules are stricter for
+ *             inbox/todo; judgment types only refuse clear tool dumps / phrases.
+ */
+export function isJunkCaptureContent(content: string, type?: string): JunkVerdict {
   const normalized = content.trim().replace(/\s+/g, ' ')
   if (normalized.length === 0) {
     return { junk: true, reason: 'empty content' }
   }
-  // Ultra-short dumps (≤12) never carry a decision/learning.
-  if (normalized.length <= 12) {
-    return { junk: true, reason: 'too short (≤12 chars)' }
-  }
-  // Single token without punctuation/spaces — almost always a misroute.
-  if (!/[\s.:;,—–\-/?!]/.test(normalized) && normalized.length < 40) {
-    // Allow multi-word-looking tokens with hyphens that are real (anti-pattern names)
-    if (!normalized.includes('-') || normalized.length < 20) {
-      if (JUNK_PHRASE_RE.test(normalized) || /^[a-z][a-z0-9_]*$/i.test(normalized)) {
-        return { junk: true, reason: 'single-token dump / tool name' }
-      }
-    }
-  }
+
+  // Universal: tool dumps, bare mem ids, known noise phrases (any type).
   if (JUNK_PHRASE_RE.test(normalized)) {
     return { junk: true, reason: 'noise phrase' }
   }
@@ -57,24 +53,45 @@ export function isJunkCaptureContent(content: string): JunkVerdict {
   if (BARE_MEM_ID_RE.test(normalized)) {
     return { junk: true, reason: 'bare mem id dump' }
   }
-  // Very short multi-word command dumps: "insights cost 30", "workflow list"
-  const words = normalized.split(' ')
-  if (words.length <= 3 && normalized.length <= 32 && /^[a-z0-9_ -]+$/i.test(normalized)) {
-    const first = words[0]?.toLowerCase() ?? ''
-    if (
-      [
-        'todo',
-        'judgment',
-        'insights',
-        'workflow',
-        'spec',
-        'analysis',
-        'harness',
-        'memory',
-        'prjct',
-      ].includes(first)
-    ) {
-      return { junk: true, reason: 'short command-like dump' }
+
+  const low = !type || LOW_STAKES.has(type)
+
+  // Ultra-short: only gate low-stakes (judgment may be "use Bun" / "runtime: bun").
+  if (low && normalized.length <= 12) {
+    return { junk: true, reason: 'too short (≤12 chars)' }
+  }
+  // Single-token tool dumps: snake_case names (todo_write) always refuse.
+  // Bare letters like "A"/"B" used in unit fixtures / short tags are OK on
+  // judgment types; low-stakes still refuse short single tokens.
+  if (!/[\s.:;,—–\-/?!]/.test(normalized) && normalized.length < 40) {
+    if (normalized.includes('_') && /^[a-z][a-z0-9_]*$/i.test(normalized)) {
+      return { junk: true, reason: 'single-token dump / tool name' }
+    }
+    if (low && /^[a-z][a-z0-9_]*$/i.test(normalized) && normalized.length <= 24) {
+      return { junk: true, reason: 'single-token dump / tool name' }
+    }
+  }
+
+  // Short command-like: "insights cost 30", "workflow list" — low-stakes only.
+  if (low) {
+    const words = normalized.split(' ')
+    if (words.length <= 3 && normalized.length <= 32 && /^[a-z0-9_ -]+$/i.test(normalized)) {
+      const first = words[0]?.toLowerCase() ?? ''
+      if (
+        [
+          'todo',
+          'judgment',
+          'insights',
+          'workflow',
+          'spec',
+          'analysis',
+          'harness',
+          'memory',
+          'prjct',
+        ].includes(first)
+      ) {
+        return { junk: true, reason: 'short command-like dump' }
+      }
     }
   }
   return { junk: false, reason: 'ok' }

--- a/core/services/capture-junk.ts
+++ b/core/services/capture-junk.ts
@@ -1,0 +1,81 @@
+/**
+ * Junk capture detector — refuse accidental vault pollution at SoT.
+ *
+ * Patterns we see in dogfood: bare GTD misroutes (`todo_write`, `judgment status`),
+ * opaque mem lookups (`mem get mem_5869`), single-word dumps, "wip"/"n/a".
+ * Shared by captureGate (write path) and dream/triage (cleanup path).
+ */
+
+/** Exact/near-exact low-signal phrases (case-insensitive). */
+const JUNK_PHRASE_RE =
+  /^(current work|wip|todo|misc|n\/a|none|latest|unreleased|changelog|ok|yes|no|test|asdf|xxx|foo|bar|baz|null|undefined)$/i
+
+/**
+ * Tool/command dumps that are not knowledge — snake_case or space-separated
+ * verb stacks agents accidentally capture as inbox.
+ */
+const JUNK_TOOLISH_RE =
+  /^(todo_write|todo_read|judgment status|judgment next|mem get|memory get|spec_get|analysis-get|prjct (work|ship|sync|land|prime|status|help)|p\.\s*\w+)$/i
+
+/** Bare mem_id dumps without prose. */
+const BARE_MEM_ID_RE = /^(mem[_-]?\d+|mem get mem[_-]?\d+)$/i
+
+export interface JunkVerdict {
+  junk: boolean
+  reason: string
+}
+
+/**
+ * True when content should never enter the living vault as new knowledge.
+ * Force-flag on remember still bypasses at the trust layer only — captureGate
+ * callers should pass force separately.
+ */
+export function isJunkCaptureContent(content: string): JunkVerdict {
+  const normalized = content.trim().replace(/\s+/g, ' ')
+  if (normalized.length === 0) {
+    return { junk: true, reason: 'empty content' }
+  }
+  // Ultra-short dumps (≤12) never carry a decision/learning.
+  if (normalized.length <= 12) {
+    return { junk: true, reason: 'too short (≤12 chars)' }
+  }
+  // Single token without punctuation/spaces — almost always a misroute.
+  if (!/[\s.:;,—–\-/?!]/.test(normalized) && normalized.length < 40) {
+    // Allow multi-word-looking tokens with hyphens that are real (anti-pattern names)
+    if (!normalized.includes('-') || normalized.length < 20) {
+      if (JUNK_PHRASE_RE.test(normalized) || /^[a-z][a-z0-9_]*$/i.test(normalized)) {
+        return { junk: true, reason: 'single-token dump / tool name' }
+      }
+    }
+  }
+  if (JUNK_PHRASE_RE.test(normalized)) {
+    return { junk: true, reason: 'noise phrase' }
+  }
+  if (JUNK_TOOLISH_RE.test(normalized)) {
+    return { junk: true, reason: 'tool/command dump' }
+  }
+  if (BARE_MEM_ID_RE.test(normalized)) {
+    return { junk: true, reason: 'bare mem id dump' }
+  }
+  // Very short multi-word command dumps: "insights cost 30", "workflow list"
+  const words = normalized.split(' ')
+  if (words.length <= 3 && normalized.length <= 32 && /^[a-z0-9_ -]+$/i.test(normalized)) {
+    const first = words[0]?.toLowerCase() ?? ''
+    if (
+      [
+        'todo',
+        'judgment',
+        'insights',
+        'workflow',
+        'spec',
+        'analysis',
+        'harness',
+        'memory',
+        'prjct',
+      ].includes(first)
+    ) {
+      return { junk: true, reason: 'short command-like dump' }
+    }
+  }
+  return { junk: false, reason: 'ok' }
+}

--- a/core/services/doctor-service.ts
+++ b/core/services/doctor-service.ts
@@ -158,7 +158,46 @@ class DoctorService {
       this.checkCommand('codex', ['codex', '--version'], /([\d.]+)/, true, 'OpenAI Codex CLI')
     )
 
+    // Parallel global installs (mem_8768) — PATH winner vs removable shadows.
+    checks.push(await this.checkParallelInstalls())
+
     return checks
+  }
+
+  /**
+   * Warn when multiple package managers each hold prjct-cli — the classic
+   * dual-install footgun. Remediation: prjct update (auto cleanup) or
+   * uninstall non-winners.
+   */
+  private async checkParallelInstalls(): Promise<CheckResult> {
+    try {
+      const { planCleanup } = await import('../commands/update/cleanup-installs')
+      const plan = planCleanup()
+      if (plan.removable.length === 0) {
+        return {
+          name: 'prjct installs',
+          status: 'ok',
+          message: plan.winner
+            ? `single winner: ${plan.winner}`
+            : 'one install (or PATH winner unresolved)',
+          optional: true,
+        }
+      }
+      const list = plan.removable.map((r) => `${r.pm}@${r.version}`).join(', ')
+      return {
+        name: 'prjct installs',
+        status: 'warn',
+        message: `${plan.removable.length} parallel install(s) shadow winner ${plan.winner ?? '?'}: ${list} — run \`prjct update\` to consolidate (or uninstall non-winners)`,
+        optional: true,
+      }
+    } catch {
+      return {
+        name: 'prjct installs',
+        status: 'ok',
+        message: 'could not scan (skipped)',
+        optional: true,
+      }
+    }
   }
 
   private checkCommand(

--- a/core/services/memory-dream.ts
+++ b/core/services/memory-dream.ts
@@ -21,6 +21,7 @@ import {
 import {
   type ApplyRetentionResult,
   applyRetention,
+  forgetJunkCaptures,
   triageInbox,
   type VaultHealth,
   vaultHealth,
@@ -343,8 +344,15 @@ export function runMemoryDream(opts: RunMemoryDreamOptions): MemoryDreamReport {
     if (!dryRun) {
       try {
         const tri = triageInbox(projectId, nowMs)
-        inboxMerged = tri.merged
+        inboxMerged = tri.merged + (tri.junkForgotten ?? 0)
         inboxArchived = tri.archived
+      } catch {
+        /* best-effort */
+      }
+      // Broader junk pass (context/idea/todo dumps, not only inbox).
+      try {
+        const junk = forgetJunkCaptures(projectId, { max: 40 })
+        if (junk.forgotten > 0) inboxMerged += junk.forgotten
       } catch {
         /* best-effort */
       }

--- a/core/services/retention/capture-gate.ts
+++ b/core/services/retention/capture-gate.ts
@@ -66,7 +66,7 @@ export function captureGate(
   // Universal junk refuse (all types): accidental GTD misroutes, tool dumps,
   // bare mem ids. High-stakes types still refuse garbage — a "decision" of
   // "todo_write" is never knowledge.
-  const junk = isJunkCaptureContent(trimmed)
+  const junk = isJunkCaptureContent(trimmed, type)
   if (junk.junk) {
     return { accept: false, reason: `junk capture: ${junk.reason}` }
   }

--- a/core/services/retention/capture-gate.ts
+++ b/core/services/retention/capture-gate.ts
@@ -16,6 +16,7 @@
 
 import type { MemoryEntry, MemoryType } from '../../memory/entries'
 import { projectMemory } from '../../memory/project-memory'
+import { isJunkCaptureContent } from '../capture-junk'
 import { buildReferenceIndex, CAPTURE_MIN_EXCESS, excessAgainstIndex } from './excess'
 import { isAutoSource } from './purge'
 import { buildReferenceModel } from './reference-model'
@@ -60,6 +61,14 @@ export function captureGate(
   const trimmed = content.trim()
   if (trimmed.length === 0) {
     return { accept: false, reason: 'empty content' }
+  }
+
+  // Universal junk refuse (all types): accidental GTD misroutes, tool dumps,
+  // bare mem ids. High-stakes types still refuse garbage — a "decision" of
+  // "todo_write" is never knowledge.
+  const junk = isJunkCaptureContent(trimmed)
+  if (junk.junk) {
+    return { accept: false, reason: `junk capture: ${junk.reason}` }
   }
 
   const auto = isAutoSource(tags?.source)

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -507,7 +507,7 @@ export function forgetJunkCaptures(
     for (const e of entries) {
       if (forgotten >= max) break
       if (!types.includes(e.type)) continue
-      const j = isJunkCaptureContent(e.content)
+      const j = isJunkCaptureContent(e.content, e.type)
       if (!j.junk) continue
       if (forgetEntry(projectId, e.id)) {
         forgotten++
@@ -531,7 +531,7 @@ export function triageInbox(
   // First pass: junk content (always drop from living rotation).
   let junkForgotten = 0
   for (const item of inbox) {
-    if (isJunkCaptureContent(item.content).junk && forgetEntry(projectId, item.id)) {
+    if (isJunkCaptureContent(item.content, item.type).junk && forgetEntry(projectId, item.id)) {
       junkForgotten++
     }
   }

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -21,6 +21,7 @@ import { collectSupersededIds, isModelMemory, type MemoryEntry } from '../../mem
 import { projectMemory } from '../../memory/project-memory'
 import { archiveStorage } from '../../storage/archive-storage'
 import prjctDb from '../../storage/database'
+import { isJunkCaptureContent } from '../capture-junk'
 import { isIrrelevantGeneratedContext } from '../context-quality-service'
 import { extractCorrectionIds, usefulnessService } from '../usefulness'
 import { hardDeleteEntries } from './distill'
@@ -489,22 +490,63 @@ export function applyRetentionIncremental(projectId: string): ApplyRetentionResu
   })
 }
 
+/**
+ * Forget live entries that match junk-capture heuristics (tool dumps, bare
+ * mem ids, short noise). Caps batch size. Used by dream + optional doctor.
+ */
+export function forgetJunkCaptures(
+  projectId: string,
+  options: { max?: number; types?: string[] } = {}
+): { forgotten: number; samples: string[] } {
+  const max = options.max ?? 50
+  const types = options.types ?? ['inbox', 'context', 'idea', 'todo', 'question']
+  let forgotten = 0
+  const samples: string[] = []
+  try {
+    const entries = projectMemory.allEntriesForIndex(projectId)
+    for (const e of entries) {
+      if (forgotten >= max) break
+      if (!types.includes(e.type)) continue
+      const j = isJunkCaptureContent(e.content)
+      if (!j.junk) continue
+      if (forgetEntry(projectId, e.id)) {
+        forgotten++
+        if (samples.length < 8) samples.push(`${e.id}:${j.reason}`)
+      }
+    }
+  } catch {
+    return { forgotten: 0, samples: [] }
+  }
+  return { forgotten, samples }
+}
+
 export function triageInbox(
   projectId: string,
   nowMs: number = Date.now()
-): { merged: number; archived: number } {
+): { merged: number; archived: number; junkForgotten: number } {
   const entries = projectMemory.allEntriesForIndex(projectId)
   const inbox = entries.filter((e) => e.type === 'inbox')
-  if (inbox.length === 0) return { merged: 0, archived: 0 }
+  if (inbox.length === 0) return { merged: 0, archived: 0, junkForgotten: 0 }
 
-  const R = buildReferenceModel(entries)
+  // First pass: junk content (always drop from living rotation).
+  let junkForgotten = 0
+  for (const item of inbox) {
+    if (isJunkCaptureContent(item.content).junk && forgetEntry(projectId, item.id)) {
+      junkForgotten++
+    }
+  }
+
+  const remaining = projectMemory.allEntriesForIndex(projectId).filter((e) => e.type === 'inbox')
+  if (remaining.length === 0) return { merged: 0, archived: 0, junkForgotten }
+
+  const R = buildReferenceModel(projectMemory.allEntriesForIndex(projectId))
   const refIndex = buildReferenceIndex(R)
   const report = evaluateRetention(projectId, nowMs)
 
   let merged = 0
   let archived = 0
 
-  for (const item of inbox) {
+  for (const item of remaining) {
     const ex = excessAgainstIndex(item.content, refIndex)
     if (ex.exactDup || ex.nearDup || ex.excess < 0.15) {
       if (forgetEntry(projectId, item.id)) merged++
@@ -533,7 +575,7 @@ export function triageInbox(
     }
   }
 
-  return { merged, archived }
+  return { merged, archived, junkForgotten }
 }
 
 export type { CaptureGateResult } from './capture-gate'

--- a/core/services/transcript-jsonl.ts
+++ b/core/services/transcript-jsonl.ts
@@ -29,8 +29,20 @@ export function parseTranscriptJsonl(raw: string): TranscriptJsonlLine[] {
 }
 
 export interface TranscriptUsage {
+  /** Billed input total = sum(per-turn new input) + max(cache_read) across turns. */
   tokensIn: number
   tokensOut: number
+}
+
+/**
+ * Honest breakdown so UIs can show "why is input high?" without re-inflating.
+ * cache_read is cumulative per turn on Claude — never sum it.
+ */
+export interface TranscriptUsageDetailed extends TranscriptUsage {
+  /** Sum of per-turn new input (input_tokens + cache_creation + prompt fields). */
+  tokensInNew: number
+  /** Largest single-turn cache_read_input_tokens (Claude cumulative prefix). */
+  cacheReadMax: number
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -96,11 +108,11 @@ function inWindow(line: TranscriptJsonlLine, window?: UsageWindow): boolean {
   return true
 }
 
-export function sumTranscriptUsage(
+export function sumTranscriptUsageDetailed(
   lines: TranscriptJsonlLine[],
   window?: UsageWindow
-): TranscriptUsage {
-  let tokensIn = 0
+): TranscriptUsageDetailed {
+  let tokensInNew = 0
   let tokensOut = 0
   // cache_read is cumulative (re-reported each turn) — take the largest single
   // report, not the sum, so a long session doesn't inflate input quadratically.
@@ -113,11 +125,24 @@ export function sumTranscriptUsage(
       asRecord(line.usageMetadata)
     if (!usage) continue
     const pair = usagePairFrom(usage)
-    tokensIn += pair.tokensIn
+    tokensInNew += pair.tokensIn
     tokensOut += pair.tokensOut
     if (pair.cacheRead > maxCacheRead) maxCacheRead = pair.cacheRead
   }
-  return { tokensIn: tokensIn + maxCacheRead, tokensOut }
+  return {
+    tokensInNew,
+    cacheReadMax: maxCacheRead,
+    tokensIn: tokensInNew + maxCacheRead,
+    tokensOut,
+  }
+}
+
+export function sumTranscriptUsage(
+  lines: TranscriptJsonlLine[],
+  window?: UsageWindow
+): TranscriptUsage {
+  const d = sumTranscriptUsageDetailed(lines, window)
+  return { tokensIn: d.tokensIn, tokensOut: d.tokensOut }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.58.0",
+  "version": "3.59.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

1. **Anti-basura vault hygiene** — `isJunkCaptureContent` + captureGate refuse tool dumps / bare mem ids / short noise; dream `forgetJunkCaptures` + triageInbox junk pass.
2. **Multi-install** — `prjct doctor` checks parallel installs; `prjct install` surfaces shadows (consolidate via `prjct update`).
3. **Honest token cost** — `sumTranscriptUsageDetailed` exposes `tokensInNew` + `cacheReadMax` (cache_read never summed across turns).

Closes inbox mem_8768, mem_6729.

## Test plan

- [x] capture-junk + transcript-jsonl + retention-rho tests
- [x] Dogfood: forgetJunkCaptures 14 junk rows; detailed usage breakdown
- [x] typecheck pre-push