### PR TITLE
feat: upload compact structural code graph to cloud 3D

### DIFF
--- a/core/__tests__/services/code-graph-cloud.test.ts
+++ b/core/__tests__/services/code-graph-cloud.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { indexSymbols } from '../../domain/symbol-graph'
+import pathManager from '../../infrastructure/path-manager'
+import { buildCloudCodeGraphSnapshot, isUploadableGraph } from '../../services/code-graph-cloud'
+import prjctDb from '../../storage/database'
+
+describe('code-graph-cloud compact structural snapshot', () => {
+  let testDir: string
+  let testProjectId: string
+  let sourceDir: string
+  const originalGet = pathManager.getGlobalProjectPath.bind(pathManager)
+
+  beforeEach(async () => {
+    testDir = path.join(
+      os.tmpdir(),
+      `prjct-cloud-graph-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    sourceDir = path.join(testDir, 'src-repo')
+    testProjectId = `test-cloud-graph-${Date.now()}`
+    await fs.mkdir(path.join(sourceDir, 'src'), { recursive: true })
+    pathManager.getGlobalProjectPath = (id: string) => path.join(testDir, 'projects', id)
+
+    await fs.writeFile(
+      path.join(sourceDir, 'src', 'svc.ts'),
+      `
+export class Service {
+  run() {
+    return helper()
+  }
+}
+export function helper() {
+  return 1
+}
+export function unused() {
+  return 2
+}
+`
+    )
+    await fs.writeFile(
+      path.join(sourceDir, 'src', 'main.ts'),
+      `
+import { Service } from './svc'
+export function main() {
+  const s = new Service()
+  return s.run()
+}
+`
+    )
+  })
+
+  afterEach(async () => {
+    pathManager.getGlobalProjectPath = originalGet
+    try {
+      prjctDb.close(testProjectId)
+    } catch {
+      /* ok */
+    }
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+
+  it('builds Function/Class/File nodes with structural edges (not knowledge)', async () => {
+    await indexSymbols(sourceDir, testProjectId)
+    const snap = buildCloudCodeGraphSnapshot(testProjectId)
+    expect(isUploadableGraph(snap)).toBe(true)
+    expect(snap!.version).toBe(1)
+    expect(snap!.nodes.length).toBeGreaterThan(0)
+
+    const kinds = new Set(snap!.nodes.map((n) => n.kind))
+    // Must be structural kinds only
+    for (const k of kinds) {
+      expect([
+        'Function',
+        'Method',
+        'Class',
+        'Interface',
+        'Type',
+        'Enum',
+        'Const',
+        'Route',
+        'File',
+        'Symbol',
+      ]).toContain(k)
+    }
+    expect(kinds.has('Function') || kinds.has('Class') || kinds.has('Method')).toBe(true)
+
+    // No contribution/knowledge fake hubs
+    expect(snap!.nodes.every((n) => n.kind !== 'knowledge' && n.kind !== 'project')).toBe(true)
+
+    const types = new Set(snap!.links.map((l) => l.type))
+    // At least DEFINES (file→symbol) or CALLS/IMPORTS when resolvable
+    expect(types.size).toBeGreaterThan(0)
+    for (const t of types) {
+      expect(['CALLS', 'IMPORTS', 'DEFINES', 'HANDLES', 'TESTS']).toContain(t)
+    }
+  })
+
+  it('returns null without symbol index', () => {
+    expect(buildCloudCodeGraphSnapshot('no-such-project-xyz')).toBeNull()
+  })
+
+  it('respects maxNodes cap', async () => {
+    await indexSymbols(sourceDir, testProjectId)
+    const snap = buildCloudCodeGraphSnapshot(testProjectId, { maxNodes: 3, maxLinks: 20 })
+    expect(snap).not.toBeNull()
+    // File nodes are extra on top of picked symbols — total can be slightly over maxNodes
+    // but should stay bounded (picked ≤ 3 + file hubs ≤ 3)
+    expect(snap!.nodes.length).toBeLessThanOrEqual(10)
+  })
+})

--- a/core/commands/code.ts
+++ b/core/commands/code.ts
@@ -9,6 +9,7 @@
  *   prjct code architecture        → structural overview (one-shot)
  *   prjct code export              → cache under ~/.prjct-cli/projects/<id>/
  *   prjct code import              → restore SQLite from that per-project cache
+ *   prjct code push-graph          → upload compact structural graph to cloud 3D
  *   prjct code reindex             → rebuild symbol graph now
  *   prjct code dead                → zero-caller symbols (excl. entries)
  *   prjct code cbm [cli <tool> …]  → optional CBM bridge status / execute
@@ -32,6 +33,7 @@ import {
   exportCodeGraphArtifact,
   importCodeGraphArtifact,
   maybeExportAfterIndex,
+  maybeUploadCodeGraphToCloud,
 } from '../services/code-graph-artifact'
 import { findDeadCode, formatDeadCodeMd, formatDeadCodeText } from '../services/dead-code'
 import {
@@ -80,6 +82,9 @@ export class CodeCommands extends PrjctCommandsBase {
       if (sub === 'import' || sub === 'bootstrap') {
         return this.importArtifact(projectPath, options)
       }
+      if (sub === 'push-graph' || sub === 'push' || sub === 'upload-graph') {
+        return this.pushGraph(projectPath, options)
+      }
       if (sub === 'reindex' || sub === 'index') {
         return this.reindex(projectPath, options)
       }
@@ -90,7 +95,7 @@ export class CodeCommands extends PrjctCommandsBase {
         return this.cbmCmd(rest, options)
       }
       return failWith(
-        `Unknown code subcommand "${sub}". Use: symbols | trace | impact | architecture | dead | export | import | reindex | cbm`,
+        `Unknown code subcommand "${sub}". Use: symbols | trace | impact | architecture | dead | export | import | push-graph | reindex | cbm`,
         options
       )
     } catch (error) {
@@ -322,6 +327,25 @@ export class CodeCommands extends PrjctCommandsBase {
     if (options.md) console.log(mdOutput('## Code graph restore', `> ${msg}`))
     else out.success(msg)
     return { success: true, ...imp }
+  }
+
+  private async pushGraph(projectPath: string, options: MdOption): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+    if (!hasSymbolIndex(proj.value)) {
+      return failWith('No symbol index — run `prjct code reindex` first.', options)
+    }
+    const res = await maybeUploadCodeGraphToCloud(proj.value)
+    if (!res.uploaded) {
+      return failWith(
+        res.reason ?? 'Cloud upload failed (login with `prjct login` if offline).',
+        options
+      )
+    }
+    const msg = `Uploaded structural graph · ${res.nodes ?? 0} nodes · ${res.links ?? 0} links (Function/Class/File + CALLS)`
+    if (options.md) console.log(mdOutput('## Code graph cloud', `> ${msg}`))
+    else out.success(msg)
+    return { success: true, ...res }
   }
 
   private async reindex(projectPath: string, options: MdOption): Promise<CommandResult> {

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -447,10 +447,12 @@ export const COMMANDS: CommandMeta[] = [
     description:
       'Structural code graph: symbols, trace, impact/risk, architecture (run after sync)',
     usage: {
-      claude: 'p. code [symbols|trace|impact|architecture|dead|export|import|reindex|cbm]',
-      terminal: 'prjct code [symbols|trace|impact|architecture|dead|export|import|reindex|cbm]',
+      claude:
+        'p. code [symbols|trace|impact|architecture|dead|export|import|push-graph|reindex|cbm]',
+      terminal:
+        'prjct code [symbols|trace|impact|architecture|dead|export|import|push-graph|reindex|cbm]',
     },
-    params: '[symbols|trace|impact|architecture|dead|export|import|reindex|cbm] [args]',
+    params: '[symbols|trace|impact|architecture|dead|export|import|push-graph|reindex|cbm] [args]',
     implemented: true,
     hasTemplate: false,
     requiresProject: true,
@@ -459,6 +461,7 @@ export const COMMANDS: CommandMeta[] = [
       'Symbol index on sync; 4th work-scope signal; CALLS with enclosing + imports',
       'trace / impact (hunk-level) / architecture / dead one-shots',
       'Per-project cache under ~/.prjct-cli/projects/<id>/ (never in client repo)',
+      'push-graph: compact Function/Class/File + CALLS snapshot → cloud 3D',
       'PreToolUse Grep|Glob augment; ship structural risk cue; optional CBM cli',
     ],
   },

--- a/core/services/code-graph-artifact.ts
+++ b/core/services/code-graph-artifact.ts
@@ -174,6 +174,38 @@ export async function maybeExportAfterIndex(projectId: string): Promise<void> {
   } catch {
     /* non-critical */
   }
+  // Best-effort cloud upload so the SPA 3D graph stays structural (not knowledge).
+  try {
+    await maybeUploadCodeGraphToCloud(projectId)
+  } catch {
+    /* non-critical — offline / unauthed */
+  }
+}
+
+/** Build compact structural snapshot and POST to /sync/projects/{id}/code-graph. */
+export async function maybeUploadCodeGraphToCloud(
+  projectId: string
+): Promise<{ uploaded: boolean; nodes?: number; links?: number; reason?: string }> {
+  const { buildCloudCodeGraphSnapshot, isUploadableGraph } = await import('./code-graph-cloud')
+  const snap = buildCloudCodeGraphSnapshot(projectId)
+  if (!isUploadableGraph(snap)) {
+    return { uploaded: false, reason: 'no symbol index or empty graph' }
+  }
+  try {
+    const { default: syncClient } = await import('../sync/sync-client')
+    const res = await syncClient.uploadCodeGraph(projectId, snap)
+    if (!res.ok) return { uploaded: false, reason: 'upload failed or unauthenticated' }
+    return {
+      uploaded: true,
+      nodes: res.nodes ?? snap.nodes.length,
+      links: res.links ?? snap.links.length,
+    }
+  } catch (e) {
+    return {
+      uploaded: false,
+      reason: e instanceof Error ? e.message : String(e),
+    }
+  }
 }
 
 export async function ensureIndexWithBootstrap(

--- a/core/services/code-graph-cloud.ts
+++ b/core/services/code-graph-cloud.ts
@@ -1,0 +1,247 @@
+/**
+ * Compact structural code-graph snapshot for cloud 3D visualization.
+ *
+ * Same domain as CBM / native symbol index:
+ *   nodes = Function | Method | Class | Interface | Type | File | …
+ *   links = CALLS | IMPORTS | DEFINES | HANDLES | TESTS
+ *
+ * NOT knowledge/contribution clusters. Cap size for API JSONB + SPA force-graph.
+ */
+
+import { hasSymbolIndex, listAllSymbols, loadMeta } from '../domain/symbol-graph'
+import prjctDb from '../storage/database'
+import type { CodeSymbolEdge, SymbolEdgeType } from '../types/domain.js'
+
+/** Max nodes shipped to cloud (force-graph stays interactive). */
+export const CLOUD_GRAPH_MAX_NODES = 400
+/** Max directed edges shipped with the node subset. */
+export const CLOUD_GRAPH_MAX_LINKS = 900
+
+export type CloudGraphNodeKind =
+  | 'Function'
+  | 'Method'
+  | 'Class'
+  | 'Interface'
+  | 'Type'
+  | 'Enum'
+  | 'Const'
+  | 'Route'
+  | 'File'
+  | 'Symbol'
+
+export interface CloudGraphNode {
+  id: string
+  name: string
+  kind: CloudGraphNodeKind | string
+  file?: string | null
+  exported?: boolean
+}
+
+export interface CloudGraphLink {
+  source: string
+  target: string
+  type: string
+}
+
+export interface CloudCodeGraphSnapshot {
+  version: 1
+  builtAt: string
+  symbolCount: number
+  edgeCount: number
+  nodes: CloudGraphNode[]
+  links: CloudGraphLink[]
+}
+
+const KIND_MAP: Record<string, CloudGraphNodeKind> = {
+  function: 'Function',
+  method: 'Method',
+  class: 'Class',
+  interface: 'Interface',
+  type: 'Type',
+  enum: 'Enum',
+  const: 'Const',
+  route: 'Route',
+  file: 'File',
+}
+
+/** Prefer structural call graph edges; imports/defines still useful. */
+const EDGE_PRIORITY: Record<string, number> = {
+  CALLS: 5,
+  IMPORTS: 4,
+  DEFINES: 3,
+  HANDLES: 2,
+  TESTS: 1,
+}
+
+function mapKind(kind: string): CloudGraphNodeKind {
+  return KIND_MAP[kind.toLowerCase()] ?? 'Symbol'
+}
+
+function loadEdges(projectId: string): CodeSymbolEdge[] {
+  try {
+    return prjctDb
+      .query<{
+        src: string
+        dst: string
+        edge_type: string
+        confidence: number
+      }>(projectId, 'SELECT src, dst, edge_type, confidence FROM code_symbol_edges')
+      .map((r) => ({
+        src: r.src,
+        dst: r.dst,
+        edgeType: r.edge_type as SymbolEdgeType,
+        confidence: r.confidence,
+      }))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Build a compact CBM-style structural graph from the local symbol index.
+ * Scores symbols by structural degree (CALLS/IMPORTS) + export + kind weight.
+ */
+export function buildCloudCodeGraphSnapshot(
+  projectId: string,
+  opts: { maxNodes?: number; maxLinks?: number } = {}
+): CloudCodeGraphSnapshot | null {
+  if (!hasSymbolIndex(projectId)) return null
+
+  const maxNodes = opts.maxNodes ?? CLOUD_GRAPH_MAX_NODES
+  const maxLinks = opts.maxLinks ?? CLOUD_GRAPH_MAX_LINKS
+  const symbols = listAllSymbols(projectId)
+  if (symbols.length === 0) return null
+
+  const edges = loadEdges(projectId)
+  const meta = loadMeta(projectId)
+
+  // Degree from structural edges only
+  const degree = new Map<string, number>()
+  for (const e of edges) {
+    const w = EDGE_PRIORITY[e.edgeType] ?? 1
+    degree.set(e.src, (degree.get(e.src) ?? 0) + w)
+    degree.set(e.dst, (degree.get(e.dst) ?? 0) + w)
+  }
+
+  const kindWeight = (k: string): number => {
+    switch (k) {
+      case 'class':
+        return 8
+      case 'function':
+      case 'method':
+        return 6
+      case 'interface':
+      case 'type':
+        return 4
+      case 'route':
+        return 5
+      default:
+        return 2
+    }
+  }
+
+  const scored = symbols
+    .map((s) => {
+      const deg = degree.get(s.id) ?? 0
+      const exp = s.exported ? 4 : 0
+      return { s, score: deg + exp + kindWeight(s.kind) }
+    })
+    .sort((a, b) => b.score - a.score || a.s.name.localeCompare(b.s.name))
+
+  const picked = scored.slice(0, maxNodes).map((x) => x.s)
+  const keep = new Set(picked.map((s) => s.id))
+
+  // File nodes for top files among picked symbols (CBM-style File layer)
+  const fileCounts = new Map<string, number>()
+  for (const s of picked) {
+    fileCounts.set(s.file, (fileCounts.get(s.file) ?? 0) + 1)
+  }
+  const topFiles = [...fileCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, Math.min(80, Math.floor(maxNodes / 5)))
+    .map(([f]) => f)
+
+  const fileNodeId = (file: string) => `file:${file}`
+  const nodes: CloudGraphNode[] = []
+
+  for (const file of topFiles) {
+    const base = file.split('/').pop() || file
+    nodes.push({
+      id: fileNodeId(file),
+      name: base,
+      kind: 'File',
+      file,
+      exported: false,
+    })
+    keep.add(fileNodeId(file))
+  }
+
+  for (const s of picked) {
+    nodes.push({
+      id: s.id,
+      name: s.name,
+      kind: mapKind(s.kind),
+      file: s.file,
+      exported: s.exported,
+    })
+  }
+
+  // DEFINES: File → symbol for symbols in top files
+  const defineLinks: CloudGraphLink[] = []
+  const topFileSet = new Set(topFiles)
+  for (const s of picked) {
+    if (!topFileSet.has(s.file)) continue
+    defineLinks.push({
+      source: fileNodeId(s.file),
+      target: s.id,
+      type: 'DEFINES',
+    })
+  }
+
+  // Structural edges between kept symbol nodes
+  const edgeCandidates = edges
+    .filter((e) => keep.has(e.src) && keep.has(e.dst) && e.src !== e.dst)
+    .map((e) => ({
+      source: e.src,
+      target: e.dst,
+      type: e.edgeType,
+      prio: EDGE_PRIORITY[e.edgeType] ?? 0,
+      conf: e.confidence,
+    }))
+    .sort((a, b) => b.prio - a.prio || b.conf - a.conf)
+
+  const seen = new Set<string>()
+  const links: CloudGraphLink[] = []
+
+  for (const d of defineLinks) {
+    const key = `${d.source}->${d.target}:${d.type}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    links.push({ source: d.source, target: d.target, type: d.type })
+    if (links.length >= maxLinks) break
+  }
+
+  for (const e of edgeCandidates) {
+    if (links.length >= maxLinks) break
+    const key = `${e.source}->${e.target}:${e.type}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    links.push({ source: e.source, target: e.target, type: e.type })
+  }
+
+  return {
+    version: 1,
+    builtAt: meta?.builtAt ?? new Date().toISOString(),
+    symbolCount: meta?.symbolCount ?? symbols.length,
+    edgeCount: meta?.edgeCount ?? edges.length,
+    nodes,
+    links,
+  }
+}
+
+/** True when snapshot is non-empty enough to upload. */
+export function isUploadableGraph(
+  snap: CloudCodeGraphSnapshot | null
+): snap is CloudCodeGraphSnapshot {
+  return !!snap && snap.nodes.length > 0
+}

--- a/core/sync/sync-client.ts
+++ b/core/sync/sync-client.ts
@@ -191,6 +191,49 @@ class SyncClient {
   }
 
   /**
+   * Upload compact structural code graph (Function/Class/File + CALLS/IMPORTS)
+   * for the cloud 3D visualizer. Best-effort — returns false if offline/unauthed.
+   */
+  async uploadCodeGraph(
+    projectId: string,
+    graph: {
+      version: number
+      builtAt?: string
+      symbolCount?: number
+      edgeCount?: number
+      nodes: Array<{
+        id: string
+        name: string
+        kind: string
+        file?: string | null
+        exported?: boolean
+      }>
+      links: Array<{ source: string; target: string; type: string }>
+    }
+  ): Promise<{ ok: boolean; nodes?: number; links?: number }> {
+    try {
+      const { apiUrl, apiKey, deviceId } = await this.getAuthHeaders()
+      if (!apiKey) return { ok: false }
+      const response = await this.fetchWithRetry(
+        `${apiUrl}/sync/projects/${projectId}/code-graph`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...this.authHeaders(apiKey, deviceId),
+          },
+          body: JSON.stringify(graph),
+        }
+      )
+      if (!response.ok) return { ok: false }
+      const body = (await response.json()) as { ok?: boolean; nodes?: number; links?: number }
+      return { ok: body.ok !== false, nodes: body.nodes, links: body.links }
+    } catch {
+      return { ok: false }
+    }
+  }
+
+  /**
    * Publish a product benchmark to the cloud API.
    *
    * This is intentionally a cloud operation, not a GitHub write. The server is


### PR DESCRIPTION
## Summary
- Build compact CBM-domain snapshots (`Function`/`Class`/`File` + `CALLS`/`IMPORTS`/`DEFINES`) from the local symbol index — not knowledge/contribution clusters.
- Upload after index via `POST /sync/projects/{id}/code-graph` (best-effort).
- Add `prjct code push-graph` for explicit cloud upload.

## Test plan
- [x] `bun test core/__tests__/services/code-graph-cloud.test.ts`
- [x] `bun test core/__tests__/services/code-graph-artifact.test.ts`
- [x] pre-push typecheck
- [ ] With API deployed: `prjct code reindex && prjct code push-graph` then confirm SPA graph

Depends on: API `feat/structural-code-graph` (stores/serves `code_graph`).