### PR TITLE
chore: strip narration comments + realign README to actual source (v3.61.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.61.0] - 2026-07-14
+
+### Added
+- clean comments readme align
+
 ## [3.60.0] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,13 +106,17 @@ After install, **next session in any prjct-cli project**:
 - **Lookup-first protocol**: Claude queries prjct (`prjct search`, `prjct context memory`, MCP `prjct_*`) BEFORE re-exploring source. Cuts ~10K tokens of exploration per session.
 - **Auto-capture**: Stop hook scans the assistant transcript and persists durable insights (decisions/learnings/gotchas) tagged for dedup. The next session finds them via recall.
 - **Pattern detection**: Stop hook detects hot files (>3 changes in 7 days), recurring bugs (gotchas with the same topic), tech-debt growth (TODO/FIXME count rising). All persisted as learnings, surfaced next session.
-- **5 quality workflows** activated by natural language ("review this branch", "qa the UI", "security check", "investigate this bug"):
+- **6 quality workflows** activated by natural language ("review this branch", "qa the UI", "security check", "investigate this bug"):
   - `review` — Production Bug Hunt + Completeness Gate (3 modes)
   - `qa` — Real Browser, Atomic Fixes, Regression Tests
   - `security` — OWASP Top 10 + STRIDE, 8/10 confidence gate, concrete exploit per finding
   - `investigate` — Iron Law (no fix without investigation), max 3 failed hypotheses
-  - `ship` (endurecido) — Coverage Gate + Auto-Document
+  - `ship` (hardened) — Coverage Gate + Auto-Document
+  - `audit` — one-shot orchestrator: review + security + investigate combined
 - **Delivery-geometry advisory** (`prjct review-risk`): reads the committed changeset vs the merge-base and suggests a size tier (trivial/normal/large) + whether to ship direct, as one PR, or split — with the touched top-level dirs as natural split lines. Purely advisory: never gates, never mutates git.
+- **Session ceremonies**: `prjct prime` restores the full work state at session start; `prjct land` closes it — hand-off persisted to SQLite plus memory consolidation via `prjct dream` when its gates open.
+- **Multi-agent work graph**: dependency edges, ready frontier, race-free `prjct claim`, topological `prjct phases` — fan several agents out on one cycle without collisions. `prjct crew` runs the leader / implementers / reviewer flow.
+- **Code symbol graph**: `prjct code symbols|trace|impact|architecture|dead` — structural code intel built by `prjct sync` and injected by hooks alongside Grep results.
 
 ## How it works
 
@@ -286,10 +290,17 @@ Cursor and Windsurf use their installed prjct router files; otherwise run `prjct
 | `prjct sync` | Re-index files, git co-change, imports; refresh project analysis. |
 | `prjct agents doctor` | Show the auditable compatibility matrix for local and project agent runtimes. |
 | `prjct review-risk` | Advisory change-size + delivery-geometry signal for the branch (read-only; never gates, never splits). |
+| `prjct prime` / `prjct land` | Open / close a session: restore full work state · persist hand-off + trigger memory consolidation. |
+| `prjct dream` | Consolidate memory: orient / gather / consolidate / prune. |
+| `prjct ready` / `claim` / `depend` / `phases` | Multi-agent work graph: ready frontier, race-free claim, dependency edges, topological phases. |
+| `prjct crew` | Multi-subagent crew flow: leader / implementers / reviewer. |
+| `prjct code <sub>` | Symbol-graph queries: `symbols`, `trace`, `impact`, `architecture`, `dead`. |
+| `prjct tdd` / `sdd` / `lean` | Quality gates: test-first, spec-driven development, anti-over-engineering. |
+| `prjct memory export` / `import` | Git-shareable memory bundles for teams without cloud sync. |
 
 Compatibility aliases from v2 still execute for existing scripts: `task`,
 `status`, `tag`, `capture`, `spec`, `audit-spec`, `value`, `memory-doctor`,
-`report`, `handoff`, `guardrails`, `regen`, and `analyze`. They are no longer
+`report`, `handoff`, `guardrails`, and `analyze`. They are no longer
 the product surface.
 
 ## Personas & Packs
@@ -308,46 +319,54 @@ the product surface.
 }
 ```
 
-Five built-in packs (manifests, not bash pipelines):
+Seven built-in packs (TypeScript manifests in `core/packs/manifests.ts`, not bash pipelines):
 
 | Pack | Persona | Memory types enabled | Workflow slots |
 |---|---|---|---|
 | `code` | DEV | `fact`, `decision`, `learning`, `gotcha`, `pattern`, `anti-pattern`, `shipped` | `ship`, `review` |
+| `code-strict` | DEV | same as `code`, with SDD+TDD strict + delivery-geometry / land / conflict gates | `ship`, `review` |
 | `daily` | — | `inbox`, `todo`, `idea` | `morning`, `clarify`, `review` |
-| `pm` | PM | `decision`, `insight`, `question`, `stakeholder` | `spec`, `triage`, `update` |
-| `founder` | Founder | `goal`, `okr`, `person`, `stakeholder`, `decision` | `ship`, `review` |
-| `research` | Research | `source`, `claim`, `question`, `insight` | `research`, `review` |
+| `pm` | PM | `insight`, `question`, `stakeholder`, `decision`, `source` | `spec`, `triage`, `interview` |
+| `founder` | Founder | `goal`, `okr`, `person`, `stakeholder`, `decision`, `shipped` | `investor-update`, `1on1`, `strategy` |
+| `lean` | — | `over-engineering`, `lean-debt` | `review`, `audit`, `debt` |
+| `research` | Research | `source`, `claim`, `question`, `insight` | `lit-review`, `analyze` |
 
 Slots ship **empty** — the human or the agent fills them on demand.
 
 ## Claude Hooks Adapter (opt-in)
 
-`prjct install` refreshes the universal project surface (`AGENTS.md`) when run inside a prjct project, writes the Claude Code hooks adapter to `~/.claude/settings.json`, and repairs detected Codex config in `~/.codex/config.toml` (prjct MCP + TUI `status_line`). The Claude hooks inject `additionalContext`; none block by default. Other agents use the support level shown by `prjct agents doctor`.
+`prjct install` refreshes the universal project surface (`AGENTS.md`) when run inside a prjct project, writes the Claude Code hooks adapter to `~/.claude/settings.json`, and repairs detected Codex config in `~/.codex/config.toml` (prjct MCP + TUI `status_line`). Most of the 13 hook subcommands inject `additionalContext`; two guard: the credential guard denies tool calls that would leak secrets, and the package guard denies unknown installs under strict packs. Other agents use the support level shown by `prjct agents doctor`.
 
-| Event | Injects |
+| Event | Does |
 |---|---|
 | `SessionStart` | Persona; on cold start (startup/clear/compact) also the knowledge digest — top traps + decisions in force, so a freshly-updated model starts grounded |
 | `UserPromptSubmit` | Active project state (task, branch, inbox) |
+| `PreToolUse` (any tool) | Credential guard — **denies** the call when tool arguments contain secret material, so credentials never leave the machine |
+| `PreToolUse` (Bash package installs) | Package legitimacy — flags packages not already in `package.json` before the install runs (strict packs deny) |
 | `PreToolUse` (Bash git commit) | Anti-patterns tagged with touched files |
 | `PreToolUse` (Edit/Write) | The file's preventive memory (gotchas/anti-patterns) right before you edit it — pushes what `prjct guard` makes pull |
+| `PreToolUse` (Grep/Glob) | Injects indexed symbol-graph hits alongside search results (never gates) |
 | `PostToolUse` (Edit/Write) | Silently annotates `files_touched` on active task |
 | `Stop` | Async prompt: "learn anything reusable?"; scans the transcript for durable captures |
 | `SubagentStart` | Persona for fresh-brain subagents (cache-stable, digest-free) |
+| `SubagentStop` | Desktop notification when a subagent finishes (`config.notify`, default on) |
+| `Notification` | Desktop notification when the agent is waiting for input or permission |
 | `CwdChanged` | Re-contextualizes on project switch |
 
 Remove with `prjct claude uninstall` (hooks only) or `prjct uninstall` (everything).
 
 ## MCP Server
 
-prjct-cli exposes an MCP server with 5 tool groups:
+prjct-cli exposes an MCP server with 6 tool groups (every tool is prefixed `prjct_`):
 
 | Group | Tools |
 |---|---|
-| **memory** | save, list, similar, forget |
-| **project** | patterns, status, summary |
-| **files** | files, recent |
-| **workflow** | list, run, log |
-| **code-intel** | related, impact, stale |
+| **memory** | `mem_save`, `mem_list`, `mem_similar`, `mem_forget`, `guard`, `record_decision` / `record_gotcha` / `record_learning` / `record_fact`, `capture_inbox` |
+| **project** | `session_resume`, `task_status`, `task_start`, `task_set_status`, `analysis`, `cost_add`, `developer`, `signals`, `skills`, `context_tiers`, `safe_artifacts` |
+| **files** | `relevant_files`, `signatures`, `history` |
+| **workflow** | `workflow_rules`, `workflow_list`, `workflow_status` |
+| **code-intel** | `impact_analysis`, `search_symbols`, `trace_path`, `architecture`, `cochange`, `dead_code`, `import_graph`, `related_context` |
+| **spec** | 9 `spec_*` tools — create, get, list, update, and the rest of the SDD lifecycle |
 
 The broker model: if you already have `linear`, `jira`, `posthog`, `gmail` MCPs wired, prjct-cli **does not duplicate them** — it tells your agent they're available for the current persona and caches your insights locally.
 
@@ -375,9 +394,9 @@ Every command supports `--md` to emit LLM-optimized markdown for agent consumpti
 
 ## Memory
 
-14 built-in types + user-defined lowercase identifiers:
+20 built-in types + user-defined lowercase identifiers:
 
-`fact`, `decision`, `learning`, `gotcha`, `pattern`, `anti-pattern`, `shipped`, `inbox`, `todo`, `idea`, `insight`, `question`, `source`, `person` — plus anything you invent (`recipe`, `workout`, `interview`, …).
+`fact`, `decision`, `learning`, `gotcha`, `pattern`, `anti-pattern`, `shipped`, `identity`, `voice`, `glossary`, `framework`, `context`, `inbox`, `todo`, `idea`, `insight`, `question`, `source`, `person`, `spec` — plus anything you invent (`recipe`, `workout`, `interview`, …). Packs add more on top (e.g. `goal`, `okr` from `founder`).
 
 ```bash
 prjct remember decision "we chose SQLite because the app is local"
@@ -434,15 +453,16 @@ Without a key the built-in local embedder is used. Vector dimensionality is dete
 
 ## Code Intelligence
 
-`prjct sync` builds three indexes:
+`prjct sync` builds four indexes:
 
 | Index | Purpose |
 |---|---|
 | BM25 | Full-text search over names, symbols, comments |
+| Symbol graph | Structural code symbols + call sites — powers `prjct code symbols/trace/impact/architecture/dead` and the Grep/Glob hook augment |
 | Import graph | Forward + reverse dependency edges |
 | Git co-change | Files that change together |
 
-A combined ranker fuses the three signals (`core/domain/file-ranker.ts`) and powers `prjct context files`, plus `prjct_related`, `prjct_impact`, and `prjct_stale` in the MCP server.
+A combined ranker fuses the signals (`core/domain/file-ranker.ts`) and powers `prjct context files`, plus the code-intel MCP tools (`prjct_related_context`, `prjct_impact_analysis`, `prjct_search_symbols`, `prjct_trace_path`, …).
 
 ## Issue Tracker Integration
 
@@ -469,28 +489,42 @@ Bring your own MCP — prjct-cli doesn't duplicate trackers.
 ```
 prjct-cli/
   bin/prjct.cjs          Portable package-manager launcher
-  dist/bin/prjct.mjs     Thin JS shim (daemon-first)
+  bin/prjct.ts           Source entry — daemon + hook fast paths, self-heal
+  dist/bin/prjct.mjs     Built JS shim (daemon-first)
   core/
-    cli/                 CLI command handlers + dispatcher
-    hooks/               7 passive Claude Code hook subcommands
-    packs/               Pack manifests + pack-manager
-    mcp/                 MCP server (5 tool groups)
-    domain/              BM25, import-graph, git-cochange, file-ranker
-    services/            sync-service, skill-generator, pattern-detector
-    storage/             SQLite (one DB per project) — source of truth
+    agentic/             Agent template loader
+    cli/                 Bin-command helpers
+    commands/            Command registry (command-data.ts) + all verb handlers
+    config/              Static command-context config
+    constants/           Algorithm / timing / token constants
+    daemon/              Background daemon (client, dispatch, protocol)
+    domain/              BM25, symbol graph, import-graph, git-cochange, file-ranker
+    eval/                Retrieval evals + ledger
+    events/              Sync event bus
+    hooks/               13 hook subcommands (Claude Code adapter)
+    infrastructure/      path-manager, ai-provider, command-installer, agent-detector
+    mcp/                 MCP server (6 tool groups)
+    memory/              Memory model, recall, formatting
+    packs/               Pack manifests (TS) + pack-manager
     schemas/             Zod — runtime validation
-    infrastructure/      path-manager, ai-provider, command-installer
-    daemon/              Background daemon (file watching)
-    sync/                Cloud sync client + auth-config
+    services/            sync-service, skill-generator, embeddings, retention
+    session/             Git session helpers
+    storage/             SQLite (one DB per project) — source of truth
+    sync/                Cloud sync client + auth + entity handlers
+    tools/               Context tools (signatures, history, relevant files)
+    types/               Shared TypeScript types
+    utils/               Output, branding, cache helpers
+    workflow-engine/     Rule state-machine + when-evaluator
+    workflows/           Onboarding wizard
   templates/
-    commands/            Thin per-command templates (defer to CLI --md)
-    packs/               JSON pack manifests
+    codex/ crew/ cursor/ windsurf/ antigravity/   Per-agent surfaces
     global/              Per-editor router templates
+    skills/              Skill templates
 ```
 
 ## Requirements
 
-- Node.js 22.22.2+ or Bun 1.0+
+- Node.js 22.5+ (ships `node:sqlite`) or Bun 1.0+
 - One of: Claude Code, Gemini CLI, Cursor IDE, Windsurf, OpenAI Codex, Antigravity
 
 ## Common questions

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -380,7 +380,6 @@ export class AnalysisCommands extends PrjctCommandsBase {
         return { success: false, error: result.error || 'Failed to gather project data' }
       }
 
-      // Check if LLM analysis is already current
       const currentCommit = result.git.recentCommits[0]?.hash ?? null
       if (currentCommit && llmAnalysisStorage.isCurrent(projectId, currentCommit)) {
         if (options.md) {

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -91,7 +91,6 @@ export class SetupCommands extends PrjctCommandsBase {
    * the CLI exchanges the code for a device key (never a bearer in the URL).
    */
   async login(options: { md?: boolean } = {}): Promise<CommandResult> {
-    // Check if already authenticated
     const status = await authConfig.getStatus()
     if (status.authenticated) {
       if (!options.md) {

--- a/core/domain/bm25.ts
+++ b/core/domain/bm25.ts
@@ -274,7 +274,6 @@ export async function buildIndex(projectPath: string): Promise<BM25Index> {
     documents[filePath] = { tokens, length: tokens.length }
     totalLength += tokens.length
 
-    // Add to inverted index
     for (const [token, tf] of termFrequencies(tokens)) {
       if (!invertedIndex[token]) {
         invertedIndex[token] = []

--- a/core/index.ts
+++ b/core/index.ts
@@ -341,7 +341,6 @@ function validateCommandParams(
   const requiredParams = requiredParamSource.match(/<[^>]+>/g)
   if (!requiredParams || requiredParams.length === 0) return null
 
-  // Check if enough positional args provided
   if (parsedArgs.length < requiredParams.length) {
     const paramNames = requiredParams.map((p) => p.slice(1, -1)).join(', ')
     const usage = cmd.usage.terminal || `prjct ${cmd.name} ${cmd.params}`
@@ -368,7 +367,6 @@ function parseCommandArgs(_cmd: CommandMeta, rawArgs: string[]): ParsedCommandAr
       // Handle flags
       const flagName = arg.slice(2)
 
-      // Check if next arg is a value
       if (i + 1 < rawArgs.length && !rawArgs[i + 1].startsWith('--')) {
         options[flagName] = rawArgs[++i]
       } else {
@@ -390,7 +388,6 @@ function parseCommandArgs(_cmd: CommandMeta, rawArgs: string[]): ParsedCommandAr
 async function displayVersion(version: string): Promise<void> {
   const detection = await detectAllProviders()
 
-  // Check if prjct commands are installed for each provider
   const claudeCommandPath = path.join(os.homedir(), '.claude', 'commands', 'p.md')
   const geminiCommandPath = path.join(os.homedir(), '.gemini', 'commands', 'p.toml')
   const [claudeConfigured, geminiConfigured, cursorConfigured, cursorExists] = await Promise.all([

--- a/core/infrastructure/codex-skill.ts
+++ b/core/infrastructure/codex-skill.ts
@@ -99,10 +99,8 @@ export async function installCodexSkill(): Promise<{
   try {
     const skillMdPath = getCodexSkillPath()
     const prjctSkillDir = path.dirname(skillMdPath)
-    // Ensure skills directory exists
     await fs.mkdir(prjctSkillDir, { recursive: true })
 
-    // Check if SKILL.md already exists
     const skillExists = await fileExists(skillMdPath)
 
     // Read template content - try bundle first

--- a/core/infrastructure/setup.ts
+++ b/core/infrastructure/setup.ts
@@ -155,7 +155,6 @@ export async function run(): Promise<SetupResults> {
       configAction: null,
     }
 
-    // Check if CLI is installed
     if (!providerDetection.installed) {
       // Only prompt to install the primary (selected) provider
       if (providerName === selection.provider) {
@@ -293,7 +292,6 @@ async function installGeminiGlobalConfig(): Promise<{ success: boolean; action: 
   try {
     const geminiDir = path.join(os.homedir(), '.gemini')
     const globalConfigPath = path.join(geminiDir, 'GEMINI.md')
-    // Ensure ~/.gemini directory exists
     await fs.mkdir(geminiDir, { recursive: true })
 
     // Read template content from the package bundle or synthesize it from the
@@ -304,7 +302,6 @@ async function installGeminiGlobalConfig(): Promise<{ success: boolean; action: 
       return { success: false, action: null }
     }
 
-    // Check if global config already exists
     let existingContent = ''
     let configExists = false
 
@@ -353,10 +350,8 @@ async function installAntigravitySkill(): Promise<{
     const antigravitySkillsDir = path.join(os.homedir(), '.gemini', 'antigravity', 'skills')
     const prjctSkillDir = path.join(antigravitySkillsDir, 'prjct')
     const skillMdPath = path.join(prjctSkillDir, 'SKILL.md')
-    // Ensure skills directory exists
     await fs.mkdir(prjctSkillDir, { recursive: true })
 
-    // Check if SKILL.md already exists
     const skillExists = await fileExists(skillMdPath)
 
     // Read template content from the package bundle or synthesize it from the

--- a/core/infrastructure/statusline-installer.ts
+++ b/core/infrastructure/statusline-installer.ts
@@ -66,7 +66,6 @@ export async function installStatusLine(): Promise<void> {
     const sourceComponentsDir = path.join(assetsDir, 'components')
     const sourceConfigPath = path.join(assetsDir, 'default-config.json')
 
-    // Ensure directories exist
     if (!(await fileExists(claudeDir))) {
       await fs.mkdir(claudeDir, { recursive: true })
     }
@@ -83,7 +82,6 @@ export async function installStatusLine(): Promise<void> {
       await fs.mkdir(prjctComponentsDir, { recursive: true })
     }
 
-    // Check if statusline already exists
     if (await fileExists(prjctStatusLinePath)) {
       const existingContent = await fs.readFile(prjctStatusLinePath, 'utf8')
 
@@ -104,7 +102,6 @@ export async function installStatusLine(): Promise<void> {
         await installStatusLineModules(sourceLibDir, prjctLibDir)
         await installStatusLineModules(sourceComponentsDir, prjctComponentsDir)
 
-        // Ensure symlink and settings
         await ensureStatusLineSymlink(claudeStatusLinePath, prjctStatusLinePath)
         await ensureStatusLineSettings(settingsPath, claudeStatusLinePath)
         return
@@ -211,7 +208,6 @@ async function installStatusLineModules(sourceDir: string, destDir: string): Pro
  */
 async function ensureStatusLineSymlink(linkPath: string, targetPath: string): Promise<void> {
   try {
-    // Check if link already points to correct target
     if (await fileExists(linkPath)) {
       const stats = await fs.lstat(linkPath)
       if (stats.isSymbolicLink()) {

--- a/core/infrastructure/template-generator.ts
+++ b/core/infrastructure/template-generator.ts
@@ -32,7 +32,6 @@ class TemplateGenerator {
     description: string
   ): Promise<{ success: boolean; path?: string; error?: string }> {
     try {
-      // Ensure commands directory exists
       await fs.mkdir(this.commandsPath, { recursive: true })
 
       const templatePath = path.join(this.commandsPath, `${workflowName}.md`)

--- a/core/schemas/analysis.ts
+++ b/core/schemas/analysis.ts
@@ -157,7 +157,6 @@ async function verifyFrameworks(
     const found: string[] = []
 
     for (const framework of analysis.frameworks) {
-      // Check if framework name (or lowercase variant) exists in dependencies
       const frameworkLower = framework.toLowerCase()
       const exists = Object.keys(allDeps).some((dep) => dep.toLowerCase().includes(frameworkLower))
 

--- a/core/services/changelog-service.ts
+++ b/core/services/changelog-service.ts
@@ -219,7 +219,6 @@ export class ChangelogService {
   private insertMarkdownEntry(content: string, entry: ChangelogEntry, date: string): string {
     const entryText = this.formatMarkdownEntry(entry, date)
 
-    // Find the end of the first heading line
     const firstHeadingEnd = content.indexOf('\n')
 
     if (firstHeadingEnd !== -1) {

--- a/core/services/dependency-validator.ts
+++ b/core/services/dependency-validator.ts
@@ -264,7 +264,6 @@ class DependencyValidator {
     const timestamp = this.cacheTimestamps.get(toolName)
     if (!timestamp) return null
 
-    // Check if cache is expired
     if (isExpired(timestamp, this.cacheTimeout)) {
       this.cache.delete(toolName)
       this.cacheTimestamps.delete(toolName)

--- a/core/services/stack-detector.ts
+++ b/core/services/stack-detector.ts
@@ -37,7 +37,6 @@ export class StackDetector {
       frameworks: [],
     }
 
-    // Try to read package.json for JS/TS projects
     const pkg = await this.readPackageJson()
 
     if (pkg) {

--- a/core/services/watch-service.ts
+++ b/core/services/watch-service.ts
@@ -115,7 +115,6 @@ class WatchService {
       return { success: false, error: 'No prjct project. Run "prjct init" first.' }
     }
 
-    // Check if already running
     if (this.isRunning) {
       return { success: false, error: 'Watch mode is already running' }
     }
@@ -127,7 +126,6 @@ class WatchService {
       this.printStartup()
     }
 
-    // Initialize watcher
     this.watcher = chokidar.watch(TRIGGER_PATTERNS, {
       cwd: this.projectPath,
       ignored: IGNORE_PATTERNS,
@@ -202,7 +200,6 @@ class WatchService {
    * Handle file change event
    */
   private handleChange(event: 'add' | 'change' | 'unlink', filePath: string): void {
-    // Add to pending changes
     this.pendingChanges.add(filePath)
 
     if (this.options.verbose && !this.options.quiet) {

--- a/core/services/worktree-service.ts
+++ b/core/services/worktree-service.ts
@@ -54,7 +54,6 @@ class WorktreeService {
     const worktreePath = path.join(mainPath, WORKTREE_DIR, slug)
     const branch = options.branch || `feat/${slug}`
 
-    // Ensure .worktrees directory exists
     await fs.mkdir(path.join(mainPath, WORKTREE_DIR), { recursive: true })
 
     // Create worktree with new branch
@@ -218,7 +217,6 @@ class WorktreeService {
     for (const wt of worktrees) {
       if (wt.isMain) continue
 
-      // Check if the worktree directory still exists
       if (!(await fileExists(wt.path))) {
         removed.push(wt.slug)
       }

--- a/core/storage/analysis-storage.ts
+++ b/core/storage/analysis-storage.ts
@@ -327,7 +327,6 @@ class AnalysisStorage extends StorageManager<AnalysisStoreData> {
   ): Promise<SemanticVerificationReport> {
     const data = await this.read(projectId)
 
-    // Get the active analysis (sealed if available, otherwise draft)
     const analysis = data.sealed ?? data.draft
 
     if (!analysis) {

--- a/core/storage/custom-workflow-storage.ts
+++ b/core/storage/custom-workflow-storage.ts
@@ -46,7 +46,6 @@ class CustomWorkflowStorage {
       workflow.metadata ? JSON.stringify(workflow.metadata) : null
     )
 
-    // Get the inserted ID
     const result = prjctDb.get<{ id: number }>(
       projectId,
       'SELECT id FROM custom_workflows WHERE name = ?',

--- a/core/sync/sync-client.ts
+++ b/core/sync/sync-client.ts
@@ -334,7 +334,6 @@ class SyncClient {
     } catch (error) {
       clearTimeout(timeoutId)
 
-      // Check if this is a timeout (AbortError)
       if (error instanceof Error && error.name === 'AbortError') {
         throw this.createError(
           'NETWORK_ERROR',

--- a/core/sync/sync-manager.ts
+++ b/core/sync/sync-manager.ts
@@ -203,7 +203,6 @@ class SyncManager {
       // never block sync on the backfill
     }
 
-    // Push first
     const pushResult = await this.push(projectId, opts)
     if (pushResult.success && !pushResult.skipped) {
       result.pushed = {
@@ -212,7 +211,6 @@ class SyncManager {
       }
     }
 
-    // Then pull
     const pullResult = await this.pull(projectId)
     if (pullResult.success && !pullResult.skipped) {
       result.pulled = {
@@ -221,7 +219,6 @@ class SyncManager {
       }
     }
 
-    // Determine overall success
     if (!pushResult.success || !pullResult.success) {
       result.success = false
       result.error = pushResult.error || pullResult.error

--- a/core/utils/next-steps.ts
+++ b/core/utils/next-steps.ts
@@ -62,7 +62,6 @@ const COMMAND_TO_STATE: Record<string, WorkflowState> = {
 export function showNextSteps(command: string, options: { quiet?: boolean } = {}): void {
   if (options.quiet) return
 
-  // Get the state after this command
   const resultingState = COMMAND_TO_STATE[command] || 'idle'
 
   // Get valid commands for that state

--- a/core/utils/retry.ts
+++ b/core/utils/retry.ts
@@ -200,13 +200,11 @@ export class RetryPolicy {
         lastError = error
         attempt++
 
-        // Check if error is permanent (fail fast)
         if (isPermanentError(error)) {
           recordFailure(operationId, this.options.circuitBreakerThreshold)
           throw error
         }
 
-        // Check if error is transient and we have attempts left
         const shouldRetry = isTransientError(error) && attempt < this.options.maxAttempts
 
         if (!shouldRetry) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.60.0",
+  "version": "3.61.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## What

**Source cleanup (20 files):** removed 36 pure-narration comments that restated the next line (e.g. `// Check if already running` above `if (this.isRunning)`). Kept section banners (consistent repo pattern in large files), `types/` JSDoc (real documentation), and every comment carrying a why/constraint. Zero code lines touched.

**README realignment — verified claim-by-claim against source:**
- Node floor `22.22.2+` → `22.5+` (matches `engines` and the `node:sqlite` floor)
- MCP: 5 → **6 tool groups** with the real `prjct_*` tool names (the `spec` group with 9 tools was undocumented; old table listed tools that don't exist, e.g. `prjct_stale`)
- Memory: 14 → **20 built-in types** (adds `identity/voice/glossary/framework`, `context`, `spec`)
- Packs: 5 → **7** (`code-strict`, `lean` were missing; fixed `pm`/`founder`/`research` rows against `manifests.ts`)
- Hooks: 7 → **13** subcommands; documents the credential guard (DENIES — old README claimed "none block"), package guard, Grep/Glob symbol augment, and desktop notifications (`SubagentStop`/`Notification`)
- Dropped phantom `regen` compatibility alias (removed verb, not a live alias)
- Architecture tree rewritten: all 24 `core/` dirs, removed phantom `templates/commands/` + `templates/packs/`
- Code intelligence: 3 → 4 indexes (symbol graph)
- Added missing shipped surfaces: `prime`/`land`/`dream` ceremonies, multi-agent work graph (`ready`/`claim`/`depend`/`phases`), `crew`, `prjct code` symbol graph, `tdd`/`sdd`/`lean` gates, `audit` workflow, `memory export/import`

## Verification

- `biome check` clean · `tsc --noEmit` clean
- 2393 unit tests pass (0 fail)
- Comment deletions verified comment-only via `git diff -U0` (no code lines removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)