### PR TITLE
feat: structural code symbol graph (CBM-inspired S1+S2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.prjct/code-graph.json.gz merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.prjct/code-graph.json.gz merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,6 @@ tmp/
 .prjct/**
 # Team memory export is meant to be committed (zero-server onboarding).
 !.prjct/memory-export/
-# Optional team code-graph bootstrap (gzip symbols). Force-add if you want
-# shared index onboarding — otherwise everyone reindexes via `prjct sync`.
-# !.prjct/code-graph.json.gz
 !.prjct/memory-export/**
 
 # prjct: legacy wiki — vault moved to ~/Documents/prjct/ in 2.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ tmp/
 .prjct/**
 # Team memory export is meant to be committed (zero-server onboarding).
 !.prjct/memory-export/
+# Optional team code-graph bootstrap (gzip symbols). Force-add if you want
+# shared index onboarding — otherwise everyone reindexes via `prjct sync`.
+# !.prjct/code-graph.json.gz
 !.prjct/memory-export/**
 
 # prjct: legacy wiki — vault moved to ~/Documents/prjct/ in 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.60.0] - 2026-07-14
+
+### Added
+- Harness repositioning — all user-facing copy: 'AI Agile OS' → 'The agentic harness for AI coding agents'
+
 ## [3.59.0] - 2026-07-14
 
 ### Added

--- a/core/__tests__/domain/symbol-graph.test.ts
+++ b/core/__tests__/domain/symbol-graph.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Symbol graph — extraction, index, search, trace
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  extractFile,
+  hasSymbolIndex,
+  indexSymbols,
+  scoreFilesFromQuery,
+  searchSymbols,
+  tracePath,
+} from '../../domain/symbol-graph'
+import pathManager from '../../infrastructure/path-manager'
+import prjctDb from '../../storage/database'
+
+describe('symbol-graph', () => {
+  let testDir: string
+  let testProjectId: string
+  const originalGetGlobalProjectPath = pathManager.getGlobalProjectPath.bind(pathManager)
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `prjct-symbol-graph-${Date.now()}`)
+    testProjectId = `test-symbols-${Date.now()}`
+    await fs.mkdir(testDir, { recursive: true })
+    pathManager.getGlobalProjectPath = () => testDir
+  })
+
+  afterEach(async () => {
+    pathManager.getGlobalProjectPath = originalGetGlobalProjectPath
+    prjctDb.close()
+    try {
+      await fs.rm(testDir, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  })
+
+  describe('extractFile', () => {
+    it('extracts exported functions and classes from TypeScript', () => {
+      const content = `
+export function validateUser(id: string) {
+  return checkId(id)
+}
+export class AuthService {
+  login() { return validateUser('x') }
+}
+function checkId(id: string) { return id.length > 0 }
+`
+      const ex = extractFile(content, 'auth.ts')
+      const names = ex.symbols.map((s) => s.name)
+      expect(names).toContain('validateUser')
+      expect(names).toContain('AuthService')
+      expect(names).toContain('checkId')
+      expect(ex.callNames).toContain('checkId')
+      expect(ex.callNames).toContain('validateUser')
+    })
+
+    it('extracts named import bindings', () => {
+      const content = `import { validate } from './validator'\nexport function run() { validate() }\n`
+      const ex = extractFile(content, 'app.ts')
+      expect(ex.importBindings.get('validate')).toBe('./validator')
+      expect(ex.callNames).toContain('validate')
+    })
+  })
+
+  describe('index + search + score', () => {
+    it('indexes project and finds symbols by name', async () => {
+      await fs.writeFile(
+        path.join(testDir, 'validator.ts'),
+        `export function validate() { return true }\n`
+      )
+      await fs.writeFile(
+        path.join(testDir, 'auth.ts'),
+        `import { validate } from './validator'\nexport function login() { return validate() }\n`
+      )
+
+      const meta = await indexSymbols(testDir, testProjectId)
+      expect(meta.symbolCount).toBeGreaterThan(0)
+      expect(hasSymbolIndex(testProjectId)).toBe(true)
+
+      const hits = searchSymbols(testProjectId, 'validate')
+      expect(hits.some((h) => h.name === 'validate')).toBe(true)
+
+      const scored = scoreFilesFromQuery(testProjectId, 'login validate')
+      expect(scored.length).toBeGreaterThan(0)
+      expect(scored.some((s) => s.path.includes('auth') || s.path.includes('validator'))).toBe(true)
+    })
+
+    it('traces call path between login and validate', async () => {
+      await fs.writeFile(
+        path.join(testDir, 'validator.ts'),
+        `export function validate() { return true }\n`
+      )
+      await fs.writeFile(
+        path.join(testDir, 'auth.ts'),
+        `import { validate } from './validator'\nexport function login() { return validate() }\n`
+      )
+
+      await indexSymbols(testDir, testProjectId)
+      const tr = tracePath(testProjectId, 'validate', { direction: 'inbound', depth: 3 })
+      expect(tr).not.toBeNull()
+      // login should appear as inbound caller when CALLS edge resolved
+      // (may be empty if resolution fails — at least roots exist)
+      expect(tr!.root.some((r) => r.name === 'validate')).toBe(true)
+    })
+  })
+})

--- a/core/__tests__/domain/symbol-graph.test.ts
+++ b/core/__tests__/domain/symbol-graph.test.ts
@@ -1,5 +1,5 @@
 /**
- * Symbol graph — extraction, index, search, trace
+ * Symbol graph — extraction quality, import resolve, CALLS, trace
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -12,6 +12,7 @@ import {
   indexSymbols,
   scoreFilesFromQuery,
   searchSymbols,
+  stripNoise,
   tracePath,
 } from '../../domain/symbol-graph'
 import pathManager from '../../infrastructure/path-manager'
@@ -23,7 +24,10 @@ describe('symbol-graph', () => {
   const originalGetGlobalProjectPath = pathManager.getGlobalProjectPath.bind(pathManager)
 
   beforeEach(async () => {
-    testDir = path.join(os.tmpdir(), `prjct-symbol-graph-${Date.now()}`)
+    testDir = path.join(
+      os.tmpdir(),
+      `prjct-symbol-graph-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
     testProjectId = `test-symbols-${Date.now()}`
     await fs.mkdir(testDir, { recursive: true })
     pathManager.getGlobalProjectPath = () => testDir
@@ -37,6 +41,30 @@ describe('symbol-graph', () => {
     } catch {
       /* ignore */
     }
+  })
+
+  describe('stripNoise / false positives', () => {
+    it('does not extract symbols from string / template literals', () => {
+      const content = `
+const doc = \`
+export function validateUser(id: string) {
+  return checkId(id)
+}
+\`
+export function realFn() { return 1 }
+`
+      const ex = extractFile(content, 'noise.ts')
+      const names = ex.symbols.map((s) => s.name)
+      expect(names).toContain('realFn')
+      expect(names).not.toContain('validateUser')
+      expect(names).not.toContain('checkId')
+    })
+
+    it('stripNoise preserves newlines (line alignment)', () => {
+      const src = 'a\n"hello\\nworld"\nb\n'
+      const cleaned = stripNoise(src)
+      expect(cleaned.split('\n').length).toBe(src.split('\n').length)
+    })
   })
 
   describe('extractFile', () => {
@@ -57,6 +85,7 @@ function checkId(id: string) { return id.length > 0 }
       expect(names).toContain('checkId')
       expect(ex.callNames).toContain('checkId')
       expect(ex.callNames).toContain('validateUser')
+      expect(ex.calls.some((c) => c.name === 'checkId' && c.line > 0)).toBe(true)
     })
 
     it('extracts named import bindings', () => {
@@ -67,7 +96,7 @@ function checkId(id: string) { return id.length > 0 }
     })
   })
 
-  describe('index + search + score', () => {
+  describe('index + CALLS quality', () => {
     it('indexes project and finds symbols by name', async () => {
       await fs.writeFile(
         path.join(testDir, 'validator.ts'),
@@ -90,7 +119,7 @@ function checkId(id: string) { return id.length > 0 }
       expect(scored.some((s) => s.path.includes('auth') || s.path.includes('validator'))).toBe(true)
     })
 
-    it('traces call path between login and validate', async () => {
+    it('traces login as inbound caller of validate (symbol-level CALLS)', async () => {
       await fs.writeFile(
         path.join(testDir, 'validator.ts'),
         `export function validate() { return true }\n`
@@ -103,9 +132,54 @@ function checkId(id: string) { return id.length > 0 }
       await indexSymbols(testDir, testProjectId)
       const tr = tracePath(testProjectId, 'validate', { direction: 'inbound', depth: 3 })
       expect(tr).not.toBeNull()
-      // login should appear as inbound caller when CALLS edge resolved
-      // (may be empty if resolution fails — at least roots exist)
       expect(tr!.root.some((r) => r.name === 'validate')).toBe(true)
+      // login should appear as a real caller symbol
+      expect(tr!.inbound.some((h) => h.symbol.name === 'login')).toBe(true)
+    })
+
+    it('resolves @/ and tsconfig paths for CALLS', async () => {
+      await fs.mkdir(path.join(testDir, 'src', 'lib'), { recursive: true })
+      await fs.writeFile(
+        path.join(testDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            paths: { '@/*': ['src/*'] },
+          },
+        })
+      )
+      await fs.writeFile(
+        path.join(testDir, 'src', 'lib', 'util.ts'),
+        `export function helper() { return 42 }\n`
+      )
+      await fs.writeFile(
+        path.join(testDir, 'src', 'app.ts'),
+        `import { helper } from '@/lib/util'\nexport function main() { return helper() }\n`
+      )
+
+      await indexSymbols(testDir, testProjectId)
+      const tr = tracePath(testProjectId, 'helper', { direction: 'inbound', depth: 2 })
+      expect(tr).not.toBeNull()
+      expect(tr!.inbound.some((h) => h.symbol.name === 'main')).toBe(true)
+    })
+
+    it('does not invent symbols from test string fixtures', async () => {
+      await fs.writeFile(path.join(testDir, 'real.ts'), `export function onlyReal() { return 1 }\n`)
+      await fs.writeFile(
+        path.join(testDir, 'spec.ts'),
+        [
+          'const sample = `',
+          'export function ghostFn() {}',
+          '`',
+          'export function realSpec() { return onlyReal() }',
+          '',
+        ].join('\n')
+      )
+
+      await indexSymbols(testDir, testProjectId)
+      const ghosts = searchSymbols(testProjectId, 'ghostFn')
+      expect(ghosts.filter((g) => g.name === 'ghostFn')).toHaveLength(0)
+      expect(searchSymbols(testProjectId, 'onlyReal').some((s) => s.name === 'onlyReal')).toBe(true)
     })
   })
 })

--- a/core/__tests__/hooks/pre-search.test.ts
+++ b/core/__tests__/hooks/pre-search.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test'
+import { _internal } from '../../hooks/pre-search'
+
+describe('pre-search extractToken', () => {
+  it('pulls longest identifier from grep pattern', () => {
+    expect(_internal.extractToken({ tool_input: { pattern: 'validateUser' } })).toBe('validateUser')
+    expect(_internal.extractToken({ tool_input: { pattern: 'function\\s+ProcessOrder\\(' } })).toBe(
+      'ProcessOrder'
+    )
+  })
+
+  it('returns null for empty / noise-only', () => {
+    expect(_internal.extractToken({ tool_input: { pattern: '.*' } })).toBeNull()
+    expect(_internal.extractToken({ tool_input: {} })).toBeNull()
+  })
+})

--- a/core/__tests__/services/architecture-snapshot.test.ts
+++ b/core/__tests__/services/architecture-snapshot.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { indexSymbols } from '../../domain/symbol-graph'
+import pathManager from '../../infrastructure/path-manager'
+import {
+  buildArchitectureSnapshot,
+  formatArchitectureMd,
+} from '../../services/architecture-snapshot'
+import prjctDb from '../../storage/database'
+
+describe('architecture-snapshot', () => {
+  let testDir: string
+  let testProjectId: string
+  const original = pathManager.getGlobalProjectPath.bind(pathManager)
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `prjct-arch-${Date.now()}`)
+    testProjectId = `test-arch-${Date.now()}`
+    await fs.mkdir(testDir, { recursive: true })
+    pathManager.getGlobalProjectPath = () => testDir
+  })
+
+  afterEach(async () => {
+    pathManager.getGlobalProjectPath = original
+    prjctDb.close()
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('returns not-ready without index', () => {
+    const snap = buildArchitectureSnapshot(testProjectId)
+    expect(snap.ready).toBe(false)
+  })
+
+  it('summarizes symbols, kinds, and packages after index', async () => {
+    await fs.mkdir(path.join(testDir, 'core'), { recursive: true })
+    await fs.writeFile(
+      path.join(testDir, 'core', 'main.ts'),
+      `export function main() {}\nexport class App {}\n`
+    )
+    await fs.writeFile(
+      path.join(testDir, 'core', 'router.ts'),
+      `app.get('/api/users', handler)\nexport function handler() {}\n`
+    )
+    await indexSymbols(testDir, testProjectId)
+    const snap = buildArchitectureSnapshot(testProjectId)
+    expect(snap.ready).toBe(true)
+    expect(snap.symbols).toBeGreaterThan(0)
+    expect(snap.kinds.some((k) => k.kind === 'function')).toBe(true)
+    expect(snap.packages).toContain('core')
+    const md = formatArchitectureMd(snap)
+    expect(md).toContain('Architecture')
+    expect(md).toContain('Symbols')
+  })
+})

--- a/core/__tests__/services/cbm-bridge.test.ts
+++ b/core/__tests__/services/cbm-bridge.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test'
+import { detectCbm, formatCbmStatus } from '../../services/cbm-bridge'
+
+describe('cbm-bridge', () => {
+  it('detectCbm returns a structured status without throwing', async () => {
+    const s = await detectCbm()
+    expect(typeof s.available).toBe('boolean')
+    expect(typeof s.note).toBe('string')
+    const line = formatCbmStatus(s)
+    expect(line.includes('CBM')).toBe(true)
+  })
+})

--- a/core/__tests__/services/code-graph-artifact.test.ts
+++ b/core/__tests__/services/code-graph-artifact.test.ts
@@ -5,51 +5,94 @@ import path from 'node:path'
 import { hasSymbolIndex, indexSymbols, listAllSymbols } from '../../domain/symbol-graph'
 import pathManager from '../../infrastructure/path-manager'
 import {
+  artifactPath,
   exportCodeGraphArtifact,
   importCodeGraphArtifact,
 } from '../../services/code-graph-artifact'
 import prjctDb from '../../storage/database'
 
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
 describe('code-graph-artifact', () => {
   let testDir: string
   let testProjectId: string
-  const original = pathManager.getGlobalProjectPath.bind(pathManager)
+  let sourceDir: string
+  const originalGet = pathManager.getGlobalProjectPath.bind(pathManager)
 
   beforeEach(async () => {
-    testDir = path.join(os.tmpdir(), `prjct-artifact-${Date.now()}`)
+    testDir = path.join(
+      os.tmpdir(),
+      `prjct-artifact-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    sourceDir = path.join(testDir, 'src-repo')
     testProjectId = `test-artifact-${Date.now()}`
-    await fs.mkdir(testDir, { recursive: true })
-    pathManager.getGlobalProjectPath = () => testDir
+    await fs.mkdir(sourceDir, { recursive: true })
+    // Project storage (where artifact MUST live) separate from client source
+    pathManager.getGlobalProjectPath = (id: string) => path.join(testDir, 'projects', id)
   })
 
   afterEach(async () => {
-    pathManager.getGlobalProjectPath = original
+    pathManager.getGlobalProjectPath = originalGet
     prjctDb.close()
     await fs.rm(testDir, { recursive: true, force: true }).catch(() => {})
   })
 
-  it('exports and re-imports symbols', async () => {
+  it('exports under projects/<id>/ — never into client source tree', async () => {
     await fs.writeFile(
-      path.join(testDir, 'svc.ts'),
+      path.join(sourceDir, 'svc.ts'),
       `export function doWork() { return 1 }\nexport class Svc {}\n`
     )
-    await indexSymbols(testDir, testProjectId)
+    await indexSymbols(sourceDir, testProjectId)
     const before = listAllSymbols(testProjectId).length
     expect(before).toBeGreaterThan(0)
 
-    const exp = await exportCodeGraphArtifact(testDir, testProjectId)
+    const exp = await exportCodeGraphArtifact(testProjectId)
     expect(exp).not.toBeNull()
     expect(exp!.bytes).toBeGreaterThan(20)
+    expect(exp!.path).toBe(artifactPath(testProjectId))
+    // Must NOT appear under the client source tree
+    expect(await exists(path.join(sourceDir, 'code-graph.json.gz'))).toBe(false)
+    expect(await exists(path.join(sourceDir, '.prjct', 'code-graph.json.gz'))).toBe(false)
+    // Must exist under project storage
+    expect(await exists(artifactPath(testProjectId))).toBe(true)
+    // Path must not be under sourceDir
+    expect(exp!.path.startsWith(sourceDir)).toBe(false)
+    expect(exp!.path.includes(path.join('projects', testProjectId))).toBe(true)
 
-    // Wipe index
+    // Wipe SQLite index
     prjctDb.transaction(testProjectId, (db) => {
       db.prepare('DELETE FROM code_symbols').run()
       db.prepare('DELETE FROM code_symbol_edges').run()
     })
     expect(hasSymbolIndex(testProjectId)).toBe(false)
 
-    const imp = await importCodeGraphArtifact(testDir, testProjectId)
+    const imp = await importCodeGraphArtifact(testProjectId)
     expect(imp.imported).toBe(true)
     expect(listAllSymbols(testProjectId).length).toBe(before)
+  })
+
+  it('refuses restore when artifact projectId mismatches', async () => {
+    await fs.writeFile(path.join(sourceDir, 'svc.ts'), `export function doWork() { return 1 }\n`)
+    const meta = await indexSymbols(sourceDir, testProjectId)
+    expect(meta.symbolCount).toBeGreaterThan(0)
+    expect(hasSymbolIndex(testProjectId)).toBe(true)
+
+    const exp = await exportCodeGraphArtifact(testProjectId)
+    expect(exp).not.toBeNull()
+    expect(await exists(artifactPath(testProjectId))).toBe(true)
+
+    const otherId = `${testProjectId}-other`
+    await fs.mkdir(path.dirname(artifactPath(otherId)), { recursive: true })
+    await fs.copyFile(artifactPath(testProjectId), artifactPath(otherId))
+    const imp = await importCodeGraphArtifact(otherId)
+    expect(imp.imported).toBe(false)
+    expect(imp.reason).toMatch(/mismatch/)
   })
 })

--- a/core/__tests__/services/code-graph-artifact.test.ts
+++ b/core/__tests__/services/code-graph-artifact.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { hasSymbolIndex, indexSymbols, listAllSymbols } from '../../domain/symbol-graph'
+import pathManager from '../../infrastructure/path-manager'
+import {
+  exportCodeGraphArtifact,
+  importCodeGraphArtifact,
+} from '../../services/code-graph-artifact'
+import prjctDb from '../../storage/database'
+
+describe('code-graph-artifact', () => {
+  let testDir: string
+  let testProjectId: string
+  const original = pathManager.getGlobalProjectPath.bind(pathManager)
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `prjct-artifact-${Date.now()}`)
+    testProjectId = `test-artifact-${Date.now()}`
+    await fs.mkdir(testDir, { recursive: true })
+    pathManager.getGlobalProjectPath = () => testDir
+  })
+
+  afterEach(async () => {
+    pathManager.getGlobalProjectPath = original
+    prjctDb.close()
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('exports and re-imports symbols', async () => {
+    await fs.writeFile(
+      path.join(testDir, 'svc.ts'),
+      `export function doWork() { return 1 }\nexport class Svc {}\n`
+    )
+    await indexSymbols(testDir, testProjectId)
+    const before = listAllSymbols(testProjectId).length
+    expect(before).toBeGreaterThan(0)
+
+    const exp = await exportCodeGraphArtifact(testDir, testProjectId)
+    expect(exp).not.toBeNull()
+    expect(exp!.bytes).toBeGreaterThan(20)
+
+    // Wipe index
+    prjctDb.transaction(testProjectId, (db) => {
+      db.prepare('DELETE FROM code_symbols').run()
+      db.prepare('DELETE FROM code_symbol_edges').run()
+    })
+    expect(hasSymbolIndex(testProjectId)).toBe(false)
+
+    const imp = await importCodeGraphArtifact(testDir, testProjectId)
+    expect(imp.imported).toBe(true)
+    expect(listAllSymbols(testProjectId).length).toBe(before)
+  })
+})

--- a/core/__tests__/services/dead-code.test.ts
+++ b/core/__tests__/services/dead-code.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { indexSymbols } from '../../domain/symbol-graph'
+import pathManager from '../../infrastructure/path-manager'
+import { findDeadCode } from '../../services/dead-code'
+import prjctDb from '../../storage/database'
+
+describe('dead-code', () => {
+  let testDir: string
+  let testProjectId: string
+  const original = pathManager.getGlobalProjectPath.bind(pathManager)
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `prjct-dead-${Date.now()}`)
+    testProjectId = `test-dead-${Date.now()}`
+    await fs.mkdir(testDir, { recursive: true })
+    pathManager.getGlobalProjectPath = () => testDir
+  })
+
+  afterEach(async () => {
+    pathManager.getGlobalProjectPath = original
+    prjctDb.close()
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('flags uncalled functions and skips entry main', async () => {
+    await fs.writeFile(
+      path.join(testDir, 'lib.ts'),
+      `export function used() { return 1 }\nexport function orphan() { return 2 }\n`
+    )
+    await fs.writeFile(
+      path.join(testDir, 'main.ts'),
+      `import { used } from './lib'\nexport function main() { return used() }\n`
+    )
+    await indexSymbols(testDir, testProjectId)
+    const r = findDeadCode(testProjectId, { limit: 20 })
+    expect(r.ready).toBe(true)
+    const names = r.dead.map((d) => d.symbol.name)
+    expect(names).toContain('orphan')
+    // main is entry — not dead
+    expect(names).not.toContain('main')
+    // used has inbound CALLS from main
+    expect(names).not.toContain('used')
+  })
+})

--- a/core/__tests__/services/detect-changes.test.ts
+++ b/core/__tests__/services/detect-changes.test.ts
@@ -1,0 +1,69 @@
+/**
+ * detect_changes — risk classification + blast radius
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { indexImports } from '../../domain/import-graph'
+import { indexSymbols } from '../../domain/symbol-graph'
+import pathManager from '../../infrastructure/path-manager'
+import { detectChanges } from '../../services/detect-changes'
+import prjctDb from '../../storage/database'
+
+describe('detect-changes', () => {
+  let testDir: string
+  let testProjectId: string
+  const originalGetGlobalProjectPath = pathManager.getGlobalProjectPath.bind(pathManager)
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `prjct-detect-changes-${Date.now()}`)
+    testProjectId = `test-detect-${Date.now()}`
+    await fs.mkdir(testDir, { recursive: true })
+    pathManager.getGlobalProjectPath = () => testDir
+  })
+
+  afterEach(async () => {
+    pathManager.getGlobalProjectPath = originalGetGlobalProjectPath
+    prjctDb.close()
+    try {
+      await fs.rm(testDir, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  })
+
+  it('classifies explicit changed files with import blast radius', async () => {
+    await fs.writeFile(path.join(testDir, 'core.ts'), `export function core() {}\n`)
+    await fs.writeFile(
+      path.join(testDir, 'app.ts'),
+      `import { core } from './core'\nexport function app() { return core() }\n`
+    )
+    await indexImports(testDir, testProjectId)
+    await indexSymbols(testDir, testProjectId)
+
+    const result = await detectChanges(testDir, testProjectId, {
+      files: ['core.ts'],
+    })
+
+    expect(result.changedFiles).toEqual(['core.ts'])
+    expect(result.affectedFiles).toContain('core.ts')
+    // app imports core → in blast radius
+    expect(result.affectedFiles).toContain('app.ts')
+    expect(result.changes[0]?.file).toBe('core.ts')
+    expect(['critical', 'high', 'medium', 'low']).toContain(result.changes[0]!.risk)
+  })
+
+  it('flags auth path as elevated risk', async () => {
+    await fs.mkdir(path.join(testDir, 'auth'), { recursive: true })
+    await fs.writeFile(path.join(testDir, 'auth', 'login.ts'), `export function login() {}\n`)
+    await indexSymbols(testDir, testProjectId)
+
+    const result = await detectChanges(testDir, testProjectId, {
+      files: ['auth/login.ts'],
+    })
+    expect(result.changes[0]?.risk).toBe('critical')
+    expect(result.summary.critical).toBe(1)
+  })
+})

--- a/core/__tests__/services/detect-hunks.test.ts
+++ b/core/__tests__/services/detect-hunks.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { parseChangedLinesFromUnifiedDiff } from '../../services/detect-changes'
+
+describe('parseChangedLinesFromUnifiedDiff', () => {
+  it('maps addition lines to new-file line numbers', () => {
+    const diff = [
+      'diff --git a/a.ts b/a.ts',
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -10,0 +11,2 @@',
+      '+export function foo() {}',
+      '+export function bar() {}',
+    ].join('\n')
+    const map = parseChangedLinesFromUnifiedDiff(diff)
+    expect(map.has('a.ts')).toBe(true)
+    const lines = map.get('a.ts')!
+    expect(lines.has(11)).toBe(true)
+    expect(lines.has(12)).toBe(true)
+  })
+})

--- a/core/cli/bin-commands.ts
+++ b/core/cli/bin-commands.ts
@@ -441,6 +441,11 @@ export async function runBinCommand(args: string[], ctx: BinCommandContext): Pro
           await runPreEditHook(projectPath)
           break
         }
+        case 'pre-search': {
+          const { runPreSearchHook } = await import('../hooks/pre-search')
+          await runPreSearchHook(projectPath)
+          break
+        }
         case 'post-edit': {
           const { runPostEditHook } = await import('../hooks/post-edit')
           await runPostEditHook(projectPath)

--- a/core/commands/code.ts
+++ b/core/commands/code.ts
@@ -1,0 +1,307 @@
+/**
+ * `prjct code` — structural code intelligence surface (symbol graph).
+ *
+ * One registered verb, subcommand-parsed (same shape as lean/tdd):
+ *   prjct code                     → index stats + optional CBM status
+ *   prjct code symbols [pattern]   → search symbols
+ *   prjct code trace <name>        → inbound/outbound call path
+ *   prjct code impact              → detect_changes (git diff blast + risk)
+ *   prjct code architecture        → structural overview (one-shot)
+ *   prjct code export              → write .prjct/code-graph.json.gz
+ *   prjct code import              → bootstrap index from team artifact
+ *   prjct code reindex             → rebuild symbol graph now
+ *   prjct code cbm                 → optional CBM bridge status
+ */
+
+import {
+  hasSymbolIndex,
+  indexSymbols,
+  listAllSymbols,
+  loadMeta,
+  searchSymbols,
+  tracePath,
+} from '../domain/symbol-graph'
+import {
+  buildArchitectureSnapshot,
+  formatArchitectureMd,
+  formatArchitectureText,
+} from '../services/architecture-snapshot'
+import { detectCbm, formatCbmStatus } from '../services/cbm-bridge'
+import {
+  exportCodeGraphArtifact,
+  importCodeGraphArtifact,
+  maybeExportAfterIndex,
+} from '../services/code-graph-artifact'
+import {
+  detectChanges,
+  formatDetectChangesMd,
+  formatDetectChangesText,
+} from '../services/detect-changes'
+import type { MdOption } from '../types/cli'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { failHard, failWith } from '../utils/md-aware'
+import { mdOutput } from '../utils/md-formatter'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
+
+export class CodeCommands extends PrjctCommandsBase {
+  async code(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: MdOption = {}
+  ): Promise<CommandResult> {
+    try {
+      const parts = (input ?? '').trim().split(/\s+/).filter(Boolean)
+      const sub = (parts[0] ?? '').toLowerCase()
+      const rest = parts.slice(1).join(' ')
+
+      if (!sub || sub === 'status' || sub === 'stats') {
+        return this.showStats(projectPath, options)
+      }
+      if (sub === 'symbols' || sub === 'search') {
+        return this.symbols(rest, projectPath, options)
+      }
+      if (sub === 'trace') {
+        return this.trace(rest, projectPath, options)
+      }
+      if (sub === 'impact' || sub === 'detect' || sub === 'changes') {
+        return this.impact(projectPath, options)
+      }
+      if (sub === 'architecture' || sub === 'arch') {
+        return this.architecture(projectPath, options)
+      }
+      if (sub === 'export') {
+        return this.exportArtifact(projectPath, options)
+      }
+      if (sub === 'import' || sub === 'bootstrap') {
+        return this.importArtifact(projectPath, options)
+      }
+      if (sub === 'reindex' || sub === 'index') {
+        return this.reindex(projectPath, options)
+      }
+      if (sub === 'cbm') {
+        return this.cbmStatus(options)
+      }
+      return failWith(
+        `Unknown code subcommand "${sub}". Use: symbols | trace | impact | architecture | export | import | reindex | cbm`,
+        options
+      )
+    } catch (error) {
+      return failHard(getErrorMessage(error), options)
+    }
+  }
+
+  private async showStats(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const meta = loadMeta(proj.value)
+    const ready = hasSymbolIndex(proj.value)
+    const cbm = await detectCbm().catch(() => null)
+    const cbmLine = cbm ? formatCbmStatus(cbm) : null
+    if (options.md) {
+      console.log(
+        mdOutput(
+          '## Code symbol graph',
+          ready
+            ? [
+                `- **Symbols**: ${meta?.symbolCount ?? '?'}`,
+                `- **Edges**: ${meta?.edgeCount ?? '?'}`,
+                `- **Files**: ${meta?.fileCount ?? '?'}`,
+                `- **Built**: ${meta?.builtAt ?? 'unknown'}`,
+                cbmLine ? `- **${cbmLine}**` : '',
+                '',
+                'Commands: `symbols` · `trace` · `impact` · `architecture` · `export` · `import` · `reindex` · `cbm`',
+              ]
+                .filter(Boolean)
+                .join('\n')
+            : [
+                '> No symbol index yet. Run `prjct sync` or `prjct code reindex`.',
+                cbmLine ? `> ${cbmLine}` : '',
+              ]
+                .filter(Boolean)
+                .join('\n')
+        )
+      )
+    } else {
+      if (!ready) {
+        out.info('Code graph: empty — run `prjct sync` or `prjct code reindex`')
+      } else {
+        out.info(
+          `Code graph: ${meta?.symbolCount ?? 0} symbols · ${meta?.edgeCount ?? 0} edges · ${meta?.fileCount ?? 0} files (built ${meta?.builtAt ?? '?'})`
+        )
+        out.info('  symbols | trace | impact | architecture | export | import | reindex | cbm')
+      }
+      if (cbmLine) out.info(`  ${cbmLine}`)
+    }
+    return { success: true, ready, meta, cbm }
+  }
+
+  private async symbols(
+    pattern: string,
+    projectPath: string,
+    options: MdOption
+  ): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    if (!hasSymbolIndex(proj.value)) {
+      return failWith('No symbol index — run `prjct sync` or `prjct code reindex` first.', options)
+    }
+    const q = pattern.trim()
+    const effective = q
+      ? searchSymbols(proj.value, q, { limit: 40 })
+      : listAllSymbols(proj.value)
+          .filter((s) => s.exported)
+          .slice(0, 40)
+
+    if (options.md) {
+      const lines = [
+        `## Symbols${q ? `: \`${q}\`` : ' (exported sample)'}`,
+        '',
+        `| Kind | Name | File | Line |`,
+        `|---|---|---|---:|`,
+      ]
+      for (const s of effective) {
+        lines.push(`| ${s.kind} | \`${s.name}\` | \`${s.file}\` | ${s.startLine} |`)
+      }
+      if (effective.length === 0) lines.push('| — | _no matches_ | | |')
+      console.log(lines.join('\n'))
+    } else {
+      if (effective.length === 0) out.info('No symbols matched.')
+      else {
+        out.info(`${effective.length} symbol(s)${q ? ` matching "${q}"` : ''}:`)
+        for (const s of effective) {
+          out.info(`  ${s.kind.padEnd(9)} ${s.name}  ${s.file}:${s.startLine}`)
+        }
+      }
+    }
+    return { success: true, count: effective.length, symbols: effective }
+  }
+
+  private async trace(
+    name: string,
+    projectPath: string,
+    options: MdOption
+  ): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const fn = name.trim()
+    if (!fn) {
+      return failWith('Usage: prjct code trace <functionOrClassName>', options)
+    }
+    if (!hasSymbolIndex(proj.value)) {
+      return failWith('No symbol index — run `prjct sync` or `prjct code reindex` first.', options)
+    }
+    const result = tracePath(proj.value, fn, { direction: 'both', depth: 3 })
+    if (!result) {
+      return failWith(`No symbol named "${fn}". Try \`prjct code symbols ${fn}\`.`, options)
+    }
+    if (options.md) {
+      const lines = [
+        `## Trace: \`${fn}\``,
+        '',
+        '### Roots',
+        ...result.root.map((r) => `- \`${r.kind}\` **${r.name}** — \`${r.file}:${r.startLine}\``),
+        '',
+        `### Inbound callers (${result.inbound.length})`,
+        ...(result.inbound.length === 0
+          ? ['_none_']
+          : result.inbound.map(
+              (h) =>
+                `- d${h.depth} \`${h.symbol.name}\` (${h.symbol.kind}) — \`${h.symbol.file}:${h.symbol.startLine}\``
+            )),
+        '',
+        `### Outbound callees (${result.outbound.length})`,
+        ...(result.outbound.length === 0
+          ? ['_none_']
+          : result.outbound.map(
+              (h) =>
+                `- d${h.depth} \`${h.symbol.name}\` (${h.symbol.kind}) — \`${h.symbol.file}:${h.symbol.startLine}\``
+            )),
+      ]
+      console.log(lines.join('\n'))
+    } else {
+      out.info(`Trace ${fn}:`)
+      for (const r of result.root) {
+        out.info(`  root: ${r.kind} ${r.name} @ ${r.file}:${r.startLine}`)
+      }
+      out.info(`  inbound (${result.inbound.length}):`)
+      for (const h of result.inbound.slice(0, 20)) {
+        out.info(`    d${h.depth} ${h.symbol.name} ← ${h.symbol.file}`)
+      }
+      out.info(`  outbound (${result.outbound.length}):`)
+      for (const h of result.outbound.slice(0, 20)) {
+        out.info(`    d${h.depth} ${h.symbol.name} → ${h.symbol.file}`)
+      }
+    }
+    return {
+      success: true,
+      root: result.root,
+      inbound: result.inbound.length,
+      outbound: result.outbound.length,
+    }
+  }
+
+  private async impact(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const result = await detectChanges(projectPath, proj.value, { source: 'auto' })
+    console.log(options.md ? formatDetectChangesMd(result) : formatDetectChangesText(result))
+    return { success: true, ...result }
+  }
+
+  private async architecture(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const snap = buildArchitectureSnapshot(proj.value)
+    console.log(options.md ? formatArchitectureMd(snap) : formatArchitectureText(snap))
+    return { success: true, ...snap }
+  }
+
+  private async exportArtifact(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    if (!hasSymbolIndex(proj.value)) {
+      return failWith('No symbol index — run `prjct code reindex` first.', options)
+    }
+    const exp = await exportCodeGraphArtifact(projectPath, proj.value)
+    if (!exp) return failWith('Export failed.', options)
+    const msg = `Exported ${exp.symbols} symbols · ${exp.edges} edges → ${exp.path} (${exp.bytes} bytes gzip)`
+    if (options.md) console.log(mdOutput('## Code graph export', `> ${msg}`))
+    else out.success(msg)
+    return { success: true, ...exp }
+  }
+
+  private async importArtifact(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const imp = await importCodeGraphArtifact(projectPath, proj.value)
+    if (!imp.imported) {
+      return failWith(imp.reason ?? 'Import failed', options)
+    }
+    const msg = `Imported ${imp.symbols} symbols · ${imp.edges} edges from team artifact`
+    if (options.md) console.log(mdOutput('## Code graph import', `> ${msg}`))
+    else out.success(msg)
+    return { success: true, ...imp }
+  }
+
+  private async reindex(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const meta = await indexSymbols(projectPath, proj.value)
+    await maybeExportAfterIndex(projectPath, proj.value)
+    const msg = `Indexed ${meta.symbolCount} symbols · ${meta.edgeCount} edges · ${meta.fileCount} files`
+    if (options.md) console.log(mdOutput('## Code reindex', `> ${msg}`))
+    else out.success(msg)
+    return { success: true, meta }
+  }
+
+  private async cbmStatus(options: MdOption): Promise<CommandResult> {
+    const s = await detectCbm()
+    const line = formatCbmStatus(s)
+    if (options.md) console.log(mdOutput('## CBM bridge', `> ${line}`))
+    else out.info(line)
+    return { success: true, ...s }
+  }
+}

--- a/core/commands/code.ts
+++ b/core/commands/code.ts
@@ -10,7 +10,8 @@
  *   prjct code export              → cache under ~/.prjct-cli/projects/<id>/
  *   prjct code import              → restore SQLite from that per-project cache
  *   prjct code reindex             → rebuild symbol graph now
- *   prjct code cbm                 → optional CBM bridge status
+ *   prjct code dead                → zero-caller symbols (excl. entries)
+ *   prjct code cbm [cli <tool> …]  → optional CBM bridge status / execute
  */
 
 import {
@@ -26,12 +27,13 @@ import {
   formatArchitectureMd,
   formatArchitectureText,
 } from '../services/architecture-snapshot'
-import { detectCbm, formatCbmStatus } from '../services/cbm-bridge'
+import { cbmCli, detectCbm, formatCbmStatus } from '../services/cbm-bridge'
 import {
   exportCodeGraphArtifact,
   importCodeGraphArtifact,
   maybeExportAfterIndex,
 } from '../services/code-graph-artifact'
+import { findDeadCode, formatDeadCodeMd, formatDeadCodeText } from '../services/dead-code'
 import {
   detectChanges,
   formatDetectChangesMd,
@@ -81,11 +83,14 @@ export class CodeCommands extends PrjctCommandsBase {
       if (sub === 'reindex' || sub === 'index') {
         return this.reindex(projectPath, options)
       }
+      if (sub === 'dead') {
+        return this.dead(projectPath, options)
+      }
       if (sub === 'cbm') {
-        return this.cbmStatus(options)
+        return this.cbmCmd(rest, options)
       }
       return failWith(
-        `Unknown code subcommand "${sub}". Use: symbols | trace | impact | architecture | export | import | reindex | cbm`,
+        `Unknown code subcommand "${sub}". Use: symbols | trace | impact | architecture | dead | export | import | reindex | cbm`,
         options
       )
     } catch (error) {
@@ -112,7 +117,7 @@ export class CodeCommands extends PrjctCommandsBase {
                 `- **Built**: ${meta?.builtAt ?? 'unknown'}`,
                 cbmLine ? `- **${cbmLine}**` : '',
                 '',
-                'Commands: `symbols` · `trace` · `impact` · `architecture` · `export` · `import` · `reindex` · `cbm`',
+                'Commands: `symbols` · `trace` · `impact` · `architecture` · `dead` · `export` · `import` · `reindex` · `cbm`',
               ]
                 .filter(Boolean)
                 .join('\n')
@@ -131,7 +136,9 @@ export class CodeCommands extends PrjctCommandsBase {
         out.info(
           `Code graph: ${meta?.symbolCount ?? 0} symbols · ${meta?.edgeCount ?? 0} edges · ${meta?.fileCount ?? 0} files (built ${meta?.builtAt ?? '?'})`
         )
-        out.info('  symbols | trace | impact | architecture | export | import | reindex | cbm')
+        out.info(
+          '  symbols | trace | impact | architecture | dead | export | import | reindex | cbm'
+        )
       }
       if (cbmLine) out.info(`  ${cbmLine}`)
     }
@@ -297,11 +304,52 @@ export class CodeCommands extends PrjctCommandsBase {
     return { success: true, meta }
   }
 
-  private async cbmStatus(options: MdOption): Promise<CommandResult> {
+  private async dead(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    const result = findDeadCode(proj.value, { limit: 50 })
+    console.log(options.md ? formatDeadCodeMd(result) : formatDeadCodeText(result))
+    return { success: true, count: result.dead.length, ...result }
+  }
+
+  private async cbmCmd(rest: string, options: MdOption): Promise<CommandResult> {
+    const parts = rest.trim().split(/\s+/).filter(Boolean)
+    if (parts[0] === 'cli' && parts[1]) {
+      const tool = parts[1]!
+      let args: Record<string, unknown> = {}
+      const jsonArg = parts.slice(2).join(' ')
+      if (jsonArg) {
+        try {
+          args = JSON.parse(jsonArg) as Record<string, unknown>
+        } catch {
+          return failWith('cbm cli args must be JSON object', options)
+        }
+      }
+      const r = await cbmCli(tool, args)
+      if (!r.ok) {
+        return failWith(r.error ?? r.stderr ?? 'CBM cli failed', options)
+      }
+      console.log(r.stdout || r.stderr)
+      return { success: true, stdout: r.stdout }
+    }
     const s = await detectCbm()
     const line = formatCbmStatus(s)
-    if (options.md) console.log(mdOutput('## CBM bridge', `> ${line}`))
-    else out.info(line)
+    if (options.md) {
+      console.log(
+        mdOutput(
+          '## CBM bridge',
+          `> ${line}`,
+          s.available
+            ? 'Execute: `prjct code cbm cli <tool> \'{"key":"val"}\'` (see CBM docs for tools).'
+            : ''
+        )
+      )
+    } else {
+      out.info(line)
+      if (s.available) {
+        out.info("  Execute: prjct code cbm cli <tool> '{\"…}'")
+      }
+    }
     return { success: true, ...s }
   }
 }

--- a/core/commands/code.ts
+++ b/core/commands/code.ts
@@ -27,7 +27,7 @@ import {
   formatArchitectureMd,
   formatArchitectureText,
 } from '../services/architecture-snapshot'
-import { cbmCli, detectCbm, formatCbmStatus } from '../services/cbm-bridge'
+import { cbmCli, cbmFallback, detectCbm, formatCbmStatus } from '../services/cbm-bridge'
 import {
   exportCodeGraphArtifact,
   importCodeGraphArtifact,
@@ -162,6 +162,14 @@ export class CodeCommands extends PrjctCommandsBase {
           .filter((s) => s.exported)
           .slice(0, 40)
 
+    if (effective.length === 0 && q) {
+      const fb = await cbmFallback('search', projectPath, { pattern: q })
+      if (fb) {
+        console.log(fb.text)
+        return { success: true, count: 0, source: 'cbm', symbols: [] }
+      }
+    }
+
     if (options.md) {
       const lines = [
         `## Symbols${q ? `: \`${q}\`` : ' (exported sample)'}`,
@@ -197,12 +205,27 @@ export class CodeCommands extends PrjctCommandsBase {
     if (!fn) {
       return failWith('Usage: prjct code trace <functionOrClassName>', options)
     }
-    if (!hasSymbolIndex(proj.value)) {
-      return failWith('No symbol index — run `prjct sync` or `prjct code reindex` first.', options)
+    const hasNative = hasSymbolIndex(proj.value)
+    const result = hasNative ? tracePath(proj.value, fn, { direction: 'both', depth: 3 }) : null
+    const weak =
+      !result ||
+      (result.inbound.length === 0 && result.outbound.length === 0 && result.root.length === 0)
+
+    if (weak) {
+      const fb = await cbmFallback('trace', projectPath, { name: fn })
+      if (fb) {
+        console.log(fb.text)
+        return { success: true, source: 'cbm', inbound: 0, outbound: 0 }
+      }
     }
-    const result = tracePath(proj.value, fn, { direction: 'both', depth: 3 })
+
     if (!result) {
-      return failWith(`No symbol named "${fn}". Try \`prjct code symbols ${fn}\`.`, options)
+      return failWith(
+        hasNative
+          ? `No symbol named "${fn}". Try \`prjct code symbols ${fn}\`${(await detectCbm()).available ? ' or index the repo in CBM for polyglot depth' : ''}.`
+          : 'No symbol index — run `prjct sync` or `prjct code reindex` first.',
+        options
+      )
     }
     if (options.md) {
       const lines = [
@@ -244,6 +267,7 @@ export class CodeCommands extends PrjctCommandsBase {
     }
     return {
       success: true,
+      source: 'native',
       root: result.root,
       inbound: result.inbound.length,
       outbound: result.outbound.length,
@@ -262,8 +286,15 @@ export class CodeCommands extends PrjctCommandsBase {
     const proj = await requireProject(projectPath, options)
     if (!proj.ok) return proj.result
     const snap = buildArchitectureSnapshot(proj.value)
+    if (!snap.ready || snap.symbols === 0) {
+      const fb = await cbmFallback('architecture', projectPath)
+      if (fb) {
+        console.log(fb.text)
+        return { success: true, source: 'cbm', ready: false }
+      }
+    }
     console.log(options.md ? formatArchitectureMd(snap) : formatArchitectureText(snap))
-    return { success: true, ...snap }
+    return { success: true, source: 'native', ...snap }
   }
 
   private async exportArtifact(projectPath: string, options: MdOption): Promise<CommandResult> {

--- a/core/commands/code.ts
+++ b/core/commands/code.ts
@@ -7,8 +7,8 @@
  *   prjct code trace <name>        → inbound/outbound call path
  *   prjct code impact              → detect_changes (git diff blast + risk)
  *   prjct code architecture        → structural overview (one-shot)
- *   prjct code export              → write .prjct/code-graph.json.gz
- *   prjct code import              → bootstrap index from team artifact
+ *   prjct code export              → cache under ~/.prjct-cli/projects/<id>/
+ *   prjct code import              → restore SQLite from that per-project cache
  *   prjct code reindex             → rebuild symbol graph now
  *   prjct code cbm                 → optional CBM bridge status
  */
@@ -265,10 +265,10 @@ export class CodeCommands extends PrjctCommandsBase {
     if (!hasSymbolIndex(proj.value)) {
       return failWith('No symbol index — run `prjct code reindex` first.', options)
     }
-    const exp = await exportCodeGraphArtifact(projectPath, proj.value)
+    const exp = await exportCodeGraphArtifact(proj.value)
     if (!exp) return failWith('Export failed.', options)
-    const msg = `Exported ${exp.symbols} symbols · ${exp.edges} edges → ${exp.path} (${exp.bytes} bytes gzip)`
-    if (options.md) console.log(mdOutput('## Code graph export', `> ${msg}`))
+    const msg = `Cached ${exp.symbols} symbols · ${exp.edges} edges → ${exp.path} (${exp.bytes} bytes gzip) [per-project, not in client repo]`
+    if (options.md) console.log(mdOutput('## Code graph cache', `> ${msg}`))
     else out.success(msg)
     return { success: true, ...exp }
   }
@@ -276,12 +276,12 @@ export class CodeCommands extends PrjctCommandsBase {
   private async importArtifact(projectPath: string, options: MdOption): Promise<CommandResult> {
     const proj = await requireProject(projectPath, options)
     if (!proj.ok) return proj.result
-    const imp = await importCodeGraphArtifact(projectPath, proj.value)
+    const imp = await importCodeGraphArtifact(proj.value)
     if (!imp.imported) {
       return failWith(imp.reason ?? 'Import failed', options)
     }
-    const msg = `Imported ${imp.symbols} symbols · ${imp.edges} edges from team artifact`
-    if (options.md) console.log(mdOutput('## Code graph import', `> ${msg}`))
+    const msg = `Restored ${imp.symbols} symbols · ${imp.edges} edges from per-project cache`
+    if (options.md) console.log(mdOutput('## Code graph restore', `> ${msg}`))
     else out.success(msg)
     return { success: true, ...imp }
   }
@@ -290,7 +290,7 @@ export class CodeCommands extends PrjctCommandsBase {
     const proj = await requireProject(projectPath, options)
     if (!proj.ok) return proj.result
     const meta = await indexSymbols(projectPath, proj.value)
-    await maybeExportAfterIndex(projectPath, proj.value)
+    await maybeExportAfterIndex(proj.value)
     const msg = `Indexed ${meta.symbolCount} symbols · ${meta.edgeCount} edges · ${meta.fileCount} files`
     if (options.md) console.log(mdOutput('## Code reindex', `> ${msg}`))
     else out.success(msg)

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -10,7 +10,7 @@ import type { CategoryInfo, CommandMeta } from '../types/commands'
 // Category definitions
 export const CATEGORIES: Record<string, CategoryInfo> = {
   core: {
-    title: 'AI Agile Loop',
+    title: 'Work Cycle',
     description: 'Intent, context, execution, learning, and improvement',
     order: 1,
   },
@@ -51,7 +51,7 @@ export const COMMANDS: CommandMeta[] = [
     hasTemplate: false,
     requiresProject: true,
     features: [
-      'v3 AI Agile replacement for ticket-style planning',
+      'v3 work-cycle replacement for ticket-style planning',
       'Stores the durable brief in SQLite',
       'Sub-verbs mirror spec for compatibility: list, show, update, audit, link-work, ship',
     ],
@@ -62,7 +62,7 @@ export const COMMANDS: CommandMeta[] = [
     surface: 'ai-agile',
     routing: { group: 'workflow', method: 'now' },
     optionSchema: { strings: ['spec', 'geometry'], booleans: ['extend'] },
-    description: 'Start or inspect an AI Agile work cycle with context and evidence',
+    description: 'Start or inspect a work cycle with context and evidence',
     usage: {
       claude: 'p. work "<intent>"',
       terminal: 'prjct work "<intent>" [--geometry split|single|direct]',
@@ -137,7 +137,7 @@ export const COMMANDS: CommandMeta[] = [
     requiresProject: true,
     features: [
       'No arg → shows the active task (or none)',
-      'Deprecated public language: use `prjct work` for the v3 AI Agile cycle',
+      'Deprecated public language: use `prjct work` for the v3 work cycle',
       'Auto-harness classifies H0-H3 and stores expected evidence on the task',
       'Writes to stateStorage; runs before/after workflow rules',
       'Optional Linear issue link when the arg matches `[A-Z]+-\\d+`',
@@ -447,19 +447,19 @@ export const COMMANDS: CommandMeta[] = [
     description:
       'Structural code graph: symbols, trace, impact/risk, architecture (run after sync)',
     usage: {
-      claude: 'p. code [symbols|trace|impact|architecture|export|import|reindex|cbm]',
-      terminal: 'prjct code [symbols|trace|impact|architecture|export|import|reindex|cbm]',
+      claude: 'p. code [symbols|trace|impact|architecture|dead|export|import|reindex|cbm]',
+      terminal: 'prjct code [symbols|trace|impact|architecture|dead|export|import|reindex|cbm]',
     },
-    params: '[symbols|trace|impact|architecture|export|import|reindex|cbm] [args]',
+    params: '[symbols|trace|impact|architecture|dead|export|import|reindex|cbm] [args]',
     implemented: true,
     hasTemplate: false,
     requiresProject: true,
     isOptional: true,
     features: [
-      'Symbol index on sync (TS/JS + light multi-lang); 4th work-scope signal',
-      'trace / impact / architecture one-shots for agents',
+      'Symbol index on sync; 4th work-scope signal; CALLS with enclosing + imports',
+      'trace / impact (hunk-level) / architecture / dead one-shots',
       'Per-project cache under ~/.prjct-cli/projects/<id>/ (never in client repo)',
-      'PreToolUse Grep|Glob non-blocking graph augment; optional CBM bridge',
+      'PreToolUse Grep|Glob augment; ship structural risk cue; optional CBM cli',
     ],
   },
   {
@@ -718,7 +718,7 @@ export const COMMANDS: CommandMeta[] = [
     routing: { group: 'product', method: 'insights' },
     optionSchema: { numbers: ['days'] },
     description:
-      'AI Agile intelligence: value, quality, reliability, token cost, reports, continuation, and guardrails',
+      'Harness intelligence: value, quality, reliability, token cost, reports, continuation, and guardrails',
     usage: {
       claude: 'p. insights [value|quality|reliability|cost|report|continue|guardrails]',
       terminal: 'prjct insights [value|quality|reliability|cost|report|continue|guardrails] [--md]',

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -445,7 +445,7 @@ export const COMMANDS: CommandMeta[] = [
     routing: { group: 'code', method: 'code' },
     optionSchema: {},
     description:
-      'Structural code graph: symbols, trace, impact/risk, architecture, team artifact (run after sync)',
+      'Structural code graph: symbols, trace, impact/risk, architecture (run after sync)',
     usage: {
       claude: 'p. code [symbols|trace|impact|architecture|export|import|reindex|cbm]',
       terminal: 'prjct code [symbols|trace|impact|architecture|export|import|reindex|cbm]',
@@ -458,7 +458,7 @@ export const COMMANDS: CommandMeta[] = [
     features: [
       'Symbol index on sync (TS/JS + light multi-lang); 4th work-scope signal',
       'trace / impact / architecture one-shots for agents',
-      'Team artifact .prjct/code-graph.json.gz (export/import/bootstrap)',
+      'Per-project cache under ~/.prjct-cli/projects/<id>/ (never in client repo)',
       'PreToolUse Grep|Glob non-blocking graph augment; optional CBM bridge',
     ],
   },

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -439,6 +439,30 @@ export const COMMANDS: CommandMeta[] = [
     requiresLlm: true,
   },
   {
+    name: 'code',
+    group: 'optional',
+    surface: 'support',
+    routing: { group: 'code', method: 'code' },
+    optionSchema: {},
+    description:
+      'Structural code graph: symbols, trace, impact/risk, architecture, team artifact (run after sync)',
+    usage: {
+      claude: 'p. code [symbols|trace|impact|architecture|export|import|reindex|cbm]',
+      terminal: 'prjct code [symbols|trace|impact|architecture|export|import|reindex|cbm]',
+    },
+    params: '[symbols|trace|impact|architecture|export|import|reindex|cbm] [args]',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: true,
+    isOptional: true,
+    features: [
+      'Symbol index on sync (TS/JS + light multi-lang); 4th work-scope signal',
+      'trace / impact / architecture one-shots for agents',
+      'Team artifact .prjct/code-graph.json.gz (export/import/bootstrap)',
+      'PreToolUse Grep|Glob non-blocking graph augment; optional CBM bridge',
+    ],
+  },
+  {
     name: 'lean',
     group: 'optional',
     surface: 'support',

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -83,6 +83,7 @@ export const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = 
   product: lazy(async () => new (await import('./product')).ProductCommands()),
   eval: lazy(async () => new (await import('./eval')).EvalCommands()),
   judgment: lazy(async () => new (await import('./judgment')).JudgmentCommands()),
+  code: lazy(async () => new (await import('./code')).CodeCommands()),
 }
 
 function registerCategories(): void {

--- a/core/commands/review-risk.ts
+++ b/core/commands/review-risk.ts
@@ -17,6 +17,7 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { failHard } from '../utils/md-aware'
 import { PrjctCommandsBase } from './base'
+import { requireProject } from './guards'
 
 export class ReviewRiskCommands extends PrjctCommandsBase {
   async reviewRisk(
@@ -46,10 +47,29 @@ export class ReviewRiskCommands extends PrjctCommandsBase {
       const geometry = geometryOf(tier)
       const intensity = routeIntensity(tier, { paths: cs.dirs })
       const protocol = intensityProtocol(intensity)
+
+      // Optional structural blast/risk when symbol index exists
+      let blastNote = ''
+      try {
+        const proj = await requireProject(projectPath, options)
+        if (proj.ok) {
+          const { hasSymbolIndex } = await import('../domain/symbol-graph')
+          if (hasSymbolIndex(proj.value)) {
+            const { detectChanges } = await import('../services/detect-changes')
+            const det = await detectChanges(projectPath, proj.value, { source: 'committed' })
+            if (det.changedFiles.length > 0) {
+              blastNote = `Structural risk: critical=${det.summary.critical} high=${det.summary.high} medium=${det.summary.medium} low=${det.summary.low} · blast ${det.affectedFiles.length} files`
+            }
+          }
+        }
+      } catch {
+        /* advisory only */
+      }
+
       console.log(
         options.md
-          ? formatMd(cs, tier, geometry, intensity, protocol)
-          : formatText(cs, tier, geometry, intensity, protocol)
+          ? formatMd(cs, tier, geometry, intensity, protocol, blastNote)
+          : formatText(cs, tier, geometry, intensity, protocol, blastNote)
       )
       return { success: true, tier, files: cs.files, loc: cs.loc, geometry, intensity }
     } catch (error) {
@@ -73,13 +93,15 @@ function formatText(
   tier: DeliveryTier,
   geometry: DeliveryGeometry,
   intensity: ReviewIntensity,
-  protocol: ReturnType<typeof intensityProtocol>
+  protocol: ReturnType<typeof intensityProtocol>,
+  blastNote = ''
 ): string {
   return [
     `Review risk: ${tier.toUpperCase()} — ${cs.files} files, ${cs.loc} LOC vs ${cs.base}`,
     `Delivery: ${geometry} — ${suggestion(geometry, cs.dirs)}`,
     `Judgment intensity: ${intensity} — ${protocol.reviewers}`,
     `  severity floor: ${protocol.severityFloor}`,
+    ...(blastNote ? [`  ${blastNote}`] : []),
     `  next: prjct judgment plan | open  (ledger + ship gate)`,
     '(advisory for delivery; judgment ledger enforces intensity on code-strict ship)',
   ].join('\n')
@@ -90,7 +112,8 @@ function formatMd(
   tier: DeliveryTier,
   geometry: DeliveryGeometry,
   intensity: ReviewIntensity,
-  protocol: ReturnType<typeof intensityProtocol>
+  protocol: ReturnType<typeof intensityProtocol>,
+  blastNote = ''
 ): string {
   return [
     '## Review risk',
@@ -102,6 +125,7 @@ function formatMd(
     `- **Judgment intensity**: \`${intensity}\` — ${protocol.reviewers}`,
     `- **Severity floor**: ${protocol.severityFloor}`,
     `- **Max fix rounds**: ${protocol.maxFixRounds}`,
+    ...(blastNote ? [`- **${blastNote}**`] : []),
     '',
     '_Delivery is advisory. On code-strict packs, `prjct ship` hard-gates on `prjct judgment` ledger.approved._',
   ].join('\n')

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -195,6 +195,36 @@ export class ShippingCommands extends PrjctCommandsBase {
         /* geometry best-effort */
       }
 
+      // Structural code-graph risk (advisory; hard only when deliveryGeometry=strict
+      // AND critical fan-in — never surprises default ships).
+      try {
+        const { hasSymbolIndex } = await import('../domain/symbol-graph')
+        if (hasSymbolIndex(projectId)) {
+          const { detectChanges, shipStructuralRiskCue } = await import(
+            '../services/detect-changes'
+          )
+          const det = await detectChanges(projectPath, projectId, { source: 'auto' })
+          const cue = shipStructuralRiskCue(det)
+          if (cue) console.log(cue)
+          const geomMode = shipConfig?.deliveryGeometry?.mode ?? 'off'
+          if (
+            geomMode === 'strict' &&
+            det.summary.critical > 0 &&
+            !options.geometry &&
+            !options.allowNewDeps
+          ) {
+            // Soft-block only when geometry is already strict and critical structural risk.
+            // Override: pass --geometry single|split|direct explicitly.
+            return {
+              success: false,
+              error: `Strict delivery geometry + structural CRITICAL risk (${det.summary.critical} file(s), blast ${det.affectedFiles.length}). Review \`prjct code impact --md\`, then re-ship with explicit \`--geometry single|split|direct\`.`,
+            }
+          }
+        }
+      } catch {
+        /* structural risk best-effort */
+      }
+
       // Precision-gated judgment ship gate (human-invoked ship only — never
       // auto-ship). Intensity standard|full hard-blocks without ledger.approved.
       // Override: --no-judgment-gate only (consent-scoped; not --no-spec-gate).

--- a/core/domain/file-ranker.ts
+++ b/core/domain/file-ranker.ts
@@ -2,31 +2,32 @@
  * File Ranker — Combined Scoring
  *
  * Combines every signal in the indexer registry to rank files by
- * relevance to a task description. Today the registry contains:
- *   - BM25 text search        (query-driven, default 0.5 weight)
- *   - Import graph proximity  (seed-driven,  default 0.3 weight)
- *   - Git co-change           (seed-driven,  default 0.2 weight)
+ * relevance to a task description. The registry contains:
+ *   - BM25 text search        (query-driven)
+ *   - Symbol-name match       (query-driven — functions/classes/routes)
+ *   - Import graph proximity  (seed-driven)
+ *   - Git co-change           (seed-driven)
  *
  * Adding a new signal is a one-file change in `./indexers/registry.ts`.
  * Zero API calls. Pure math on pre-built indexes.
  *
  * Algorithm:
- * 1. Run every query indexer to build candidates (today: BM25 only).
- * 2. Take top-10 candidates as seed files for graph traversal.
+ * 1. Run every query indexer to build candidates (BM25 + symbols).
+ * 2. Merge top candidates as seed files for graph traversal.
  * 3. Run every seed indexer over those seeds.
  * 4. Combine: finalScore = Σ (signal × weight).
  *
  * Performance target: <50ms per query (all indexes pre-loaded from SQLite).
- *
  */
 
 import type { RankedFile, RankingConfig } from '../types/domain.js'
 import { indexerRegistry, type QueryIndexer, type SeedIndexer } from './indexers/registry'
 
 const DEFAULT_CONFIG: Required<RankingConfig> = {
-  bm25Weight: 0.5,
-  importWeight: 0.3,
-  cochangeWeight: 0.2,
+  bm25Weight: 0.45,
+  importWeight: 0.2,
+  cochangeWeight: 0.15,
+  symbolsWeight: 0.2,
   topN: 15,
   importDepth: 2,
 }
@@ -41,6 +42,7 @@ export function rankFiles(
   const cfg = { ...DEFAULT_CONFIG, ...config }
   const weights: Record<string, number> = {
     bm25: cfg.bm25Weight,
+    symbols: cfg.symbolsWeight,
     imports: cfg.importWeight,
     cochange: cfg.cochangeWeight,
   }
@@ -48,19 +50,23 @@ export function rankFiles(
   const queryIndexers = indexerRegistry.filter((i): i is QueryIndexer => i.kind === 'query')
   const seedIndexers = indexerRegistry.filter((i): i is SeedIndexer => i.kind === 'seed')
 
-  // Run every query-driven indexer to build candidates. The first non-empty
-  // result also seeds the seed-driven indexers below.
+  // Run every query-driven indexer; merge seeds from all of them (union of top hits).
   const scoresByIndexer = new Map<string, Map<string, number>>()
-  let seedFiles: string[] = []
+  const seedScores = new Map<string, number>()
   for (const idx of queryIndexers) {
     const scores = idx.scoreFromQuery(projectId, query, cfg.topN * 3)
     if (scores.length === 0) continue
     scoresByIndexer.set(idx.name, new Map(scores.map((s) => [s.path, s.score])))
-    if (seedFiles.length === 0) {
-      seedFiles = scores.slice(0, SEED_FILE_LIMIT).map((s) => s.path)
+    for (const s of scores.slice(0, SEED_FILE_LIMIT)) {
+      seedScores.set(s.path, Math.max(seedScores.get(s.path) ?? 0, s.score))
     }
   }
   if (scoresByIndexer.size === 0) return []
+
+  const seedFiles = [...seedScores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, SEED_FILE_LIMIT)
+    .map(([p]) => p)
 
   for (const idx of seedIndexers) {
     const scores = idx.scoreFromSeeds(projectId, seedFiles, {
@@ -90,6 +96,7 @@ export function rankFiles(
         bm25: scoresByIndexer.get('bm25')?.get(filePath) ?? 0,
         imports: scoresByIndexer.get('imports')?.get(filePath) ?? 0,
         cochange: scoresByIndexer.get('cochange')?.get(filePath) ?? 0,
+        symbols: scoresByIndexer.get('symbols')?.get(filePath) ?? 0,
       },
     })
   }
@@ -101,13 +108,13 @@ export function rankFiles(
 /**
  * Check whether each registered index has data for this project.
  * Public shape (`bm25`, `imports`, `cochange`) is preserved for
- * existing callers (CLI / tests). New signals added to the registry
- * are reachable via `hasIndexesAll(projectId)`.
+ * existing callers (CLI / tests). `symbols` is additive.
  */
 export function hasIndexes(projectId: string): {
   bm25: boolean
   imports: boolean
   cochange: boolean
+  symbols: boolean
 } {
   const presence: Record<string, boolean> = {}
   for (const idx of indexerRegistry) {
@@ -117,5 +124,6 @@ export function hasIndexes(projectId: string): {
     bm25: presence.bm25 ?? false,
     imports: presence.imports ?? false,
     cochange: presence.cochange ?? false,
+    symbols: presence.symbols ?? false,
   }
 }

--- a/core/domain/indexers/registry.ts
+++ b/core/domain/indexers/registry.ts
@@ -18,6 +18,7 @@
 import { hasIndex as bm25HasIndex, queryFiles } from '../bm25'
 import { scoreFromSeeds as cochangeScoreFromSeeds, loadMatrix } from '../git-cochange'
 import { scoreFromSeeds as importScoreFromSeeds, loadGraph } from '../import-graph'
+import { hasSymbolIndex, scoreFilesFromQuery } from '../symbol-graph'
 
 export interface NormalizedScore {
   path: string
@@ -57,14 +58,23 @@ export const indexerRegistry: Indexer[] = [
   {
     name: 'bm25',
     kind: 'query',
-    defaultWeight: 0.5,
+    defaultWeight: 0.45,
     hasIndex: (projectId) => bm25HasIndex(projectId),
     scoreFromQuery: (projectId, query, topN) => normalize(queryFiles(projectId, query, topN)),
   },
   {
+    name: 'symbols',
+    kind: 'query',
+    // Structural symbol-name match (functions/classes/routes) — CBM-inspired.
+    defaultWeight: 0.2,
+    hasIndex: (projectId) => hasSymbolIndex(projectId),
+    scoreFromQuery: (projectId, query, topN) =>
+      normalize(scoreFilesFromQuery(projectId, query, topN)),
+  },
+  {
     name: 'imports',
     kind: 'seed',
-    defaultWeight: 0.3,
+    defaultWeight: 0.2,
     hasIndex: (projectId) => loadGraph(projectId) !== null,
     scoreFromSeeds: (projectId, seeds, opts) => {
       const graph = loadGraph(projectId)
@@ -75,7 +85,7 @@ export const indexerRegistry: Indexer[] = [
   {
     name: 'cochange',
     kind: 'seed',
-    defaultWeight: 0.2,
+    defaultWeight: 0.15,
     hasIndex: (projectId) => loadMatrix(projectId) !== null,
     scoreFromSeeds: (projectId, seeds) => {
       const index = loadMatrix(projectId)

--- a/core/domain/symbol-graph.ts
+++ b/core/domain/symbol-graph.ts
@@ -406,7 +406,8 @@ function extractTsJs(content: string, filePath: string): FileExtract {
     if (calls.length >= MAX_CALLS) break
   }
 
-  // Routes (from clean — string paths were blanked; use original for route strings)
+  // Routes — original source (paths live in strings)
+  // Express/Hono/Fastify: app.get('/path'
   const routeRe = /\.(?:get|post|put|patch|delete|options|head|all)\s*\(\s*['"`](\/[^'"`]*)['"`]/gi
   let rm: RegExpExecArray | null
   while ((rm = routeRe.exec(content)) !== null) {
@@ -419,6 +420,34 @@ function extractTsJs(content: string, filePath: string): FileExtract {
       endLine: null,
       exported: true,
     })
+  }
+  // FastAPI / Flask decorators
+  const decoRe =
+    /@(?:app|router|api|bp)\.(?:get|post|put|patch|delete|options|head|api_route)\s*\(\s*['"`](\/[^'"`]*)['"`]/gi
+  while ((rm = decoRe.exec(content)) !== null) {
+    const routePath = rm[1]!
+    const name = routePath.replace(/[^\w/.-]/g, '').slice(0, 64) || 'route'
+    symbols.push({
+      kind: 'route',
+      name,
+      startLine: lineOf(content, rm.index),
+      endLine: null,
+      exported: true,
+    })
+  }
+  // Next.js App Router route.ts handlers
+  if (/(?:^|\/)route\.(ts|js|tsx|jsx)$/.test(filePath.replace(/\\/g, '/'))) {
+    const nextHandlers =
+      /\bexport\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b/g
+    while ((rm = nextHandlers.exec(content)) !== null) {
+      symbols.push({
+        kind: 'route',
+        name: `${rm[1]} ${filePath.replace(/\\/g, '/')}`,
+        startLine: lineOf(content, rm.index),
+        endLine: null,
+        exported: true,
+      })
+    }
   }
 
   const fin = finalizeCalls(calls)

--- a/core/domain/symbol-graph.ts
+++ b/core/domain/symbol-graph.ts
@@ -1,0 +1,1025 @@
+/**
+ * Symbol Graph — structural code intelligence (file → symbol layer).
+ *
+ * Inspired by codebase-memory-mcp's knowledge graph, but scoped to what
+ * prjct needs without Hybrid LSP / tree-sitter vendoring:
+ *   - Extract functions/classes/types (+ call sites) via regex AST-lite
+ *   - Persist symbols + CALLS/DEFINES edges in SQLite
+ *   - Score files by symbol-name match (4th ranker signal)
+ *   - Trace inbound/outbound call paths
+ *   - Power detect_changes blast radius
+ *
+ * Languages (S1): TypeScript / JavaScript / TSX / JSX, plus lightweight
+ * Python / Go / Rust / Java definition extraction (calls best-effort).
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import prjctDb from '../storage/database'
+import type {
+  CodeSymbol,
+  CodeSymbolEdge,
+  SymbolEdgeType,
+  SymbolGraphMeta,
+  SymbolKind,
+  SymbolScore,
+  TraceHop,
+  TraceResult,
+} from '../types/domain.js'
+import { batchProcess, walkDir } from '../utils/file-helper'
+
+const META_KEY = 'symbol-graph'
+const SYMBOL_EXTS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.go',
+  '.rs',
+  '.java',
+])
+
+// Extraction
+
+interface RawSymbol {
+  kind: SymbolKind
+  name: string
+  startLine: number
+  endLine: number | null
+  exported: boolean
+}
+
+interface FileExtract {
+  filePath: string
+  symbols: RawSymbol[]
+  /** Call names found in this file (not yet resolved). */
+  callNames: string[]
+  /** Named imports: localName → resolved relative module path (best-effort). */
+  importBindings: Map<string, string>
+}
+
+function lineOf(content: string, index: number): number {
+  let line = 1
+  for (let i = 0; i < index && i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) line++
+  }
+  return line
+}
+
+function symbolId(file: string, kind: string, name: string, startLine: number): string {
+  return `${file}#${kind}:${name}@${startLine}`
+}
+
+function qnameOf(file: string, name: string): string {
+  const base = file.replace(/\.[^.]+$/, '').replace(/[/\\]/g, '.')
+  return `${base}.${name}`
+}
+
+function isSourceFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase()
+  return SYMBOL_EXTS.has(ext)
+}
+
+/** Strip strings/comments so call extraction doesn't match noise. */
+function stripNoise(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/`(?:\\.|[^`\\])*`/g, '``')
+}
+
+function extractTsJs(content: string, filePath: string): FileExtract {
+  const symbols: RawSymbol[] = []
+  const callNames: string[] = []
+  const importBindings = new Map<string, string>()
+  const clean = stripNoise(content)
+
+  const declPatterns: Array<{
+    re: RegExp
+    kind: SymbolKind
+    nameIdx: number
+    exported?: boolean
+  }> = [
+    {
+      re: /export\s+(?:async\s+)?function\s+(\w+)/g,
+      kind: 'function',
+      nameIdx: 1,
+      exported: true,
+    },
+    { re: /(?:^|[^\w.])(?:async\s+)?function\s+(\w+)/g, kind: 'function', nameIdx: 1 },
+    {
+      re: /export\s+(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_]\w*)\s*=>/g,
+      kind: 'function',
+      nameIdx: 1,
+      exported: true,
+    },
+    {
+      re: /(?:^|[\n;])(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_]\w*)\s*=>/g,
+      kind: 'function',
+      nameIdx: 1,
+    },
+    {
+      re: /export\s+(?:abstract\s+)?class\s+(\w+)/g,
+      kind: 'class',
+      nameIdx: 1,
+      exported: true,
+    },
+    { re: /(?:^|[^\w.])(?:abstract\s+)?class\s+(\w+)/g, kind: 'class', nameIdx: 1 },
+    { re: /export\s+interface\s+(\w+)/g, kind: 'interface', nameIdx: 1, exported: true },
+    { re: /(?:^|[^\w.])interface\s+(\w+)/g, kind: 'interface', nameIdx: 1 },
+    { re: /export\s+type\s+(\w+)\s*[=<]/g, kind: 'type', nameIdx: 1, exported: true },
+    { re: /(?:^|[^\w.])type\s+(\w+)\s*[=<]/g, kind: 'type', nameIdx: 1 },
+    { re: /export\s+enum\s+(\w+)/g, kind: 'enum', nameIdx: 1, exported: true },
+    { re: /(?:^|[^\w.])enum\s+(\w+)/g, kind: 'enum', nameIdx: 1 },
+    {
+      re: /export\s+(?:const|let|var)\s+(\w+)\s*[:=]/g,
+      kind: 'const',
+      nameIdx: 1,
+      exported: true,
+    },
+    // Methods inside classes (indent heuristic)
+    {
+      re: /(?:^|\n)\s+(?:public|private|protected|static|async|readonly|\s)*\s*(?:async\s+)?(\w+)\s*\([^;{]*\)\s*[:{]/g,
+      kind: 'method',
+      nameIdx: 1,
+    },
+  ]
+
+  const seen = new Set<string>()
+  for (const { re, kind, nameIdx, exported } of declPatterns) {
+    re.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = re.exec(content)) !== null) {
+      const name = m[nameIdx]
+      if (!name || name.length < 2) continue
+      // Skip keywords / control
+      if (
+        /^(if|for|while|switch|catch|return|await|typeof|new|throw|else|case|from|import|export|class|function|const|let|var|get|set|constructor)$/.test(
+          name
+        )
+      )
+        continue
+      const startLine = lineOf(content, m.index)
+      const key = `${kind}:${name}@${startLine}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      symbols.push({
+        kind,
+        name,
+        startLine,
+        endLine: null,
+        exported: exported === true,
+      })
+    }
+  }
+
+  // Named imports: import { a as b, c } from './mod'
+  const importRe =
+    /import\s+(?:type\s+)?(?:\{([^}]+)\}|(\w+))\s+from\s+['"](\.[^'"]+|@\/[^'"]+)['"]/g
+  let im: RegExpExecArray | null
+  while ((im = importRe.exec(content)) !== null) {
+    const source = im[3]!
+    if (im[1]) {
+      for (const part of im[1].split(',')) {
+        const bits = part
+          .trim()
+          .replace(/^type\s+/, '')
+          .split(/\s+as\s+/)
+        const local = (bits[1] ?? bits[0])?.trim()
+        if (local) importBindings.set(local, source)
+      }
+    } else if (im[2]) {
+      importBindings.set(im[2], source)
+    }
+  }
+
+  // Call sites: identifier(
+  const callRe = /\b([A-Za-z_][\w]*)\s*\(/g
+  let cm: RegExpExecArray | null
+  const callSeen = new Set<string>()
+  while ((cm = callRe.exec(clean)) !== null) {
+    const name = cm[1]!
+    if (
+      /^(if|for|while|switch|catch|function|class|return|typeof|new|throw|await|void|super|this|import|require|console|Math|JSON|Object|Array|Promise|Map|Set|Date|Error|Buffer|process|describe|it|test|expect|beforeEach|afterEach)$/.test(
+        name
+      )
+    )
+      continue
+    if (callSeen.has(name)) continue
+    callSeen.add(name)
+    callNames.push(name)
+  }
+
+  // Route heuristics (Express/Hono/Next-ish)
+  const routeRe = /\.(?:get|post|put|patch|delete|options|head|all)\s*\(\s*['"`](\/[^'"`]*)['"`]/gi
+  let rm: RegExpExecArray | null
+  while ((rm = routeRe.exec(content)) !== null) {
+    const routePath = rm[1]!
+    const name = routePath.replace(/[^\w/.-]/g, '').slice(0, 64) || 'route'
+    symbols.push({
+      kind: 'route',
+      name,
+      startLine: lineOf(content, rm.index),
+      endLine: null,
+      exported: true,
+    })
+  }
+
+  return { filePath, symbols, callNames, importBindings }
+}
+
+function extractPython(content: string, filePath: string): FileExtract {
+  const symbols: RawSymbol[] = []
+  const callNames: string[] = []
+  const reFn = /^(?:async\s+)?def\s+(\w+)\s*\(/gm
+  const reClass = /^class\s+(\w+)/gm
+  let m: RegExpExecArray | null
+  while ((m = reFn.exec(content)) !== null) {
+    symbols.push({
+      kind: 'function',
+      name: m[1]!,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: !m[1]!.startsWith('_'),
+    })
+  }
+  while ((m = reClass.exec(content)) !== null) {
+    symbols.push({
+      kind: 'class',
+      name: m[1]!,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: !m[1]!.startsWith('_'),
+    })
+  }
+  const callRe = /\b([A-Za-z_][\w]*)\s*\(/g
+  const clean = stripNoise(content)
+  const seen = new Set<string>()
+  while ((m = callRe.exec(clean)) !== null) {
+    const name = m[1]!
+    if (/^(if|for|while|return|print|len|range|str|int|list|dict|set|super|self)$/.test(name))
+      continue
+    if (seen.has(name)) continue
+    seen.add(name)
+    callNames.push(name)
+  }
+  return { filePath, symbols, callNames, importBindings: new Map() }
+}
+
+function extractGo(content: string, filePath: string): FileExtract {
+  const symbols: RawSymbol[] = []
+  const callNames: string[] = []
+  const reFn = /^func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(/gm
+  const reType = /^type\s+(\w+)\s+(?:struct|interface)/gm
+  let m: RegExpExecArray | null
+  while ((m = reFn.exec(content)) !== null) {
+    const name = m[1]!
+    symbols.push({
+      kind: name[0] === name[0]!.toUpperCase() ? 'function' : 'function',
+      name,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: name[0] === name[0]!.toUpperCase(),
+    })
+  }
+  while ((m = reType.exec(content)) !== null) {
+    symbols.push({
+      kind: 'type',
+      name: m[1]!,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: m[1]![0] === m[1]![0]!.toUpperCase(),
+    })
+  }
+  return { filePath, symbols, callNames, importBindings: new Map() }
+}
+
+function extractRust(content: string, filePath: string): FileExtract {
+  const symbols: RawSymbol[] = []
+  const reFn = /^(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/gm
+  const reStruct = /^(?:pub\s+)?struct\s+(\w+)/gm
+  const reTrait = /^(?:pub\s+)?trait\s+(\w+)/gm
+  const reEnum = /^(?:pub\s+)?enum\s+(\w+)/gm
+  let m: RegExpExecArray | null
+  for (const [re, kind] of [
+    [reFn, 'function'],
+    [reStruct, 'class'],
+    [reTrait, 'interface'],
+    [reEnum, 'enum'],
+  ] as const) {
+    while ((m = re.exec(content)) !== null) {
+      symbols.push({
+        kind: kind as SymbolKind,
+        name: m[1]!,
+        startLine: lineOf(content, m.index),
+        endLine: null,
+        exported: /^pub\b/.test(m[0]!),
+      })
+    }
+  }
+  return { filePath, symbols, callNames: [], importBindings: new Map() }
+}
+
+function extractJava(content: string, filePath: string): FileExtract {
+  const symbols: RawSymbol[] = []
+  const reClass = /(?:public\s+|private\s+|protected\s+)?(?:abstract\s+|final\s+)?class\s+(\w+)/g
+  const reIface = /(?:public\s+)?interface\s+(\w+)/g
+  const reMethod =
+    /(?:public|private|protected)\s+(?:static\s+)?(?:final\s+)?[\w.<>,[\]\s]+\s+(\w+)\s*\(/g
+  let m: RegExpExecArray | null
+  while ((m = reClass.exec(content)) !== null) {
+    symbols.push({
+      kind: 'class',
+      name: m[1]!,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: true,
+    })
+  }
+  while ((m = reIface.exec(content)) !== null) {
+    symbols.push({
+      kind: 'interface',
+      name: m[1]!,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: true,
+    })
+  }
+  while ((m = reMethod.exec(content)) !== null) {
+    if (/^(if|for|while|switch|catch|return|new)$/.test(m[1]!)) continue
+    symbols.push({
+      kind: 'method',
+      name: m[1]!,
+      startLine: lineOf(content, m.index),
+      endLine: null,
+      exported: true,
+    })
+  }
+  return { filePath, symbols, callNames: [], importBindings: new Map() }
+}
+
+export function extractFile(content: string, filePath: string): FileExtract {
+  const ext = path.extname(filePath).toLowerCase()
+  if (['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'].includes(ext)) {
+    return extractTsJs(content, filePath)
+  }
+  if (ext === '.py') return extractPython(content, filePath)
+  if (ext === '.go') return extractGo(content, filePath)
+  if (ext === '.rs') return extractRust(content, filePath)
+  if (ext === '.java') return extractJava(content, filePath)
+  return { filePath, symbols: [], callNames: [], importBindings: new Map() }
+}
+
+// Resolve import path relative to file (TS/JS relative only)
+
+function resolveModuleHint(fromFile: string, source: string): string | null {
+  if (!source.startsWith('.') && !source.startsWith('@/')) return null
+  // Soft resolve: strip extension, return normalized relative path without project root
+  let base: string
+  if (source.startsWith('@/')) {
+    base = path.posix.join('src', source.slice(2))
+  } else {
+    const fromDir = path.posix.dirname(fromFile.replace(/\\/g, '/'))
+    base = path.posix.normalize(path.posix.join(fromDir, source))
+  }
+  return base.replace(/^\.\//, '')
+}
+
+// Graph build + persistence
+
+interface BuiltGraph {
+  symbols: CodeSymbol[]
+  edges: CodeSymbolEdge[]
+  fileCount: number
+}
+
+function buildFromExtracts(extracts: FileExtract[]): BuiltGraph {
+  const symbols: CodeSymbol[] = []
+  const edges: CodeSymbolEdge[] = []
+  // name → symbols (for call resolution)
+  const byName = new Map<string, CodeSymbol[]>()
+  // file → symbols
+  const byFile = new Map<string, CodeSymbol[]>()
+
+  for (const ex of extracts) {
+    const fileSyms: CodeSymbol[] = []
+    for (const raw of ex.symbols) {
+      const id = symbolId(ex.filePath, raw.kind, raw.name, raw.startLine)
+      const sym: CodeSymbol = {
+        id,
+        file: ex.filePath,
+        kind: raw.kind,
+        name: raw.name,
+        qname: qnameOf(ex.filePath, raw.name),
+        startLine: raw.startLine,
+        endLine: raw.endLine,
+        exported: raw.exported,
+      }
+      symbols.push(sym)
+      fileSyms.push(sym)
+      const list = byName.get(raw.name) ?? []
+      list.push(sym)
+      byName.set(raw.name, list)
+
+      // File DEFINES symbol
+      edges.push({
+        src: `file:${ex.filePath}`,
+        dst: id,
+        edgeType: 'DEFINES',
+        confidence: 1,
+      })
+    }
+    byFile.set(ex.filePath, fileSyms)
+  }
+
+  // Resolve CALLS. Source is the file synthetic node (stable, no false
+  // "function A calls B" when we only know the file invokes B). Trace still
+  // resolves file: → display via symbolsInFile / reverse expansion.
+  for (const ex of extracts) {
+    const fileSyms = byFile.get(ex.filePath) ?? []
+    const fileSrc = `file:${ex.filePath}`
+
+    for (const callName of ex.callNames) {
+      // 1) same-file definition
+      const local = fileSyms.filter((s) => s.name === callName)
+      let targets: CodeSymbol[] = local
+
+      // 2) import binding → module path hint → match symbol in that file
+      if (targets.length === 0) {
+        const hint = ex.importBindings.get(callName)
+        if (hint) {
+          const mod = resolveModuleHint(ex.filePath, hint)
+          if (mod) {
+            const candidates = (byName.get(callName) ?? []).filter(
+              (s) =>
+                s.file.replace(/\.[^.]+$/, '') === mod ||
+                s.file.startsWith(`${mod}.`) ||
+                s.file.startsWith(`${mod}/`) ||
+                s.file === `${mod}.ts` ||
+                s.file === `${mod}.tsx` ||
+                s.file === `${mod}.js` ||
+                s.file === `${mod}/index.ts` ||
+                s.file === `${mod}/index.js`
+            )
+            if (candidates.length > 0) targets = candidates
+          }
+        }
+      }
+
+      // 3) unique project-wide name
+      if (targets.length === 0) {
+        const all = byName.get(callName) ?? []
+        if (all.length === 1) targets = all
+        else if (all.length > 1) {
+          const exported = all.filter((s) => s.exported)
+          if (exported.length === 1) targets = exported
+        }
+      }
+
+      if (targets.length === 0) continue
+      for (const t of targets) {
+        // Skip self-calls within same file's definition noise
+        if (t.file === ex.filePath && local.includes(t)) continue
+        edges.push({
+          src: fileSrc,
+          dst: t.id,
+          edgeType: 'CALLS',
+          confidence: local.length > 0 ? 0.6 : 0.75,
+        })
+      }
+    }
+  }
+
+  // Dedup edges
+  const edgeKey = new Set<string>()
+  const uniqEdges: CodeSymbolEdge[] = []
+  for (const e of edges) {
+    const k = `${e.src}|${e.dst}|${e.edgeType}`
+    if (edgeKey.has(k)) continue
+    edgeKey.add(k)
+    uniqEdges.push(e)
+  }
+
+  return {
+    symbols,
+    edges: uniqEdges,
+    fileCount: extracts.length,
+  }
+}
+
+async function extractProject(projectPath: string, onlyFiles?: string[]): Promise<FileExtract[]> {
+  const files =
+    onlyFiles ?? (await walkDir(projectPath)).filter((f) => isSourceFile(f) && !f.includes('.d.ts'))
+  const sourceFiles = files.filter((f) => isSourceFile(f) && !f.endsWith('.d.ts'))
+
+  return batchProcess(sourceFiles, 40, async (filePath) => {
+    try {
+      const content = await fs.readFile(path.join(projectPath, filePath), 'utf-8')
+      // Cap very large files for extraction cost
+      const sliced = content.length > 400_000 ? content.slice(0, 400_000) : content
+      return extractFile(sliced, filePath)
+    } catch {
+      return {
+        filePath,
+        symbols: [],
+        callNames: [],
+        importBindings: new Map(),
+      }
+    }
+  })
+}
+
+function persistGraph(projectId: string, graph: BuiltGraph): void {
+  prjctDb.transaction(projectId, (db) => {
+    db.prepare('DELETE FROM code_symbols').run()
+    db.prepare('DELETE FROM code_symbol_edges').run()
+    const insSym = db.prepare(
+      `INSERT INTO code_symbols (id, file, kind, name, qname, start_line, end_line, exported)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    const insEdge = db.prepare(
+      `INSERT OR IGNORE INTO code_symbol_edges (src, dst, edge_type, confidence)
+       VALUES (?, ?, ?, ?)`
+    )
+    for (const s of graph.symbols) {
+      insSym.run(s.id, s.file, s.kind, s.name, s.qname, s.startLine, s.endLine, s.exported ? 1 : 0)
+    }
+    for (const e of graph.edges) {
+      insEdge.run(e.src, e.dst, e.edgeType, e.confidence)
+    }
+  })
+
+  const meta: SymbolGraphMeta = {
+    symbolCount: graph.symbols.length,
+    edgeCount: graph.edges.length,
+    fileCount: graph.fileCount,
+    builtAt: new Date().toISOString(),
+  }
+  prjctDb.setDoc(projectId, META_KEY, meta)
+}
+
+function patchGraph(
+  projectId: string,
+  extracts: FileExtract[],
+  deletedFiles: string[]
+): SymbolGraphMeta | null {
+  // Incremental: drop symbols/edges for touched files, re-insert from extracts.
+  // CALLS that target/src these symbols also get cleaned via id prefix.
+  const touched = new Set([...extracts.map((e) => e.filePath), ...deletedFiles])
+  if (touched.size === 0) return loadMeta(projectId)
+
+  // Load surviving symbols for call resolution (name index of whole project after patch)
+  const existing = listAllSymbols(projectId).filter((s) => !touched.has(s.file))
+  const rebuilt = buildFromExtracts(extracts)
+
+  prjctDb.transaction(projectId, (db) => {
+    const delSym = db.prepare('DELETE FROM code_symbols WHERE file = ?')
+    for (const file of touched) {
+      // LIKE: file#… symbol ids and synthetic file: nodes
+      db.prepare(
+        `DELETE FROM code_symbol_edges WHERE src LIKE ? OR dst LIKE ? OR src = ? OR dst = ?`
+      ).run(`${file}#%`, `${file}#%`, `file:${file}`, `file:${file}`)
+      delSym.run(file)
+    }
+
+    const insSym = db.prepare(
+      `INSERT INTO code_symbols (id, file, kind, name, qname, start_line, end_line, exported)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    const insEdge = db.prepare(
+      `INSERT OR IGNORE INTO code_symbol_edges (src, dst, edge_type, confidence)
+       VALUES (?, ?, ?, ?)`
+    )
+    for (const s of rebuilt.symbols) {
+      insSym.run(s.id, s.file, s.kind, s.name, s.qname, s.startLine, s.endLine, s.exported ? 1 : 0)
+    }
+    // Re-resolve CALLS for changed files against full name index
+    const byName = new Map<string, CodeSymbol[]>()
+    for (const s of [...existing, ...rebuilt.symbols]) {
+      const list = byName.get(s.name) ?? []
+      list.push(s)
+      byName.set(s.name, list)
+    }
+    for (const ex of extracts) {
+      const fileSyms = rebuilt.symbols.filter((s) => s.file === ex.filePath)
+      const defaultSrc =
+        fileSyms.find((s) => s.kind === 'function' || s.kind === 'class' || s.kind === 'method')
+          ?.id ?? fileSyms[0]?.id
+      for (const s of fileSyms) {
+        insEdge.run(`file:${ex.filePath}`, s.id, 'DEFINES', 1)
+      }
+      if (!defaultSrc) continue
+      for (const callName of ex.callNames) {
+        let targets = fileSyms.filter((s) => s.name === callName)
+        if (targets.length === 0) {
+          const all = byName.get(callName) ?? []
+          if (all.length === 1) targets = all
+          else {
+            const exported = all.filter((s) => s.exported)
+            if (exported.length === 1) targets = exported
+          }
+        }
+        for (const t of targets) {
+          if (t.id === defaultSrc) continue
+          insEdge.run(defaultSrc, t.id, 'CALLS', 0.7)
+        }
+      }
+    }
+  })
+
+  const counts = prjctDb.get<{ sc: number; ec: number; fc: number }>(
+    projectId,
+    `SELECT
+       (SELECT COUNT(*) FROM code_symbols) AS sc,
+       (SELECT COUNT(*) FROM code_symbol_edges) AS ec,
+       (SELECT COUNT(DISTINCT file) FROM code_symbols) AS fc`
+  )
+  const meta: SymbolGraphMeta = {
+    symbolCount: counts?.sc ?? 0,
+    edgeCount: counts?.ec ?? 0,
+    fileCount: counts?.fc ?? 0,
+    builtAt: new Date().toISOString(),
+  }
+  prjctDb.setDoc(projectId, META_KEY, meta)
+  return meta
+}
+
+// Public API
+
+export async function indexSymbols(
+  projectPath: string,
+  projectId: string
+): Promise<SymbolGraphMeta> {
+  const extracts = await extractProject(projectPath)
+  const graph = buildFromExtracts(extracts)
+  persistGraph(projectId, graph)
+  return {
+    symbolCount: graph.symbols.length,
+    edgeCount: graph.edges.length,
+    fileCount: graph.fileCount,
+    builtAt: new Date().toISOString(),
+  }
+}
+
+export async function updateSymbols(
+  projectPath: string,
+  projectId: string,
+  changedFiles: string[],
+  deletedFiles: string[] = []
+): Promise<SymbolGraphMeta> {
+  if (!hasSymbolIndex(projectId)) {
+    return indexSymbols(projectPath, projectId)
+  }
+  const sourceChanged = changedFiles.filter((f) => isSourceFile(f) && !f.endsWith('.d.ts'))
+  const sourceDeleted = deletedFiles.filter((f) => isSourceFile(f))
+  if (sourceChanged.length === 0 && sourceDeleted.length === 0) {
+    return (
+      loadMeta(projectId) ?? {
+        symbolCount: 0,
+        edgeCount: 0,
+        fileCount: 0,
+        builtAt: new Date().toISOString(),
+      }
+    )
+  }
+  const extracts = await extractProject(projectPath, sourceChanged)
+  return (
+    patchGraph(projectId, extracts, sourceDeleted) ?? {
+      symbolCount: 0,
+      edgeCount: 0,
+      fileCount: 0,
+      builtAt: new Date().toISOString(),
+    }
+  )
+}
+
+export function hasSymbolIndex(projectId: string): boolean {
+  try {
+    const row = prjctDb.get<{ n: number }>(projectId, 'SELECT COUNT(*) AS n FROM code_symbols')
+    return (row?.n ?? 0) > 0
+  } catch {
+    return false
+  }
+}
+
+export function loadMeta(projectId: string): SymbolGraphMeta | null {
+  return prjctDb.getDoc<SymbolGraphMeta>(projectId, META_KEY)
+}
+
+function rowToSymbol(r: {
+  id: string
+  file: string
+  kind: string
+  name: string
+  qname: string | null
+  start_line: number
+  end_line: number | null
+  exported: number
+}): CodeSymbol {
+  return {
+    id: r.id,
+    file: r.file,
+    kind: r.kind as SymbolKind,
+    name: r.name,
+    qname: r.qname ?? qnameOf(r.file, r.name),
+    startLine: r.start_line,
+    endLine: r.end_line,
+    exported: r.exported === 1,
+  }
+}
+
+export function listAllSymbols(projectId: string): CodeSymbol[] {
+  try {
+    const rows = prjctDb.query<{
+      id: string
+      file: string
+      kind: string
+      name: string
+      qname: string | null
+      start_line: number
+      end_line: number | null
+      exported: number
+    }>(projectId, 'SELECT * FROM code_symbols ORDER BY file, start_line')
+    return rows.map(rowToSymbol)
+  } catch {
+    return []
+  }
+}
+
+export function searchSymbols(
+  projectId: string,
+  pattern: string,
+  opts: { limit?: number; kind?: SymbolKind } = {}
+): CodeSymbol[] {
+  const limit = opts.limit ?? 30
+  const like = `%${pattern.replace(/[%_]/g, '')}%`
+  try {
+    if (opts.kind) {
+      return prjctDb
+        .query<{
+          id: string
+          file: string
+          kind: string
+          name: string
+          qname: string | null
+          start_line: number
+          end_line: number | null
+          exported: number
+        }>(
+          projectId,
+          `SELECT * FROM code_symbols
+           WHERE name LIKE ? COLLATE NOCASE AND kind = ?
+           ORDER BY exported DESC, name
+           LIMIT ?`,
+          like,
+          opts.kind,
+          limit
+        )
+        .map(rowToSymbol)
+    }
+    return prjctDb
+      .query<{
+        id: string
+        file: string
+        kind: string
+        name: string
+        qname: string | null
+        start_line: number
+        end_line: number | null
+        exported: number
+      }>(
+        projectId,
+        `SELECT * FROM code_symbols
+         WHERE name LIKE ? COLLATE NOCASE OR qname LIKE ? COLLATE NOCASE
+         ORDER BY exported DESC, name
+         LIMIT ?`,
+        like,
+        like,
+        limit
+      )
+      .map(rowToSymbol)
+  } catch {
+    return []
+  }
+}
+
+/** Query indexer: files that define symbols matching query tokens. */
+export function scoreFilesFromQuery(projectId: string, query: string, topN = 20): SymbolScore[] {
+  const tokens = query
+    .split(/[^A-Za-z0-9_]+/)
+    .flatMap((t) => t.replace(/([a-z])([A-Z])/g, '$1 $2').split(/\s+/))
+    .map((t) => t.trim())
+    .filter((t) => t.length > 2)
+
+  if (tokens.length === 0 || !hasSymbolIndex(projectId)) return []
+
+  const fileScores = new Map<string, { score: number; names: Set<string> }>()
+
+  for (const token of tokens) {
+    const hits = searchSymbols(projectId, token, { limit: 40 })
+    for (const h of hits) {
+      const exact = h.name.toLowerCase() === token.toLowerCase() ? 1 : 0.55
+      const exp = h.exported ? 1.15 : 1
+      const kindBoost = h.kind === 'function' || h.kind === 'class' || h.kind === 'route' ? 1.1 : 1
+      const add = exact * exp * kindBoost
+      const cur = fileScores.get(h.file) ?? { score: 0, names: new Set<string>() }
+      cur.score += add
+      cur.names.add(h.name)
+      fileScores.set(h.file, cur)
+    }
+  }
+
+  return Array.from(fileScores.entries())
+    .map(([p, v]) => ({
+      path: p,
+      score: v.score,
+      matchedNames: [...v.names],
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topN)
+}
+
+export function symbolsInFile(projectId: string, filePath: string): CodeSymbol[] {
+  try {
+    return prjctDb
+      .query<{
+        id: string
+        file: string
+        kind: string
+        name: string
+        qname: string | null
+        start_line: number
+        end_line: number | null
+        exported: number
+      }>(projectId, 'SELECT * FROM code_symbols WHERE file = ? ORDER BY start_line', filePath)
+      .map(rowToSymbol)
+  } catch {
+    return []
+  }
+}
+
+function loadEdges(
+  projectId: string,
+  edgeType: SymbolEdgeType = 'CALLS'
+): { forward: Map<string, string[]>; reverse: Map<string, string[]> } {
+  const forward = new Map<string, string[]>()
+  const reverse = new Map<string, string[]>()
+  try {
+    const rows = prjctDb.query<{ src: string; dst: string }>(
+      projectId,
+      'SELECT src, dst FROM code_symbol_edges WHERE edge_type = ?',
+      edgeType
+    )
+    for (const r of rows) {
+      if (!forward.has(r.src)) forward.set(r.src, [])
+      forward.get(r.src)!.push(r.dst)
+      if (!reverse.has(r.dst)) reverse.set(r.dst, [])
+      reverse.get(r.dst)!.push(r.src)
+    }
+  } catch {
+    /* empty */
+  }
+  return { forward, reverse }
+}
+
+function symbolById(projectId: string, id: string): CodeSymbol | null {
+  try {
+    const r = prjctDb.get<{
+      id: string
+      file: string
+      kind: string
+      name: string
+      qname: string | null
+      start_line: number
+      end_line: number | null
+      exported: number
+    }>(projectId, 'SELECT * FROM code_symbols WHERE id = ?', id)
+    return r ? rowToSymbol(r) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * BFS call-path trace for a symbol name (first match preferred: exported).
+ */
+export function tracePath(
+  projectId: string,
+  functionName: string,
+  opts: { direction?: 'inbound' | 'outbound' | 'both'; depth?: number } = {}
+): TraceResult | null {
+  const direction = opts.direction ?? 'both'
+  const maxDepth = Math.min(Math.max(opts.depth ?? 3, 1), 5)
+  const roots = searchSymbols(projectId, functionName, { limit: 10 }).filter(
+    (s) => s.name.toLowerCase() === functionName.toLowerCase()
+  )
+  const rootList = roots.length > 0 ? roots : searchSymbols(projectId, functionName, { limit: 5 })
+  if (rootList.length === 0) return null
+
+  const { forward, reverse } = loadEdges(projectId, 'CALLS')
+  const inbound: TraceHop[] = []
+  const outbound: TraceHop[] = []
+
+  const bfs = (startIds: string[], adj: Map<string, string[]>, out: TraceHop[], maxD: number) => {
+    const visited = new Set<string>(startIds)
+    const queue: Array<{ id: string; depth: number }> = startIds.map((id) => ({
+      id,
+      depth: 0,
+    }))
+    for (let qi = 0; qi < queue.length; qi++) {
+      const { id, depth } = queue[qi]!
+      if (depth >= maxD) continue
+      for (const next of adj.get(id) ?? []) {
+        if (visited.has(next)) continue
+        visited.add(next)
+        // Synthetic file: callers — expand to primary exported symbols in that file
+        if (next.startsWith('file:')) {
+          const filePath = next.slice('file:'.length)
+          const fileSyms = symbolsInFile(projectId, filePath)
+          const primary =
+            fileSyms.find((s) => s.exported && (s.kind === 'function' || s.kind === 'class')) ??
+            fileSyms.find((s) => s.kind === 'function' || s.kind === 'class') ??
+            fileSyms[0]
+          if (primary && !visited.has(primary.id)) {
+            visited.add(primary.id)
+            out.push({ symbol: primary, depth: depth + 1, via: 'CALLS' })
+            queue.push({ id: primary.id, depth: depth + 1 })
+          }
+          // Also continue BFS from the file node for multi-hop file→symbol
+          queue.push({ id: next, depth: depth + 1 })
+          continue
+        }
+        const sym = symbolById(projectId, next)
+        if (!sym) continue
+        out.push({ symbol: sym, depth: depth + 1, via: 'CALLS' })
+        queue.push({ id: next, depth: depth + 1 })
+      }
+    }
+  }
+
+  const startIds = rootList.map((r) => r.id)
+  if (direction === 'inbound' || direction === 'both') {
+    bfs(startIds, reverse, inbound, maxDepth)
+  }
+  if (direction === 'outbound' || direction === 'both') {
+    bfs(startIds, forward, outbound, maxDepth)
+  }
+
+  return { root: rootList, inbound, outbound }
+}
+
+/** Fan-in (callers) count for symbols in a file. */
+export function fileFanIn(projectId: string, filePath: string): number {
+  const syms = symbolsInFile(projectId, filePath)
+  if (syms.length === 0) return 0
+  const { reverse } = loadEdges(projectId, 'CALLS')
+  let count = 0
+  const callers = new Set<string>()
+  for (const s of syms) {
+    for (const c of reverse.get(s.id) ?? []) {
+      // Count file: callers as one fan-in unit each
+      callers.add(c)
+    }
+  }
+  count = callers.size
+  return count
+}
+
+/** Files that call into symbols defined in seed files (call-graph expand). */
+export function filesCallingInto(projectId: string, seedFiles: string[], maxDepth = 2): string[] {
+  const seedSet = new Set(seedFiles)
+  const { reverse } = loadEdges(projectId, 'CALLS')
+  const seedSymIds = new Set<string>()
+  for (const f of seedFiles) {
+    for (const s of symbolsInFile(projectId, f)) seedSymIds.add(s.id)
+  }
+  const files = new Set<string>()
+  const visited = new Set<string>(seedSymIds)
+  let frontier = [...seedSymIds]
+  for (let d = 0; d < maxDepth; d++) {
+    const next: string[] = []
+    for (const id of frontier) {
+      for (const caller of reverse.get(id) ?? []) {
+        if (visited.has(caller)) continue
+        visited.add(caller)
+        next.push(caller)
+        if (caller.startsWith('file:')) {
+          const fp = caller.slice('file:'.length)
+          if (!seedSet.has(fp)) files.add(fp)
+        } else {
+          const sym = symbolById(projectId, caller)
+          if (sym && !seedSet.has(sym.file)) files.add(sym.file)
+        }
+      }
+    }
+    frontier = next
+  }
+  return [...files]
+}
+
+export type { SymbolEdgeType }

--- a/core/domain/symbol-graph.ts
+++ b/core/domain/symbol-graph.ts
@@ -1,20 +1,19 @@
 /**
  * Symbol Graph — structural code intelligence (file → symbol layer).
  *
- * Inspired by codebase-memory-mcp's knowledge graph, but scoped to what
- * prjct needs without Hybrid LSP / tree-sitter vendoring:
- *   - Extract functions/classes/types (+ call sites) via regex AST-lite
- *   - Persist symbols + CALLS/DEFINES edges in SQLite
- *   - Score files by symbol-name match (4th ranker signal)
- *   - Trace inbound/outbound call paths
- *   - Power detect_changes blast radius
+ * P0 quality:
+ *   - Extract from noise-stripped source (no symbols/calls inside strings/comments)
+ *   - CALLS edges from enclosing function/method/class (by line), not only file:
+ *   - Import resolution: relative, @/, tsconfig paths, RESOLVE_EXTENSIONS
+ *   - call sites keep line numbers for enclosing-symbol attribution
  *
- * Languages (S1): TypeScript / JavaScript / TSX / JSX, plus lightweight
- * Python / Go / Rust / Java definition extraction (calls best-effort).
+ * Languages: TypeScript / JavaScript / TSX / JSX (full CALLS path),
+ * plus lightweight Python / Go / Rust / Java definition extraction.
  */
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { RESOLVE_EXTENSIONS } from '../constants/file-patterns'
 import prjctDb from '../storage/database'
 import type {
   CodeSymbol,
@@ -42,7 +41,94 @@ const SYMBOL_EXTS = new Set([
   '.java',
 ])
 
-// Extraction
+const CALL_KEYWORDS = new Set([
+  'if',
+  'for',
+  'while',
+  'switch',
+  'catch',
+  'function',
+  'class',
+  'return',
+  'typeof',
+  'new',
+  'throw',
+  'await',
+  'void',
+  'super',
+  'this',
+  'import',
+  'require',
+  'console',
+  'Math',
+  'JSON',
+  'Object',
+  'Array',
+  'Promise',
+  'Map',
+  'Set',
+  'Date',
+  'Error',
+  'Buffer',
+  'process',
+  'describe',
+  'it',
+  'test',
+  'expect',
+  'beforeEach',
+  'afterEach',
+  'beforeAll',
+  'afterAll',
+])
+
+const DECL_KEYWORDS = new Set([
+  'if',
+  'for',
+  'while',
+  'switch',
+  'catch',
+  'return',
+  'await',
+  'typeof',
+  'new',
+  'throw',
+  'else',
+  'case',
+  'from',
+  'import',
+  'export',
+  'class',
+  'function',
+  'const',
+  'let',
+  'var',
+  'get',
+  'set',
+  'constructor',
+  'async',
+  'static',
+  'public',
+  'private',
+  'protected',
+  'readonly',
+  'abstract',
+  'extends',
+  'implements',
+  'interface',
+  'type',
+  'enum',
+  'default',
+  'as',
+  'of',
+  'in',
+  'do',
+  'try',
+  'finally',
+  'yield',
+  'with',
+])
+
+// Extraction types
 
 interface RawSymbol {
   kind: SymbolKind
@@ -52,13 +138,22 @@ interface RawSymbol {
   exported: boolean
 }
 
-interface FileExtract {
+interface CallSite {
+  name: string
+  line: number
+}
+
+export interface FileExtract {
   filePath: string
   symbols: RawSymbol[]
-  /** Call names found in this file (not yet resolved). */
+  /** Unique call names (compat + scoring). */
   callNames: string[]
-  /** Named imports: localName → resolved relative module path (best-effort). */
+  /** Call sites with line for enclosing-symbol attribution. */
+  calls: CallSite[]
+  /** Named import local → specifier as written in source. */
   importBindings: Map<string, string>
+  /** local → resolved project-relative file path (filled during extractProject). */
+  resolvedImports: Map<string, string>
 }
 
 function lineOf(content: string, index: number): number {
@@ -83,20 +178,119 @@ function isSourceFile(filePath: string): boolean {
   return SYMBOL_EXTS.has(ext)
 }
 
-/** Strip strings/comments so call extraction doesn't match noise. */
-function stripNoise(content: string): string {
-  return content
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .replace(/\/\/[^\n]*/g, '')
-    .replace(/'(?:\\.|[^'\\])*'/g, "''")
-    .replace(/"(?:\\.|[^"\\])*"/g, '""')
-    .replace(/`(?:\\.|[^`\\])*`/g, '``')
+/**
+ * Strip comments + string/template literals while preserving newlines so
+ * line numbers stay aligned with the original source.
+ * Linear scan (no catastrophic regex backtracking on large files).
+ */
+export function stripNoise(content: string): string {
+  const out: string[] = []
+  let i = 0
+  const n = content.length
+  while (i < n) {
+    const c = content[i]!
+    const next = content[i + 1]
+
+    // line comment
+    if (c === '/' && next === '/') {
+      out.push(' ')
+      i += 2
+      while (i < n && content[i] !== '\n') {
+        out.push(' ')
+        i++
+      }
+      continue
+    }
+    // block comment
+    if (c === '/' && next === '*') {
+      out.push(' ')
+      out.push(' ')
+      i += 2
+      while (i < n) {
+        if (content[i] === '*' && content[i + 1] === '/') {
+          out.push(' ')
+          out.push(' ')
+          i += 2
+          break
+        }
+        out.push(content[i] === '\n' ? '\n' : ' ')
+        i++
+      }
+      continue
+    }
+    // single / double quoted string
+    if (c === "'" || c === '"') {
+      const q = c
+      out.push(q)
+      i++
+      while (i < n) {
+        const ch = content[i]!
+        if (ch === '\\' && i + 1 < n) {
+          out.push(' ')
+          out.push(' ')
+          i += 2
+          continue
+        }
+        if (ch === q) {
+          out.push(q)
+          i++
+          break
+        }
+        out.push(ch === '\n' ? '\n' : ' ')
+        i++
+      }
+      continue
+    }
+    // template literal (no ${} expansion handling — blank whole span)
+    if (c === '`') {
+      out.push('`')
+      i++
+      while (i < n) {
+        const ch = content[i]!
+        if (ch === '\\' && i + 1 < n) {
+          out.push(' ')
+          out.push(' ')
+          i += 2
+          continue
+        }
+        if (ch === '`') {
+          out.push('`')
+          i++
+          break
+        }
+        out.push(ch === '\n' ? '\n' : ' ')
+        i++
+      }
+      continue
+    }
+
+    out.push(c)
+    i++
+  }
+  return out.join('')
+}
+
+function emptyExtract(filePath: string): FileExtract {
+  return {
+    filePath,
+    symbols: [],
+    callNames: [],
+    calls: [],
+    importBindings: new Map(),
+    resolvedImports: new Map(),
+  }
+}
+
+function finalizeCalls(calls: CallSite[]): { calls: CallSite[]; callNames: string[] } {
+  const names = [...new Set(calls.map((c) => c.name))]
+  return { calls, callNames: names }
 }
 
 function extractTsJs(content: string, filePath: string): FileExtract {
   const symbols: RawSymbol[] = []
-  const callNames: string[] = []
+  const calls: CallSite[] = []
   const importBindings = new Map<string, string>()
+  // Extract from cleaned source so string literals don't mint fake symbols/calls
   const clean = stripNoise(content)
 
   const declPatterns: Array<{
@@ -142,9 +336,9 @@ function extractTsJs(content: string, filePath: string): FileExtract {
       nameIdx: 1,
       exported: true,
     },
-    // Methods inside classes (indent heuristic)
+    // Methods: keep the param span bounded to avoid catastrophic backtracking
     {
-      re: /(?:^|\n)\s+(?:public|private|protected|static|async|readonly|\s)*\s*(?:async\s+)?(\w+)\s*\([^;{]*\)\s*[:{]/g,
+      re: /(?:^|\n)[ \t]+(?:(?:public|private|protected|static|async|readonly)\s+)*(\w+)\s*\([^)]{0,200}\)\s*[:{]/g,
       kind: 'method',
       nameIdx: 1,
     },
@@ -154,17 +348,10 @@ function extractTsJs(content: string, filePath: string): FileExtract {
   for (const { re, kind, nameIdx, exported } of declPatterns) {
     re.lastIndex = 0
     let m: RegExpExecArray | null
-    while ((m = re.exec(content)) !== null) {
+    while ((m = re.exec(clean)) !== null) {
       const name = m[nameIdx]
-      if (!name || name.length < 2) continue
-      // Skip keywords / control
-      if (
-        /^(if|for|while|switch|catch|return|await|typeof|new|throw|else|case|from|import|export|class|function|const|let|var|get|set|constructor)$/.test(
-          name
-        )
-      )
-        continue
-      const startLine = lineOf(content, m.index)
+      if (!name || name.length < 2 || DECL_KEYWORDS.has(name)) continue
+      const startLine = lineOf(clean, m.index)
       const key = `${kind}:${name}@${startLine}`
       if (seen.has(key)) continue
       seen.add(key)
@@ -178,44 +365,48 @@ function extractTsJs(content: string, filePath: string): FileExtract {
     }
   }
 
-  // Named imports: import { a as b, c } from './mod'
+  // Imports MUST read original source — stripNoise blanks string literals.
   const importRe =
-    /import\s+(?:type\s+)?(?:\{([^}]+)\}|(\w+))\s+from\s+['"](\.[^'"]+|@\/[^'"]+)['"]/g
+    /import\s+(?:type\s+)?(?:\{([^}]+)\}|(\w+)(?:\s*,\s*\{([^}]+)\})?|\*\s+as\s+(\w+))\s+from\s+['"]([^'"]+)['"]/g
   let im: RegExpExecArray | null
   while ((im = importRe.exec(content)) !== null) {
-    const source = im[3]!
-    if (im[1]) {
-      for (const part of im[1].split(',')) {
+    const source = im[5]!
+    const bindNamed = (chunk: string | undefined) => {
+      if (!chunk) return
+      for (const part of chunk.split(',')) {
         const bits = part
           .trim()
           .replace(/^type\s+/, '')
           .split(/\s+as\s+/)
         const local = (bits[1] ?? bits[0])?.trim()
-        if (local) importBindings.set(local, source)
+        if (local && /^[A-Za-z_][\w]*$/.test(local)) importBindings.set(local, source)
       }
-    } else if (im[2]) {
-      importBindings.set(im[2], source)
     }
+    bindNamed(im[1])
+    bindNamed(im[3])
+    if (im[2]) importBindings.set(im[2], source)
+    if (im[4]) importBindings.set(im[4], source)
   }
 
-  // Call sites: identifier(
+  // require('...') — also from original
+  const reqRe = /(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/g
+  while ((im = reqRe.exec(content)) !== null) {
+    importBindings.set(im[1]!, im[2]!)
+  }
+
+  // Call sites with lines — cap to avoid edge explosion on huge files
   const callRe = /\b([A-Za-z_][\w]*)\s*\(/g
   let cm: RegExpExecArray | null
-  const callSeen = new Set<string>()
+  const MAX_CALLS = 400
   while ((cm = callRe.exec(clean)) !== null) {
     const name = cm[1]!
-    if (
-      /^(if|for|while|switch|catch|function|class|return|typeof|new|throw|await|void|super|this|import|require|console|Math|JSON|Object|Array|Promise|Map|Set|Date|Error|Buffer|process|describe|it|test|expect|beforeEach|afterEach)$/.test(
-        name
-      )
-    )
-      continue
-    if (callSeen.has(name)) continue
-    callSeen.add(name)
-    callNames.push(name)
+    if (CALL_KEYWORDS.has(name) || name.length < 2) continue
+    const line = lineOf(clean, cm.index)
+    calls.push({ name, line })
+    if (calls.length >= MAX_CALLS) break
   }
 
-  // Route heuristics (Express/Hono/Next-ish)
+  // Routes (from clean — string paths were blanked; use original for route strings)
   const routeRe = /\.(?:get|post|put|patch|delete|options|head|all)\s*\(\s*['"`](\/[^'"`]*)['"`]/gi
   let rm: RegExpExecArray | null
   while ((rm = routeRe.exec(content)) !== null) {
@@ -230,77 +421,98 @@ function extractTsJs(content: string, filePath: string): FileExtract {
     })
   }
 
-  return { filePath, symbols, callNames, importBindings }
+  const fin = finalizeCalls(calls)
+  return {
+    filePath,
+    symbols,
+    callNames: fin.callNames,
+    calls: fin.calls,
+    importBindings,
+    resolvedImports: new Map(),
+  }
 }
 
 function extractPython(content: string, filePath: string): FileExtract {
   const symbols: RawSymbol[] = []
-  const callNames: string[] = []
+  const calls: CallSite[] = []
+  const clean = stripNoise(content)
   const reFn = /^(?:async\s+)?def\s+(\w+)\s*\(/gm
   const reClass = /^class\s+(\w+)/gm
   let m: RegExpExecArray | null
-  while ((m = reFn.exec(content)) !== null) {
+  while ((m = reFn.exec(clean)) !== null) {
     symbols.push({
       kind: 'function',
       name: m[1]!,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: !m[1]!.startsWith('_'),
     })
   }
-  while ((m = reClass.exec(content)) !== null) {
+  while ((m = reClass.exec(clean)) !== null) {
     symbols.push({
       kind: 'class',
       name: m[1]!,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: !m[1]!.startsWith('_'),
     })
   }
   const callRe = /\b([A-Za-z_][\w]*)\s*\(/g
-  const clean = stripNoise(content)
-  const seen = new Set<string>()
   while ((m = callRe.exec(clean)) !== null) {
     const name = m[1]!
     if (/^(if|for|while|return|print|len|range|str|int|list|dict|set|super|self)$/.test(name))
       continue
-    if (seen.has(name)) continue
-    seen.add(name)
-    callNames.push(name)
+    calls.push({ name, line: lineOf(clean, m.index) })
   }
-  return { filePath, symbols, callNames, importBindings: new Map() }
+  const fin = finalizeCalls(calls)
+  return {
+    filePath,
+    symbols,
+    callNames: fin.callNames,
+    calls: fin.calls,
+    importBindings: new Map(),
+    resolvedImports: new Map(),
+  }
 }
 
 function extractGo(content: string, filePath: string): FileExtract {
   const symbols: RawSymbol[] = []
-  const callNames: string[] = []
+  const clean = stripNoise(content)
   const reFn = /^func\s+(?:\([^)]+\)\s+)?(\w+)\s*\(/gm
   const reType = /^type\s+(\w+)\s+(?:struct|interface)/gm
   let m: RegExpExecArray | null
-  while ((m = reFn.exec(content)) !== null) {
+  while ((m = reFn.exec(clean)) !== null) {
     const name = m[1]!
     symbols.push({
-      kind: name[0] === name[0]!.toUpperCase() ? 'function' : 'function',
+      kind: 'function',
       name,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: name[0] === name[0]!.toUpperCase(),
     })
   }
-  while ((m = reType.exec(content)) !== null) {
+  while ((m = reType.exec(clean)) !== null) {
     symbols.push({
       kind: 'type',
       name: m[1]!,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: m[1]![0] === m[1]![0]!.toUpperCase(),
     })
   }
-  return { filePath, symbols, callNames, importBindings: new Map() }
+  return {
+    filePath,
+    symbols,
+    callNames: [],
+    calls: [],
+    importBindings: new Map(),
+    resolvedImports: new Map(),
+  }
 }
 
 function extractRust(content: string, filePath: string): FileExtract {
   const symbols: RawSymbol[] = []
+  const clean = stripNoise(content)
   const reFn = /^(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/gm
   const reStruct = /^(?:pub\s+)?struct\s+(\w+)/gm
   const reTrait = /^(?:pub\s+)?trait\s+(\w+)/gm
@@ -312,55 +524,70 @@ function extractRust(content: string, filePath: string): FileExtract {
     [reTrait, 'interface'],
     [reEnum, 'enum'],
   ] as const) {
-    while ((m = re.exec(content)) !== null) {
+    while ((m = re.exec(clean)) !== null) {
       symbols.push({
         kind: kind as SymbolKind,
         name: m[1]!,
-        startLine: lineOf(content, m.index),
+        startLine: lineOf(clean, m.index),
         endLine: null,
         exported: /^pub\b/.test(m[0]!),
       })
     }
   }
-  return { filePath, symbols, callNames: [], importBindings: new Map() }
+  return {
+    filePath,
+    symbols,
+    callNames: [],
+    calls: [],
+    importBindings: new Map(),
+    resolvedImports: new Map(),
+  }
 }
 
 function extractJava(content: string, filePath: string): FileExtract {
   const symbols: RawSymbol[] = []
+  const clean = stripNoise(content)
   const reClass = /(?:public\s+|private\s+|protected\s+)?(?:abstract\s+|final\s+)?class\s+(\w+)/g
   const reIface = /(?:public\s+)?interface\s+(\w+)/g
   const reMethod =
     /(?:public|private|protected)\s+(?:static\s+)?(?:final\s+)?[\w.<>,[\]\s]+\s+(\w+)\s*\(/g
   let m: RegExpExecArray | null
-  while ((m = reClass.exec(content)) !== null) {
+  while ((m = reClass.exec(clean)) !== null) {
     symbols.push({
       kind: 'class',
       name: m[1]!,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: true,
     })
   }
-  while ((m = reIface.exec(content)) !== null) {
+  while ((m = reIface.exec(clean)) !== null) {
     symbols.push({
       kind: 'interface',
       name: m[1]!,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: true,
     })
   }
-  while ((m = reMethod.exec(content)) !== null) {
+  while ((m = reMethod.exec(clean)) !== null) {
     if (/^(if|for|while|switch|catch|return|new)$/.test(m[1]!)) continue
     symbols.push({
       kind: 'method',
       name: m[1]!,
-      startLine: lineOf(content, m.index),
+      startLine: lineOf(clean, m.index),
       endLine: null,
       exported: true,
     })
   }
-  return { filePath, symbols, callNames: [], importBindings: new Map() }
+  return {
+    filePath,
+    symbols,
+    callNames: [],
+    calls: [],
+    importBindings: new Map(),
+    resolvedImports: new Map(),
+  }
 }
 
 export function extractFile(content: string, filePath: string): FileExtract {
@@ -372,25 +599,114 @@ export function extractFile(content: string, filePath: string): FileExtract {
   if (ext === '.go') return extractGo(content, filePath)
   if (ext === '.rs') return extractRust(content, filePath)
   if (ext === '.java') return extractJava(content, filePath)
-  return { filePath, symbols: [], callNames: [], importBindings: new Map() }
+  return emptyExtract(filePath)
 }
 
-// Resolve import path relative to file (TS/JS relative only)
+// Import resolution
 
-function resolveModuleHint(fromFile: string, source: string): string | null {
-  if (!source.startsWith('.') && !source.startsWith('@/')) return null
-  // Soft resolve: strip extension, return normalized relative path without project root
-  let base: string
-  if (source.startsWith('@/')) {
-    base = path.posix.join('src', source.slice(2))
-  } else {
-    const fromDir = path.posix.dirname(fromFile.replace(/\\/g, '/'))
-    base = path.posix.normalize(path.posix.join(fromDir, source))
+type TsPathMap = Array<{ pattern: string; targets: string[] }>
+
+async function loadTsPathMap(projectPath: string): Promise<TsPathMap> {
+  const map: TsPathMap = []
+  for (const conf of ['tsconfig.json', 'jsconfig.json']) {
+    try {
+      const raw = await fs.readFile(path.join(projectPath, conf), 'utf-8')
+      // Strip comments (tsconfig often has them)
+      const json = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+      const parsed = JSON.parse(json) as {
+        compilerOptions?: { paths?: Record<string, string[]>; baseUrl?: string }
+      }
+      const paths = parsed.compilerOptions?.paths
+      const baseUrl = parsed.compilerOptions?.baseUrl ?? '.'
+      if (!paths) continue
+      for (const [pattern, targets] of Object.entries(paths)) {
+        map.push({
+          pattern,
+          targets: targets.map((t) => path.posix.join(baseUrl.replace(/\\/g, '/'), t)),
+        })
+      }
+      break
+    } catch {
+      /* try next */
+    }
   }
-  return base.replace(/^\.\//, '')
+  return map
 }
 
-// Graph build + persistence
+function applyTsPath(specifier: string, tsPaths: TsPathMap): string[] {
+  const out: string[] = []
+  for (const { pattern, targets } of tsPaths) {
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -1) // keep trailing path start
+      const pre = pattern.slice(0, -2)
+      if (specifier === pre || specifier.startsWith(pre + '/')) {
+        const rest = specifier.slice(pre.length).replace(/^\//, '')
+        for (const t of targets) {
+          const base = t.endsWith('/*') ? t.slice(0, -1) : t
+          out.push(path.posix.join(base.replace(/\*$/, ''), rest).replace(/\\/g, '/'))
+        }
+      }
+      void prefix
+    } else if (specifier === pattern) {
+      for (const t of targets) out.push(t.replace(/\*$/, ''))
+    }
+  }
+  return out
+}
+
+async function resolveSpecifierToFile(
+  projectPath: string,
+  fromFile: string,
+  specifier: string,
+  tsPaths: TsPathMap
+): Promise<string | null> {
+  const candidates: string[] = []
+
+  if (specifier.startsWith('.')) {
+    const fromDir = path.dirname(path.join(projectPath, fromFile))
+    candidates.push(path.resolve(fromDir, specifier))
+  } else if (specifier.startsWith('@/')) {
+    candidates.push(path.join(projectPath, 'src', specifier.slice(2)))
+    candidates.push(path.join(projectPath, specifier.slice(2)))
+  } else {
+    // tsconfig paths / bare alias
+    for (const mapped of applyTsPath(specifier, tsPaths)) {
+      candidates.push(path.join(projectPath, mapped))
+    }
+    // monorepo-ish packages/* fallback
+    candidates.push(path.join(projectPath, 'packages', specifier))
+    candidates.push(path.join(projectPath, 'src', specifier))
+  }
+
+  for (const base of candidates) {
+    for (const ext of RESOLVE_EXTENSIONS) {
+      const full = base + ext
+      try {
+        const st = await fs.stat(full)
+        if (st.isFile()) {
+          return path.relative(projectPath, full).replace(/\\/g, '/')
+        }
+      } catch {
+        /* next */
+      }
+    }
+    // directory index already covered by RESOLVE_EXTENSIONS entries like /index.ts
+  }
+  return null
+}
+
+async function resolveImportsForExtract(
+  projectPath: string,
+  ex: FileExtract,
+  tsPaths: TsPathMap
+): Promise<void> {
+  for (const [local, spec] of ex.importBindings) {
+    const resolved = await resolveSpecifierToFile(projectPath, ex.filePath, spec, tsPaths)
+    if (resolved) ex.resolvedImports.set(local, resolved)
+  }
+}
+
+// Graph build
 
 interface BuiltGraph {
   symbols: CodeSymbol[]
@@ -398,12 +714,81 @@ interface BuiltGraph {
   fileCount: number
 }
 
+function matchFileToMod(file: string, mod: string): boolean {
+  const norm = file.replace(/\\/g, '/')
+  const m = mod.replace(/\\/g, '/').replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/, '')
+  return (
+    norm === mod ||
+    norm.replace(/\.(ts|tsx|js|jsx|mjs|cjs)$/, '') === m ||
+    norm === `${m}.ts` ||
+    norm === `${m}.tsx` ||
+    norm === `${m}.js` ||
+    norm === `${m}.jsx` ||
+    norm === `${m}/index.ts` ||
+    norm === `${m}/index.tsx` ||
+    norm === `${m}/index.js`
+  )
+}
+
+/** Enclosing callable for a call line: nearest prior function/method/class. */
+function enclosingSymbol(fileSyms: CodeSymbol[], callLine: number): CodeSymbol | null {
+  const callables = fileSyms.filter(
+    (s) => s.kind === 'function' || s.kind === 'method' || s.kind === 'class'
+  )
+  let best: CodeSymbol | null = null
+  for (const s of callables) {
+    if (s.startLine <= callLine && (!best || s.startLine > best.startLine)) {
+      best = s
+    }
+  }
+  return best
+}
+
+function resolveCallTargets(
+  callName: string,
+  ex: FileExtract,
+  fileSyms: CodeSymbol[],
+  byName: Map<string, CodeSymbol[]>
+): { targets: CodeSymbol[]; confidence: number } {
+  // 1) same-file definition (not the call site itself)
+  const local = fileSyms.filter((s) => s.name === callName)
+  if (local.length === 1) return { targets: local, confidence: 0.95 }
+  if (local.length > 1) {
+    const exported = local.filter((s) => s.exported)
+    if (exported.length === 1) return { targets: exported, confidence: 0.9 }
+  }
+
+  // 2) import binding → resolved file
+  const resolvedFile = ex.resolvedImports.get(callName)
+  if (resolvedFile) {
+    const candidates = (byName.get(callName) ?? []).filter((s) =>
+      matchFileToMod(s.file, resolvedFile)
+    )
+    if (candidates.length > 0) return { targets: candidates, confidence: 0.9 }
+    // default import: use primary export of that file
+    const fileSymsOf = [...byName.values()]
+      .flat()
+      .filter((s) => matchFileToMod(s.file, resolvedFile) && s.exported)
+    const primary =
+      fileSymsOf.find((s) => s.kind === 'function' || s.kind === 'class') ?? fileSymsOf[0]
+    if (primary) return { targets: [primary], confidence: 0.65 }
+  }
+
+  // 3) unique project-wide name
+  const all = byName.get(callName) ?? []
+  if (all.length === 1) return { targets: all, confidence: 0.75 }
+  if (all.length > 1) {
+    const exported = all.filter((s) => s.exported)
+    if (exported.length === 1) return { targets: exported, confidence: 0.7 }
+  }
+
+  return { targets: [], confidence: 0 }
+}
+
 function buildFromExtracts(extracts: FileExtract[]): BuiltGraph {
   const symbols: CodeSymbol[] = []
   const edges: CodeSymbolEdge[] = []
-  // name → symbols (for call resolution)
   const byName = new Map<string, CodeSymbol[]>()
-  // file → symbols
   const byFile = new Map<string, CodeSymbol[]>()
 
   for (const ex of extracts) {
@@ -425,8 +810,6 @@ function buildFromExtracts(extracts: FileExtract[]): BuiltGraph {
       const list = byName.get(raw.name) ?? []
       list.push(sym)
       byName.set(raw.name, list)
-
-      // File DEFINES symbol
       edges.push({
         src: `file:${ex.filePath}`,
         dst: id,
@@ -437,65 +820,35 @@ function buildFromExtracts(extracts: FileExtract[]): BuiltGraph {
     byFile.set(ex.filePath, fileSyms)
   }
 
-  // Resolve CALLS. Source is the file synthetic node (stable, no false
-  // "function A calls B" when we only know the file invokes B). Trace still
-  // resolves file: → display via symbolsInFile / reverse expansion.
   for (const ex of extracts) {
     const fileSyms = byFile.get(ex.filePath) ?? []
-    const fileSrc = `file:${ex.filePath}`
+    const seenCall = new Set<string>() // src|dst per file to limit fan-out
 
-    for (const callName of ex.callNames) {
-      // 1) same-file definition
-      const local = fileSyms.filter((s) => s.name === callName)
-      let targets: CodeSymbol[] = local
+    for (const call of ex.calls) {
+      // Skip call that is the declaration line of a same-name symbol
+      if (fileSyms.some((s) => s.name === call.name && s.startLine === call.line)) continue
 
-      // 2) import binding → module path hint → match symbol in that file
-      if (targets.length === 0) {
-        const hint = ex.importBindings.get(callName)
-        if (hint) {
-          const mod = resolveModuleHint(ex.filePath, hint)
-          if (mod) {
-            const candidates = (byName.get(callName) ?? []).filter(
-              (s) =>
-                s.file.replace(/\.[^.]+$/, '') === mod ||
-                s.file.startsWith(`${mod}.`) ||
-                s.file.startsWith(`${mod}/`) ||
-                s.file === `${mod}.ts` ||
-                s.file === `${mod}.tsx` ||
-                s.file === `${mod}.js` ||
-                s.file === `${mod}/index.ts` ||
-                s.file === `${mod}/index.js`
-            )
-            if (candidates.length > 0) targets = candidates
-          }
-        }
-      }
-
-      // 3) unique project-wide name
-      if (targets.length === 0) {
-        const all = byName.get(callName) ?? []
-        if (all.length === 1) targets = all
-        else if (all.length > 1) {
-          const exported = all.filter((s) => s.exported)
-          if (exported.length === 1) targets = exported
-        }
-      }
-
+      const { targets, confidence } = resolveCallTargets(call.name, ex, fileSyms, byName)
       if (targets.length === 0) continue
+
+      const enc = enclosingSymbol(fileSyms, call.line)
+      const srcId = enc?.id ?? `file:${ex.filePath}`
+
       for (const t of targets) {
-        // Skip self-calls within same file's definition noise
-        if (t.file === ex.filePath && local.includes(t)) continue
+        if (t.id === srcId) continue
+        const key = `${srcId}|${t.id}`
+        if (seenCall.has(key)) continue
+        seenCall.add(key)
         edges.push({
-          src: fileSrc,
+          src: srcId,
           dst: t.id,
           edgeType: 'CALLS',
-          confidence: local.length > 0 ? 0.6 : 0.75,
+          confidence,
         })
       }
     }
   }
 
-  // Dedup edges
   const edgeKey = new Set<string>()
   const uniqEdges: CodeSymbolEdge[] = []
   for (const e of edges) {
@@ -516,22 +869,25 @@ async function extractProject(projectPath: string, onlyFiles?: string[]): Promis
   const files =
     onlyFiles ?? (await walkDir(projectPath)).filter((f) => isSourceFile(f) && !f.includes('.d.ts'))
   const sourceFiles = files.filter((f) => isSourceFile(f) && !f.endsWith('.d.ts'))
+  const tsPaths = await loadTsPathMap(projectPath)
 
-  return batchProcess(sourceFiles, 40, async (filePath) => {
+  const extracts = await batchProcess(sourceFiles, 40, async (filePath) => {
     try {
       const content = await fs.readFile(path.join(projectPath, filePath), 'utf-8')
-      // Cap very large files for extraction cost
       const sliced = content.length > 400_000 ? content.slice(0, 400_000) : content
       return extractFile(sliced, filePath)
     } catch {
-      return {
-        filePath,
-        symbols: [],
-        callNames: [],
-        importBindings: new Map(),
-      }
+      return emptyExtract(filePath)
     }
   })
+
+  // Resolve imports (bounded parallelism via batch)
+  await batchProcess(extracts, 40, async (ex) => {
+    await resolveImportsForExtract(projectPath, ex, tsPaths)
+    return ex
+  })
+
+  return extracts
 }
 
 function persistGraph(projectId: string, graph: BuiltGraph): void {
@@ -568,19 +924,17 @@ function patchGraph(
   extracts: FileExtract[],
   deletedFiles: string[]
 ): SymbolGraphMeta | null {
-  // Incremental: drop symbols/edges for touched files, re-insert from extracts.
-  // CALLS that target/src these symbols also get cleaned via id prefix.
   const touched = new Set([...extracts.map((e) => e.filePath), ...deletedFiles])
   if (touched.size === 0) return loadMeta(projectId)
 
-  // Load surviving symbols for call resolution (name index of whole project after patch)
   const existing = listAllSymbols(projectId).filter((s) => !touched.has(s.file))
+  // Merge extracts with a synthetic full extract set for call resolution:
+  // build only from changed extracts, then re-link CALLS using existing+new names.
   const rebuilt = buildFromExtracts(extracts)
 
   prjctDb.transaction(projectId, (db) => {
     const delSym = db.prepare('DELETE FROM code_symbols WHERE file = ?')
     for (const file of touched) {
-      // LIKE: file#… symbol ids and synthetic file: nodes
       db.prepare(
         `DELETE FROM code_symbol_edges WHERE src LIKE ? OR dst LIKE ? OR src = ? OR dst = ?`
       ).run(`${file}#%`, `${file}#%`, `file:${file}`, `file:${file}`)
@@ -598,35 +952,37 @@ function patchGraph(
     for (const s of rebuilt.symbols) {
       insSym.run(s.id, s.file, s.kind, s.name, s.qname, s.startLine, s.endLine, s.exported ? 1 : 0)
     }
-    // Re-resolve CALLS for changed files against full name index
+
     const byName = new Map<string, CodeSymbol[]>()
     for (const s of [...existing, ...rebuilt.symbols]) {
       const list = byName.get(s.name) ?? []
       list.push(s)
       byName.set(s.name, list)
     }
+    const byFile = new Map<string, CodeSymbol[]>()
+    for (const s of [...existing, ...rebuilt.symbols]) {
+      if (!byFile.has(s.file)) byFile.set(s.file, [])
+      byFile.get(s.file)!.push(s)
+    }
+
     for (const ex of extracts) {
-      const fileSyms = rebuilt.symbols.filter((s) => s.file === ex.filePath)
-      const defaultSrc =
-        fileSyms.find((s) => s.kind === 'function' || s.kind === 'class' || s.kind === 'method')
-          ?.id ?? fileSyms[0]?.id
-      for (const s of fileSyms) {
+      const fileSyms = byFile.get(ex.filePath) ?? []
+      for (const s of fileSyms.filter((x) => x.file === ex.filePath)) {
         insEdge.run(`file:${ex.filePath}`, s.id, 'DEFINES', 1)
       }
-      if (!defaultSrc) continue
-      for (const callName of ex.callNames) {
-        let targets = fileSyms.filter((s) => s.name === callName)
-        if (targets.length === 0) {
-          const all = byName.get(callName) ?? []
-          if (all.length === 1) targets = all
-          else {
-            const exported = all.filter((s) => s.exported)
-            if (exported.length === 1) targets = exported
-          }
-        }
+      const seen = new Set<string>()
+      for (const call of ex.calls) {
+        if (fileSyms.some((s) => s.name === call.name && s.startLine === call.line)) continue
+        const { targets, confidence } = resolveCallTargets(call.name, ex, fileSyms, byName)
+        if (targets.length === 0) continue
+        const enc = enclosingSymbol(fileSyms, call.line)
+        const srcId = enc?.id ?? `file:${ex.filePath}`
         for (const t of targets) {
-          if (t.id === defaultSrc) continue
-          insEdge.run(defaultSrc, t.id, 'CALLS', 0.7)
+          if (t.id === srcId) continue
+          const key = `${srcId}|${t.id}`
+          if (seen.has(key)) continue
+          seen.add(key)
+          insEdge.run(srcId, t.id, 'CALLS', confidence)
         }
       }
     }
@@ -906,7 +1262,8 @@ function symbolById(projectId: string, id: string): CodeSymbol | null {
 }
 
 /**
- * BFS call-path trace for a symbol name (first match preferred: exported).
+ * BFS call-path trace for a symbol name.
+ * Prefers symbol→symbol CALLS; still expands residual file: nodes.
  */
 export function tracePath(
   projectId: string,
@@ -937,7 +1294,6 @@ export function tracePath(
       for (const next of adj.get(id) ?? []) {
         if (visited.has(next)) continue
         visited.add(next)
-        // Synthetic file: callers — expand to primary exported symbols in that file
         if (next.startsWith('file:')) {
           const filePath = next.slice('file:'.length)
           const fileSyms = symbolsInFile(projectId, filePath)
@@ -950,7 +1306,6 @@ export function tracePath(
             out.push({ symbol: primary, depth: depth + 1, via: 'CALLS' })
             queue.push({ id: primary.id, depth: depth + 1 })
           }
-          // Also continue BFS from the file node for multi-hop file→symbol
           queue.push({ id: next, depth: depth + 1 })
           continue
         }
@@ -978,16 +1333,13 @@ export function fileFanIn(projectId: string, filePath: string): number {
   const syms = symbolsInFile(projectId, filePath)
   if (syms.length === 0) return 0
   const { reverse } = loadEdges(projectId, 'CALLS')
-  let count = 0
   const callers = new Set<string>()
   for (const s of syms) {
     for (const c of reverse.get(s.id) ?? []) {
-      // Count file: callers as one fan-in unit each
       callers.add(c)
     }
   }
-  count = callers.size
-  return count
+  return callers.size
 }
 
 /** Files that call into symbols defined in seed files (call-graph expand). */

--- a/core/hooks/pre-search.ts
+++ b/core/hooks/pre-search.ts
@@ -1,0 +1,123 @@
+/**
+ * PreToolUse hook (matcher: Grep|Glob) — non-blocking graph augment.
+ *
+ * CBM-inspired: when the agent greps/globs a token that matches indexed
+ * symbols, inject those hits as additionalContext so the agent gets
+ * structural context alongside search results. Never gates, never denies,
+ * never blocks Read (read-before-edit invariant).
+ *
+ * Fail-open: any error → null context → host proceeds normally.
+ */
+
+import { hasSymbolIndex, searchSymbols } from '../domain/symbol-graph'
+import configManager from '../infrastructure/config-manager'
+import { type HookIo, runHook } from './_runner'
+import { safeTruncate } from './_shared'
+
+const MAX_CHARS = 900
+const HARD_CAP_MS = 80
+const MAX_HITS = 8
+
+interface HookInput {
+  tool_name?: string
+  tool_input?: {
+    pattern?: string
+    path?: string
+    glob?: string
+    /** Claude Code Grep */
+    query?: string
+  }
+}
+
+function extractToken(input: HookInput): string | null {
+  const raw = input.tool_input?.pattern ?? input.tool_input?.query ?? input.tool_input?.glob ?? ''
+  if (!raw || typeof raw !== 'string') return null
+  // Pull the most symbol-like token (identifier, not pure regex noise)
+  const identifiers = raw.match(/[A-Za-z_][A-Za-z0-9_]{2,}/g)
+  if (!identifiers || identifiers.length === 0) return null
+  // Prefer longest camel/Pascal token
+  identifiers.sort((a, b) => b.length - a.length)
+  const skip = new Set([
+    'the',
+    'and',
+    'for',
+    'from',
+    'import',
+    'export',
+    'function',
+    'class',
+    'const',
+    'type',
+    'interface',
+    'return',
+    'async',
+    'await',
+    'true',
+    'false',
+    'null',
+    'undefined',
+    'test',
+    'describe',
+    'src',
+    'core',
+    'node',
+    'modules',
+  ])
+  for (const id of identifiers) {
+    if (!skip.has(id.toLowerCase())) return id
+  }
+  return identifiers[0] ?? null
+}
+
+async function buildSearchAugment(projectPath: string, input: HookInput): Promise<string | null> {
+  const started = Date.now()
+  try {
+    const tool = (input.tool_name ?? '').toLowerCase()
+    if (tool && !/grep|glob|search/i.test(tool)) return null
+
+    const token = extractToken(input)
+    if (!token) return null
+
+    const config = await configManager.readConfig(projectPath)
+    if (!config?.projectId) return null
+    if (!hasSymbolIndex(config.projectId)) return null
+    if (Date.now() - started > HARD_CAP_MS) return null
+
+    const hits = searchSymbols(config.projectId, token, { limit: MAX_HITS })
+    if (hits.length === 0) return null
+    if (Date.now() - started > HARD_CAP_MS) return null
+
+    const lines = [
+      `# prjct code graph (non-blocking)`,
+      ``,
+      `Grep/Glob token \`${token}\` matches indexed symbols — prefer these before more tree walks:`,
+      '',
+    ]
+    for (const h of hits) {
+      lines.push(
+        `- **${h.name}** (${h.kind}${h.exported ? ', exported' : ''}) — \`${h.file}:${h.startLine}\``
+      )
+    }
+    lines.push('')
+    lines.push(
+      `> Expand: \`prjct code trace ${token}\` or MCP \`prjct_trace_path\`. This inject never blocks the tool.`
+    )
+    return safeTruncate(lines.join('\n'), MAX_CHARS)
+  } catch {
+    return null
+  }
+}
+
+export async function runPreSearchHook(projectPath?: string, io?: HookIo): Promise<void> {
+  await runHook<HookInput>(
+    {
+      event: 'PreToolUse',
+      projectPath,
+      // Never deny — always fall through to build (or empty)
+      build: (input, p) => buildSearchAugment(p, input),
+    },
+    io
+  )
+}
+
+export const _internal = { extractToken, buildSearchAugment }

--- a/core/hooks/registry.ts
+++ b/core/hooks/registry.ts
@@ -49,6 +49,10 @@ const HOOK_LOADERS: Record<string, { load: HookLoader; exportName: string }> = {
     load: () => import('./pre-edit'),
     exportName: 'runPreEditHook',
   },
+  'pre-search': {
+    load: () => import('./pre-search'),
+    exportName: 'runPreSearchHook',
+  },
   'post-edit': {
     load: () => import('./post-edit'),
     exportName: 'runPostEditHook',

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -279,7 +279,22 @@ async function buildStalenessNotice(
     } catch {
       /* never block SessionStart */
     }
-    return `**Understanding may be stale:** ${warning} — run \`prjct sync\` before big calls.`
+    // Symbol graph age: if sync is stale OR index missing, nudge code reindex.
+    let symbolCue = ''
+    try {
+      const { hasSymbolIndex, loadMeta } = await import('../domain/symbol-graph')
+      if (!hasSymbolIndex(projectId)) {
+        symbolCue =
+          ' Code graph empty — `prjct code reindex` (or `prjct sync`) before trace/impact.'
+      } else if (status.commitsSinceSync >= 5) {
+        const meta = loadMeta(projectId)
+        const built = meta?.builtAt ? ` (index ${meta.builtAt.slice(0, 10)})` : ''
+        symbolCue = ` Symbol index may lag${built} — prefer \`prjct code reindex\` after big pulls.`
+      }
+    } catch {
+      /* optional */
+    }
+    return `**Understanding may be stale:** ${warning} — run \`prjct sync\` before big calls.${symbolCue}`
   } catch {
     return null
   }

--- a/core/mcp/tools/code-intel.ts
+++ b/core/mcp/tools/code-intel.ts
@@ -1,8 +1,8 @@
 /**
- * MCP Code Intelligence Tools (4 tools)
+ * MCP Code Intelligence Tools
  *
  * Exposes import graph, co-change analysis, change propagation,
- * and combined related-context via MCP.
+ * symbol search/trace, detect_changes, and combined related-context.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -14,6 +14,12 @@ import {
   loadMatrix,
 } from '../../domain/git-cochange'
 import { scoreFromSeeds as importScore, indexImports, loadGraph } from '../../domain/import-graph'
+import { hasSymbolIndex, loadMeta, searchSymbols, tracePath } from '../../domain/symbol-graph'
+import {
+  buildArchitectureSnapshot,
+  formatArchitectureMd,
+} from '../../services/architecture-snapshot'
+import { detectChanges, formatDetectChangesMd } from '../../services/detect-changes'
 import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
 
@@ -26,21 +32,40 @@ export function registerCodeIntelTools(server: McpServer) {
 
   s.tool(
     'prjct_impact_analysis',
-    'Given changed files, find affected files via import graph + affected domains',
+    'Blast radius + risk for changed files (or git working tree / committed range). Prefer over manual Grep for review scope.',
     {
       projectPath: optionalProjectPath,
       changedFiles: z
         .array(z.string())
-        .describe('List of changed file paths (relative to project root)'),
+        .optional()
+        .describe(
+          'Changed file paths relative to project root. Omit to auto-detect from git working tree / committed range.'
+        ),
     },
     safeMcpCall(
       'prjct_impact_analysis',
-      async (args: { projectPath: string; changedFiles: string[] }) => {
+      async (args: { projectPath: string; changedFiles?: string[] }) => {
         const projectId = await resolveProjectId(args.projectPath)
+        const projectPath = resolveProjectPath(args.projectPath)
 
+        // Prefer full detect_changes (risk + call-graph) when no explicit list,
+        // or when symbol index is available for richer analysis.
+        if (!args.changedFiles?.length || hasSymbolIndex(projectId)) {
+          const detected = await detectChanges(projectPath, projectId, {
+            files: args.changedFiles,
+            source: 'auto',
+          })
+          if (detected.changedFiles.length > 0 || !args.changedFiles?.length) {
+            return {
+              content: [{ type: 'text', text: formatDetectChangesMd(detected) }],
+            }
+          }
+        }
+
+        const changed = args.changedFiles ?? []
         const diff = {
           added: [] as string[],
-          modified: args.changedFiles,
+          modified: changed,
           deleted: [] as string[],
           unchanged: [] as string[],
         }
@@ -66,10 +91,139 @@ export function registerCodeIntelTools(server: McpServer) {
         parts.push(domains.size > 0 ? Array.from(domains).join(', ') : 'none detected')
 
         parts.push(`\nTotal affected: ${propagated.allAffected.length} files`)
+        parts.push(
+          '\n_Tip: run `prjct code reindex` for symbol-level risk + call-graph blast radius._'
+        )
 
         return { content: [{ type: 'text', text: parts.join('\n') }] }
       }
     )
+  )
+
+  s.tool(
+    'prjct_search_symbols',
+    'Search the structural symbol graph (functions, classes, routes). Run prjct sync first.',
+    {
+      projectPath: optionalProjectPath,
+      pattern: z.string().describe('Symbol name substring (case-insensitive)'),
+      limit: z.number().optional().default(30).describe('Max results'),
+    },
+    safeMcpCall(
+      'prjct_search_symbols',
+      async (args: { projectPath: string; pattern: string; limit: number }) => {
+        const projectId = await resolveProjectId(args.projectPath)
+        if (!hasSymbolIndex(projectId)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No symbol index. Run `prjct sync` or `prjct code reindex`.',
+              },
+            ],
+          }
+        }
+        const hits = searchSymbols(projectId, args.pattern, { limit: args.limit })
+        if (hits.length === 0) {
+          return { content: [{ type: 'text', text: `No symbols matching "${args.pattern}".` }] }
+        }
+        const lines = [
+          `## Symbols: ${args.pattern}`,
+          `Index: ${loadMeta(projectId)?.symbolCount ?? '?'} symbols`,
+          '',
+          ...hits.map(
+            (s) =>
+              `- **${s.name}** (${s.kind}${s.exported ? ', exported' : ''}) — \`${s.file}:${s.startLine}\``
+          ),
+        ]
+        return { content: [{ type: 'text', text: lines.join('\n') }] }
+      }
+    )
+  )
+
+  s.tool(
+    'prjct_trace_path',
+    'BFS call-path trace: who calls a function and what it calls. Prefer over Grep for "who uses X?".',
+    {
+      projectPath: optionalProjectPath,
+      functionName: z.string().describe('Function/class/method name to trace'),
+      direction: z
+        .enum(['inbound', 'outbound', 'both'])
+        .optional()
+        .default('both')
+        .describe('inbound = callers, outbound = callees'),
+      depth: z.number().optional().default(3).describe('BFS depth 1-5'),
+    },
+    safeMcpCall(
+      'prjct_trace_path',
+      async (args: {
+        projectPath: string
+        functionName: string
+        direction: 'inbound' | 'outbound' | 'both'
+        depth: number
+      }) => {
+        const projectId = await resolveProjectId(args.projectPath)
+        if (!hasSymbolIndex(projectId)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No symbol index. Run `prjct sync` or `prjct code reindex`.',
+              },
+            ],
+          }
+        }
+        const result = tracePath(projectId, args.functionName, {
+          direction: args.direction,
+          depth: args.depth,
+        })
+        if (!result) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No symbol "${args.functionName}". Try prjct_search_symbols first.`,
+              },
+            ],
+          }
+        }
+        const lines = [
+          `## Trace: ${args.functionName}`,
+          '',
+          '### Roots',
+          ...result.root.map((r) => `- ${r.kind} **${r.name}** \`${r.file}:${r.startLine}\``),
+          '',
+          `### Inbound (${result.inbound.length})`,
+          ...(result.inbound.length
+            ? result.inbound.map(
+                (h) =>
+                  `- d${h.depth} ${h.symbol.name} (${h.symbol.kind}) \`${h.symbol.file}:${h.symbol.startLine}\``
+              )
+            : ['_none_']),
+          '',
+          `### Outbound (${result.outbound.length})`,
+          ...(result.outbound.length
+            ? result.outbound.map(
+                (h) =>
+                  `- d${h.depth} ${h.symbol.name} (${h.symbol.kind}) \`${h.symbol.file}:${h.symbol.startLine}\``
+              )
+            : ['_none_']),
+        ]
+        return { content: [{ type: 'text', text: lines.join('\n') }] }
+      }
+    )
+  )
+
+  s.tool(
+    'prjct_architecture',
+    'Structural architecture overview: languages, symbol kinds, packages, hotspots (call fan-in), routes, entry candidates. One shot — prefer over tree walks.',
+    {
+      projectPath: optionalProjectPath,
+    },
+    safeMcpCall('prjct_architecture', async (args: { projectPath: string }) => {
+      const projectId = await resolveProjectId(args.projectPath)
+      const snap = buildArchitectureSnapshot(projectId)
+      return { content: [{ type: 'text', text: formatArchitectureMd(snap) }] }
+    })
   )
 
   s.tool(

--- a/core/mcp/tools/code-intel.ts
+++ b/core/mcp/tools/code-intel.ts
@@ -19,6 +19,7 @@ import {
   buildArchitectureSnapshot,
   formatArchitectureMd,
 } from '../../services/architecture-snapshot'
+import { findDeadCode, formatDeadCodeMd } from '../../services/dead-code'
 import { detectChanges, formatDetectChangesMd } from '../../services/detect-changes'
 import { optionalProjectPath, resolveProjectId, resolveProjectPath } from '../resolve'
 import { safeMcpCall } from './error-handler'
@@ -223,6 +224,20 @@ export function registerCodeIntelTools(server: McpServer) {
       const projectId = await resolveProjectId(args.projectPath)
       const snap = buildArchitectureSnapshot(projectId)
       return { content: [{ type: 'text', text: formatArchitectureMd(snap) }] }
+    })
+  )
+
+  s.tool(
+    'prjct_dead_code',
+    'Find functions/methods/classes with zero inbound CALLS (excludes entry points, tests, types). Best-effort graph.',
+    {
+      projectPath: optionalProjectPath,
+      limit: z.number().optional().default(50).describe('Max candidates'),
+    },
+    safeMcpCall('prjct_dead_code', async (args: { projectPath: string; limit: number }) => {
+      const projectId = await resolveProjectId(args.projectPath)
+      const result = findDeadCode(projectId, { limit: args.limit })
+      return { content: [{ type: 'text', text: formatDeadCodeMd(result) }] }
     })
   )
 

--- a/core/mcp/tools/files.ts
+++ b/core/mcp/tools/files.ts
@@ -21,7 +21,7 @@ export function registerFileTools(server: McpServer) {
 
   s.tool(
     'prjct_relevant_files',
-    'MUST call before Grep/Glob tree walks. Resolves a constrained work scope via prjct: memory (FTS + semantic embeddings when enabled) + code BM25 index + import graph + co-change. Prefer this over scanning the repo.',
+    'MUST call before Grep/Glob tree walks. Resolves a constrained work scope via prjct: memory (FTS + semantic embeddings when enabled) + code BM25 + symbol graph + import graph + co-change. Prefer this over scanning the repo. For call chains use prjct_trace_path.',
     {
       projectPath: optionalProjectPath,
       query: z.string().describe('Task or query to find relevant files for'),

--- a/core/services/architecture-snapshot.ts
+++ b/core/services/architecture-snapshot.ts
@@ -1,0 +1,197 @@
+/**
+ * Structural architecture overview — one-shot for agents (CBM get_architecture-inspired).
+ * Pure reads over symbol graph + import graph + file inventory. No LLM.
+ */
+
+import { loadGraph } from '../domain/import-graph'
+import {
+  fileFanIn,
+  hasSymbolIndex,
+  listAllSymbols,
+  loadMeta,
+  searchSymbols,
+} from '../domain/symbol-graph'
+import { loadFileInventory } from './project-file-inventory'
+
+export interface ArchitectureSnapshot {
+  ready: boolean
+  builtAt: string | null
+  symbols: number
+  edges: number
+  files: number
+  languages: Array<{ ext: string; count: number }>
+  kinds: Array<{ kind: string; count: number }>
+  routes: Array<{ name: string; file: string; line: number }>
+  hotspots: Array<{ file: string; fanIn: number; symbolCount: number }>
+  entryCandidates: Array<{ name: string; file: string; kind: string }>
+  packages: string[]
+  note: string
+}
+
+const ENTRY_NAME = /^(main|index|app|server|cli|handler|router|bootstrap|init|start|run|default)$/i
+
+export function buildArchitectureSnapshot(projectId: string): ArchitectureSnapshot {
+  const meta = loadMeta(projectId)
+  const ready = hasSymbolIndex(projectId)
+  if (!ready) {
+    return {
+      ready: false,
+      builtAt: meta?.builtAt ?? null,
+      symbols: 0,
+      edges: 0,
+      files: 0,
+      languages: [],
+      kinds: [],
+      routes: [],
+      hotspots: [],
+      entryCandidates: [],
+      packages: [],
+      note: 'No symbol index. Run `prjct sync` or `prjct code reindex`.',
+    }
+  }
+
+  const symbols = listAllSymbols(projectId)
+  const kindMap = new Map<string, number>()
+  const fileMap = new Map<string, number>()
+  const langMap = new Map<string, number>()
+  const routes: ArchitectureSnapshot['routes'] = []
+  const entryCandidates: ArchitectureSnapshot['entryCandidates'] = []
+
+  for (const s of symbols) {
+    kindMap.set(s.kind, (kindMap.get(s.kind) ?? 0) + 1)
+    fileMap.set(s.file, (fileMap.get(s.file) ?? 0) + 1)
+    const ext = s.file.includes('.') ? s.file.slice(s.file.lastIndexOf('.')) : '(none)'
+    langMap.set(ext, (langMap.get(ext) ?? 0) + 1)
+    if (s.kind === 'route') {
+      routes.push({ name: s.name, file: s.file, line: s.startLine })
+    }
+    if (
+      s.exported &&
+      ENTRY_NAME.test(s.name) &&
+      (s.kind === 'function' || s.kind === 'class') &&
+      !/__tests__|\.test\.|\.spec\.|fixtures?\//i.test(s.file)
+    ) {
+      entryCandidates.push({ name: s.name, file: s.file, kind: s.kind })
+    }
+  }
+
+  // Hotspots: top files by call fan-in (cap work)
+  const files = [...fileMap.keys()]
+  const hotspotScores: ArchitectureSnapshot['hotspots'] = []
+  // Sample up to 400 files for fan-in cost
+  const sample = files.length > 400 ? files.slice(0, 400) : files
+  for (const f of sample) {
+    const fanIn = fileFanIn(projectId, f)
+    if (fanIn > 0) {
+      hotspotScores.push({ file: f, fanIn, symbolCount: fileMap.get(f) ?? 0 })
+    }
+  }
+  hotspotScores.sort((a, b) => b.fanIn - a.fanIn)
+
+  // Package roots from import graph / inventory top-level dirs
+  const packages = new Set<string>()
+  const inv = loadFileInventory(projectId)
+  if (inv?.extensions) {
+    /* inventory may not have paths */
+  }
+  const graph = loadGraph(projectId)
+  if (graph) {
+    for (const f of Object.keys(graph.forward).slice(0, 2000)) {
+      const top = f.includes('/') ? f.slice(0, f.indexOf('/')) : f
+      if (top && !top.startsWith('.')) packages.add(top)
+    }
+  }
+  for (const f of files.slice(0, 500)) {
+    const top = f.includes('/') ? f.slice(0, f.indexOf('/')) : '.'
+    if (top && top !== '.') packages.add(top)
+  }
+
+  // Also surface high-export classes as entry-ish
+  if (entryCandidates.length < 8) {
+    for (const s of symbols) {
+      if (entryCandidates.length >= 12) break
+      if (s.exported && s.kind === 'class' && !entryCandidates.some((e) => e.file === s.file)) {
+        entryCandidates.push({ name: s.name, file: s.file, kind: s.kind })
+      }
+    }
+  }
+
+  void searchSymbols // keep import stable for future filters
+
+  return {
+    ready: true,
+    builtAt: meta?.builtAt ?? null,
+    symbols: meta?.symbolCount ?? symbols.length,
+    edges: meta?.edgeCount ?? 0,
+    files: meta?.fileCount ?? fileMap.size,
+    languages: [...langMap.entries()]
+      .map(([ext, count]) => ({ ext, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 12),
+    kinds: [...kindMap.entries()]
+      .map(([kind, count]) => ({ kind, count }))
+      .sort((a, b) => b.count - a.count),
+    routes: routes.slice(0, 30),
+    hotspots: hotspotScores.slice(0, 15),
+    entryCandidates: entryCandidates.slice(0, 15),
+    packages: [...packages].sort().slice(0, 40),
+    note: 'Structural only (symbol + import graphs). Narrative architecture lives in prjct analysis / memory decisions.',
+  }
+}
+
+export function formatArchitectureMd(snap: ArchitectureSnapshot): string {
+  if (!snap.ready) {
+    return `## Architecture\n\n> ${snap.note}\n`
+  }
+  const lines = [
+    '## Architecture (structural)',
+    '',
+    `- **Symbols**: ${snap.symbols} · **Edges**: ${snap.edges} · **Files**: ${snap.files}`,
+    snap.builtAt ? `- **Index built**: ${snap.builtAt}` : '',
+    '',
+    '### Languages (by symbol files)',
+    ...snap.languages.map((l) => `- \`${l.ext}\`: ${l.count}`),
+    '',
+    '### Symbol kinds',
+    ...snap.kinds.map((k) => `- **${k.kind}**: ${k.count}`),
+    '',
+    '### Top-level packages / dirs',
+    snap.packages.length ? snap.packages.map((p) => `\`${p}\``).join(', ') : '_none detected_',
+    '',
+    '### Hotspots (call fan-in)',
+    ...(snap.hotspots.length
+      ? snap.hotspots.map(
+          (h) => `- \`${h.file}\` — fan-in **${h.fanIn}** · ${h.symbolCount} symbol(s)`
+        )
+      : ['_no call edges yet_']),
+    '',
+    '### Entry candidates',
+    ...(snap.entryCandidates.length
+      ? snap.entryCandidates.map((e) => `- **${e.name}** (${e.kind}) — \`${e.file}\``)
+      : ['_none_']),
+    '',
+    '### Routes',
+    ...(snap.routes.length
+      ? snap.routes.map((r) => `- \`${r.name}\` — \`${r.file}:${r.line}\``)
+      : ['_no HTTP route nodes detected_']),
+    '',
+    `_${snap.note}_`,
+  ]
+  return lines.filter((l) => l !== '').join('\n')
+}
+
+export function formatArchitectureText(snap: ArchitectureSnapshot): string {
+  if (!snap.ready) return `architecture: ${snap.note}`
+  return [
+    `Architecture: ${snap.symbols} symbols · ${snap.edges} edges · ${snap.files} files`,
+    `Kinds: ${snap.kinds.map((k) => `${k.kind}=${k.count}`).join(' ')}`,
+    `Hotspots: ${
+      snap.hotspots
+        .slice(0, 5)
+        .map((h) => `${h.file}(${h.fanIn})`)
+        .join(', ') || '—'
+    }`,
+    `Packages: ${snap.packages.slice(0, 12).join(', ')}`,
+    'Detail: prjct code architecture --md',
+  ].join('\n')
+}

--- a/core/services/cbm-bridge.ts
+++ b/core/services/cbm-bridge.ts
@@ -125,3 +125,118 @@ export async function cbmCli(
     }
   }
 }
+
+/**
+ * Resolve CBM project name for a repo path (list_projects → match by path).
+ * Returns null if CBM missing or project not indexed.
+ */
+export async function cbmProjectName(projectPath: string): Promise<string | null> {
+  const abs = path.resolve(projectPath)
+  const listed = await cbmCli('list_projects', {})
+  if (!listed.ok || !listed.stdout) return null
+  try {
+    const data = JSON.parse(listed.stdout) as unknown
+    const projects = extractProjectsList(data)
+    for (const p of projects) {
+      const pPath = typeof p.path === 'string' ? path.resolve(p.path) : ''
+      const pName =
+        typeof p.name === 'string' ? p.name : typeof p.project === 'string' ? p.project : null
+      if (pName && pPath && (pPath === abs || abs.startsWith(pPath + path.sep))) return pName
+      if (pName && typeof p.repo_path === 'string' && path.resolve(p.repo_path) === abs)
+        return pName
+    }
+    // Single-project install: use the only name
+    if (projects.length === 1) {
+      const only = projects[0]!
+      return (
+        (typeof only.name === 'string' && only.name) ||
+        (typeof only.project === 'string' && only.project) ||
+        null
+      )
+    }
+  } catch {
+    /* non-JSON — ignore */
+  }
+  return null
+}
+
+function extractProjectsList(data: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(data)) return data as Array<Record<string, unknown>>
+  if (data && typeof data === 'object') {
+    const o = data as Record<string, unknown>
+    if (Array.isArray(o.projects)) return o.projects as Array<Record<string, unknown>>
+    if (Array.isArray(o.results)) return o.results as Array<Record<string, unknown>>
+  }
+  return []
+}
+
+export type CbmFallbackKind = 'trace' | 'architecture' | 'search'
+
+/**
+ * Best-effort polyglot fallback when native graph is empty/weak.
+ * Never throws; returns null if CBM unavailable or call fails.
+ */
+export async function cbmFallback(
+  kind: CbmFallbackKind,
+  projectPath: string,
+  opts: { name?: string; pattern?: string } = {}
+): Promise<{ text: string; source: 'cbm' } | null> {
+  const status = await detectCbm()
+  if (!status.available) return null
+
+  const project = await cbmProjectName(projectPath)
+  // If unknown, still try tools that accept repo_path / omit project
+  const base: Record<string, unknown> = project ? { project } : {}
+
+  let tool: string
+  let args: Record<string, unknown>
+  if (kind === 'trace') {
+    if (!opts.name) return null
+    tool = 'trace_path'
+    args = {
+      ...base,
+      function_name: opts.name,
+      direction: 'both',
+    }
+  } else if (kind === 'architecture') {
+    tool = 'get_architecture'
+    args = { ...base }
+  } else {
+    tool = 'search_graph'
+    args = {
+      ...base,
+      name_pattern: opts.pattern ? `.*${escapeRegex(opts.pattern)}.*` : '.*',
+      limit: 30,
+    }
+  }
+
+  const r = await cbmCli(tool, args, { timeoutMs: 20_000 })
+  if (!r.ok) return null
+  const body = r.stdout || r.stderr
+  if (!body || body.length < 2) return null
+  const header =
+    kind === 'trace'
+      ? `## Trace (CBM fallback): \`${opts.name}\``
+      : kind === 'architecture'
+        ? '## Architecture (CBM fallback)'
+        : `## Symbols (CBM fallback)${opts.pattern ? `: \`${opts.pattern}\`` : ''}`
+  return {
+    source: 'cbm',
+    text: [
+      header,
+      '',
+      '_Native prjct graph had no/weak hit — results from codebase-memory-mcp (Hybrid LSP / polyglot)._',
+      '',
+      '```',
+      body.slice(0, 12_000),
+      body.length > 12_000 ? '…(truncated)…' : '',
+      '```',
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/core/services/cbm-bridge.ts
+++ b/core/services/cbm-bridge.ts
@@ -81,3 +81,47 @@ export async function detectCbmNear(projectPath: string): Promise<string | null>
     return null
   }
 }
+
+export interface CbmCliResult {
+  ok: boolean
+  stdout: string
+  stderr: string
+  error?: string
+}
+
+/**
+ * Optional execute bridge: run a CBM CLI tool if installed.
+ * Never a hard dependency — fails soft when missing.
+ *
+ * Example: cbmCli('search_graph', { project: 'x', name_pattern: '.*Handler.*' })
+ */
+export async function cbmCli(
+  tool: string,
+  args: Record<string, unknown>,
+  opts: { timeoutMs?: number } = {}
+): Promise<CbmCliResult> {
+  const bin = await which('codebase-memory-mcp')
+  if (!bin) {
+    return {
+      ok: false,
+      stdout: '',
+      stderr: '',
+      error: 'codebase-memory-mcp not on PATH',
+    }
+  }
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, ['cli', tool, JSON.stringify(args)], {
+      timeout: opts.timeoutMs ?? 30_000,
+      maxBuffer: 4 * 1024 * 1024,
+    })
+    return { ok: true, stdout: stdout.trim(), stderr: stderr.trim() }
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; message?: string }
+    return {
+      ok: false,
+      stdout: (err.stdout ?? '').toString(),
+      stderr: (err.stderr ?? '').toString(),
+      error: err.message ?? String(e),
+    }
+  }
+}

--- a/core/services/cbm-bridge.ts
+++ b/core/services/cbm-bridge.ts
@@ -1,0 +1,83 @@
+/**
+ * Optional codebase-memory-mcp (CBM) bridge.
+ *
+ * prjct owns harness + authored memory + native symbol graph. When the
+ * CBM binary is on PATH, we surface it as a polyglot upgrade path without
+ * making it a hard dependency.
+ */
+
+import { execFile } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export interface CbmStatus {
+  available: boolean
+  path: string | null
+  version: string | null
+  note: string
+}
+
+async function which(cmd: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      process.platform === 'win32' ? 'where' : 'which',
+      [cmd],
+      { timeout: 2000 }
+    )
+    const first = stdout.trim().split(/\r?\n/)[0]
+    return first || null
+  } catch {
+    return null
+  }
+}
+
+export async function detectCbm(): Promise<CbmStatus> {
+  const bin = await which('codebase-memory-mcp')
+  if (!bin) {
+    return {
+      available: false,
+      path: null,
+      version: null,
+      note: 'CBM not on PATH. Native prjct symbol graph is active. Install: https://github.com/DeusData/codebase-memory-mcp',
+    }
+  }
+  let version: string | null = null
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, ['--version'], { timeout: 3000 })
+    version = (stdout || stderr).trim().split(/\r?\n/)[0] || null
+  } catch {
+    try {
+      const { stdout, stderr } = await execFileAsync(bin, ['version'], { timeout: 3000 })
+      version = (stdout || stderr).trim().split(/\r?\n/)[0] || null
+    } catch {
+      version = 'unknown'
+    }
+  }
+  return {
+    available: true,
+    path: bin,
+    version,
+    note: 'CBM available. prjct native graph remains default; use CBM for polyglot Hybrid-LSP depth when needed.',
+  }
+}
+
+export function formatCbmStatus(s: CbmStatus): string {
+  if (!s.available) return `CBM: not installed — ${s.note}`
+  return `CBM: ${s.path}${s.version ? ` (${s.version})` : ''} — ${s.note}`
+}
+
+/** Soft path check for a project-local binary too. */
+export async function detectCbmNear(projectPath: string): Promise<string | null> {
+  const global = await which('codebase-memory-mcp')
+  if (global) return global
+  const local = path.join(projectPath, 'node_modules', '.bin', 'codebase-memory-mcp')
+  try {
+    await access(local)
+    return local
+  } catch {
+    return null
+  }
+}

--- a/core/services/code-graph-artifact.ts
+++ b/core/services/code-graph-artifact.ts
@@ -1,37 +1,39 @@
 /**
- * Team-shared code graph artifact (CBM graph.db.zst-inspired).
+ * Per-project code-graph cache artifact.
  *
- * Exports a gzipped JSON snapshot of symbols + CALLS/DEFINES edges next to
- * the repo so teammates can bootstrap without a full reindex.
+ * Lives ONLY under prjct project storage — never in the client repo:
+ *   ~/.prjct-cli/projects/<projectId>/code-graph.json.gz
  *
- * Path: `.prjct/code-graph.json.gz`
- * Optional: `.gitattributes` merge=ours line for the artifact.
+ * One file per projectId (same isolation as prjct.db). Not global, not
+ * committed with the customer's source tree. Optional gzip snapshot of
+ * symbols + edges for local bootstrap if the SQLite symbol tables are empty.
  */
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { gunzipSync, gzipSync } from 'node:zlib'
 import { hasSymbolIndex, indexSymbols, listAllSymbols, loadMeta } from '../domain/symbol-graph'
+import pathManager from '../infrastructure/path-manager'
 import prjctDb from '../storage/database'
 import type { CodeSymbol, CodeSymbolEdge, SymbolGraphMeta } from '../types/domain.js'
 
-const ARTIFACT_REL = path.join('.prjct', 'code-graph.json.gz')
-const GITATTRIBUTES_LINE = '.prjct/code-graph.json.gz merge=ours'
+const ARTIFACT_NAME = 'code-graph.json.gz'
 
 interface ArtifactPayload {
   version: 1
+  projectId: string
   exportedAt: string
   meta: SymbolGraphMeta
   symbols: CodeSymbol[]
   edges: CodeSymbolEdge[]
 }
 
-export function artifactPath(projectPath: string): string {
-  return path.join(projectPath, ARTIFACT_REL)
+/** Absolute path under ~/.prjct-cli/projects/<id>/ — never under client cwd. */
+export function artifactPath(projectId: string): string {
+  return path.join(pathManager.getGlobalProjectPath(projectId), ARTIFACT_NAME)
 }
 
 export async function exportCodeGraphArtifact(
-  projectPath: string,
   projectId: string
 ): Promise<{ path: string; bytes: number; symbols: number; edges: number } | null> {
   if (!hasSymbolIndex(projectId)) return null
@@ -62,6 +64,7 @@ export async function exportCodeGraphArtifact(
   }
   const payload: ArtifactPayload = {
     version: 1,
+    projectId,
     exportedAt: new Date().toISOString(),
     meta,
     symbols,
@@ -69,23 +72,26 @@ export async function exportCodeGraphArtifact(
   }
   const raw = Buffer.from(JSON.stringify(payload), 'utf-8')
   const gz = gzipSync(raw, { level: 6 })
-  const out = artifactPath(projectPath)
+  const out = artifactPath(projectId)
   await fs.mkdir(path.dirname(out), { recursive: true })
   await fs.writeFile(out, gz)
-  await ensureGitattributes(projectPath)
-  return { path: ARTIFACT_REL, bytes: gz.length, symbols: symbols.length, edges: edges.length }
+  return {
+    path: out,
+    bytes: gz.length,
+    symbols: symbols.length,
+    edges: edges.length,
+  }
 }
 
 export async function importCodeGraphArtifact(
-  projectPath: string,
   projectId: string
 ): Promise<{ imported: boolean; symbols: number; edges: number; reason?: string }> {
-  const file = artifactPath(projectPath)
+  const file = artifactPath(projectId)
   let buf: Buffer
   try {
     buf = await fs.readFile(file)
   } catch {
-    return { imported: false, symbols: 0, edges: 0, reason: 'no artifact' }
+    return { imported: false, symbols: 0, edges: 0, reason: 'no per-project artifact' }
   }
   let payload: ArtifactPayload
   try {
@@ -101,6 +107,15 @@ export async function importCodeGraphArtifact(
   }
   if (payload.version !== 1 || !Array.isArray(payload.symbols)) {
     return { imported: false, symbols: 0, edges: 0, reason: 'unsupported artifact version' }
+  }
+  // Refuse cross-project restore (artifact stamped with projectId)
+  if (payload.projectId && payload.projectId !== projectId) {
+    return {
+      imported: false,
+      symbols: 0,
+      edges: 0,
+      reason: `artifact projectId mismatch (got ${payload.projectId}, expected ${projectId})`,
+    }
   }
 
   prjctDb.transaction(projectId, (db) => {
@@ -133,51 +148,29 @@ export async function importCodeGraphArtifact(
 }
 
 /**
- * Bootstrap: if local index empty but artifact present, import then optional
- * incremental reindex of dirty tree is left to sync.
+ * Bootstrap: if SQLite symbol tables empty but this project's cache file
+ * exists under ~/.prjct-cli/projects/<id>/, restore into SQLite.
  */
 export async function bootstrapCodeGraphFromArtifact(
-  projectPath: string,
   projectId: string
 ): Promise<{ bootstrapped: boolean; detail: string }> {
   if (hasSymbolIndex(projectId)) {
     return { bootstrapped: false, detail: 'local index already present' }
   }
-  const result = await importCodeGraphArtifact(projectPath, projectId)
+  const result = await importCodeGraphArtifact(projectId)
   if (!result.imported) {
     return { bootstrapped: false, detail: result.reason ?? 'import failed' }
   }
   return {
     bootstrapped: true,
-    detail: `imported ${result.symbols} symbols / ${result.edges} edges from ${ARTIFACT_REL}`,
+    detail: `imported ${result.symbols} symbols / ${result.edges} edges from per-project cache`,
   }
 }
 
-async function ensureGitattributes(projectPath: string): Promise<void> {
-  const ga = path.join(projectPath, '.gitattributes')
+/** After a successful full index, refresh the per-project cache (non-fatal). */
+export async function maybeExportAfterIndex(projectId: string): Promise<void> {
   try {
-    let existing = ''
-    try {
-      existing = await fs.readFile(ga, 'utf-8')
-    } catch {
-      existing = ''
-    }
-    if (existing.includes('code-graph.json.gz')) return
-    const next = existing
-      ? existing.endsWith('\n')
-        ? `${existing}${GITATTRIBUTES_LINE}\n`
-        : `${existing}\n${GITATTRIBUTES_LINE}\n`
-      : `${GITATTRIBUTES_LINE}\n`
-    await fs.writeFile(ga, next)
-  } catch {
-    /* best-effort */
-  }
-}
-
-/** After a successful full index, refresh the team artifact (non-fatal). */
-export async function maybeExportAfterIndex(projectPath: string, projectId: string): Promise<void> {
-  try {
-    await exportCodeGraphArtifact(projectPath, projectId)
+    await exportCodeGraphArtifact(projectId)
   } catch {
     /* non-critical */
   }
@@ -188,8 +181,7 @@ export async function ensureIndexWithBootstrap(
   projectId: string
 ): Promise<SymbolGraphMeta | null> {
   if (hasSymbolIndex(projectId)) return loadMeta(projectId)
-  const boot = await bootstrapCodeGraphFromArtifact(projectPath, projectId)
+  const boot = await bootstrapCodeGraphFromArtifact(projectId)
   if (boot.bootstrapped) return loadMeta(projectId)
-  // No artifact — full index
   return indexSymbols(projectPath, projectId)
 }

--- a/core/services/code-graph-artifact.ts
+++ b/core/services/code-graph-artifact.ts
@@ -1,0 +1,195 @@
+/**
+ * Team-shared code graph artifact (CBM graph.db.zst-inspired).
+ *
+ * Exports a gzipped JSON snapshot of symbols + CALLS/DEFINES edges next to
+ * the repo so teammates can bootstrap without a full reindex.
+ *
+ * Path: `.prjct/code-graph.json.gz`
+ * Optional: `.gitattributes` merge=ours line for the artifact.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { gunzipSync, gzipSync } from 'node:zlib'
+import { hasSymbolIndex, indexSymbols, listAllSymbols, loadMeta } from '../domain/symbol-graph'
+import prjctDb from '../storage/database'
+import type { CodeSymbol, CodeSymbolEdge, SymbolGraphMeta } from '../types/domain.js'
+
+const ARTIFACT_REL = path.join('.prjct', 'code-graph.json.gz')
+const GITATTRIBUTES_LINE = '.prjct/code-graph.json.gz merge=ours'
+
+interface ArtifactPayload {
+  version: 1
+  exportedAt: string
+  meta: SymbolGraphMeta
+  symbols: CodeSymbol[]
+  edges: CodeSymbolEdge[]
+}
+
+export function artifactPath(projectPath: string): string {
+  return path.join(projectPath, ARTIFACT_REL)
+}
+
+export async function exportCodeGraphArtifact(
+  projectPath: string,
+  projectId: string
+): Promise<{ path: string; bytes: number; symbols: number; edges: number } | null> {
+  if (!hasSymbolIndex(projectId)) return null
+  const symbols = listAllSymbols(projectId)
+  let edges: CodeSymbolEdge[] = []
+  try {
+    edges = prjctDb
+      .query<{
+        src: string
+        dst: string
+        edge_type: string
+        confidence: number
+      }>(projectId, 'SELECT src, dst, edge_type, confidence FROM code_symbol_edges')
+      .map((r) => ({
+        src: r.src,
+        dst: r.dst,
+        edgeType: r.edge_type as CodeSymbolEdge['edgeType'],
+        confidence: r.confidence,
+      }))
+  } catch {
+    edges = []
+  }
+  const meta = loadMeta(projectId) ?? {
+    symbolCount: symbols.length,
+    edgeCount: edges.length,
+    fileCount: new Set(symbols.map((s) => s.file)).size,
+    builtAt: new Date().toISOString(),
+  }
+  const payload: ArtifactPayload = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    meta,
+    symbols,
+    edges,
+  }
+  const raw = Buffer.from(JSON.stringify(payload), 'utf-8')
+  const gz = gzipSync(raw, { level: 6 })
+  const out = artifactPath(projectPath)
+  await fs.mkdir(path.dirname(out), { recursive: true })
+  await fs.writeFile(out, gz)
+  await ensureGitattributes(projectPath)
+  return { path: ARTIFACT_REL, bytes: gz.length, symbols: symbols.length, edges: edges.length }
+}
+
+export async function importCodeGraphArtifact(
+  projectPath: string,
+  projectId: string
+): Promise<{ imported: boolean; symbols: number; edges: number; reason?: string }> {
+  const file = artifactPath(projectPath)
+  let buf: Buffer
+  try {
+    buf = await fs.readFile(file)
+  } catch {
+    return { imported: false, symbols: 0, edges: 0, reason: 'no artifact' }
+  }
+  let payload: ArtifactPayload
+  try {
+    const json = gunzipSync(buf).toString('utf-8')
+    payload = JSON.parse(json) as ArtifactPayload
+  } catch (e) {
+    return {
+      imported: false,
+      symbols: 0,
+      edges: 0,
+      reason: `corrupt artifact: ${e instanceof Error ? e.message : String(e)}`,
+    }
+  }
+  if (payload.version !== 1 || !Array.isArray(payload.symbols)) {
+    return { imported: false, symbols: 0, edges: 0, reason: 'unsupported artifact version' }
+  }
+
+  prjctDb.transaction(projectId, (db) => {
+    db.prepare('DELETE FROM code_symbols').run()
+    db.prepare('DELETE FROM code_symbol_edges').run()
+    const insSym = db.prepare(
+      `INSERT INTO code_symbols (id, file, kind, name, qname, start_line, end_line, exported)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    const insEdge = db.prepare(
+      `INSERT OR IGNORE INTO code_symbol_edges (src, dst, edge_type, confidence)
+       VALUES (?, ?, ?, ?)`
+    )
+    for (const s of payload.symbols) {
+      insSym.run(s.id, s.file, s.kind, s.name, s.qname, s.startLine, s.endLine, s.exported ? 1 : 0)
+    }
+    for (const e of payload.edges) {
+      insEdge.run(e.src, e.dst, e.edgeType, e.confidence)
+    }
+  })
+  prjctDb.setDoc(projectId, 'symbol-graph', {
+    ...payload.meta,
+    builtAt: payload.meta.builtAt ?? payload.exportedAt,
+  })
+  return {
+    imported: true,
+    symbols: payload.symbols.length,
+    edges: payload.edges.length,
+  }
+}
+
+/**
+ * Bootstrap: if local index empty but artifact present, import then optional
+ * incremental reindex of dirty tree is left to sync.
+ */
+export async function bootstrapCodeGraphFromArtifact(
+  projectPath: string,
+  projectId: string
+): Promise<{ bootstrapped: boolean; detail: string }> {
+  if (hasSymbolIndex(projectId)) {
+    return { bootstrapped: false, detail: 'local index already present' }
+  }
+  const result = await importCodeGraphArtifact(projectPath, projectId)
+  if (!result.imported) {
+    return { bootstrapped: false, detail: result.reason ?? 'import failed' }
+  }
+  return {
+    bootstrapped: true,
+    detail: `imported ${result.symbols} symbols / ${result.edges} edges from ${ARTIFACT_REL}`,
+  }
+}
+
+async function ensureGitattributes(projectPath: string): Promise<void> {
+  const ga = path.join(projectPath, '.gitattributes')
+  try {
+    let existing = ''
+    try {
+      existing = await fs.readFile(ga, 'utf-8')
+    } catch {
+      existing = ''
+    }
+    if (existing.includes('code-graph.json.gz')) return
+    const next = existing
+      ? existing.endsWith('\n')
+        ? `${existing}${GITATTRIBUTES_LINE}\n`
+        : `${existing}\n${GITATTRIBUTES_LINE}\n`
+      : `${GITATTRIBUTES_LINE}\n`
+    await fs.writeFile(ga, next)
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** After a successful full index, refresh the team artifact (non-fatal). */
+export async function maybeExportAfterIndex(projectPath: string, projectId: string): Promise<void> {
+  try {
+    await exportCodeGraphArtifact(projectPath, projectId)
+  } catch {
+    /* non-critical */
+  }
+}
+
+export async function ensureIndexWithBootstrap(
+  projectPath: string,
+  projectId: string
+): Promise<SymbolGraphMeta | null> {
+  if (hasSymbolIndex(projectId)) return loadMeta(projectId)
+  const boot = await bootstrapCodeGraphFromArtifact(projectPath, projectId)
+  if (boot.bootstrapped) return loadMeta(projectId)
+  // No artifact — full index
+  return indexSymbols(projectPath, projectId)
+}

--- a/core/services/dead-code.ts
+++ b/core/services/dead-code.ts
@@ -1,0 +1,136 @@
+/**
+ * Dead-code surface — symbols with zero inbound CALLS (excluding entry points).
+ */
+
+import { hasSymbolIndex, listAllSymbols, loadMeta } from '../domain/symbol-graph'
+import prjctDb from '../storage/database'
+import type { CodeSymbol } from '../types/domain.js'
+
+const ENTRY_NAME =
+  /^(main|index|app|server|cli|handler|router|bootstrap|init|start|run|default|setup|config|plugin|middleware|layout|page|loader|action)$/i
+
+const ENTRY_PATH =
+  /(?:^|\/)(?:bin\/|scripts\/|cli\.|main\.|index\.|app\.|server\.|page\.|layout\.|route\.|middleware\.)/i
+
+export interface DeadCodeHit {
+  symbol: CodeSymbol
+  reason: string
+}
+
+export interface DeadCodeResult {
+  ready: boolean
+  totalSymbols: number
+  dead: DeadCodeHit[]
+  skippedEntries: number
+  note: string
+}
+
+function isEntryPoint(s: CodeSymbol): boolean {
+  if (s.kind === 'route') return true
+  if (ENTRY_NAME.test(s.name) && s.exported) return true
+  if (ENTRY_PATH.test(s.file) && s.exported) return true
+  // Test harness symbols are not dead-code targets of interest for product
+  if (/__tests__|\.test\.|\.spec\.|fixtures?\//i.test(s.file)) return true
+  // Types/interfaces/enums rarely "called"
+  if (s.kind === 'type' || s.kind === 'interface' || s.kind === 'enum') return true
+  // Consts often re-exported config — skip non-functions/classes/methods
+  if (s.kind === 'const') return true
+  return false
+}
+
+function loadCallersOf(projectId: string): Set<string> {
+  const hasCaller = new Set<string>()
+  try {
+    const rows = prjctDb.query<{ dst: string }>(
+      projectId,
+      `SELECT DISTINCT dst FROM code_symbol_edges WHERE edge_type = 'CALLS'`
+    )
+    for (const r of rows) hasCaller.add(r.dst)
+  } catch {
+    /* empty */
+  }
+  return hasCaller
+}
+
+export function findDeadCode(projectId: string, opts: { limit?: number } = {}): DeadCodeResult {
+  const limit = opts.limit ?? 50
+  if (!hasSymbolIndex(projectId)) {
+    return {
+      ready: false,
+      totalSymbols: 0,
+      dead: [],
+      skippedEntries: 0,
+      note: 'No symbol index. Run `prjct sync` or `prjct code reindex`.',
+    }
+  }
+
+  const symbols = listAllSymbols(projectId)
+  const hasCaller = loadCallersOf(projectId)
+  const dead: DeadCodeHit[] = []
+  let skippedEntries = 0
+
+  for (const s of symbols) {
+    if (isEntryPoint(s)) {
+      skippedEntries++
+      continue
+    }
+    if (s.kind !== 'function' && s.kind !== 'method' && s.kind !== 'class') continue
+    if (hasCaller.has(s.id)) continue
+    dead.push({
+      symbol: s,
+      reason: s.exported ? 'exported but no inbound CALLS in graph' : 'no inbound CALLS in graph',
+    })
+    if (dead.length >= limit) break
+  }
+
+  // Prefer exported dead first (more actionable)
+  dead.sort((a, b) => {
+    const ae = a.symbol.exported ? 0 : 1
+    const be = b.symbol.exported ? 0 : 1
+    if (ae !== be) return ae - be
+    return a.symbol.file.localeCompare(b.symbol.file)
+  })
+
+  const meta = loadMeta(projectId)
+  return {
+    ready: true,
+    totalSymbols: meta?.symbolCount ?? symbols.length,
+    dead,
+    skippedEntries,
+    note: 'Best-effort: regex CALLS graph. Dynamic dispatch / reflection may false-positive. Entry points + tests + types excluded.',
+  }
+}
+
+export function formatDeadCodeMd(r: DeadCodeResult): string {
+  if (!r.ready) return `## Dead code\n\n> ${r.note}\n`
+  const lines = [
+    '## Dead code (zero inbound CALLS)',
+    '',
+    `- **Candidates**: ${r.dead.length} (cap)`,
+    `- **Symbols scanned**: ${r.totalSymbols}`,
+    `- **Skipped entry/types/tests**: ${r.skippedEntries}`,
+    '',
+  ]
+  if (r.dead.length === 0) {
+    lines.push('_None found (or all have callers / are entries)._')
+  } else {
+    for (const d of r.dead) {
+      const s = d.symbol
+      lines.push(
+        `- \`${s.kind}\` **${s.name}** — \`${s.file}:${s.startLine}\`${s.exported ? ' (exported)' : ''}`
+      )
+      lines.push(`  - ${d.reason}`)
+    }
+  }
+  lines.push('', `_${r.note}_`)
+  return lines.join('\n')
+}
+
+export function formatDeadCodeText(r: DeadCodeResult): string {
+  if (!r.ready) return `dead-code: ${r.note}`
+  const lines = [`Dead code: ${r.dead.length} candidate(s) (of ${r.totalSymbols} symbols)`]
+  for (const d of r.dead.slice(0, 30)) {
+    lines.push(`  ${d.symbol.kind} ${d.symbol.name}  ${d.symbol.file}:${d.symbol.startLine}`)
+  }
+  return lines.join('\n')
+}

--- a/core/services/detect-changes.ts
+++ b/core/services/detect-changes.ts
@@ -1,0 +1,218 @@
+/**
+ * detect_changes — git diff → affected symbols + blast radius + risk.
+ *
+ * CBM-inspired: map uncommitted (or committed) changes to structural impact
+ * so agents can reason about review risk without tree-walking.
+ */
+
+import { loadGraph } from '../domain/import-graph'
+import { fileFanIn, filesCallingInto, hasSymbolIndex, symbolsInFile } from '../domain/symbol-graph'
+import type { ChangeRisk, DetectChangesResult, DetectedChange } from '../types/domain.js'
+import { execFileAsync } from '../utils/exec'
+
+async function safeGit(projectPath: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', args, { cwd: projectPath })
+    return stdout.trim()
+  } catch {
+    return null
+  }
+}
+
+async function listWorkingTreeFiles(projectPath: string): Promise<string[]> {
+  const unstaged = (await safeGit(projectPath, ['diff', '--name-only', 'HEAD'])) ?? ''
+  const staged = (await safeGit(projectPath, ['diff', '--name-only', '--cached'])) ?? ''
+  const untracked =
+    (await safeGit(projectPath, ['ls-files', '--others', '--exclude-standard'])) ?? ''
+  const set = new Set<string>()
+  for (const block of [unstaged, staged, untracked]) {
+    for (const line of block.split('\n')) {
+      if (line.trim()) set.add(line.trim())
+    }
+  }
+  return [...set]
+}
+
+async function listCommittedFiles(projectPath: string): Promise<string[]> {
+  let defaultRef = ''
+  const originHead = await safeGit(projectPath, ['rev-parse', '--abbrev-ref', 'origin/HEAD'])
+  if (originHead && originHead !== 'origin/HEAD') defaultRef = originHead
+  else {
+    for (const c of ['main', 'master']) {
+      if ((await safeGit(projectPath, ['rev-parse', '--verify', '--quiet', c])) !== null) {
+        defaultRef = c
+        break
+      }
+    }
+  }
+  if (!defaultRef) return []
+  const base = await safeGit(projectPath, ['merge-base', defaultRef, 'HEAD'])
+  if (!base) return []
+  const names = (await safeGit(projectPath, ['diff', '--name-only', `${base}..HEAD`])) ?? ''
+  return names.split('\n').filter(Boolean)
+}
+
+const CRITICAL_PATH =
+  /(?:^|\/)(?:auth|security|crypto|billing|payment|migrate|schema|migrations?)(?:\/|$)/i
+const HIGH_PATH = /(?:^|\/)(?:storage|database|db|sync|daemon|mcp|hooks?|session)(?:\/|$)/i
+
+function classifyRisk(
+  file: string,
+  fanIn: number,
+  importerCount: number,
+  hasSymbols: boolean
+): { risk: ChangeRisk; reasons: string[] } {
+  const reasons: string[] = []
+  let risk: ChangeRisk = 'low'
+
+  if (CRITICAL_PATH.test(file)) {
+    risk = 'critical'
+    reasons.push('touches auth/security/billing/schema path')
+  } else if (HIGH_PATH.test(file)) {
+    risk = 'high'
+    reasons.push('touches storage/sync/hooks/mcp path')
+  }
+
+  if (fanIn >= 15) {
+    risk = 'critical'
+    reasons.push(`high call fan-in (${fanIn} callers)`)
+  } else if (fanIn >= 5) {
+    // Path may already be high/critical; only escalate leaf→high
+    if (risk === 'low') risk = 'high'
+    reasons.push(`moderate call fan-in (${fanIn} callers)`)
+  } else if (fanIn > 0) {
+    if (risk === 'low') risk = 'medium'
+    reasons.push(`${fanIn} caller(s) via symbol graph`)
+  }
+
+  if (importerCount >= 10) {
+    if (risk !== 'critical') risk = 'high'
+    reasons.push(`${importerCount} importers`)
+  } else if (importerCount >= 3) {
+    if (risk === 'low') risk = 'medium'
+    reasons.push(`${importerCount} importers`)
+  }
+
+  if (!hasSymbols && importerCount === 0 && fanIn === 0) {
+    reasons.push('leaf change (no graph neighbors)')
+  }
+
+  if (reasons.length === 0) reasons.push('isolated or low connectivity')
+  return { risk, reasons }
+}
+
+export async function detectChanges(
+  projectPath: string,
+  projectId: string,
+  opts: {
+    files?: string[]
+    /** Prefer working-tree; fall back to committed range vs main. */
+    source?: 'working-tree' | 'committed' | 'auto'
+  } = {}
+): Promise<DetectChangesResult> {
+  let changedFiles = opts.files ?? []
+  let source: DetectChangesResult['source'] = 'explicit'
+
+  if (changedFiles.length === 0) {
+    const mode = opts.source ?? 'auto'
+    if (mode === 'working-tree' || mode === 'auto') {
+      changedFiles = await listWorkingTreeFiles(projectPath)
+      source = 'working-tree'
+    }
+    if (changedFiles.length === 0 && (mode === 'committed' || mode === 'auto')) {
+      changedFiles = await listCommittedFiles(projectPath)
+      source = 'committed'
+    }
+  }
+
+  const importGraph = loadGraph(projectId)
+  const hasSymbols = hasSymbolIndex(projectId)
+
+  // Expand blast radius via import reverse edges + call-graph
+  const affected = new Set<string>(changedFiles)
+  for (const f of changedFiles) {
+    const importers = importGraph?.reverse[f] ?? []
+    for (const imp of importers) affected.add(imp)
+  }
+  if (hasSymbols) {
+    for (const f of filesCallingInto(projectId, changedFiles, 2)) {
+      affected.add(f)
+    }
+  }
+
+  const changes: DetectedChange[] = []
+  const summary = { critical: 0, high: 0, medium: 0, low: 0 }
+
+  for (const file of changedFiles) {
+    const importers = importGraph?.reverse[file] ?? []
+    const fanIn = hasSymbols ? fileFanIn(projectId, file) : 0
+    const syms = hasSymbols ? symbolsInFile(projectId, file) : []
+    const { risk, reasons } = classifyRisk(file, fanIn, importers.length, syms.length > 0)
+    summary[risk]++
+    changes.push({
+      file,
+      risk,
+      touchedSymbols: syms.slice(0, 12).map((s) => s.name),
+      fanIn,
+      reasons,
+    })
+  }
+
+  // Sort critical first
+  const order: Record<ChangeRisk, number> = { critical: 0, high: 1, medium: 2, low: 3 }
+  changes.sort((a, b) => order[a.risk] - order[b.risk] || a.file.localeCompare(b.file))
+
+  return {
+    changedFiles,
+    affectedFiles: [...affected].sort(),
+    changes,
+    summary,
+    source,
+  }
+}
+
+export function formatDetectChangesMd(result: DetectChangesResult): string {
+  if (result.changedFiles.length === 0) {
+    return '## Detect changes\n\n_No changes detected (clean tree / no base range)._\n'
+  }
+  const lines = [
+    '## Detect changes',
+    '',
+    `- **Source**: ${result.source}`,
+    `- **Changed**: ${result.changedFiles.length} file(s)`,
+    `- **Blast radius**: ${result.affectedFiles.length} file(s) (imports + call-graph)`,
+    `- **Risk**: critical ${result.summary.critical} · high ${result.summary.high} · medium ${result.summary.medium} · low ${result.summary.low}`,
+    '',
+    '### Per-file risk',
+    '',
+  ]
+  for (const c of result.changes) {
+    const syms =
+      c.touchedSymbols.length > 0 ? ` · symbols: ${c.touchedSymbols.slice(0, 6).join(', ')}` : ''
+    lines.push(`- **${c.risk.toUpperCase()}** \`${c.file}\`${syms}`, `  - ${c.reasons.join('; ')}`)
+  }
+  if (result.affectedFiles.length > result.changedFiles.length) {
+    lines.push('', '### Affected beyond diff', '')
+    const extra = result.affectedFiles.filter((f) => !result.changedFiles.includes(f)).slice(0, 25)
+    for (const f of extra) lines.push(`- \`${f}\``)
+    if (result.affectedFiles.length - result.changedFiles.length > 25) {
+      lines.push(`- _…+${result.affectedFiles.length - result.changedFiles.length - 25} more_`)
+    }
+  }
+  lines.push('', '_Advisory. Expand with `prjct code trace <symbol>` or MCP `prjct_trace_path`._')
+  return lines.join('\n')
+}
+
+export function formatDetectChangesText(result: DetectChangesResult): string {
+  if (result.changedFiles.length === 0) {
+    return 'detect-changes: no changes detected'
+  }
+  const lines = [
+    `Detect changes (${result.source}): ${result.changedFiles.length} changed → blast ${result.affectedFiles.length}`,
+    `Risk: critical=${result.summary.critical} high=${result.summary.high} medium=${result.summary.medium} low=${result.summary.low}`,
+  ]
+  for (const c of result.changes.slice(0, 30)) {
+    lines.push(`  [${c.risk.toUpperCase()}] ${c.file} — ${c.reasons[0] ?? ''}`)
+  }
+  return lines.join('\n')
+}

--- a/core/services/detect-changes.ts
+++ b/core/services/detect-changes.ts
@@ -1,8 +1,7 @@
 /**
  * detect_changes — git diff → affected symbols + blast radius + risk.
  *
- * CBM-inspired: map uncommitted (or committed) changes to structural impact
- * so agents can reason about review risk without tree-walking.
+ * P1: hunk-level — map unified-diff line ranges to symbols by start_line.
  */
 
 import { loadGraph } from '../domain/import-graph'
@@ -52,6 +51,118 @@ async function listCommittedFiles(projectPath: string): Promise<string[]> {
   return names.split('\n').filter(Boolean)
 }
 
+async function resolveDiffBase(
+  projectPath: string,
+  source: DetectChangesResult['source']
+): Promise<string | null> {
+  if (source === 'working-tree' || source === 'explicit') return 'HEAD'
+  let defaultRef = ''
+  const originHead = await safeGit(projectPath, ['rev-parse', '--abbrev-ref', 'origin/HEAD'])
+  if (originHead && originHead !== 'origin/HEAD') defaultRef = originHead
+  else {
+    for (const c of ['main', 'master']) {
+      if ((await safeGit(projectPath, ['rev-parse', '--verify', '--quiet', c])) !== null) {
+        defaultRef = c
+        break
+      }
+    }
+  }
+  if (!defaultRef) return 'HEAD'
+  return (await safeGit(projectPath, ['merge-base', defaultRef, 'HEAD'])) ?? 'HEAD'
+}
+
+/**
+ * Parse unified diff for a file into new-file line numbers that changed.
+ * Handles both `@@ -a,b +c,d @@` hunks (additions/context on + side).
+ */
+export function parseChangedLinesFromUnifiedDiff(diff: string): Map<string, Set<number>> {
+  const map = new Map<string, Set<number>>()
+  let currentFile: string | null = null
+  let newLine = 0
+
+  for (const raw of diff.split('\n')) {
+    if (raw.startsWith('+++ ')) {
+      const p = raw.slice(4).trim()
+      if (p === '/dev/null') {
+        currentFile = null
+        continue
+      }
+      currentFile = p.replace(/^b\//, '')
+      if (!map.has(currentFile)) map.set(currentFile, new Set())
+      continue
+    }
+    if (!currentFile) continue
+    const hunk = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/)
+    if (hunk) {
+      newLine = Number.parseInt(hunk[1]!, 10)
+      continue
+    }
+    if (raw.startsWith('\\')) continue
+    if (raw.startsWith('+') && !raw.startsWith('+++')) {
+      map.get(currentFile)?.add(newLine)
+      newLine++
+    } else if (raw.startsWith('-') && !raw.startsWith('---')) {
+      // deletion: does not advance new-file line
+    } else if (raw.startsWith(' ') || raw === '') {
+      newLine++
+    }
+  }
+  return map
+}
+
+async function loadHunkLines(
+  projectPath: string,
+  source: DetectChangesResult['source'],
+  files: string[]
+): Promise<Map<string, Set<number>>> {
+  if (files.length === 0) return new Map()
+  const base = await resolveDiffBase(projectPath, source)
+  if (!base) return new Map()
+
+  const args =
+    source === 'committed'
+      ? ['diff', '-U0', `${base}..HEAD`, '--', ...files]
+      : ['diff', '-U0', 'HEAD', '--', ...files]
+
+  const diff = (await safeGit(projectPath, args)) ?? ''
+  // Also staged for working-tree
+  let staged = ''
+  if (source !== 'committed') {
+    staged = (await safeGit(projectPath, ['diff', '-U0', '--cached', '--', ...files])) ?? ''
+  }
+  const map = parseChangedLinesFromUnifiedDiff(diff + '\n' + staged)
+  return map
+}
+
+/** Symbols whose startLine falls in a changed hunk (or nearest prior symbol). */
+export function symbolsTouchedByHunks(
+  projectId: string,
+  file: string,
+  changedLines: Set<number> | undefined
+): string[] {
+  const all = symbolsInFile(projectId, file)
+  if (all.length === 0) return []
+  if (!changedLines || changedLines.size === 0) {
+    return all.slice(0, 12).map((s) => s.name)
+  }
+  const lines = [...changedLines].sort((a, b) => a - b)
+  const names = new Set<string>()
+  for (const line of lines) {
+    // Nearest symbol with startLine <= line
+    let best = all[0]!
+    for (const s of all) {
+      if (s.startLine <= line) best = s
+      else break
+    }
+    names.add(best.name)
+    // Also any symbol starting exactly on a changed line
+    for (const s of all) {
+      if (changedLines.has(s.startLine)) names.add(s.name)
+    }
+  }
+  return [...names].slice(0, 12)
+}
+
 const CRITICAL_PATH =
   /(?:^|\/)(?:auth|security|crypto|billing|payment|migrate|schema|migrations?)(?:\/|$)/i
 const HIGH_PATH = /(?:^|\/)(?:storage|database|db|sync|daemon|mcp|hooks?|session)(?:\/|$)/i
@@ -60,7 +171,8 @@ function classifyRisk(
   file: string,
   fanIn: number,
   importerCount: number,
-  hasSymbols: boolean
+  hasSymbols: boolean,
+  hunkSymbolCount: number
 ): { risk: ChangeRisk; reasons: string[] } {
   const reasons: string[] = []
   let risk: ChangeRisk = 'low'
@@ -77,7 +189,6 @@ function classifyRisk(
     risk = 'critical'
     reasons.push(`high call fan-in (${fanIn} callers)`)
   } else if (fanIn >= 5) {
-    // Path may already be high/critical; only escalate leaf→high
     if (risk === 'low') risk = 'high'
     reasons.push(`moderate call fan-in (${fanIn} callers)`)
   } else if (fanIn > 0) {
@@ -91,6 +202,10 @@ function classifyRisk(
   } else if (importerCount >= 3) {
     if (risk === 'low') risk = 'medium'
     reasons.push(`${importerCount} importers`)
+  }
+
+  if (hunkSymbolCount > 0) {
+    reasons.push(`${hunkSymbolCount} symbol(s) in changed hunks`)
   }
 
   if (!hasSymbols && importerCount === 0 && fanIn === 0) {
@@ -128,6 +243,10 @@ export async function detectChanges(
   const importGraph = loadGraph(projectId)
   const hasSymbols = hasSymbolIndex(projectId)
 
+  const hunkMap = hasSymbols
+    ? await loadHunkLines(projectPath, source, changedFiles.slice(0, 80))
+    : new Map<string, Set<number>>()
+
   // Expand blast radius via import reverse edges + call-graph
   const affected = new Set<string>(changedFiles)
   for (const f of changedFiles) {
@@ -146,19 +265,24 @@ export async function detectChanges(
   for (const file of changedFiles) {
     const importers = importGraph?.reverse[file] ?? []
     const fanIn = hasSymbols ? fileFanIn(projectId, file) : 0
-    const syms = hasSymbols ? symbolsInFile(projectId, file) : []
-    const { risk, reasons } = classifyRisk(file, fanIn, importers.length, syms.length > 0)
+    const touched = hasSymbols ? symbolsTouchedByHunks(projectId, file, hunkMap.get(file)) : []
+    const { risk, reasons } = classifyRisk(
+      file,
+      fanIn,
+      importers.length,
+      touched.length > 0 || (hasSymbols && symbolsInFile(projectId, file).length > 0),
+      touched.length
+    )
     summary[risk]++
     changes.push({
       file,
       risk,
-      touchedSymbols: syms.slice(0, 12).map((s) => s.name),
+      touchedSymbols: touched,
       fanIn,
       reasons,
     })
   }
 
-  // Sort critical first
   const order: Record<ChangeRisk, number> = { critical: 0, high: 1, medium: 2, low: 3 }
   changes.sort((a, b) => order[a.risk] - order[b.risk] || a.file.localeCompare(b.file))
 
@@ -212,7 +336,20 @@ export function formatDetectChangesText(result: DetectChangesResult): string {
     `Risk: critical=${result.summary.critical} high=${result.summary.high} medium=${result.summary.medium} low=${result.summary.low}`,
   ]
   for (const c of result.changes.slice(0, 30)) {
-    lines.push(`  [${c.risk.toUpperCase()}] ${c.file} — ${c.reasons[0] ?? ''}`)
+    const sym = c.touchedSymbols.length ? ` [${c.touchedSymbols.slice(0, 4).join(',')}]` : ''
+    lines.push(`  [${c.risk.toUpperCase()}] ${c.file}${sym} — ${c.reasons[0] ?? ''}`)
   }
   return lines.join('\n')
+}
+
+/** One-line ship advisory from structural risk (never hard-blocks by itself). */
+export function shipStructuralRiskCue(result: DetectChangesResult): string | null {
+  if (result.changedFiles.length === 0) return null
+  if (result.summary.critical > 0) {
+    return `⚠️  Structural risk CRITICAL (${result.summary.critical} file(s), blast ${result.affectedFiles.length}). Review: \`prjct code impact --md\`.`
+  }
+  if (result.summary.high > 0) {
+    return `⚠️  Structural risk HIGH (${result.summary.high} file(s), blast ${result.affectedFiles.length}). Consider \`prjct code impact --md\`.`
+  }
+  return null
 }

--- a/core/services/settings-installer.ts
+++ b/core/services/settings-installer.ts
@@ -50,6 +50,8 @@ export const PRJCT_HOOKS = [
   // is about to edit it — closes the apply loop that pull-only `guard` left to
   // the agent's (unreliable) instinct. Fires regardless of model = update-proof.
   { event: 'PreToolUse', matcher: 'Edit|Write', subcommand: 'pre-edit' },
+  // Non-blocking code-graph augment for Grep/Glob (CBM-inspired). Never denies.
+  { event: 'PreToolUse', matcher: 'Grep|Glob', subcommand: 'pre-search' },
   { event: 'PostToolUse', matcher: 'Edit|Write', subcommand: 'post-edit' },
   { event: 'Stop', matcher: '', subcommand: 'stop' },
   { event: 'SubagentStart', matcher: '', subcommand: 'subagent-start' },

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -7,7 +7,7 @@
  */
 
 export const PRJCT_SKILL_DESCRIPTION =
-  'AI Agile OS for coding agents: intent briefs, RAG context, synthesized memory, guardrails, performance, and ships. Run the prjct verb yourself; use `prjct work` normally.'
+  'The agentic harness for AI coding agents: intent briefs, RAG context, synthesized memory, guardrails, performance, and ships. Run the prjct verb yourself; use `prjct work` normally.'
 
 export const PRJCT_SKILL_ALLOWED_TOOLS = [
   'Bash',
@@ -61,7 +61,7 @@ export function buildPrjctSkillBody(): string {
     '### Cast + file scope (MUST)',
     '',
     '- Multi-agent Cast names (explore→Popper · implement→Copernicus · review→McClintock): use as `description` / `prjct claim --as <Name>`.',
-    '- Before Grep/Glob: Work scope from `prjct work`, MCP `prjct_relevant_files`, or `prjct context memory` + `prjct guard <file>`. No blind tree walk when indexes exist.',
+    '- Before Grep/Glob: Work scope from `prjct work`, MCP `prjct_relevant_files`, or `prjct context memory` + `prjct guard <file>`. Prefer `prjct code trace <symbol>` / `architecture` / MCP `prjct_trace_path` over file-by-file search when the symbol graph exists. No blind tree walk when indexes exist.',
     '- **Synthesis discipline:** parent never says "based on findings" — hand implementers concrete file:line specs. **Continue** a worker when it already holds the edit files; **spawn fresh** for verify or a wrong approach.',
     '',
     '### Core verbs (Tier 1=auto · 2=confirm)',

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -228,9 +228,10 @@ class SyncService {
         /* non-critical — scope falls back to open accept until next sync */
       }
 
-      // 3a-bis. Bootstrap symbol graph from team artifact if local index empty
+      // 3a-bis. Bootstrap symbol graph from per-project cache (~/.prjct-cli/projects/<id>/)
+      // if SQLite symbol tables empty — never reads from the client repo.
       try {
-        await bootstrapCodeGraphFromArtifact(this.projectPath, this.projectId!)
+        await bootstrapCodeGraphFromArtifact(this.projectId!)
       } catch {
         /* non-critical */
       }
@@ -270,8 +271,8 @@ class SyncService {
                 : indexSymbols(this.projectPath, this.projectId!),
               indexCoChanges(this.projectPath, this.projectId!),
             ])
-            // Refresh team-shared artifact after a successful index pass
-            await maybeExportAfterIndex(this.projectPath, this.projectId!)
+            // Refresh per-project cache after a successful index pass
+            await maybeExportAfterIndex(this.projectId!)
           } catch (error) {
             log.debug('File ranking index build failed (non-critical)', {
               error: getErrorMessage(error),

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -20,6 +20,7 @@ import { setupMcpServers } from '../commands/setup/mcp'
 import { indexProject as indexBm25, updateProjectIndex as updateBm25 } from '../domain/bm25'
 import { indexCoChanges } from '../domain/git-cochange'
 import { indexImports, updateImportGraph } from '../domain/import-graph'
+import { indexSymbols, updateSymbols } from '../domain/symbol-graph'
 import { getErrorMessage } from '../errors'
 import { detectCodex, getActiveProvider } from '../infrastructure/ai-provider'
 import { verifyCodexPRouterReady } from '../infrastructure/codex-skill'
@@ -32,6 +33,7 @@ import type { Context7Status } from '../types/services.js'
 import type { VerificationReport } from '../types/sync-verifier'
 import { readJson } from '../utils/file-helper'
 import log from '../utils/logger'
+import { bootstrapCodeGraphFromArtifact, maybeExportAfterIndex } from './code-graph-artifact'
 import { repairContextQuality } from './context-quality-service'
 import context7Service from './context7-service'
 import { writeProjectAgentSurfaces } from './project-agent-surfaces'
@@ -226,7 +228,14 @@ class SyncService {
         /* non-critical — scope falls back to open accept until next sync */
       }
 
-      // 3b. Build file-ranking indexes IN PARALLEL (BM25, import graph, co-change)
+      // 3a-bis. Bootstrap symbol graph from team artifact if local index empty
+      try {
+        await bootstrapCodeGraphFromArtifact(this.projectPath, this.projectId!)
+      } catch {
+        /* non-critical */
+      }
+
+      // 3b. Build file-ranking indexes IN PARALLEL (BM25, symbols, import graph, co-change)
       // Skip if no source files changed (incremental optimization)
       if (shouldRebuildIndexes) {
         await phase('index', async () => {
@@ -251,8 +260,18 @@ class SyncService {
                     deletedSourceFiles
                   )
                 : indexImports(this.projectPath, this.projectId!),
+              canUseIncrementalIndexes
+                ? updateSymbols(
+                    this.projectPath,
+                    this.projectId!,
+                    changedSourceFiles,
+                    deletedSourceFiles
+                  )
+                : indexSymbols(this.projectPath, this.projectId!),
               indexCoChanges(this.projectPath, this.projectId!),
             ])
+            // Refresh team-shared artifact after a successful index pass
+            await maybeExportAfterIndex(this.projectPath, this.projectId!)
           } catch (error) {
             log.debug('File ranking index build failed (non-critical)', {
               error: getErrorMessage(error),

--- a/core/services/work-scope.ts
+++ b/core/services/work-scope.ts
@@ -137,24 +137,29 @@ function mergeScope(
     )
   }
 
-  // 2) Code index: BM25 → import/cochange expand inside rankFiles
+  // 2) Code index: BM25 + symbols → import/cochange expand inside rankFiles
   let indexHits = 0
-  if (indexes.bm25) {
+  if (indexes.bm25 || indexes.symbols) {
     try {
       const ranked = rankFiles(projectId, query, { topN: Math.max(limit * 2, 12) })
       indexHits = ranked.length
       for (const f of ranked) {
+        const sym = f.signals.symbols ?? 0
         const signals = [
           f.signals.bm25 > 0 ? 'bm25' : null,
+          sym > 0 ? 'symbols' : null,
           f.signals.imports > 0 ? 'imports' : null,
           f.signals.cochange > 0 ? 'cochange' : null,
         ].filter((s): s is string => s !== null)
+        const topSignal = Math.max(f.signals.bm25, sym, f.signals.imports, f.signals.cochange)
         const reason =
-          f.signals.bm25 >= f.signals.imports && f.signals.bm25 >= f.signals.cochange
-            ? 'matches task terms in code index (BM25)'
-            : f.signals.imports >= f.signals.cochange
-              ? 'import-graph neighbor of matched files'
-              : 'historically co-changes with matched files'
+          sym >= topSignal && sym > 0
+            ? 'matches function/class/route symbols in code graph'
+            : f.signals.bm25 >= f.signals.imports && f.signals.bm25 >= f.signals.cochange
+              ? 'matches task terms in code index (BM25)'
+              : f.signals.imports >= f.signals.cochange
+                ? 'import-graph neighbor of matched files'
+                : 'historically co-changes with matched files'
         bump(f.path, f.finalScore, signals[0] ?? 'bm25', reason)
         for (const s of signals.slice(1)) {
           const hit = scores.get(f.path)
@@ -195,14 +200,14 @@ function mergeScope(
 
   return {
     files,
-    indexesReady: indexes.bm25 || indexes.imports || indexes.cochange,
+    indexesReady: indexes.bm25 || indexes.imports || indexes.cochange || indexes.symbols,
     sources: {
       memorySeeds: memorySeeds.size,
       indexHits,
       graphNeighbors,
     },
     agentBlock: formatWorkScopeBlock(files, {
-      indexesReady: indexes.bm25 || indexes.imports || indexes.cochange,
+      indexesReady: indexes.bm25 || indexes.imports || indexes.cochange || indexes.symbols,
       memorySeeds: memorySeeds.size,
       inventoryLine: formatInventorySummary(inv),
     }),

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2603,6 +2603,42 @@ export const migrations: Migration[] = [
       db.run('CREATE INDEX IF NOT EXISTS ix_task_handoffs_task ON task_handoffs(task_id)')
     },
   },
+  {
+    version: 62,
+    name: 'code-symbol-graph',
+    up: (db: SqliteDatabase) => {
+      // Structural symbol graph (CBM-inspired, file→symbol layer):
+      // definitions + CALLS/DEFINES edges for work-scope, trace, detect_changes.
+      db.run(`
+        CREATE TABLE IF NOT EXISTS code_symbols (
+          id         TEXT PRIMARY KEY,
+          file       TEXT NOT NULL,
+          kind       TEXT NOT NULL,
+          name       TEXT NOT NULL,
+          qname      TEXT,
+          start_line INTEGER NOT NULL,
+          end_line   INTEGER,
+          exported   INTEGER NOT NULL DEFAULT 0
+        )
+      `)
+      db.run('CREATE INDEX IF NOT EXISTS idx_code_symbols_name ON code_symbols(name)')
+      db.run('CREATE INDEX IF NOT EXISTS idx_code_symbols_file ON code_symbols(file)')
+      db.run(
+        'CREATE INDEX IF NOT EXISTS idx_code_symbols_name_nocase ON code_symbols(name COLLATE NOCASE)'
+      )
+      db.run(`
+        CREATE TABLE IF NOT EXISTS code_symbol_edges (
+          src        TEXT NOT NULL,
+          dst        TEXT NOT NULL,
+          edge_type  TEXT NOT NULL,
+          confidence REAL NOT NULL DEFAULT 1.0,
+          PRIMARY KEY (src, dst, edge_type)
+        )
+      `)
+      db.run('CREATE INDEX IF NOT EXISTS idx_code_symbol_edges_dst ON code_symbol_edges(dst)')
+      db.run('CREATE INDEX IF NOT EXISTS idx_code_symbol_edges_src ON code_symbol_edges(src)')
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -361,6 +361,7 @@ export type CommandRoutingGroup =
   | 'product'
   | 'eval'
   | 'judgment'
+  | 'code'
 
 export interface CommandRouting {
   /** Which command-group instance owns the handler. */

--- a/core/types/domain.ts
+++ b/core/types/domain.ts
@@ -115,6 +115,8 @@ export interface RankedFile {
     bm25: number
     imports: number
     cochange: number
+    /** Symbol-name / call-graph signal (0 when index missing). */
+    symbols?: number
   }
 }
 
@@ -125,10 +127,92 @@ export interface RankingConfig {
   importWeight?: number
   /** Weight for git co-change correlation (default: 0.2) */
   cochangeWeight?: number
+  /** Weight for symbol-name match (default: 0.15 when symbols index present) */
+  symbolsWeight?: number
   /** Maximum number of results (default: 15) */
   topN?: number
   /** Maximum depth for import graph traversal (default: 2) */
   importDepth?: number
+}
+
+// Symbol Graph Types (structural code intelligence)
+
+export type SymbolKind =
+  | 'function'
+  | 'method'
+  | 'class'
+  | 'interface'
+  | 'type'
+  | 'enum'
+  | 'const'
+  | 'route'
+
+export type SymbolEdgeType = 'CALLS' | 'DEFINES' | 'IMPORTS' | 'HANDLES' | 'TESTS'
+
+export interface CodeSymbol {
+  id: string
+  file: string
+  kind: SymbolKind
+  name: string
+  qname: string
+  startLine: number
+  endLine: number | null
+  exported: boolean
+}
+
+export interface CodeSymbolEdge {
+  src: string
+  dst: string
+  edgeType: SymbolEdgeType
+  confidence: number
+}
+
+export interface SymbolGraphMeta {
+  symbolCount: number
+  edgeCount: number
+  fileCount: number
+  builtAt: string
+}
+
+export interface SymbolScore {
+  path: string
+  score: number
+  matchedNames: string[]
+}
+
+export interface TraceHop {
+  symbol: CodeSymbol
+  depth: number
+  via: SymbolEdgeType
+}
+
+export interface TraceResult {
+  root: CodeSymbol[]
+  inbound: TraceHop[]
+  outbound: TraceHop[]
+}
+
+export type ChangeRisk = 'critical' | 'high' | 'medium' | 'low'
+
+export interface DetectedChange {
+  file: string
+  risk: ChangeRisk
+  touchedSymbols: string[]
+  fanIn: number
+  reasons: string[]
+}
+
+export interface DetectChangesResult {
+  changedFiles: string[]
+  affectedFiles: string[]
+  changes: DetectedChange[]
+  summary: {
+    critical: number
+    high: number
+    medium: number
+    low: number
+  }
+  source: 'working-tree' | 'committed' | 'explicit'
 }
 
 // Change Propagator Types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.59.0",
+  "version": "3.60.0",
   "description": "Project memory and workflow context for AI coding agents.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Adds a **file → symbol** structural intelligence layer inspired by [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp), without reimplementing Hybrid LSP / pure-C tree-sitter.

prjct keeps harness + authored memory; this PR makes agents answer “who calls X?”, blast radius, and architecture **in one tool call**.

### S1 — symbol graph core
- SQLite tables `code_symbols` / `code_symbol_edges` (migration 62)
- Index on `prjct sync` (TS/JS + light Python/Go/Rust/Java)
- **4th work-scope ranker signal** (`symbols`, weight 0.2)
- CLI: `prjct code symbols|trace|impact|reindex`
- MCP: `prjct_search_symbols`, `prjct_trace_path`, richer `prjct_impact_analysis`
- `detect_changes` risk (critical/high/medium/low) + `review-risk` blast note

### S2 — agent UX + team + bridge
- `prjct code architecture` + MCP `prjct_architecture` (languages, kinds, packages, hotspots, routes, entries)
- PreToolUse **Grep|Glob** non-blocking graph augment (`pre-search` hook)
- Team artifact `.prjct/code-graph.json.gz` (export / import / sync bootstrap)
- Optional **CBM bridge** status when `codebase-memory-mcp` is on PATH

### Benchmark (this repo after reindex)
~**4845** symbols · **10273** edges · **768** files

## Usage

```bash
prjct code reindex          # or prjct sync
prjct code symbols ProcessOrder
prjct code trace validateUser --md
prjct code impact --md
prjct code architecture --md
prjct code export           # .prjct/code-graph.json.gz
prjct code cbm              # optional polyglot backend status
```

After upgrade: `prjct daemon stop` (or restart agent) so the new verb/hook load; `prjct install` / settings merge picks up Grep|Glob hook.

## Test plan

- [x] Unit: symbol extract/index/search/trace
- [x] Unit: detect_changes risk + import blast
- [x] Unit: architecture snapshot
- [x] Unit: code-graph artifact export/import
- [x] Unit: pre-search token extract
- [x] Manifest completeness + MCP tier tests
- [x] Broader suite: **895 pass** across related test trees
- [ ] Manual: `prjct code reindex` on a client project; `trace` a real symbol
- [ ] Manual: Grep in Claude Code injects symbol context when index present
- [ ] Manual: clone + `prjct code import` from committed artifact (optional)

## Out of scope (deliberate)

- Hybrid LSP / 158 tree-sitter grammars
- openCypher engine
- 3D graph UI