### PR TITLE
fix(daemon): 10min client timeout for ship/sync and long verbs

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -322,14 +322,21 @@ if (_fastCommand && !_binCommands.has(_fastCommand) && process.env.PRJCT_NO_DAEM
     }
 
     try {
-      const response = await sendRequest({
-        id: crypto.randomUUID(),
-        command: _fastCommand,
-        args: commandArgs,
-        options: commandOptions,
-        cwd: process.cwd(),
-        perfStartNs: ((globalThis as Record<string, unknown>).__perfStartNs as bigint)?.toString(),
-      })
+      const { commandRequestTimeoutMs } = await import('../core/daemon/protocol')
+      const response = await sendRequest(
+        {
+          id: crypto.randomUUID(),
+          command: _fastCommand,
+          args: commandArgs,
+          options: commandOptions,
+          cwd: process.cwd(),
+          perfStartNs: (
+            (globalThis as Record<string, unknown>).__perfStartNs as bigint
+          )?.toString(),
+        },
+        // ship/sync/dream/… need the long budget; default 30s is for snappy verbs.
+        { timeoutMs: commandRequestTimeoutMs(_fastCommand) }
+      )
 
       // Daemon refused because its code is stale (newer build/install on
       // disk). The command did NOT run there — fall through to direct

--- a/core/__tests__/daemon/protocol-platform.test.ts
+++ b/core/__tests__/daemon/protocol-platform.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from 'bun:test'
 import path from 'node:path'
-import { getDaemonRunDir, getDaemonSocketPath, isDaemonNamedPipe } from '../../daemon/protocol'
+import {
+  COMMAND_REQUEST_TIMEOUT_MS,
+  commandRequestTimeoutMs,
+  getDaemonRunDir,
+  getDaemonSocketPath,
+  HOOK_REQUEST_TIMEOUT_MS,
+  isDaemonNamedPipe,
+  LONG_COMMAND_TIMEOUT_MS,
+  LONG_RUNNING_COMMANDS,
+} from '../../daemon/protocol'
 
 describe('daemon IPC platform paths', () => {
   test('uses Unix socket paths on POSIX platforms', () => {
@@ -19,5 +28,27 @@ describe('daemon IPC platform paths', () => {
     expect(socketPath).not.toContain('daemon.sock')
     expect(isDaemonNamedPipe(socketPath)).toBe(true)
     expect(getDaemonSocketPath('win32', cliHome)).toBe(socketPath)
+  })
+})
+
+describe('commandRequestTimeoutMs', () => {
+  test('hooks stay fail-soft at 5s', () => {
+    expect(commandRequestTimeoutMs('hook')).toBe(HOOK_REQUEST_TIMEOUT_MS)
+    expect(HOOK_REQUEST_TIMEOUT_MS).toBe(5_000)
+  })
+
+  test('ship/sync and other long verbs get the 10min budget', () => {
+    for (const cmd of LONG_RUNNING_COMMANDS) {
+      expect(commandRequestTimeoutMs(cmd)).toBe(LONG_COMMAND_TIMEOUT_MS)
+    }
+    expect(LONG_COMMAND_TIMEOUT_MS).toBe(10 * 60 * 1000)
+    // Ship alone can exceed 65s (version+changelog+commit+push) before gates.
+    expect(commandRequestTimeoutMs('ship')).toBeGreaterThan(65_000)
+  })
+
+  test('snappy verbs stay at 30s so a hung daemon cannot pin the shell', () => {
+    expect(commandRequestTimeoutMs('search')).toBe(COMMAND_REQUEST_TIMEOUT_MS)
+    expect(commandRequestTimeoutMs('remember')).toBe(COMMAND_REQUEST_TIMEOUT_MS)
+    expect(COMMAND_REQUEST_TIMEOUT_MS).toBe(30_000)
   })
 })

--- a/core/daemon/client.ts
+++ b/core/daemon/client.ts
@@ -14,13 +14,7 @@ import { connect } from 'node:net'
 import path from 'node:path'
 import type { DaemonRequest, DaemonResponse, DaemonStatus } from '../types/daemon'
 import { isBunAvailable } from '../utils/runtime'
-import {
-  COMMAND_REQUEST_TIMEOUT_MS,
-  DAEMON_PATHS,
-  encodeMessage,
-  HOOK_REQUEST_TIMEOUT_MS,
-  isDaemonNamedPipe,
-} from './protocol'
+import { commandRequestTimeoutMs, DAEMON_PATHS, encodeMessage, isDaemonNamedPipe } from './protocol'
 import { releaseSpawnLock, tryAcquireSpawnLock } from './startup-lock'
 
 /**
@@ -100,23 +94,23 @@ export async function getDaemonStatus(): Promise<DaemonStatus> {
 }
 
 export interface SendRequestOptions {
-  /** Override the default timeout (commands 30s, hooks should pass HOOK_REQUEST_TIMEOUT_MS). */
+  /**
+   * Override the default timeout. Defaults come from
+   * `commandRequestTimeoutMs(command)` (hooks 5s, long verbs 10min, else 30s).
+   */
   timeoutMs?: number
 }
 
 /**
  * Send a command to the daemon and return the response.
- * Default timeout is 30s for CLI commands. Callers serving hooks MUST pass
- * `timeoutMs: HOOK_REQUEST_TIMEOUT_MS` (5s) so a hung daemon cannot stall
- * the host agent for half a minute.
+ * Default budget: hooks 5s, ship/sync/dream… 10min, everything else 30s.
+ * Callers can still override with `timeoutMs`.
  */
 export function sendRequest(
   request: DaemonRequest,
   options: SendRequestOptions = {}
 ): Promise<DaemonResponse> {
-  const timeoutMs =
-    options.timeoutMs ??
-    (request.command === 'hook' ? HOOK_REQUEST_TIMEOUT_MS : COMMAND_REQUEST_TIMEOUT_MS)
+  const timeoutMs = options.timeoutMs ?? commandRequestTimeoutMs(request.command)
 
   return new Promise((resolve, reject) => {
     const socketPath = DAEMON_PATHS.socket()

--- a/core/daemon/dispatch.ts
+++ b/core/daemon/dispatch.ts
@@ -21,7 +21,9 @@ export async function executeCommand(
   request: DaemonRequest
 ): Promise<CommandResult> {
   const param = request.args.join(' ') || null
-  const opts = request.options
+  // Wire clients always send options, but a malformed/legacy peer must not
+  // crash the daemon with `undefined is not an object (evaluating 'r.md')`.
+  const opts = request.options ?? {}
   const md = opts.md === true
 
   // Short-circuit v2-removed verbs with a migration message so the daemon

--- a/core/daemon/protocol.ts
+++ b/core/daemon/protocol.ts
@@ -59,11 +59,44 @@ export const MAX_BUFFER_SIZE = 1024 * 1024
 export const COMMAND_REQUEST_TIMEOUT_MS = 30_000
 
 /**
+ * Client timeout for long-running verbs (ship/sync/dream/…). Ship alone can
+ * spend >65s on version+changelog+commit+push (plus optional test gates up
+ * to 5min). A 30s hard cut made `prjct ship` exit 1 mid-flight ("daemon
+ * dropped the request (Daemon request timed out)") while the daemon still
+ * ran partial side effects — agents then looped "Retry after daemon timeout".
+ * Must stay in lockstep with the production shim in scripts/build.js.
+ */
+export const LONG_COMMAND_TIMEOUT_MS = 10 * 60 * 1000
+
+/**
+ * Verbs that routinely exceed COMMAND_REQUEST_TIMEOUT_MS. Keep this list
+ * short and intentional — everything else stays at 30s so a hung daemon
+ * cannot pin a shell for 10 minutes.
+ */
+export const LONG_RUNNING_COMMANDS: ReadonlySet<string> = new Set([
+  'ship',
+  'sync',
+  'dream',
+  'update',
+  'upgrade',
+  'analyze',
+  'init',
+  'cloud',
+])
+
+/**
  * Client timeout for hook requests. Hooks are fail-soft and latency-critical
  * (Claude Code waits). A hung daemon must not block the host for 30s — the
  * production shim already uses 5s; keep the source path identical.
  */
 export const HOOK_REQUEST_TIMEOUT_MS = 5_000
+
+/** Resolve the client-side wait budget for a daemon-routed command. */
+export function commandRequestTimeoutMs(command: string): number {
+  if (command === 'hook') return HOOK_REQUEST_TIMEOUT_MS
+  if (LONG_RUNNING_COMMANDS.has(command)) return LONG_COMMAND_TIMEOUT_MS
+  return COMMAND_REQUEST_TIMEOUT_MS
+}
 
 /**
  * How long shutdown waits for in-flight requests before force-exit.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -249,9 +249,11 @@ function deriveShimSkipSet() {
  * This avoids parsing the ~600KB core bundle when daemon handles the command.
  */
 function generateDaemonShim() {
-  // Fallback policy MUST mirror bin/prjct.ts:206-251 + core/daemon/client.ts:87-145:
+  // Fallback policy MUST mirror bin/prjct.ts + core/daemon/client.ts + protocol.ts:
   //
-  //   - Timeout = 30s (sendRequest uses 30_000).
+  //   - Timeout = 30s for snappy verbs; 10min for long-running (ship/sync/dream/
+  //     update/upgrade/analyze/init/cloud). Ship alone can exceed 65s before
+  //     test gates. Mirrors commandRequestTimeoutMs() in protocol.ts.
   //   - On socket error: fall through ONLY for ECONNREFUSED / ENOENT (stale
   //     socket, no listener — the request never reached a daemon, safe to
   //     re-run). Anything else (timeout, "Connection closed before response",
@@ -269,7 +271,7 @@ function generateDaemonShim() {
   // This blocked the bin/prjct.ts hardening from commit d08727b8 from
   // reaching production for ~10 days (the shim is what end users actually
   // execute via dist/bin/prjct.mjs). Any future change to the fallback
-  // policy MUST update both this string and bin/prjct.ts.
+  // policy MUST update both this string and bin/prjct.ts + protocol.ts.
   return `#!/usr/bin/env node
 import{connect}from"node:net";import{existsSync}from"node:fs";import{createHash,randomUUID}from"node:crypto";import{homedir}from"node:os";import{join,resolve}from"node:path";
 const cliHome=process.env.PRJCT_CLI_HOME?resolve(process.env.PRJCT_CLI_HOME):join(homedir(),".prjct-cli");
@@ -312,7 +314,10 @@ if(cmd==="hook"){
   for(let i=0;i<args.length;i++){const a=args[i];if(a.startsWith("--")){const r=a.slice(2);if(r.includes("=")){const e=r.indexOf("=");cOpts[r.slice(0,e)]=r.slice(e+1)}else if(i+1<args.length&&!args[i+1].startsWith("--")){cOpts[r]=args[++i]}else{cOpts[r]=true}}else if(a.startsWith("-")&&a.length===2){cOpts[a.slice(1)]=true}else if(i>0){cArgs.push(a)}}
   const msg=JSON.stringify({id:randomUUID(),command:cmd,args:cArgs,options:cOpts,cwd:process.cwd()})+"\\n";
   const sock=connect(sockPath);let buf="",done=false;
-  const t=setTimeout(()=>{if(!done){done=true;sock.destroy();refuse("timed out")}},30000);
+  // Long verbs (ship/sync/…) need 10min; everything else stays at 30s.
+  const LONG=new Set(["ship","sync","dream","update","upgrade","analyze","init","cloud"]);
+  const waitMs=LONG.has(cmd)?600000:30000;
+  const t=setTimeout(()=>{if(!done){done=true;sock.destroy();refuse("timed out")}},waitMs);
   sock.on("connect",()=>sock.write(msg));
   sock.on("data",c=>{buf+=c.toString();const n=buf.indexOf("\\n");if(n!==-1){const r=JSON.parse(buf.slice(0,n));done=true;clearTimeout(t);sock.end();if(r.retry){process.env.PRJCT_NO_DAEMON="1";fallback();return}if(r.stdout)console.log(r.stdout);if(r.stderr)console.error(r.stderr);process.exit(r.exitCode)}});
   sock.on("error",e=>{if(!done){done=true;clearTimeout(t);if(isSafeRetry(e))fallback();else refuse(e&&e.message||String(e))}});


### PR DESCRIPTION
## Summary
- **Bug:** `prjct ship` (and other long verbs) used the daemon client’s hard **30s** timeout. Ship alone can exceed ~65s before optional test gates. On timeout the client exited 1 with `daemon dropped the request (Daemon request timed out)` while the daemon could still be applying partial side effects — agents looped “Retry after daemon timeout” with stuck hooks.
- **Fix:** `commandRequestTimeoutMs()` → hooks **5s**, long verbs (`ship`, `sync`, `dream`, `update`, `upgrade`, `analyze`, `init`, `cloud`) **10min**, everything else **30s**. Wired through `client.ts`, `bin/prjct.ts`, and the production shim in `scripts/build.js`.
- **Harden:** `dispatch.ts` uses `request.options ?? {}` so a malformed peer cannot crash the daemon with `evaluating 'r.md'`.

## Test plan
- [x] `bun test core/__tests__/daemon/protocol-platform.test.ts`
- [ ] After publish/restart daemon: `prjct ship` that takes >30s completes without client timeout
- [ ] Snappy verbs still fail fast if the daemon hangs (~30s)
- [ ] Hooks still soft-fail by ~5s