### PR TITLE
fix: skill diet ≤900 after code-graph cue

### DIFF
--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -61,7 +61,7 @@ export function buildPrjctSkillBody(): string {
     '### Cast + file scope (MUST)',
     '',
     '- Multi-agent Cast names (explore→Popper · implement→Copernicus · review→McClintock): use as `description` / `prjct claim --as <Name>`.',
-    '- Before Grep/Glob: Work scope from `prjct work`, MCP `prjct_relevant_files`, or `prjct context memory` + `prjct guard <file>`. Prefer `prjct code trace <symbol>` / `architecture` / MCP `prjct_trace_path` over file-by-file search when the symbol graph exists. No blind tree walk when indexes exist.',
+    '- Before Grep/Glob: `prjct work` / `prjct_relevant_files` / `prjct code trace` — no blind tree walk when indexes exist.',
     '- **Synthesis discipline:** parent never says "based on findings" — hand implementers concrete file:line specs. **Continue** a worker when it already holds the edit files; **spawn fresh** for verify or a wrong approach.',
     '',
     '### Core verbs (Tier 1=auto · 2=confirm)',


### PR DESCRIPTION
## Summary
CI failed on main after #568: weak-model gate `skill diet ≤900` (916 tok).

Compress the always-on skill Grep/code-graph line so the cue remains without blowing the budget (now 871 tok, 44/44 PASS).

## Test plan
- [x] `bun run bench:weak-model` → PASS 44/44
- [x] weak-model-bench + skill-generator tests green