### PR TITLE
chore: reposition copy — 'AI Agile OS' → 'The agentic harness for AI coding agents'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # prjct-cli
 
-**AI Agile OS for coding agents.** prjct-cli gives Claude Code, Codex, Gemini,
-Cursor, Windsurf, and any agent a project second brain: intent briefs, bounded
-RAG context, preventive guardrails, synthesized learning, and performance
-signals for each dev+LLM work cycle.
+**The agentic harness for AI coding agents.** Intelligence is rented, the
+harness is owned: prjct-cli gives Claude Code, Codex, Gemini, Cursor,
+OpenCode, and any agent intent briefs, bounded RAG context, preventive
+guardrails, synthesized learning, and performance signals for each dev+LLM
+work cycle.
 
 [![npm](https://img.shields.io/npm/v/prjct-cli)](https://www.npmjs.com/package/prjct-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
@@ -176,7 +177,7 @@ Use `prjct agents doctor --fix` inside a prjct project to refresh the portable
 `AGENTS.md` surface and any repo-local IDE rule adapters prjct manages. The
 command is idempotent and reports what changed.
 
-## AI Agile intelligence
+## Harness intelligence
 
 prjct should justify itself with project evidence, not vague claims. These
 read-only commands show whether dev+LLM work cycles are getting cheaper,
@@ -240,7 +241,7 @@ $ prjct work "add OAuth refresh" --md
 ```bash
 # In any git repo
 prjct sync                                  # register the project (auto on first prjct command)
-prjct work "add OAuth refresh"              # start an AI Agile work cycle
+prjct work "add OAuth refresh"              # start a work cycle
 prjct remember decision "we chose JWT + refresh rotation"
 prjct remember context "implemented refresh rotation; model/tokens unknown; tests passed"
 prjct ship                                  # bump version, commit, push, open PR
@@ -261,7 +262,7 @@ prjct team --enforce               # pre-commit hook blocks commits without prjc
 
 ```bash
 p. remember context "call Ana re pricing; no work cycle yet"
-p. work "add OAuth refresh"                   # start an AI Agile work cycle
+p. work "add OAuth refresh"                   # start a work cycle
 p. remember decision "we chose JWT + refresh rotation"
 p. performance 7                              # inspect dev+LLM efficiency
 p. ship                                       # commit, push, open PR
@@ -269,12 +270,12 @@ p. ship                                       # commit, push, open PR
 
 Cursor and Windsurf use their installed prjct router files; otherwise run `prjct <command> --md` and follow the output.
 
-### AI Agile verbs
+### Harness verbs
 
 | Verb | What it does |
 |---|---|
 | `prjct intent "<title>"` | Frame objective, constraints, risks, and success signal before high-stakes work. |
-| `prjct work ["<intent>"]` | Start or inspect an AI Agile work cycle with context and evidence. |
+| `prjct work ["<intent>"]` | Start or inspect a work cycle with context and evidence. |
 | `prjct remember <type> "<content>"` | Persist a memory entry (decision, learning, gotcha, …). |
 | `prjct forget <id>` | Delete a memory entry by id (`prjct forget mem_1234`) — the delete half of `remember`. |
 | `prjct search "<query>"` | Search project memory — blended BM25 + semantic + recency recall (`prjct search mem_1234` resolves an entry by id). |
@@ -499,7 +500,7 @@ In any git repo, run `prjct sync` (it auto-runs on the first `prjct` command) or
 `prjct init`. This creates `.prjct/prjct.config.json` with a `projectId` and
 builds the SQLite store at `~/.prjct-cli/projects/<projectId>/`.
 
-**How do I start an AI Agile work cycle?**
+**How do I start a work cycle?**
 Run `prjct work "<intent>"` from the repo. It registers the work cycle in
 SQLite, pulls relevant second-brain context, auto-classifies a lightweight
 harness (H0-H3) with expected evidence, and marks it active — worked example:

--- a/core/__tests__/commands/command-data.test.ts
+++ b/core/__tests__/commands/command-data.test.ts
@@ -74,7 +74,7 @@ describe('COMMANDS', () => {
     })
   })
 
-  it('registers v3 AI Agile primitives and keeps task-manager verbs as legacy aliases', () => {
+  it('registers v3 work-cycle primitives and keeps task-manager verbs as legacy aliases', () => {
     for (const name of ['work', 'intent', 'insights', 'performance']) {
       const command = COMMANDS.find((entry) => entry.name === name)
       expect(command?.surface).toBe('ai-agile')

--- a/core/__tests__/services/skill-generator.test.ts
+++ b/core/__tests__/services/skill-generator.test.ts
@@ -126,7 +126,7 @@ describe('SkillGenerator (alpha.11 single skill)', () => {
       expect(content).toContain('never injected into CLAUDE.md / AGENTS.md')
     })
 
-    it('frames work as the single entrypoint for transparent AI Agile orchestration', async () => {
+    it('frames work as the single entrypoint for transparent work-cycle orchestration', async () => {
       // Lean L0: single-entrypoint contract only. Spec/test-first pipeline
       // detail stays in workflows.md (not always-on prose).
       const content = await readClaudeSkill()

--- a/core/__tests__/utils/help.test.ts
+++ b/core/__tests__/utils/help.test.ts
@@ -24,10 +24,10 @@ describe('getHelp', () => {
     }
   })
 
-  it('presents the v3 AI Agile surface instead of task-manager primitives', () => {
+  it('presents the v3 harness surface instead of task-manager primitives', () => {
     const help = getHelp()
 
-    expect(help).toContain('AI Agile OS')
+    expect(help).toContain('agentic harness')
     expect(help).toContain('p. work')
     expect(help).toContain('p. intent')
     expect(help).toContain('p. insights')

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -93,7 +93,7 @@ export class AnalysisCommands extends PrjctCommandsBase {
       console.log(summary)
       console.log('\nNext steps:')
       console.log('• p. sync → Generate agents based on stack')
-      console.log('• p. work "<intent>" → Start an AI Agile work cycle')
+      console.log('• p. work "<intent>" → Start a work cycle')
 
       return {
         success: true,

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -10,7 +10,7 @@ import type { CategoryInfo, CommandMeta } from '../types/commands'
 // Category definitions
 export const CATEGORIES: Record<string, CategoryInfo> = {
   core: {
-    title: 'AI Agile Loop',
+    title: 'Work Cycle',
     description: 'Intent, context, execution, learning, and improvement',
     order: 1,
   },
@@ -51,7 +51,7 @@ export const COMMANDS: CommandMeta[] = [
     hasTemplate: false,
     requiresProject: true,
     features: [
-      'v3 AI Agile replacement for ticket-style planning',
+      'v3 work-cycle replacement for ticket-style planning',
       'Stores the durable brief in SQLite',
       'Sub-verbs mirror spec for compatibility: list, show, update, audit, link-work, ship',
     ],
@@ -62,7 +62,7 @@ export const COMMANDS: CommandMeta[] = [
     surface: 'ai-agile',
     routing: { group: 'workflow', method: 'now' },
     optionSchema: { strings: ['spec', 'geometry'], booleans: ['extend'] },
-    description: 'Start or inspect an AI Agile work cycle with context and evidence',
+    description: 'Start or inspect a work cycle with context and evidence',
     usage: {
       claude: 'p. work "<intent>"',
       terminal: 'prjct work "<intent>" [--geometry split|single|direct]',
@@ -137,7 +137,7 @@ export const COMMANDS: CommandMeta[] = [
     requiresProject: true,
     features: [
       'No arg → shows the active task (or none)',
-      'Deprecated public language: use `prjct work` for the v3 AI Agile cycle',
+      'Deprecated public language: use `prjct work` for the v3 work cycle',
       'Auto-harness classifies H0-H3 and stores expected evidence on the task',
       'Writes to stateStorage; runs before/after workflow rules',
       'Optional Linear issue link when the arg matches `[A-Z]+-\\d+`',
@@ -694,7 +694,7 @@ export const COMMANDS: CommandMeta[] = [
     routing: { group: 'product', method: 'insights' },
     optionSchema: { numbers: ['days'] },
     description:
-      'AI Agile intelligence: value, quality, reliability, token cost, reports, continuation, and guardrails',
+      'Harness intelligence: value, quality, reliability, token cost, reports, continuation, and guardrails',
     usage: {
       claude: 'p. insights [value|quality|reliability|cost|report|continue|guardrails]',
       terminal: 'prjct insights [value|quality|reliability|cost|report|continue|guardrails] [--md]',

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -816,7 +816,7 @@ echo "⚡ prjct"
     console.log('')
     console.log(`   ${chalk.yellow('⚡')} Improve developer + agent performance`)
     console.log(`   ${chalk.green('🧠')} Rich project context without context bloat`)
-    console.log(`   ${chalk.cyan('🤖')} Human-in-the-loop AI Agile work cycles`)
+    console.log(`   ${chalk.cyan('🤖')} Human-in-the-loop work cycles`)
     console.log('')
     console.log(chalk.cyan('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'))
     console.log('')

--- a/core/mcp/server.ts
+++ b/core/mcp/server.ts
@@ -20,7 +20,7 @@ import { registerWorkflowTools } from './tools/workflow'
  * Compact instructions — hosts already list tool names; avoid duplicating
  * the tool laundry list here (token tax on every session).
  */
-const PRJCT_INSTRUCTIONS = `# prjct — project memory + AI Agile work cycles
+const PRJCT_INSTRUCTIONS = `# prjct — project memory + work cycles
 
 Use when work needs durable project memory, intent, or harness gates. Prefer tools over Grep for recall.
 

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -77,7 +77,7 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
 
   s.tool(
     'prjct_task_status',
-    'The active AI Agile work cycle (description, branch, when it started) plus queued work. Read this to see what is in progress before starting new work.',
+    'The active work cycle (description, branch, when it started) plus queued work. Read this to see what is in progress before starting new work.',
     {
       projectPath: optionalProjectPath,
     },
@@ -116,7 +116,7 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
 
   s.tool(
     'prjct_task_start',
-    'Start an AI Agile work cycle. Fires before/after workflow gates and memory logging through the compatibility task backend; a gate may block the start. Pass linked_spec_id only when a durable intent/spec brief is required. Use when the user begins concrete work.',
+    'Start a work cycle. Fires before/after workflow gates and memory logging through the compatibility task backend; a gate may block the start. Pass linked_spec_id only when a durable intent/spec brief is required. Use when the user begins concrete work.',
     {
       projectPath: optionalProjectPath,
       description: z.string().describe('What the work cycle is — a short intent phrase'),

--- a/core/services/skill-generator/editor-surfaces.ts
+++ b/core/services/skill-generator/editor-surfaces.ts
@@ -51,7 +51,7 @@ export function buildCompactSkill(): string {
   return `${[
     '---',
     'name: prjct',
-    'description: prjct AI Agile work/memory; run prjct verbs, do not preload context.',
+    'description: prjct work cycles + memory; run prjct verbs, do not preload context.',
     '---',
     '',
     '# prjct',
@@ -88,7 +88,7 @@ export function buildGlobalConfig(rigName: string): string {
     'Other commands: run `prjct <command> --md` and follow CLI output',
     '',
     'Flow: `prjct work` is the single normal entrypoint. Trivial work proceeds',
-    'directly. Substantive implementation work follows the persisted AI Agile',
+    'directly. Substantive implementation work follows the persisted work-cycle',
     'station from `prjct work --md`: reviewed intent, evidence, tests when',
     'required, then code.',
     '',

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -7,7 +7,7 @@
  */
 
 export const PRJCT_SKILL_DESCRIPTION =
-  'AI Agile OS for coding agents: intent briefs, RAG context, synthesized memory, guardrails, performance, and ships. Run the prjct verb yourself; use `prjct work` normally.'
+  'The agentic harness for AI coding agents: intent briefs, RAG context, synthesized memory, guardrails, performance, and ships. Run the prjct verb yourself; use `prjct work` normally.'
 
 export const PRJCT_SKILL_ALLOWED_TOOLS = [
   'Bash',

--- a/core/services/sync/state-update.ts
+++ b/core/services/sync/state-update.ts
@@ -96,7 +96,7 @@ export async function updateStateDoc(args: {
     ...((state.context as Record<string, unknown>) || {}),
     lastSession: dateHelper.getTimestamp(),
     lastAction: 'Synced project',
-    nextAction: 'Run `p. work "intent"` to start an AI Agile work cycle',
+    nextAction: 'Run `p. work "intent"` to start a work cycle',
   }
 
   await stateStorage.write(projectId, state as StateJson)

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -115,7 +115,7 @@ export const migrations: Migration[] = [
         -- Seed built-in workflows (task, done, ship, sync)
         INSERT INTO custom_workflows (name, description, is_builtin, enabled, created_at, updated_at)
         VALUES
-          ('task', 'Start an AI Agile work cycle', 1, 1, datetime('now'), datetime('now')),
+          ('task', 'Start a work cycle', 1, 1, datetime('now'), datetime('now')),
           ('done', 'Complete current task/subtask', 1, 1, datetime('now'), datetime('now')),
           ('ship', 'Ship feature with version bump and PR', 1, 1, datetime('now'), datetime('now')),
           ('sync', 'Analyze project and regenerate context', 1, 1, datetime('now'), datetime('now'));

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -406,7 +406,7 @@ export interface CommandMeta {
   name: string
   group: string
   /** Product-facing surface. `legacy` commands still execute for compatibility
-   *  but are hidden from the v3 AI Agile command surface. */
+   *  but are hidden from the v3 command surface. */
   surface?: 'ai-agile' | 'support' | 'legacy' | 'internal'
   description: string
   requiresProject: boolean

--- a/core/utils/help.ts
+++ b/core/utils/help.ts
@@ -110,7 +110,7 @@ function formatMainHelp(): string {
 
   // Header
   lines.push('')
-  lines.push(`${chalk.cyan.bold('prjct')} v${VERSION} - AI Agile OS for coding agents`)
+  lines.push(`${chalk.cyan.bold('prjct')} v${VERSION} - The agentic harness for AI coding agents`)
   lines.push(chalk.dim('Intent → context → execution → learning → performance improvement.'))
   lines.push('')
 
@@ -122,9 +122,7 @@ function formatMainHelp(): string {
   )
   lines.push(`  ${chalk.green('2.')} cd my-project && prjct init`)
   lines.push(`  ${chalk.green('3.')} Open in Claude Code / Gemini CLI / Cursor`)
-  lines.push(
-    `  ${chalk.green('4.')} p. work "improve auth"   ${chalk.dim('# Start an AI Agile cycle')}`
-  )
+  lines.push(`  ${chalk.green('4.')} p. work "improve auth"   ${chalk.dim('# Start a work cycle')}`)
   lines.push('')
 
   // Terminal Commands
@@ -288,7 +286,7 @@ function formatCommandList(): string {
   const lines: string[] = []
 
   lines.push('')
-  lines.push(chalk.cyan.bold('AI Agile Commands'))
+  lines.push(chalk.cyan.bold('Harness Commands'))
   lines.push('')
 
   // Group by category

--- a/core/utils/mcp-config.ts
+++ b/core/utils/mcp-config.ts
@@ -13,7 +13,7 @@ interface MCPConfig {
 }
 
 const PRJCT_MCP_DESCRIPTION =
-  'prjct: AI Agile OS with project memory, workflow gates, intent briefs, and performance context. Use prjct_task_start as the MCP entrypoint for a work cycle; prjct retrieves focused context, persists evidence stations, and keeps humans in the loop for risky gates. Agents resume from prjct_task_status/workflow output, create or link reviewed intent/spec briefs when required, and persist synthesized learning instead of raw transcript fragments.'
+  'prjct: agentic harness with project memory, workflow gates, intent briefs, and performance context. Use prjct_task_start as the MCP entrypoint for a work cycle; prjct retrieves focused context, persists evidence stations, and keeps humans in the loop for risky gates. Agents resume from prjct_task_status/workflow output, create or link reviewed intent/spec briefs when required, and persist synthesized learning instead of raw transcript fragments.'
 
 /**
  * Get the prjct MCP server config, resolving the path from the installed package.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prjct-cli",
   "version": "3.59.0",
-  "description": "Project memory and workflow context for AI coding agents.",
+  "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {
     "prjct": "bin/prjct.cjs"

--- a/templates/skills/prjct/SKILL.md
+++ b/templates/skills/prjct/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "AI Agile OS for coding agents: intent briefs, RAG context, synthesized memory, guardrails, performance, and ships. Run the prjct verb yourself; use `prjct work` normally."
+description: "The agentic harness for AI coding agents: intent briefs, RAG context, synthesized memory, guardrails, performance, and ships. Run the prjct verb yourself; use `prjct work` normally."
 allowed-tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Task"]
 user-invocable: true
 ---


### PR DESCRIPTION
## What

Sweeps every user-facing "AI Agile" phrase out of the tree and aligns it with the new public positioning (GitHub About updated today): **The agentic harness for AI coding agents — intelligence is rented, the harness is owned.**

- README intro rewritten (also drops legacy Windsurf → OpenCode per the 2026-07 runtime benchmark)
- `--help` tagline, "AI Agile Commands" → "Harness Commands", category "AI Agile Loop" → "Work Cycle"
- npm `package.json` description
- MCP server + tool descriptions, generated prjct skill tagline (template regenerated)
- "AI Agile work cycle" → "work cycle" everywhere; 3 test files updated

## Not touched

- Internal `surface: 'ai-agile'` enum (code plumbing, separate refactor if ever)
- CHANGELOG history

## Verification

- `tsc` clean, `biome check` clean
- Full unit suite: **2373 pass / 0 fail** (1 skip)
- `prjct --help` renders the new tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)