### PR TITLE
fix(sync): resolve work-cycle entity_id from taskId

### DIFF
--- a/core/__tests__/sync/event-mapper.test.ts
+++ b/core/__tests__/sync/event-mapper.test.ts
@@ -62,6 +62,26 @@ describe('mapCliEventToWebFormat', () => {
     expect(result?.entity_id).toBe('')
   })
 
+  it('maps work-cycle task.started (taskId only) to entity_id + data.id', () => {
+    // Real producer shape from state-storage: no top-level entityId, no data.id —
+    // only taskId. Cloud work visibility depends on this resolving.
+    const result = mapCliEventToWebFormat(
+      'proj-1',
+      makeEvent('task.started', {
+        taskId: 'cycle-abc',
+        description: 'fix work sync',
+        startedAt: '2026-07-15T00:00:00Z',
+        sessionId: 'sess-1',
+      })
+    )
+    expect(result).not.toBeNull()
+    expect(result?.entity_type).toBe('tasks')
+    expect(result?.entity_id).toBe('cycle-abc')
+    expect(result?.data.id).toBe('cycle-abc')
+    expect(result?.data.task_id).toBe('cycle-abc')
+    expect(result?.data.started_at).toBe('2026-07-15T00:00:00Z')
+  })
+
   it('handles undefined data', () => {
     const event: SyncEvent = {
       type: 'task.created',

--- a/core/sync/event-mapper.ts
+++ b/core/sync/event-mapper.ts
@@ -78,8 +78,22 @@ export function mapCliEventToWebFormat(projectId: string, event: SyncEvent): Web
   const rawData = (event.data || {}) as Record<string, unknown>
   const data = snakeCaseKeys(rawData)
 
-  // Extract entity_id: explicit field wins, then the payload id.
-  const entityId = event.entityId || (data.id as string) || (rawData.id as string) || ''
+  // Extract entity_id: explicit field wins, then common payload keys.
+  // Work-cycle producers (`task.started` / `.paused` / `.resumed` / `.completed`)
+  // put the id in `taskId` (→ `task_id`), not `id`. Without this fallback the
+  // cloud row lands with empty entity_id and work never appears to sync.
+  const entityId =
+    event.entityId ||
+    (typeof data.id === 'string' ? data.id : '') ||
+    (typeof rawData.id === 'string' ? rawData.id : '') ||
+    (typeof data.task_id === 'string' ? data.task_id : '') ||
+    (typeof rawData.taskId === 'string' ? rawData.taskId : '') ||
+    (typeof data.entity_id === 'string' ? data.entity_id : '') ||
+    ''
+
+  // Normalize so cloud consumers always see `id` even when the producer only
+  // set taskId / entity_id aliases.
+  if (entityId && data.id == null) data.id = entityId
 
   const out: WebSyncEvent = {
     event_type: eventType,


### PR DESCRIPTION
## Summary
- Work-cycle events (`task.started` / `.paused` / `.resumed` / `.completed`) put the id in `taskId`, not `data.id`.
- `mapCliEventToWebFormat` only read `id`, so cloud rows could land with an empty `entity_id`.
- Fallback to `task_id` / `taskId` / `entity_id`, and normalize `data.id` for consumers.

## Test plan
- [x] `bun test core/__tests__/sync/event-mapper.test.ts` (21 pass)
- [ ] After publish: start a work cycle and confirm cloud/sync events carry non-empty `entity_id` for `tasks`