### PR TITLE
feat(memory): signal-quality substrate Fase 0 (precision, cluster, health, T1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+## [3.64.0] - 2026-07-16
+
+### Added
+- implement signal quality substrate ws0 p
+
 ## [3.63.2] - 2026-07-16
 
 ### Bug Fixes
 
 - 10min client timeout for ship/sync and long verbs (#575)
-
 
 ## [3.63.1] - 2026-07-15
 
@@ -15,20 +19,17 @@
 
 - resolve work-cycle entity_id from taskId (#574)
 
-
 ## [3.63.0] - 2026-07-15
 
 ### Features
 
 - connect/disconnect + bulk cloud project modes (#573)
 
-
 ## [3.62.0] - 2026-07-14
 
 ### Features
 
 - upload compact structural code graph to cloud 3D (#572)
-
 
 ## [3.61.0] - 2026-07-14
 

--- a/core/__tests__/memory/precision-classifier.test.ts
+++ b/core/__tests__/memory/precision-classifier.test.ts
@@ -59,12 +59,13 @@ describe('gotcha vs open narration', () => {
     expect(v.reasonCode).toBe('gotcha_open_narration')
   })
 
-  it('accepts closed gotchas with cause→fix shape', () => {
+  it('retypes closed not-the-cause gotchas to red-herring', () => {
     const body =
       'It was not RLS — the RPC is SECURITY DEFINER and bypasses policies; fix: gate with can_access_company'
     expect(isOpenGotchaNarration(body)).toBe(false)
     const v = classifyCapturePrecision(body, 'gotcha')
-    expect(v.action).toBe('accept')
+    expect(v.action).toBe('demote')
+    expect(v.demoteTo).toBe('red-herring')
   })
 
   it('accepts short imperative traps', () => {
@@ -75,9 +76,19 @@ describe('gotcha vs open narration', () => {
     expect(v.action).toBe('accept')
   })
 
-  it('accepts Spanish closed negative knowledge', () => {
+  it('retypes Spanish closed negative knowledge to red-herring', () => {
     const v = classifyCapturePrecision(
       'No era RLS: el bug era cache stale en search_inventory; fix: invalidar tag de compañía',
+      'gotcha'
+    )
+    expect(v.action).toBe('demote')
+    expect(v.demoteTo).toBe('red-herring')
+    expect(v.reasonCode).toBe('gotcha_is_red_herring')
+  })
+
+  it('accepts closed gotcha that is not negative knowledge', () => {
+    const v = classifyCapturePrecision(
+      'Never call router.refresh() after inventory save — it resets scroll',
       'gotcha'
     )
     expect(v.action).toBe('accept')

--- a/core/__tests__/memory/precision-classifier.test.ts
+++ b/core/__tests__/memory/precision-classifier.test.ts
@@ -21,14 +21,19 @@ describe('empty spec mirror', () => {
     expect(isEmptySpecMirror(title, goal)).toBe(true)
     const v = classifySpecCreate(title, goal)
     expect(v.action).toBe('refuse')
-    expect(v.reasonCode).toBe('empty_spec_mirror')
+    expect(['empty_spec_mirror', 'bare_id_body']).toContain(v.reasonCode)
   })
 
-  it('flags memory mirror body title===goal', () => {
+  it('flags memory mirror body title===goal (no living graduation)', () => {
     const body = 'Crew mode migration\n\nGoal: Crew mode migration'
     const v = classifyCapturePrecision(body, 'spec')
     expect(v.action).toBe('refuse')
     expect(v.reasonCode).toBe('empty_spec_mirror')
+  })
+
+  it('allows draft create when goal seeds as title (CLI ergonomics)', () => {
+    const v = classifySpecCreate('rate limiting', 'rate limiting')
+    expect(v.action).toBe('accept')
   })
 
   it('allows real specs with distinct goals', () => {
@@ -103,6 +108,12 @@ describe('inbox substance', () => {
     expect(v.action).toBe('refuse')
     // junk single-token may fire first, or substance — either is refuse
     expect(['junk', 'inbox_no_substance']).toContain(v.reasonCode)
+  })
+
+  it('allows short two-token inbox notes', () => {
+    expect(lacksInboxSubstance('random thought')).toBe(false)
+    const v = classifyCapturePrecision('random thought', 'inbox')
+    expect(v.action).toBe('accept')
   })
 
   it('allows real inbox capture', () => {

--- a/core/__tests__/memory/precision-classifier.test.ts
+++ b/core/__tests__/memory/precision-classifier.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Precision classifier — client signal-quality corpus + shape rules.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  classifyCapturePrecision,
+  classifySpecCreate,
+  isBareIdBody,
+  isEmptySpecMirror,
+  isOpenGotchaNarration,
+  lacksInboxSubstance,
+  parseSpecMirrorContent,
+  stripPipelineLabelsForHuman,
+} from '../../memory/precision-classifier'
+
+describe('empty spec mirror', () => {
+  it('flags goal identical to title (client UUID lookup pattern)', () => {
+    const title = 'get 3a9aa714-ffda-42cc-adea-afe158155a90'
+    const goal = 'get 3a9aa714-ffda-42cc-adea-afe158155a90'
+    expect(isEmptySpecMirror(title, goal)).toBe(true)
+    const v = classifySpecCreate(title, goal)
+    expect(v.action).toBe('refuse')
+    expect(v.reasonCode).toBe('empty_spec_mirror')
+  })
+
+  it('flags memory mirror body title===goal', () => {
+    const body = 'Crew mode migration\n\nGoal: Crew mode migration'
+    const v = classifyCapturePrecision(body, 'spec')
+    expect(v.action).toBe('refuse')
+    expect(v.reasonCode).toBe('empty_spec_mirror')
+  })
+
+  it('allows real specs with distinct goals', () => {
+    const v = classifySpecCreate(
+      'Signal-quality substrate',
+      'Raise living-memory signal with a precision classifier before graduation'
+    )
+    expect(v.action).toBe('accept')
+    expect(v.reasonCode).toBe('ok')
+  })
+
+  it('flags bare id / UUID goals without action verbs', () => {
+    expect(isBareIdBody('3a9aa714-ffda-42cc-adea-afe158155a90')).toBe(true)
+    expect(isBareIdBody('get 3a9aa714-ffda-42cc-adea-afe158155a90')).toBe(true)
+    const v = classifySpecCreate('Lookup', 'get 3a9aa714-ffda-42cc-adea-afe158155a90')
+    expect(v.action).toBe('refuse')
+    expect(['empty_spec_mirror', 'bare_id_body']).toContain(v.reasonCode)
+  })
+})
+
+describe('gotcha vs open narration', () => {
+  it('demotes in-progress narration with open colon (client example)', () => {
+    const body = 'Reviso cómo refrescan hoy para no meter un bug:'
+    expect(isOpenGotchaNarration(body)).toBe(true)
+    const v = classifyCapturePrecision(body, 'gotcha')
+    expect(v.action).toBe('demote')
+    expect(v.demoteTo).toBe('context')
+    expect(v.reasonCode).toBe('gotcha_open_narration')
+  })
+
+  it('accepts closed gotchas with cause→fix shape', () => {
+    const body =
+      'It was not RLS — the RPC is SECURITY DEFINER and bypasses policies; fix: gate with can_access_company'
+    expect(isOpenGotchaNarration(body)).toBe(false)
+    const v = classifyCapturePrecision(body, 'gotcha')
+    expect(v.action).toBe('accept')
+  })
+
+  it('accepts short imperative traps', () => {
+    const v = classifyCapturePrecision(
+      'Never call router.refresh() after inventory save — it resets scroll',
+      'gotcha'
+    )
+    expect(v.action).toBe('accept')
+  })
+
+  it('accepts Spanish closed negative knowledge', () => {
+    const v = classifyCapturePrecision(
+      'No era RLS: el bug era cache stale en search_inventory; fix: invalidar tag de compañía',
+      'gotcha'
+    )
+    expect(v.action).toBe('accept')
+  })
+})
+
+describe('inbox substance', () => {
+  it('refuses sub-substance inbox', () => {
+    expect(lacksInboxSubstance('upgrade')).toBe(true)
+    expect(lacksInboxSubstance('fix later')).toBe(true)
+    const v = classifyCapturePrecision('upgrade', 'inbox')
+    expect(v.action).toBe('refuse')
+    // junk single-token may fire first, or substance — either is refuse
+    expect(['junk', 'inbox_no_substance']).toContain(v.reasonCode)
+  })
+
+  it('allows real inbox capture', () => {
+    const v = classifyCapturePrecision(
+      'Investigate why stock audits cannot reopen after complete in mobile',
+      'inbox'
+    )
+    expect(v.action).toBe('accept')
+  })
+})
+
+describe('stripPipelineLabelsForHuman', () => {
+  it('removes Context synthesis prefix from user-facing text', () => {
+    const raw =
+      'Context synthesis: Passive land hand-off from durable signals. · Key data: source=land-auto'
+    const out = stripPipelineLabelsForHuman(raw)
+    expect(out).not.toMatch(/Context synthesis:/i)
+    expect(out).toContain('Passive land hand-off')
+    expect(out).toContain('Key data:')
+  })
+
+  it('strips mid-string Context synthesis labels', () => {
+    const raw = 'Session close done · Context synthesis: Shipped P0 · Key data: pr=537'
+    const out = stripPipelineLabelsForHuman(raw)
+    expect(out).not.toMatch(/Context synthesis:/i)
+    expect(out).toContain('Shipped P0')
+  })
+})
+
+describe('parseSpecMirrorContent', () => {
+  it('splits title and goal', () => {
+    const p = parseSpecMirrorContent('My feature\n\nGoal: Implement X safely')
+    expect(p).toEqual({ title: 'My feature', goal: 'Implement X safely' })
+  })
+})
+
+describe('force override', () => {
+  it('accepts when force is set', () => {
+    const v = classifyCapturePrecision('upgrade', 'inbox', { force: true })
+    expect(v.action).toBe('accept')
+    expect(v.reasonCode).toBe('forced')
+  })
+})

--- a/core/__tests__/memory/semantic-cluster.test.ts
+++ b/core/__tests__/memory/semantic-cluster.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Semantic cluster — cross-language dups, keep-fullest, no over-collapse.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { MemoryEntry } from '../../memory/entries'
+import { formatMemoryMd } from '../../memory/format'
+import {
+  clusterMemoryEntries,
+  collapseEntriesForSurface,
+  extractKeyEntities,
+  fullnessScore,
+  shouldClusterPair,
+} from '../../memory/semantic-cluster'
+
+function entry(
+  partial: Partial<MemoryEntry> & Pick<MemoryEntry, 'id' | 'type' | 'content'>
+): MemoryEntry {
+  return {
+    tags: {},
+    rememberedAt: new Date().toISOString(),
+    provenance: 'declared',
+    ...partial,
+  }
+}
+
+describe('extractKeyEntities', () => {
+  it('captures RLS and RPC-like anchors', () => {
+    const e = extractKeyEntities(
+      'No era RLS: search_inventory is SECURITY DEFINER; use can_access_company'
+    )
+    expect(e.has('rls')).toBe(true)
+    expect(e.has('search_inventory')).toBe(true)
+    expect(e.has('can_access_company')).toBe(true)
+    expect(e.has('security definer')).toBe(true)
+  })
+})
+
+describe('shouldClusterPair / ES-EN RLS', () => {
+  it('clusters Spanish and English variants of the same trap', () => {
+    const a = entry({
+      id: 'mem_1',
+      type: 'gotcha',
+      content: 'No era RLS — search_inventory es SECURITY DEFINER y bypasea policies',
+    })
+    const b = entry({
+      id: 'mem_2',
+      type: 'gotcha',
+      content: "It wasn't RLS — search_inventory is SECURITY DEFINER and bypasses policies",
+    })
+    const c = entry({
+      id: 'mem_3',
+      type: 'gotcha',
+      content:
+        "It wasn't RLS: search_inventory uses SECURITY DEFINER; the real gate is can_access_company. Fix: always check company access.",
+    })
+    expect(shouldClusterPair(a, b).cluster).toBe(true)
+    expect(shouldClusterPair(a, c).cluster).toBe(true)
+
+    const clusters = clusterMemoryEntries([a, b, c])
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0]!.seenInN).toBe(3)
+    // fullest primary
+    expect(clusters[0]!.primary.id).toBe('mem_3')
+    expect(fullnessScore(c)).toBeGreaterThan(fullnessScore(a))
+  })
+
+  it('does NOT merge related-but-distinct facts without shared entities', () => {
+    const a = entry({
+      id: 'mem_a',
+      type: 'gotcha',
+      content: 'Auth timeout was 5s — clients saw false 401 on slow networks',
+    })
+    const b = entry({
+      id: 'mem_b',
+      type: 'gotcha',
+      content: 'Inventory scroll reset after save — never call router.refresh in stock views',
+    })
+    expect(shouldClusterPair(a, b).cluster).toBe(false)
+    expect(clusterMemoryEntries([a, b])).toHaveLength(2)
+  })
+
+  it('does not cluster across types', () => {
+    const a = entry({ id: 'mem_d', type: 'decision', content: 'Use RLS on all public tables' })
+    const b = entry({ id: 'mem_g', type: 'gotcha', content: 'Use RLS on all public tables' })
+    expect(shouldClusterPair(a, b).cluster).toBe(false)
+  })
+})
+
+describe('collapseEntriesForSurface + formatMemoryMd', () => {
+  it('annotates seen_in_N and reports collapsed count on compact brief', () => {
+    const entries = [
+      entry({
+        id: 'mem_1',
+        type: 'gotcha',
+        content: 'No era RLS en search_inventory (SECURITY DEFINER)',
+      }),
+      entry({
+        id: 'mem_2',
+        type: 'gotcha',
+        content: "Wasn't RLS on search_inventory — SECURITY DEFINER bypass",
+      }),
+      entry({
+        id: 'mem_3',
+        type: 'gotcha',
+        content:
+          "It wasn't RLS on search_inventory: SECURITY DEFINER bypasses policies; gate with can_access_company",
+      }),
+    ]
+    const { entries: out, collapsedCount } = collapseEntriesForSurface(entries)
+    expect(out).toHaveLength(1)
+    expect(collapsedCount).toBe(2)
+    expect(out[0]!.tags.seen_in_N).toBe('3')
+    expect(out[0]!.id).toBe('mem_3')
+
+    const md = formatMemoryMd(entries, { compact: true })
+    expect(md).toMatch(/seen_in_3/)
+    expect(md).toMatch(/repeated collapsed/i)
+    // only one gotcha row body (primary)
+    expect(md.match(/\[mem_\d+ · gotcha\]/g)?.length ?? 0).toBe(1)
+  })
+
+  it('full format without cluster keeps all rows (audit path)', () => {
+    const entries = [
+      entry({ id: 'mem_1', type: 'fact', content: 'Alpha fact about widgets' }),
+      entry({ id: 'mem_2', type: 'fact', content: 'Beta fact about gadgets' }),
+    ]
+    const md = formatMemoryMd(entries, { cluster: false })
+    expect(md).toContain('mem_1')
+    expect(md).toContain('mem_2')
+    expect(md).not.toMatch(/repeated collapsed/i)
+  })
+})

--- a/core/__tests__/memory/semantic-cluster.test.ts
+++ b/core/__tests__/memory/semantic-cluster.test.ts
@@ -120,6 +120,90 @@ describe('collapseEntriesForSurface + formatMemoryMd', () => {
     expect(md.match(/\[mem_\d+ · gotcha\]/g)?.length ?? 0).toBe(1)
   })
 
+  it('T1: survivor preserves ALL source mem_ids for audit (not only primary)', () => {
+    const entries = [
+      entry({
+        id: 'mem_1',
+        type: 'gotcha',
+        content: 'No era RLS en search_inventory (SECURITY DEFINER)',
+      }),
+      entry({
+        id: 'mem_2',
+        type: 'gotcha',
+        content: "Wasn't RLS on search_inventory — SECURITY DEFINER bypass",
+      }),
+      entry({
+        id: 'mem_3',
+        type: 'gotcha',
+        content:
+          "It wasn't RLS on search_inventory: SECURITY DEFINER bypasses policies; gate with can_access_company",
+      }),
+    ]
+    const { entries: out } = collapseEntriesForSurface(entries)
+    const sources = (out[0]!.tags.cluster_sources ?? '').split(',')
+    expect(sources).toContain('mem_1')
+    expect(sources).toContain('mem_2')
+    expect(sources).toContain('mem_3')
+    // primary first
+    expect(sources[0]).toBe('mem_3')
+    // non-primary listed separately too
+    expect(out[0]!.tags.cluster_members).toMatch(/mem_1/)
+    expect(out[0]!.tags.cluster_members).toMatch(/mem_2/)
+
+    const md = formatMemoryMd(entries, { compact: true })
+    expect(md).toMatch(/sources=mem_3,mem_1,mem_2|sources=mem_3,mem_2,mem_1/)
+    // eng-lead can still pull any corroborator by id
+    expect(md).toContain('mem_1')
+    expect(md).toContain('mem_2')
+  })
+
+  it('language: multi-lang cluster tags store-original + deferred product normalize', () => {
+    const entries = [
+      entry({
+        id: 'mem_es',
+        type: 'gotcha',
+        content: 'No era RLS en search_inventory — es SECURITY DEFINER y bypasea',
+      }),
+      entry({
+        id: 'mem_en',
+        type: 'gotcha',
+        content:
+          "It wasn't RLS on search_inventory — SECURITY DEFINER bypasses policies; longer English body for fullest pick",
+      }),
+    ]
+    const { entries: out, multiLangSurvivors } = collapseEntriesForSurface(entries)
+    expect(out).toHaveLength(1)
+    expect(out[0]!.tags.surface_lang).toBe('store-original')
+    expect(out[0]!.tags.lang_normalize).toBe('deferred-product-layer')
+    expect(out[0]!.tags.cluster_langs).toMatch(/en/)
+    expect(out[0]!.tags.cluster_langs).toMatch(/es/)
+    expect(multiLangSurvivors).toBeGreaterThanOrEqual(1)
+
+    const md = formatMemoryMd(entries, { compact: true })
+    expect(md).toMatch(/lang normalize deferred|store-original/i)
+  })
+
+  it('demoted context does not rejoin gotcha cluster (type isolation)', () => {
+    // Same substance, different types after precision demote — must stay separate
+    const entries = [
+      entry({
+        id: 'mem_g',
+        type: 'gotcha',
+        content:
+          "It wasn't RLS on search_inventory: SECURITY DEFINER bypasses policies; gate with can_access_company",
+      }),
+      entry({
+        id: 'mem_c',
+        type: 'context',
+        content:
+          "It wasn't RLS on search_inventory: SECURITY DEFINER bypasses policies; gate with can_access_company",
+      }),
+    ]
+    const { entries: out, collapsedCount } = collapseEntriesForSurface(entries)
+    expect(out).toHaveLength(2)
+    expect(collapsedCount).toBe(0)
+  })
+
   it('full format without cluster keeps all rows (audit path)', () => {
     const entries = [
       entry({ id: 'mem_1', type: 'fact', content: 'Alpha fact about widgets' }),

--- a/core/__tests__/memory/substrate-health.test.ts
+++ b/core/__tests__/memory/substrate-health.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Substrate health + coverage footer.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { MemoryEntry } from '../../memory/entries'
+import { formatMemoryMd } from '../../memory/format'
+import {
+  computeSubstrateHealth,
+  formatCoverageFooter,
+  formatSubstrateHealthMd,
+} from '../../memory/substrate-health'
+
+function entry(
+  partial: Partial<MemoryEntry> & Pick<MemoryEntry, 'id' | 'type' | 'content'>
+): MemoryEntry {
+  return {
+    tags: {},
+    rememberedAt: new Date().toISOString(),
+    provenance: 'declared',
+    ...partial,
+  }
+}
+
+describe('computeSubstrateHealth', () => {
+  it('scores clean judgment high', () => {
+    const entries = [
+      entry({
+        id: 'mem_1',
+        type: 'decision',
+        content: 'Use SQLite as the single source of truth for project memory',
+      }),
+      entry({
+        id: 'mem_2',
+        type: 'gotcha',
+        content: 'Never call router.refresh() after inventory save — it resets scroll',
+      }),
+    ]
+    const h = computeSubstrateHealth(entries)
+    expect(h.live).toBe(2)
+    expect(h.judgment).toBe(2)
+    expect(h.signalRatio).toBe(1)
+    expect(h.unshapedGotchaRate).toBe(0)
+    expect(h.score).toBeGreaterThanOrEqual(85)
+  })
+
+  it('flags open-narration gotchas and empty specs', () => {
+    const entries = [
+      entry({
+        id: 'mem_g',
+        type: 'gotcha',
+        content: 'Reviso cómo refrescan hoy para no meter un bug:',
+      }),
+      entry({
+        id: 'mem_s',
+        type: 'spec',
+        content: 'get abc\n\nGoal: get abc',
+      }),
+      entry({
+        id: 'mem_d',
+        type: 'decision',
+        content: 'Ship precision classifier before any intake surface',
+      }),
+    ]
+    const h = computeSubstrateHealth(entries)
+    expect(h.unshapedGotchaRate).toBe(1)
+    expect(h.emptySpecRate).toBe(1)
+    expect(h.signalRatio).toBeLessThan(1)
+    expect(h.issues.some((i) => /open-narration|empty-spec/i.test(i))).toBe(true)
+  })
+
+  it('coverage footer never claims completeness', () => {
+    const footer = formatCoverageFooter([])
+    expect(footer).toMatch(/blind spot/i)
+    const filled = formatCoverageFooter([
+      entry({ id: 'mem_1', type: 'fact', content: 'Runtime is bun for CLI tests' }),
+    ])
+    expect(filled).toMatch(/Coverage:/)
+    expect(filled).toMatch(/density=/)
+  })
+
+  it('compact formatMemoryMd includes coverage footer', () => {
+    const md = formatMemoryMd(
+      [entry({ id: 'mem_1', type: 'fact', content: 'Something durable about auth cookies' })],
+      { compact: true }
+    )
+    expect(md).toMatch(/Coverage:/)
+  })
+
+  it('formatSubstrateHealthMd includes honesty line', () => {
+    const h = computeSubstrateHealth([
+      entry({ id: 'mem_1', type: 'decision', content: 'Prefer pure gates over fail-open capture' }),
+    ])
+    const md = formatSubstrateHealthMd(h)
+    expect(md).toMatch(/Substrate health/)
+    expect(md).toMatch(/not proof/i)
+  })
+})

--- a/core/__tests__/services/capture-junk.test.ts
+++ b/core/__tests__/services/capture-junk.test.ts
@@ -80,18 +80,15 @@ describe('captureGate + forgetJunkCaptures', () => {
   })
 
   it('refuses empty-spec mirrors as type=spec', () => {
-    const body = 'get 3a9aa714-ffda-42cc-adea-afe158155a90\n\nGoal: get 3a9aa714-ffda-42cc-adea-afe158155a90'
+    const body =
+      'get 3a9aa714-ffda-42cc-adea-afe158155a90\n\nGoal: get 3a9aa714-ffda-42cc-adea-afe158155a90'
     const g = captureGate(projectId, 'spec', body)
     expect(g.accept).toBe(false)
     expect(g.reason).toMatch(/precision|empty spec/i)
   })
 
   it('refuses open-narration gotchas at the gate (demote path)', () => {
-    const g = captureGate(
-      projectId,
-      'gotcha',
-      'Reviso cómo refrescan hoy para no meter un bug:'
-    )
+    const g = captureGate(projectId, 'gotcha', 'Reviso cómo refrescan hoy para no meter un bug:')
     expect(g.accept).toBe(false)
     expect(g.reason).toMatch(/demote|narration|precision/i)
   })

--- a/core/__tests__/services/capture-junk.test.ts
+++ b/core/__tests__/services/capture-junk.test.ts
@@ -79,6 +79,23 @@ describe('captureGate + forgetJunkCaptures', () => {
     expect(g.accept).toBe(false)
   })
 
+  it('refuses empty-spec mirrors as type=spec', () => {
+    const body = 'get 3a9aa714-ffda-42cc-adea-afe158155a90\n\nGoal: get 3a9aa714-ffda-42cc-adea-afe158155a90'
+    const g = captureGate(projectId, 'spec', body)
+    expect(g.accept).toBe(false)
+    expect(g.reason).toMatch(/precision|empty spec/i)
+  })
+
+  it('refuses open-narration gotchas at the gate (demote path)', () => {
+    const g = captureGate(
+      projectId,
+      'gotcha',
+      'Reviso cómo refrescan hoy para no meter un bug:'
+    )
+    expect(g.accept).toBe(false)
+    expect(g.reason).toMatch(/demote|narration|precision/i)
+  })
+
   it('forgets junk inbox rows on cleanup pass', async () => {
     // Bypass gate by writing raw rows (simulates pre-gate pollution)
     prjctDb.run(

--- a/core/commands/product.ts
+++ b/core/commands/product.ts
@@ -8,6 +8,11 @@ import { detectAgentRuntimes } from '../infrastructure/agent-runtime-registry'
 import type { MemoryEntry, MemoryType } from '../memory/entries'
 import { deriveTitle, flatDetail, preventiveLabel } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
+import {
+  computeSubstrateHealth,
+  formatSubstrateHealthMd,
+  type SubstrateHealth,
+} from '../memory/substrate-health'
 import { isJunkCaptureContent } from '../services/capture-junk'
 import { resolveActiveTask } from '../services/task-service'
 import {
@@ -140,7 +145,7 @@ interface ReliabilitySnapshot {
   nextActions: string[]
 }
 
-const PREVENTIVE_TYPES = ['gotcha', 'anti-pattern', 'learning']
+const PREVENTIVE_TYPES = ['gotcha', 'red-herring', 'anti-pattern', 'learning']
 const NOISE_RE = /^(current work|wip|todo|misc|n\/a|none|latest|unreleased|changelog)$/i
 
 export class ProductCommands extends PrjctCommandsBase {
@@ -423,6 +428,7 @@ function buildMemoryDoctor(projectId: string): {
   noise: MemoryRow[]
   missingType: number
   provenUseful: number
+  substrate: SubstrateHealth | null
 } {
   const byType = query<TypeCountRow>(
     projectId,
@@ -471,6 +477,14 @@ function buildMemoryDoctor(projectId: string): {
     'SELECT COUNT(*) AS value FROM memory_usefulness WHERE score > 0'
   )
 
+  // Precision + density substrate (signal-quality plan): pure over live index.
+  let substrate: SubstrateHealth | null = null
+  try {
+    substrate = computeSubstrateHealth(projectMemory.allEntriesForIndex(projectId))
+  } catch {
+    substrate = null
+  }
+
   const issues: string[] = []
   if (duplicateGroups > 0) issues.push(`${duplicateGroups} duplicate memory group(s) need review.`)
   if (staleInbox.length > 0) issues.push(`${staleInbox.length} old inbox item(s) need promotion.`)
@@ -480,10 +494,21 @@ function buildMemoryDoctor(projectId: string): {
   if (provenUseful === 0 && rows.length > 10) {
     issues.push('No memory has usefulness credit yet; run guard/context during real tasks.')
   }
+  if (substrate) {
+    for (const issue of substrate.issues.slice(0, 8)) issues.push(issue)
+  }
 
-  const penalty = duplicateGroups * 8 + staleInbox.length * 4 + noise.length * 6 + missingType * 5
+  const penalty =
+    duplicateGroups * 8 +
+    staleInbox.length * 4 +
+    noise.length * 6 +
+    missingType * 5 +
+    (substrate ? Math.round((1 - substrate.signalRatio) * 25) : 0)
+  const base = Math.max(0, Math.min(100, 100 - penalty))
+  // Blend classic doctor score with substrate precision score when available.
+  const score = substrate ? Math.round(base * 0.55 + substrate.score * 0.45) : base
   return {
-    score: Math.max(0, Math.min(100, 100 - penalty)),
+    score,
     byType,
     issues,
     duplicateGroups,
@@ -491,6 +516,7 @@ function buildMemoryDoctor(projectId: string): {
     noise,
     missingType,
     provenUseful,
+    substrate,
   }
 }
 
@@ -938,6 +964,9 @@ function formatMemoryDoctorMd(
   const lines = ['# Memory Doctor', '', `**Quality score:** ${report.score}/100`, '']
   lines.push('## Distribution', '', '| Type | Entries |', '|---|---:|')
   for (const row of report.byType) lines.push(`| ${row.type ?? 'unknown'} | ${row.value} |`)
+  if (report.substrate) {
+    lines.push('', formatSubstrateHealthMd(report.substrate))
+  }
   lines.push('', '## Issues')
   if (report.issues.length === 0) lines.push('', '- No obvious memory quality issues found.')
   else for (const issue of report.issues) lines.push(`- ${issue}`)
@@ -946,7 +975,8 @@ function formatMemoryDoctorMd(
   appendMemoryRows(lines, 'Low signal', report.noise)
   lines.push(
     '',
-    'Recommended actions: promote old inbox entries into `decision`, `learning`, `gotcha`, or `todo`; forget noise by id; keep useful memories explicit and file-linked when possible.'
+    'Recommended actions: promote old inbox entries into `decision`, `learning`, `gotcha`, `red-herring`, or `todo`; forget noise by id; keep useful memories explicit and file-linked when possible.',
+    'Absence of a risk in memory is not proof it does not exist — trust density + blind spots above.'
   )
   if (includeFixPlan) appendMemoryFixPlan(lines, report)
   return lines.join('\n')
@@ -957,6 +987,11 @@ function formatMemoryDoctorText(
   includeFixPlan = false
 ): string {
   const lines = [`Memory doctor: ${report.score}/100`]
+  if (report.substrate) {
+    lines.push(
+      `substrate: signal=${Math.round(report.substrate.signalRatio * 100)}% unshaped_gotcha=${Math.round(report.substrate.unshapedGotchaRate * 100)}% empty_spec=${Math.round(report.substrate.emptySpecRate * 100)}% cluster≈${report.substrate.clusterCollapsedEstimate}`
+    )
+  }
   if (report.issues.length === 0) lines.push('No obvious memory quality issues found.')
   else lines.push(...report.issues.map((issue) => `- ${issue}`))
   if (includeFixPlan) lines.push(`Fix-plan actions: ${memoryFixPlan(report).length}`)

--- a/core/memory/entries.ts
+++ b/core/memory/entries.ts
@@ -30,6 +30,12 @@ export const BASE_MEMORY_TYPES = [
   'decision',
   'learning',
   'gotcha',
+  /**
+   * Negative knowledge — "not the cause" / red herring. First-class so
+   * discarded hypotheses stay visible (not buried inside generic gotcha).
+   * Differentiator vs trackers that only store decisions that shipped.
+   */
+  'red-herring',
   'pattern',
   'anti-pattern',
   'shipped',

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -249,11 +249,13 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
   const doCluster = opts?.cluster === true || (compact && opts?.cluster !== false)
 
   let collapsedCount = 0
+  let multiLangSurvivors = 0
   let surfaceEntries = entries
   if (doCluster && entries.length > 1) {
     const collapsed = collapseEntriesForSurface(entries)
     surfaceEntries = collapsed.entries
     collapsedCount = collapsed.collapsedCount
+    multiLangSurvivors = collapsed.multiLangSurvivors
   }
 
   const groups = new Map<MemoryType, MemoryEntry[]>()
@@ -323,7 +325,17 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
         const flat = flatDetail(e.content, COMPACT_CONTENT_MAX)
         const cue = llmBoundary ? escapeMarkdownInline(flat) : flat
         const seenN = Number(e.tags?.seen_in_N ?? '1')
-        const seenCue = seenN > 1 ? ` · seen_in_${seenN}` : ''
+        // T1: every claim is auditable — when clustered, list ALL source mem_ids
+        // (primary first via cluster_sources) so eng-lead can open corroborators.
+        const sources =
+          seenN > 1
+            ? (e.tags?.cluster_sources ??
+              [e.id, ...(e.tags?.cluster_members ?? '').split(',').filter(Boolean)].join(','))
+            : ''
+        const seenCue =
+          seenN > 1
+            ? ` · seen_in_${seenN} · sources=${sources}`
+            : ''
         lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${cue}${seenCue}${staleCue(e)}`)
         continue
       }
@@ -382,7 +394,13 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
 
   if (collapsedCount > 0) {
     lines.push(
-      `_Semantic cluster: ${collapsedCount} repeated collapsed (keep fullest · seen_in_N on survivors)._`
+      `_Semantic cluster: ${collapsedCount} repeated collapsed (keep fullest · seen_in_N · sources=all mem_ids on survivors for audit)._`
+    )
+  }
+  if (multiLangSurvivors > 0) {
+    // PRD §7.3: surface language unify deferred — storage stays original.
+    lines.push(
+      `_Language: ${multiLangSurvivors} multi-lang cluster(s) keep store-original text (lang normalize deferred to product layer; not rewritten in DB)._`
     )
   }
 

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -152,8 +152,10 @@ export function preventiveLabel(e: Pick<MemoryEntry, 'type' | 'tags'>): string {
 
 /** One-line detail: whitespace-flattened content, ellipsis-truncated. */
 export function flatDetail(content: string, max = 220): string {
-  const flat = content.replace(/\s+/g, ' ').trim()
-  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+  // Lazy import avoided — strip is pure and tiny; inline the lead label so
+  // compact brief rows never show "Context synthesis:" as the cue.
+  const stripped = content.replace(/^Context synthesis:\s*/i, '').replace(/\s+/g, ' ').trim()
+  return stripped.length > max ? `${stripped.slice(0, max - 1)}…` : stripped
 }
 
 /**
@@ -164,6 +166,8 @@ export function flatDetail(content: string, max = 220): string {
  */
 export function deriveTitle(entry: Pick<MemoryEntry, 'content' | 'type' | 'id' | 'tags'>): string {
   let raw = (entry.content ?? '').trim()
+  // Pipeline labels are storage contract, not human titles.
+  raw = raw.replace(/^Context synthesis:\s*/i, '')
   raw = raw.replace(/^(?:[-*•]\s+|\s+)+/, '')
   raw = raw.replace(/^(?:\[\[[^\]]*\]\]|mem[_-]\d+)[\s:,-]*/i, '').trim()
   let cut = raw.length
@@ -316,7 +320,11 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
       // (`^mem-N`) so it is a real navigable target (mem_3233 — the
       // dangling-pointer class is closed where the user actually reads:
       // Obsidian).
-      const content = opts?.vault ? linkifyMemRefs(e.content, opts) : e.content
+      // Human surface: strip internal pipeline labels (Context synthesis:).
+      // Storage keeps the structured body; presentation does not leak SoT labels.
+      let body = e.content.replace(/^Context synthesis:\s*/i, '')
+      body = body.replace(/(\s*[·|]\s*)Context synthesis:\s*/gi, '$1')
+      const content = opts?.vault ? linkifyMemRefs(body, opts) : body
       const tagSuffix = tags ? `  _(${opts?.vault ? linkifyMemRefs(tags, opts) : tags})_` : ''
       const rowid = e.id.replace(/^mem[_-]/, '')
       const anchor = opts?.vault ? ` ^mem-${rowid}` : ''

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -9,6 +9,7 @@
 import { escapeMarkdownInline } from '../utils/prompt-injection'
 import type { MemoryEntry, MemoryProvenance, MemoryType } from './entries'
 import { collapseEntriesForSurface } from './semantic-cluster'
+import { formatCoverageFooter } from './substrate-health'
 
 /**
  * Render memory entries as compact markdown grouped by type.
@@ -267,6 +268,7 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
     'learning',
     'anti-pattern',
     'gotcha',
+    'red-herring',
     'pattern',
     'fact',
     'inbox',
@@ -382,6 +384,11 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
     lines.push(
       `_Semantic cluster: ${collapsedCount} repeated collapsed (keep fullest · seen_in_N on survivors)._`
     )
+  }
+
+  // Honest density: compact brief never implies complete risk coverage.
+  if (compact) {
+    lines.push(formatCoverageFooter(surfaceEntries))
   }
 
   return lines.join('\n').trim()

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -163,7 +163,10 @@ export function preventiveLabel(e: Pick<MemoryEntry, 'type' | 'tags'>): string {
 export function flatDetail(content: string, max = 220): string {
   // Lazy import avoided — strip is pure and tiny; inline the lead label so
   // compact brief rows never show "Context synthesis:" as the cue.
-  const stripped = content.replace(/^Context synthesis:\s*/i, '').replace(/\s+/g, ' ').trim()
+  const stripped = content
+    .replace(/^Context synthesis:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
   return stripped.length > max ? `${stripped.slice(0, max - 1)}…` : stripped
 }
 
@@ -332,10 +335,7 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
             ? (e.tags?.cluster_sources ??
               [e.id, ...(e.tags?.cluster_members ?? '').split(',').filter(Boolean)].join(','))
             : ''
-        const seenCue =
-          seenN > 1
-            ? ` · seen_in_${seenN} · sources=${sources}`
-            : ''
+        const seenCue = seenN > 1 ? ` · seen_in_${seenN} · sources=${sources}` : ''
         lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${cue}${seenCue}${staleCue(e)}`)
         continue
       }

--- a/core/memory/format.ts
+++ b/core/memory/format.ts
@@ -8,6 +8,7 @@
 
 import { escapeMarkdownInline } from '../utils/prompt-injection'
 import type { MemoryEntry, MemoryProvenance, MemoryType } from './entries'
+import { collapseEntriesForSurface } from './semantic-cluster'
 
 /**
  * Render memory entries as compact markdown grouped by type.
@@ -45,6 +46,13 @@ export interface FormatMemoryMdOptions {
    * Mutually exclusive with `vault` (compact never feeds Obsidian).
    */
   compact?: boolean
+  /**
+   * Collapse semantic near-duplicates within each type (keep fullest body,
+   * annotate seen_in_N). Default ON for compact brief surfaces; OFF for
+   * full-body / by-id pulls so audit still sees every row. Pass `false` to
+   * force expand, `true` to force collapse on full format.
+   */
+  cluster?: boolean
   /**
    * `mem_N → type` so a cross-ref resolves to the right vault target.
    * @deprecated Dead since the vault removal — see interface doc comment.
@@ -235,8 +243,20 @@ export function linkifyMemRefs(text: string, opts?: FormatMemoryMdOptions): stri
 export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOptions): string {
   if (entries.length === 0) return '> No matching memory entries.'
 
+  const compact = opts?.compact === true
+  // Compact brief defaults to cluster; full format opt-in only (audit/by-id).
+  const doCluster = opts?.cluster === true || (compact && opts?.cluster !== false)
+
+  let collapsedCount = 0
+  let surfaceEntries = entries
+  if (doCluster && entries.length > 1) {
+    const collapsed = collapseEntriesForSurface(entries)
+    surfaceEntries = collapsed.entries
+    collapsedCount = collapsed.collapsedCount
+  }
+
   const groups = new Map<MemoryType, MemoryEntry[]>()
-  for (const e of entries) {
+  for (const e of surfaceEntries) {
     const bucket = groups.get(e.type) ?? []
     bucket.push(e)
     groups.set(e.type, bucket)
@@ -270,7 +290,6 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
   }
 
   const llmBoundary = opts?.boundary === 'llm'
-  const compact = opts?.compact === true
 
   // Staleness lifecycle: knowledge older than ~6 months gets a visible
   // verify-before-trusting cue. Recall still surfaces it (old ≠ wrong), but
@@ -301,7 +320,9 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
         const prov = PROV_PREFIX[e.provenance]
         const flat = flatDetail(e.content, COMPACT_CONTENT_MAX)
         const cue = llmBoundary ? escapeMarkdownInline(flat) : flat
-        lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${cue}${staleCue(e)}`)
+        const seenN = Number(e.tags?.seen_in_N ?? '1')
+        const seenCue = seenN > 1 ? ` · seen_in_${seenN}` : ''
+        lines.push(`- \`${prov}\` [${e.id} · ${e.type}] ${cue}${seenCue}${staleCue(e)}`)
         continue
       }
       // Vault output hides machine-bookkeeping tags (source=, touches=,
@@ -355,6 +376,12 @@ export function formatMemoryMd(entries: MemoryEntry[], opts?: FormatMemoryMdOpti
   for (const [type, items] of groups) {
     if (rendered.has(type)) continue
     renderGroup(type, items)
+  }
+
+  if (collapsedCount > 0) {
+    lines.push(
+      `_Semantic cluster: ${collapsedCount} repeated collapsed (keep fullest · seen_in_N on survivors)._`
+    )
   }
 
   return lines.join('\n').trim()

--- a/core/memory/precision-classifier.ts
+++ b/core/memory/precision-classifier.ts
@@ -1,0 +1,298 @@
+/**
+ * Precision classifier — hard gate before a capture graduates to a public
+ * judgment type (spec / gotcha / low-stakes inbox surfaces).
+ *
+ * Pure + deterministic + zero I/O. Must never fail-open: callers that cannot
+ * run this still own their own error paths; this module always returns a
+ * verdict.
+ *
+ * Contract fields for future consumers (intake / RiskClaim renderers):
+ *   reasonCode · action · demoteTo · (mem_id assigned at write)
+ *
+ * Does NOT replace isJunkCaptureContent (tool dumps / noise phrases) — that
+ * runs first. This layer catches *typed* pollution: empty specs, open
+ * narration labeled as gotcha, sub-substance inbox that would pollute brief.
+ */
+
+import { isJunkCaptureContent } from '../services/capture-junk'
+
+/** Stable reason codes — machine-queryable, never free prose alone. */
+export type PrecisionReasonCode =
+  | 'ok'
+  | 'forced'
+  | 'empty_content'
+  | 'junk'
+  | 'empty_spec_mirror'
+  | 'bare_id_body'
+  | 'gotcha_open_narration'
+  | 'inbox_no_substance'
+
+export type PrecisionAction = 'accept' | 'refuse' | 'demote'
+
+export interface PrecisionVerdict {
+  action: PrecisionAction
+  reasonCode: PrecisionReasonCode
+  reason: string
+  /** When action === 'demote', store as this type instead. */
+  demoteTo?: string
+}
+
+export interface PrecisionClassifyOpts {
+  /** Spec title when known separately from body. */
+  title?: string
+  /** Spec goal when known separately from body. */
+  goal?: string
+  /** Bypass shape gates (audit tag should be applied by caller). */
+  force?: boolean
+}
+
+const LOW_STAKES = new Set(['inbox', 'todo', 'idea', 'question'])
+
+/** UUID / hex / opaque id token (no prose). */
+const BARE_ID_RE =
+  /^(?:get\s+)?[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$|^[0-9a-f]{16,64}$|^[a-z]*[_-]?[0-9a-f]{8,}$/i
+
+/** Action verbs that make a goal more than a lookup label. */
+const ACTION_VERB_RE =
+  /\b(add|build|create|fix|implement|migrate|refactor|remove|replace|ship|support|enable|disable|update|upgrade|design|audit|verify|ensure|prevent|allow|block|wire|integrate|document|test|measure|reduce|increase|hacer|agregar|crear|arreglar|implementar|migrar|eliminar|actualizar|soportar|permitir|bloquear|integrar|documentar|verificar|evitar)\b/i
+
+/** Closed-knowledge markers (cause → resolution / past trap). */
+const CLOSED_GOTCHA_RE =
+  /\b(was|were|wasn't|weren't|had been|used to|era|eran|fue|fueron|estaba|estaban|fixed|fix:|resolved|root cause|because|caused|broke|broken|failed|failure|don't|do not|never|always|must not|must never|sin\s+eso|no era|no fue|no es rls|wasn't|instead|rather than|anti-pattern|gotcha:|trap:)\b/i
+
+/** Open narration / in-progress intent (not knowledge yet). */
+const OPEN_NARRATION_RE =
+  /^(reviso|revisando|voy a|estoy|vamos a|i('ll| will)|i am |i'm |checking|looking at|let me |need to |tengo que |hay que |todo:|wip:)/i
+
+function normalize(s: string): string {
+  return s.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+/** Strip common mirror prefixes for comparison. */
+function stripGoalPrefix(s: string): string {
+  return s.replace(/^goal:\s*/i, '').trim()
+}
+
+/**
+ * Parse the memory-mirror shape used by spec-service:
+ *   `${title}\n\nGoal: ${goal}`
+ */
+export function parseSpecMirrorContent(content: string): { title: string; goal: string } | null {
+  const m = content.trim().match(/^([\s\S]*?)\n\nGoal:\s*([\s\S]+)$/i)
+  if (!m) return null
+  return { title: m[1]!.trim(), goal: m[2]!.trim() }
+}
+
+/**
+ * True when title and goal are the same knowledge-free mirror
+ * (client: "get 3a9aa714… Goal: get 3a9aa714").
+ */
+export function isEmptySpecMirror(title: string, goal: string): boolean {
+  const t = normalize(title)
+  const g = normalize(stripGoalPrefix(goal))
+  if (!t || !g) return true
+  if (t === g) return true
+  // "get <id>" repeated as both sides
+  if (t.replace(/^get\s+/i, '') === g.replace(/^get\s+/i, '') && BARE_ID_RE.test(g.replace(/^get\s+/i, ''))) {
+    return true
+  }
+  return false
+}
+
+/** Body is essentially an id/UUID with no action verb — not a spec goal. */
+export function isBareIdBody(text: string): boolean {
+  const n = normalize(stripGoalPrefix(text))
+  if (!n) return true
+  if (BARE_ID_RE.test(n)) return true
+  // "get <uuid>" / "show mem_123" style lookups
+  if (/^(get|show|open|fetch|load|ver|obtener)\s+\S+$/i.test(n) && !ACTION_VERB_RE.test(n)) {
+    const rest = n.replace(/^(get|show|open|fetch|load|ver|obtener)\s+/i, '')
+    if (BARE_ID_RE.test(rest) || /^[a-z0-9_-]{8,}$/i.test(rest)) return true
+  }
+  return false
+}
+
+/**
+ * Gotcha must look like closed knowledge, not live narration.
+ * Open: present/future intent, trailing open colon, no cause→fix signals.
+ */
+export function isOpenGotchaNarration(content: string): boolean {
+  const raw = content.trim()
+  if (!raw) return true
+  const flat = raw.replace(/\s+/g, ' ')
+
+  // Explicit open colon at end ("Reviso X:") without closed body after.
+  if (/:\s*$/.test(flat) && !CLOSED_GOTCHA_RE.test(flat)) return true
+
+  if (OPEN_NARRATION_RE.test(flat) && !CLOSED_GOTCHA_RE.test(flat)) return true
+
+  // No closed markers and very short present-tense review → not a gotcha.
+  if (!CLOSED_GOTCHA_RE.test(flat) && flat.length < 80 && /^(reviso|checking|looking)\b/i.test(flat)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Low-stakes substance floor beyond junk phrases: needs real tokens.
+ * "upgrade" is already junk; this catches "do it" / "fix later" fluff.
+ */
+export function lacksInboxSubstance(content: string): boolean {
+  const n = content.trim().replace(/\s+/g, ' ')
+  if (n.length < 16) return true
+  const tokens = n.split(' ').filter((t) => t.length > 1)
+  if (tokens.length < 3) return true
+  // Only stopwords / filler
+  const filler = new Set([
+    'the',
+    'a',
+    'an',
+    'to',
+    'for',
+    'and',
+    'or',
+    'of',
+    'in',
+    'on',
+    'it',
+    'this',
+    'that',
+    'el',
+    'la',
+    'de',
+    'en',
+    'y',
+    'o',
+    'un',
+    'una',
+    'por',
+    'para',
+  ])
+  const contentTokens = tokens.filter((t) => !filler.has(t.toLowerCase()))
+  return contentTokens.length < 2
+}
+
+/**
+ * Classify whether content may graduate as `type`.
+ *
+ * Order: empty → force → junk → type-specific shape.
+ */
+export function classifyCapturePrecision(
+  content: string,
+  type?: string,
+  opts: PrecisionClassifyOpts = {}
+): PrecisionVerdict {
+  const trimmed = (content ?? '').trim()
+  if (!trimmed) {
+    return { action: 'refuse', reasonCode: 'empty_content', reason: 'empty content' }
+  }
+
+  if (opts.force) {
+    return { action: 'accept', reasonCode: 'forced', reason: 'force override' }
+  }
+
+  const junk = isJunkCaptureContent(trimmed, type)
+  if (junk.junk) {
+    return { action: 'refuse', reasonCode: 'junk', reason: `junk capture: ${junk.reason}` }
+  }
+
+  // --- Spec graduation ---
+  if (type === 'spec') {
+    const title = opts.title ?? parseSpecMirrorContent(trimmed)?.title ?? ''
+    const goal = opts.goal ?? parseSpecMirrorContent(trimmed)?.goal ?? trimmed
+
+    if (title && goal && isEmptySpecMirror(title, goal)) {
+      return {
+        action: 'refuse',
+        reasonCode: 'empty_spec_mirror',
+        reason: 'empty spec: goal identical to title (lookup, not a goal)',
+      }
+    }
+    // Content-only path (mirror or freeform)
+    const mirror = parseSpecMirrorContent(trimmed)
+    if (mirror && isEmptySpecMirror(mirror.title, mirror.goal)) {
+      return {
+        action: 'refuse',
+        reasonCode: 'empty_spec_mirror',
+        reason: 'empty spec: goal identical to title (lookup, not a goal)',
+      }
+    }
+    const goalText = mirror?.goal ?? goal ?? trimmed
+    if (isBareIdBody(goalText) && !ACTION_VERB_RE.test(goalText)) {
+      return {
+        action: 'refuse',
+        reasonCode: 'bare_id_body',
+        reason: 'empty spec: body is an id/lookup without an action verb',
+      }
+    }
+  }
+
+  // Spec create path with separate title/goal (before type is set)
+  if (opts.title !== undefined && opts.goal !== undefined && type === 'spec') {
+    // already handled above
+  }
+
+  // --- Gotcha shape ---
+  if (type === 'gotcha') {
+    if (isOpenGotchaNarration(trimmed)) {
+      return {
+        action: 'demote',
+        reasonCode: 'gotcha_open_narration',
+        reason: 'open narration is not a gotcha — demote to context',
+        demoteTo: 'context',
+      }
+    }
+  }
+
+  // --- Inbox / low-stakes substance ---
+  if (type && LOW_STAKES.has(type) && lacksInboxSubstance(trimmed)) {
+    return {
+      action: 'refuse',
+      reasonCode: 'inbox_no_substance',
+      reason: 'sub-substance low-stakes capture — keep out of brief',
+    }
+  }
+
+  return { action: 'accept', reasonCode: 'ok', reason: 'ok' }
+}
+
+/**
+ * Spec create helper — title + goal before any row exists.
+ * Pure; throws nothing — caller decides error UX.
+ */
+export function classifySpecCreate(title: string, goal: string): PrecisionVerdict {
+  if (isEmptySpecMirror(title, goal)) {
+    return {
+      action: 'refuse',
+      reasonCode: 'empty_spec_mirror',
+      reason: 'empty spec: goal identical to title (lookup, not a goal)',
+    }
+  }
+  if (isBareIdBody(goal) && !ACTION_VERB_RE.test(goal)) {
+    return {
+      action: 'refuse',
+      reasonCode: 'bare_id_body',
+      reason: 'empty spec: goal is an id/lookup without an action verb',
+    }
+  }
+  // Also run as type=spec on the mirror body for junk/etc.
+  return classifyCapturePrecision(`${title}\n\nGoal: ${goal}`, 'spec', { title, goal })
+}
+
+/**
+ * Strip internal pipeline labels from human/LLM-facing text.
+ * Storage may still keep structured fields; presentation must not leak
+ * "Context synthesis:" as a user-facing prefix.
+ */
+export function stripPipelineLabelsForHuman(content: string): string {
+  if (!content) return content
+  let s = content
+  // Leading label
+  s = s.replace(/^Context synthesis:\s*/i, '')
+  // Mid-string separators used by living-v2 (" · Context synthesis: …")
+  s = s.replace(/(\s*[·|]\s*)Context synthesis:\s*/gi, '$1')
+  // Orphaned leading separator after strip
+  s = s.replace(/^\s*[·|]\s*/, '')
+  return s.trim()
+}

--- a/core/memory/precision-classifier.ts
+++ b/core/memory/precision-classifier.ts
@@ -25,6 +25,7 @@ export type PrecisionReasonCode =
   | 'empty_spec_mirror'
   | 'bare_id_body'
   | 'gotcha_open_narration'
+  | 'gotcha_is_red_herring'
   | 'inbox_no_substance'
 
 export type PrecisionAction = 'accept' | 'refuse' | 'demote'
@@ -63,6 +64,13 @@ const CLOSED_GOTCHA_RE =
 /** Open narration / in-progress intent (not knowledge yet). */
 const OPEN_NARRATION_RE =
   /^(reviso|revisando|voy a|estoy|vamos a|i('ll| will)|i am |i'm |checking|looking at|let me |need to |tengo que |hay que |todo:|wip:)/i
+
+/**
+ * Negative knowledge shape — discarded cause / not-the-cause.
+ * Closed gotchas that are primarily "it was NOT X" retype to red-herring.
+ */
+const RED_HERRING_RE =
+  /\b(no era|no fue|no es|wasn't|was not|weren't|were not|not the cause|red herring|false lead|not rls|no era rls|it wasn't|no fue rls)\b/i
 
 function normalize(s: string): string {
   return s.trim().replace(/\s+/g, ' ').toLowerCase()
@@ -241,6 +249,15 @@ export function classifyCapturePrecision(
         reasonCode: 'gotcha_open_narration',
         reason: 'open narration is not a gotcha — demote to context',
         demoteTo: 'context',
+      }
+    }
+    // Closed negative knowledge → first-class red-herring (not generic gotcha).
+    if (RED_HERRING_RE.test(trimmed) && CLOSED_GOTCHA_RE.test(trimmed)) {
+      return {
+        action: 'demote',
+        reasonCode: 'gotcha_is_red_herring',
+        reason: 'negative knowledge (not-the-cause) — store as red-herring',
+        demoteTo: 'red-herring',
       }
     }
   }

--- a/core/memory/precision-classifier.ts
+++ b/core/memory/precision-classifier.ts
@@ -101,7 +101,10 @@ export function isEmptySpecMirror(title: string, goal: string): boolean {
   if (!t || !g) return true
   if (t === g) return true
   // "get <id>" repeated as both sides
-  if (t.replace(/^get\s+/i, '') === g.replace(/^get\s+/i, '') && BARE_ID_RE.test(g.replace(/^get\s+/i, ''))) {
+  if (
+    t.replace(/^get\s+/i, '') === g.replace(/^get\s+/i, '') &&
+    BARE_ID_RE.test(g.replace(/^get\s+/i, ''))
+  ) {
     return true
   }
   return false
@@ -135,7 +138,11 @@ export function isOpenGotchaNarration(content: string): boolean {
   if (OPEN_NARRATION_RE.test(flat) && !CLOSED_GOTCHA_RE.test(flat)) return true
 
   // No closed markers and very short present-tense review → not a gotcha.
-  if (!CLOSED_GOTCHA_RE.test(flat) && flat.length < 80 && /^(reviso|checking|looking)\b/i.test(flat)) {
+  if (
+    !CLOSED_GOTCHA_RE.test(flat) &&
+    flat.length < 80 &&
+    /^(reviso|checking|looking)\b/i.test(flat)
+  ) {
     return true
   }
 
@@ -148,9 +155,11 @@ export function isOpenGotchaNarration(content: string): boolean {
  */
 export function lacksInboxSubstance(content: string): boolean {
   const n = content.trim().replace(/\s+/g, ' ')
-  if (n.length < 16) return true
+  // Align with junk ultra-short floor; allow short two-token notes
+  // ("random thought", "call Ana") while still killing "upgrade" / "fix later".
+  if (n.length < 12) return true
   const tokens = n.split(' ').filter((t) => t.length > 1)
-  if (tokens.length < 3) return true
+  if (tokens.length < 2) return true
   // Only stopwords / filler
   const filler = new Set([
     'the',
@@ -275,26 +284,48 @@ export function classifyCapturePrecision(
 }
 
 /**
- * Spec create helper — title + goal before any row exists.
- * Pure; throws nothing — caller decides error UX.
+ * Spec *table* create gate — ergonomic drafts may seed goal=title
+ * (`prjct spec "rate limiting"`). Hard-refuse only lookup/id pollution.
+ *
+ * Public *memory* graduation still uses {@link classifyCapturePrecision}
+ * with type=spec, which refuses empty_spec_mirror so brief surfaces stay clean.
  */
 export function classifySpecCreate(title: string, goal: string): PrecisionVerdict {
-  if (isEmptySpecMirror(title, goal)) {
-    return {
-      action: 'refuse',
-      reasonCode: 'empty_spec_mirror',
-      reason: 'empty spec: goal identical to title (lookup, not a goal)',
-    }
+  const t = title.trim()
+  const g = goal.trim()
+  if (!t || !g) {
+    return { action: 'refuse', reasonCode: 'empty_content', reason: 'empty title or goal' }
   }
-  if (isBareIdBody(goal) && !ACTION_VERB_RE.test(goal)) {
+  if (isBareIdBody(g) && !ACTION_VERB_RE.test(g)) {
     return {
       action: 'refuse',
       reasonCode: 'bare_id_body',
       reason: 'empty spec: goal is an id/lookup without an action verb',
     }
   }
-  // Also run as type=spec on the mirror body for junk/etc.
-  return classifyCapturePrecision(`${title}\n\nGoal: ${goal}`, 'spec', { title, goal })
+  // goal===title is a draft seed, not a memory graduation — allow create.
+  // Bare "get <uuid>" still fails via isBareIdBody above.
+  if (isEmptySpecMirror(t, g) && isBareIdBody(t)) {
+    return {
+      action: 'refuse',
+      reasonCode: 'empty_spec_mirror',
+      reason: 'empty spec: goal identical to title (lookup, not a goal)',
+    }
+  }
+  return { action: 'accept', reasonCode: 'ok', reason: 'ok' }
+}
+
+/**
+ * True when a draft may exist in the specs table but must NOT mirror into
+ * living memory as type=spec (goal is still a placeholder).
+ */
+export function shouldMirrorSpecToMemory(title: string, goal: string): boolean {
+  if (isEmptySpecMirror(title, goal)) return false
+  if (isBareIdBody(goal) && !ACTION_VERB_RE.test(goal)) return false
+  return (
+    classifyCapturePrecision(`${title}\n\nGoal: ${goal}`, 'spec', { title, goal }).action ===
+    'accept'
+  )
 }
 
 /**

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -413,7 +413,11 @@ export const projectMemory = {
           return
         }
       } catch (err) {
-        if (args.requireWrite && err instanceof Error && err.message.startsWith('capture refused')) {
+        if (
+          args.requireWrite &&
+          err instanceof Error &&
+          err.message.startsWith('capture refused')
+        ) {
           throw err
         }
         /* gate unavailable — proceed with write */

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -301,7 +301,8 @@ export const projectMemory = {
       force?: boolean
     }
   ): Promise<void> {
-    const tags = args.tags ?? {}
+    let type = args.type
+    const tags: Record<string, string> = { ...(args.tags ?? {}) }
     const provenance = args.provenance ?? 'declared'
     const contentHash = memoryFingerprint(args.content)
 
@@ -324,6 +325,32 @@ export const projectMemory = {
           if (args.requireWrite) throw new Error(trust.denyMessage)
           return
         }
+      }
+    }
+
+    // Precision classifier (pure, hard gate): empty specs, open-narration
+    // gotchas, sub-substance inbox. Demote rewrites type before gate/dedup so
+    // knowledge is preserved as context instead of polluting judgment types.
+    // force (CLI/MCP) bypasses shape gates with an audit tag.
+    {
+      const { classifyCapturePrecision } = await import('./precision-classifier')
+      const precision = classifyCapturePrecision(args.content, type, {
+        force: args.force === true,
+      })
+      if (precision.action === 'refuse') {
+        if (args.requireWrite) {
+          throw new Error(`precision refuse (${precision.reasonCode}): ${precision.reason}`)
+        }
+        return
+      }
+      if (precision.action === 'demote' && precision.demoteTo) {
+        tags.shape_demoted = 'true'
+        tags.original_type = type
+        tags.precision_reason = precision.reasonCode
+        type = precision.demoteTo as MemoryType
+      }
+      if (args.force) {
+        tags['precision:force'] = 'true'
       }
     }
 
@@ -353,7 +380,7 @@ export const projectMemory = {
           projectId,
           'SELECT id FROM memory_entries WHERE content_hash = ? AND type = ? AND deleted_at IS NULL LIMIT 1',
           contentHash,
-          args.type
+          type
         )
         if (dup) {
           // Same content re-captured WITH a topic tag: don't create a row, but
@@ -362,7 +389,7 @@ export const projectMemory = {
           // topic X" is a silent no-op and stale revisions keep burning
           // recall slots (the exact failure the write-side upsert prevents).
           if (dedupTopicKey) {
-            this.applyTopicSupersession(projectId, args.type, contentHash, dedupTopicKey)
+            this.applyTopicSupersession(projectId, type, contentHash, dedupTopicKey)
           }
           return
         }
@@ -375,18 +402,26 @@ export const projectMemory = {
       // — never drop a capture because the gate failed to load.
       try {
         const { captureGate } = await import('../services/retention/capture-gate')
-        const gate = captureGate(projectId, args.type, args.content, tags)
+        const gate = captureGate(projectId, type, args.content, tags)
         if (!gate.accept) {
+          // Demoted open-narration already retyped; if gate still refuses
+          // (e.g. excess on context), drop silently unless requireWrite.
+          if (args.requireWrite) {
+            throw new Error(`capture refused: ${gate.reason}`)
+          }
           return
         }
-      } catch {
+      } catch (err) {
+        if (args.requireWrite && err instanceof Error && err.message.startsWith('capture refused')) {
+          throw err
+        }
         /* gate unavailable — proceed with write */
       }
     }
 
     const logResult = await memoryService.log(
       projectPath,
-      `${REMEMBER_ACTION_PREFIX}${args.type}`,
+      `${REMEMBER_ACTION_PREFIX}${type}`,
       {
         content: args.content,
         tags,
@@ -420,7 +455,7 @@ export const projectMemory = {
     // transient failure, no new row exists — superseding the old revisions
     // then would silently erase the topic's only active knowledge.
     if (projectId && dedupTopicKey && logResult?.eventId != null) {
-      this.applyTopicSupersession(projectId, args.type, contentHash, dedupTopicKey)
+      this.applyTopicSupersession(projectId, type, contentHash, dedupTopicKey)
     }
 
     // Reinforcement loop: credit the entries this new one references — they
@@ -448,9 +483,9 @@ export const projectMemory = {
     try {
       const { publishCRUD } = await import('../sync/publish-helper')
       const entityId =
-        args.tags?.spec_id ??
-        args.tags?.task_id ??
-        args.tags?.id ??
+        tags.spec_id ??
+        tags.task_id ??
+        tags.id ??
         args.source ??
         `mem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
       await publishCRUD({
@@ -460,11 +495,11 @@ export const projectMemory = {
         eventType: 'upsert',
         data: {
           id: entityId,
-          type: args.type,
+          type,
           content: args.content,
-          tags: args.tags ?? {},
+          tags,
           source: args.source ?? null,
-          provenance: args.provenance ?? 'declared',
+          provenance,
           // Origin authored time. We're creating the memory right now on
           // THIS machine, so now() IS the origin — receivers preserve it
           // verbatim instead of stamping their own ingestion clock.

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -12,6 +12,7 @@
  *   decision      — choice made and rationale (why, not what)
  *   learning      — lesson from a mistake or surprise
  *   gotcha        — non-obvious trap for future readers
+ *   red-herring   — negative knowledge: not-the-cause / discarded hypothesis
  *   pattern       — recurring technique that works here
  *   anti-pattern  — technique that hurt us and should be avoided
  *   shipped       — auto-recorded when a task ships
@@ -683,7 +684,10 @@ export const projectMemory = {
     if (!filePath) return []
     const base = filePath.split('/').pop() ?? filePath
     const isPreventive = (e: MemoryEntry) =>
-      e.type === 'gotcha' || e.type === 'anti-pattern' || e.tags?.pattern === 'recurring-bug'
+      e.type === 'gotcha' ||
+      e.type === 'red-herring' ||
+      e.type === 'anti-pattern' ||
+      e.tags?.pattern === 'recurring-bug'
     // The `file_tag` generated column (migration 27) + partial index narrow
     // the scan to file-tagged remember rows in SQL — exact / suffix / basename
     // matching mirrors the original JS filter. Preventive-type filtering and

--- a/core/memory/semantic-cluster.ts
+++ b/core/memory/semantic-cluster.ts
@@ -38,9 +38,9 @@
  * context row never re-joins a gotcha cluster (no promotion by fullness).
  */
 
+import { cosineSimilarity, embedLocalText } from '../services/embeddings'
 import { memoryFingerprint } from './content-fingerprint'
 import type { MemoryEntry } from './entries'
-import { cosineSimilarity, embedLocalText } from '../services/embeddings'
 
 /** High bar when no/weak entity overlap (local subword only). */
 export const CLUSTER_SIM_STRICT = 0.88
@@ -214,7 +214,13 @@ export function sharedEntities(a: Set<string>, b: Set<string>): string[] {
 export function fullnessScore(e: Pick<MemoryEntry, 'content' | 'provenance'>): number {
   const len = (e.content ?? '').trim().length
   const provBonus =
-    e.provenance === 'declared' ? 80 : e.provenance === 'extracted' ? 40 : e.provenance === 'inferred' ? 0 : 20
+    e.provenance === 'declared'
+      ? 80
+      : e.provenance === 'extracted'
+        ? 40
+        : e.provenance === 'inferred'
+          ? 0
+          : 20
   return len + provBonus
 }
 
@@ -258,9 +264,7 @@ export function shouldClusterPair(
   const entB = opts?.entitiesB ?? extractKeyEntities(b.content)
   const shared = sharedEntities(entA, entB)
 
-  const sim =
-    opts?.sim ??
-    cosineSimilarity(embedLocalText(a.content), embedLocalText(b.content))
+  const sim = opts?.sim ?? cosineSimilarity(embedLocalText(a.content), embedLocalText(b.content))
 
   const strongShared = shared.filter(isStrongEntity)
   if (strongShared.length >= 2 && sim >= CLUSTER_SIM_MULTI_ENTITY) {
@@ -384,9 +388,7 @@ export function clusterMemoryEntries(entries: MemoryEntry[]): MemoryCluster[] {
 
   // Stable order: original primary appearance order among entries
   const orderIndex = new Map(entries.map((e, i) => [e.id, i]))
-  clusters.sort(
-    (a, b) => (orderIndex.get(a.primary.id) ?? 0) - (orderIndex.get(b.primary.id) ?? 0)
-  )
+  clusters.sort((a, b) => (orderIndex.get(a.primary.id) ?? 0) - (orderIndex.get(b.primary.id) ?? 0))
   return clusters
 }
 

--- a/core/memory/semantic-cluster.ts
+++ b/core/memory/semantic-cluster.ts
@@ -1,0 +1,359 @@
+/**
+ * Semantic cluster for memory surfaces — collapse cross-language / near-
+ * paraphrase equivalents into one primary (fullest) row + seen_in_N.
+ *
+ * Pure + deterministic + local embeddings only (0 network). Safe for brief
+ * assembly on every recall path.
+ *
+ * Cluster rule (AND):
+ *   1. cosine(local embed) >= threshold (stricter without entities)
+ *   2. shared key entities (file, RPC/snake id, ALLCAPS token, UUID, …)
+ *      — OR exact content fingerprint
+ *
+ * Over-collapse mitigation: entity gate is mandatory unless fingerprint matches.
+ * Near-but-distinct facts without shared entities never merge.
+ *
+ * Contract tags for future intake:
+ *   cluster_id · seen_in_N · cluster_members (ids)
+ */
+
+import { memoryFingerprint } from './content-fingerprint'
+import type { MemoryEntry } from './entries'
+import { cosineSimilarity, embedLocalText } from '../services/embeddings'
+
+/** High bar when no/weak entity overlap (local subword only). */
+export const CLUSTER_SIM_STRICT = 0.88
+
+/**
+ * Lower bar when ≥1 strong shared entity — needed for ES↔EN pairs of the
+ * same fact ("No era RLS" / "It wasn't RLS") where local embed sim is weak.
+ */
+export const CLUSTER_SIM_WITH_ENTITY = 0.52
+
+/**
+ * When ≥2 strong anchors agree (RPC + RLS, file + error code), allow a
+ * lower cosine — local subword often scores ES↔EN paraphrases ~0.40.
+ */
+export const CLUSTER_SIM_MULTI_ENTITY = 0.38
+
+/** Ignore tiny tokens as entities. */
+const MIN_ENTITY_LEN = 3
+
+/** Strong anchors: paths, snake RPCs, multi-word, codes like rls/jwt. */
+export function isStrongEntity(e: string): boolean {
+  if (e.length < MIN_ENTITY_LEN) return false
+  if (e.includes('/') || e.includes('.') || e.includes('_') || e.includes(' ')) return true
+  if (e.length >= 10) return true
+  // Short product/security codes that are high-signal across languages
+  return ['rls', 'jwt', 'rpc', 'csrf', 'cors', 'oauth', 'sso'].includes(e)
+}
+
+export interface MemoryCluster {
+  /** Fullest / preferred entry shown on the surface. */
+  primary: MemoryEntry
+  /** All members including primary. */
+  members: MemoryEntry[]
+  seenInN: number
+  sharedEntities: string[]
+  clusterId: string
+}
+
+/**
+ * Extract key entities used as the cluster gate (not a full NER).
+ * Conservative: paths, long identifiers, ALLCAPS codes, UUIDs, mem refs.
+ */
+export function extractKeyEntities(text: string): Set<string> {
+  const out = new Set<string>()
+  const s = text ?? ''
+
+  for (const m of s.matchAll(/\b(?:[\w@.-]+\/)+[\w.-]+\.\w{1,8}\b/g)) {
+    out.add(m[0]!.toLowerCase())
+  }
+  for (const m of s.matchAll(/\b[\w-]+\.(ts|tsx|js|jsx|mjs|cjs|py|sql|go|rs|md|json)\b/gi)) {
+    out.add(m[0]!.toLowerCase())
+  }
+  // snake_case / long identifiers (RPC, helpers)
+  for (const m of s.matchAll(/\b[a-z][a-z0-9]*(?:_[a-z0-9]+){1,}\b/gi)) {
+    if (m[0]!.length >= 6) out.add(m[0]!.toLowerCase())
+  }
+  // camelCase long
+  for (const m of s.matchAll(/\b[a-z]+[A-Z][a-zA-Z0-9]{3,}\b/g)) {
+    out.add(m[0]!.toLowerCase())
+  }
+  // ALLCAPS codes (RLS, JWT, RPC…)
+  for (const m of s.matchAll(/\b[A-Z]{2,8}\b/g)) {
+    out.add(m[0]!.toLowerCase())
+  }
+  // UUIDs
+  for (const m of s.matchAll(
+    /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi
+  )) {
+    out.add(m[0]!.toLowerCase())
+  }
+  // mem_N cross-refs
+  for (const m of s.matchAll(/\bmem[_-]\d+\b/gi)) {
+    out.add(m[0]!.toLowerCase().replace('-', '_'))
+  }
+  // Security / product anchors that appear in multi-language traps
+  for (const anchor of [
+    'security definer',
+    'security invoker',
+    'row level security',
+    'router.refresh',
+  ]) {
+    if (s.toLowerCase().includes(anchor)) out.add(anchor)
+  }
+
+  // Drop ultra-generic tokens
+  for (const noise of ['the', 'and', 'for', 'with', 'from', 'this', 'that', 'http', 'https']) {
+    out.delete(noise)
+  }
+  return out
+}
+
+export function sharedEntities(a: Set<string>, b: Set<string>): string[] {
+  const out: string[] = []
+  for (const x of a) {
+    if (x.length >= MIN_ENTITY_LEN && b.has(x)) out.push(x)
+  }
+  return out.sort()
+}
+
+/** Prefer longer declared bodies as the surface primary. */
+export function fullnessScore(e: Pick<MemoryEntry, 'content' | 'provenance'>): number {
+  const len = (e.content ?? '').trim().length
+  const provBonus =
+    e.provenance === 'declared' ? 80 : e.provenance === 'extracted' ? 40 : e.provenance === 'inferred' ? 0 : 20
+  return len + provBonus
+}
+
+function pickPrimary(members: MemoryEntry[]): MemoryEntry {
+  let best = members[0]!
+  let bestScore = fullnessScore(best)
+  for (let i = 1; i < members.length; i++) {
+    const m = members[i]!
+    const s = fullnessScore(m)
+    if (s > bestScore) {
+      best = m
+      bestScore = s
+    }
+  }
+  return best
+}
+
+/**
+ * Should two entries collapse into one cluster?
+ * Same type required (gotcha≠decision).
+ */
+export function shouldClusterPair(
+  a: Pick<MemoryEntry, 'type' | 'content' | 'id'>,
+  b: Pick<MemoryEntry, 'type' | 'content' | 'id'>,
+  opts?: {
+    sim?: number
+    entitiesA?: Set<string>
+    entitiesB?: Set<string>
+  }
+): { cluster: boolean; sim: number; entities: string[] } {
+  if (a.type !== b.type) return { cluster: false, sim: 0, entities: [] }
+  if (a.id && b.id && a.id === b.id) return { cluster: true, sim: 1, entities: [] }
+
+  const fpA = memoryFingerprint(a.content)
+  const fpB = memoryFingerprint(b.content)
+  if (fpA === fpB) {
+    return { cluster: true, sim: 1, entities: ['*fingerprint*'] }
+  }
+
+  const entA = opts?.entitiesA ?? extractKeyEntities(a.content)
+  const entB = opts?.entitiesB ?? extractKeyEntities(b.content)
+  const shared = sharedEntities(entA, entB)
+
+  const sim =
+    opts?.sim ??
+    cosineSimilarity(embedLocalText(a.content), embedLocalText(b.content))
+
+  const strongShared = shared.filter(isStrongEntity)
+  if (strongShared.length >= 2 && sim >= CLUSTER_SIM_MULTI_ENTITY) {
+    return { cluster: true, sim, entities: shared }
+  }
+  if (strongShared.length >= 1 && sim >= CLUSTER_SIM_WITH_ENTITY) {
+    return { cluster: true, sim, entities: shared }
+  }
+  // Strict path without entities is intentionally rare for cross-lang — avoid
+  // merging "auth timeout" with "auth retry" just because subword sim is high.
+  if (shared.length === 0 && sim >= CLUSTER_SIM_STRICT) {
+    // Require moderate token Jaccard as secondary gate
+    const ja = new Set(
+      a.content
+        .toLowerCase()
+        .split(/[^a-z0-9áéíóúñü]+/i)
+        .filter((t) => t.length >= 4)
+    )
+    const jb = new Set(
+      b.content
+        .toLowerCase()
+        .split(/[^a-z0-9áéíóúñü]+/i)
+        .filter((t) => t.length >= 4)
+    )
+    let inter = 0
+    for (const t of ja) if (jb.has(t)) inter++
+    const union = ja.size + jb.size - inter || 1
+    const jaccard = inter / union
+    if (jaccard >= 0.45) return { cluster: true, sim, entities: [] }
+  }
+
+  return { cluster: false, sim, entities: shared }
+}
+
+/**
+ * Greedy union-find cluster within a flat entry list (typically one type).
+ */
+export function clusterMemoryEntries(entries: MemoryEntry[]): MemoryCluster[] {
+  if (entries.length === 0) return []
+  if (entries.length === 1) {
+    const e = entries[0]!
+    return [
+      {
+        primary: e,
+        members: [e],
+        seenInN: 1,
+        sharedEntities: [],
+        clusterId: `c_${e.id}`,
+      },
+    ]
+  }
+
+  const n = entries.length
+  const parent = Array.from({ length: n }, (_, i) => i)
+  const find = (i: number): number => {
+    let p = i
+    while (parent[p] !== p) p = parent[p]!
+    let x = i
+    while (parent[x] !== x) {
+      const next = parent[x]!
+      parent[x] = p
+      x = next
+    }
+    return p
+  }
+  const union = (i: number, j: number) => {
+    const ri = find(i)
+    const rj = find(j)
+    if (ri !== rj) parent[rj] = ri
+  }
+
+  const entityCache = entries.map((e) => extractKeyEntities(e.content))
+  const vectors = entries.map((e) => embedLocalText(e.content))
+  const pairEntities = new Map<string, string[]>()
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const sim = cosineSimilarity(vectors[i]!, vectors[j]!)
+      const r = shouldClusterPair(entries[i]!, entries[j]!, {
+        sim,
+        entitiesA: entityCache[i],
+        entitiesB: entityCache[j],
+      })
+      if (r.cluster) {
+        union(i, j)
+        pairEntities.set(`${i}:${j}`, r.entities)
+      }
+    }
+  }
+
+  const groups = new Map<number, number[]>()
+  for (let i = 0; i < n; i++) {
+    const r = find(i)
+    const g = groups.get(r) ?? []
+    g.push(i)
+    groups.set(r, g)
+  }
+
+  const clusters: MemoryCluster[] = []
+  for (const idxs of groups.values()) {
+    const members = idxs.map((i) => entries[i]!)
+    const primary = pickPrimary(members)
+    // Union of shared entities seen on any merged pair in the group
+    const ent = new Set<string>()
+    for (let a = 0; a < idxs.length; a++) {
+      for (let b = a + 1; b < idxs.length; b++) {
+        const key = `${Math.min(idxs[a]!, idxs[b]!)}:${Math.max(idxs[a]!, idxs[b]!)}`
+        for (const e of pairEntities.get(key) ?? []) {
+          if (e !== '*fingerprint*') ent.add(e)
+        }
+      }
+    }
+    clusters.push({
+      primary,
+      members,
+      seenInN: members.length,
+      sharedEntities: [...ent].sort(),
+      clusterId: `c_${primary.id}`,
+    })
+  }
+
+  // Stable order: original primary appearance order among entries
+  const orderIndex = new Map(entries.map((e, i) => [e.id, i]))
+  clusters.sort(
+    (a, b) => (orderIndex.get(a.primary.id) ?? 0) - (orderIndex.get(b.primary.id) ?? 0)
+  )
+  return clusters
+}
+
+/**
+ * Collapse a mixed-type list: cluster within each type, return primaries
+ * with synthetic tags seen_in_N / cluster_id for rendering.
+ */
+export function collapseEntriesForSurface(entries: MemoryEntry[]): {
+  entries: MemoryEntry[]
+  collapsedCount: number
+  clusters: MemoryCluster[]
+} {
+  if (entries.length <= 1) {
+    return { entries, collapsedCount: 0, clusters: [] }
+  }
+
+  const byType = new Map<string, MemoryEntry[]>()
+  for (const e of entries) {
+    const list = byType.get(e.type) ?? []
+    list.push(e)
+    byType.set(e.type, list)
+  }
+
+  const out: MemoryEntry[] = []
+  const allClusters: MemoryCluster[] = []
+  let collapsedCount = 0
+
+  // Preserve first-seen type order from original list
+  const typeOrder: string[] = []
+  for (const e of entries) {
+    if (!typeOrder.includes(e.type)) typeOrder.push(e.type)
+  }
+
+  for (const type of typeOrder) {
+    const group = byType.get(type) ?? []
+    const clusters = clusterMemoryEntries(group)
+    for (const c of clusters) {
+      allClusters.push(c)
+      if (c.seenInN > 1) collapsedCount += c.seenInN - 1
+      const tagged: MemoryEntry = {
+        ...c.primary,
+        tags: {
+          ...c.primary.tags,
+          seen_in_N: String(c.seenInN),
+          cluster_id: c.clusterId,
+          ...(c.seenInN > 1
+            ? {
+                cluster_members: c.members
+                  .map((m) => m.id)
+                  .filter((id) => id !== c.primary.id)
+                  .join(','),
+              }
+            : {}),
+        },
+      }
+      out.push(tagged)
+    }
+  }
+
+  return { entries: out, collapsedCount, clusters: allClusters }
+}

--- a/core/memory/semantic-cluster.ts
+++ b/core/memory/semantic-cluster.ts
@@ -13,8 +13,29 @@
  * Over-collapse mitigation: entity gate is mandatory unless fingerprint matches.
  * Near-but-distinct facts without shared entities never merge.
  *
- * Contract tags for future intake:
- *   cluster_id · seen_in_N · cluster_members (ids)
+ * ── Fase 0 acceptance contracts ──────────────────────────────────────────
+ *
+ * T1 TRACEABILITY (post-cluster survivor MUST preserve all sources):
+ *   - `cluster_sources`  — ALL member mem_ids, primary first (auditable set)
+ *   - `cluster_members`  — non-primary ids only (compat / "the collapsed ones")
+ *   - `seen_in_N`        — |members| (importance, not noise)
+ *   - `cluster_id`       — stable `c_<primaryId>`
+ *   Brief/compact lines MUST surface `sources=` when seen_in_N > 1 so a PO
+ *   or eng-lead can `prjct context memory mem_N` on ANY corroborating capture.
+ *   Storage rows are never deleted by clustering — only the *presentation*
+ *   collapses. Full/by-id format remains unclustered for forensic audit.
+ *
+ * LANGUAGE SURFACE (PRD §7.3):
+ *   Storage keeps original language (no silent DB rewrite — audit intact).
+ *   Brief presentation language unify is DEFERRED to the product layer
+ *   (tech→product / intake). When a cluster spans languages we tag
+ *   `cluster_langs` and `surface_lang=store-original` so the brief is honest
+ *   that survivors may remain bilingual until that layer lands. Do not
+ *   machine-translate here without an explicit product decision.
+ *
+ * Demote interaction: precision may retype gotcha→context / red-herring
+ * before recall. Clustering is within a single type only, so a demoted
+ * context row never re-joins a gotcha cluster (no promotion by fullness).
  */
 
 import { memoryFingerprint } from './content-fingerprint'
@@ -56,6 +77,76 @@ export interface MemoryCluster {
   seenInN: number
   sharedEntities: string[]
   clusterId: string
+}
+
+/**
+ * T1: ordered source ids for a cluster — primary first, then others stable
+ * by original member order. Always includes every corroborating capture.
+ */
+export function clusterSourceIds(cluster: MemoryCluster): string[] {
+  const primaryId = cluster.primary.id
+  const rest = cluster.members.map((m) => m.id).filter((id) => id !== primaryId)
+  return [primaryId, ...rest]
+}
+
+/**
+ * Coarse language tags for honesty on multi-lang clusters (not a full detector).
+ * Used only for `cluster_langs` metadata — never rewrites content.
+ */
+export function detectContentLangHints(text: string): string[] {
+  const t = (text ?? '').toLowerCase()
+  const hints: string[] = []
+  // Spanish function words / patterns common in our vault
+  if (
+    /\b(el|la|los|las|de|que|no|era|fue|para|con|por|una|esto|esta|cómo|como)\b/.test(t) ||
+    /[áéíóúñ¿¡]/.test(t)
+  ) {
+    hints.push('es')
+  }
+  if (
+    /\b(the|was|were|wasn't|with|from|that|this|and|for|not|is|are|it)\b/.test(t) ||
+    /\b(security definer|bypass)\b/.test(t)
+  ) {
+    hints.push('en')
+  }
+  if (hints.length === 0) hints.push('und')
+  return [...new Set(hints)]
+}
+
+/** Union of language hints across cluster members. */
+export function clusterLangHints(members: MemoryEntry[]): string[] {
+  const set = new Set<string>()
+  for (const m of members) {
+    for (const h of detectContentLangHints(m.content)) set.add(h)
+  }
+  return [...set].sort()
+}
+
+/**
+ * Build the T1 tag payload that every clustered survivor carries.
+ * Guarantees: all source ids recoverable; multi-lang flagged, not translated.
+ */
+export function buildClusterSurfaceTags(cluster: MemoryCluster): Record<string, string> {
+  const sources = clusterSourceIds(cluster)
+  const membersOnly = sources.slice(1)
+  const langs = clusterLangHints(cluster.members)
+  const tags: Record<string, string> = {
+    seen_in_N: String(cluster.seenInN),
+    cluster_id: cluster.clusterId,
+  }
+  if (cluster.seenInN > 1) {
+    // Primary-first full audit set (T1 contract — never drop corroborating ids)
+    tags.cluster_sources = sources.join(',')
+    // Non-primary only (legacy / "who was collapsed")
+    tags.cluster_members = membersOnly.join(',')
+    tags.surface_lang = 'store-original'
+    if (langs.length > 0) tags.cluster_langs = langs.join(',')
+    if (langs.length > 1) {
+      // Explicit: bilingual survivor is allowed until product-layer normalize
+      tags.lang_normalize = 'deferred-product-layer'
+    }
+  }
+  return tags
 }
 
 /**
@@ -301,15 +392,19 @@ export function clusterMemoryEntries(entries: MemoryEntry[]): MemoryCluster[] {
 
 /**
  * Collapse a mixed-type list: cluster within each type, return primaries
- * with synthetic tags seen_in_N / cluster_id for rendering.
+ * with T1 tags (cluster_sources / seen_in_N / …) for rendering + intake.
+ *
+ * Within-type only — demoted gotcha→context never re-clusters into gotcha.
  */
 export function collapseEntriesForSurface(entries: MemoryEntry[]): {
   entries: MemoryEntry[]
   collapsedCount: number
   clusters: MemoryCluster[]
+  /** True when any survivor carries multi-lang cluster_langs. */
+  multiLangSurvivors: number
 } {
   if (entries.length <= 1) {
-    return { entries, collapsedCount: 0, clusters: [] }
+    return { entries, collapsedCount: 0, clusters: [], multiLangSurvivors: 0 }
   }
 
   const byType = new Map<string, MemoryEntry[]>()
@@ -322,6 +417,7 @@ export function collapseEntriesForSurface(entries: MemoryEntry[]): {
   const out: MemoryEntry[] = []
   const allClusters: MemoryCluster[] = []
   let collapsedCount = 0
+  let multiLangSurvivors = 0
 
   // Preserve first-seen type order from original list
   const typeOrder: string[] = []
@@ -335,25 +431,18 @@ export function collapseEntriesForSurface(entries: MemoryEntry[]): {
     for (const c of clusters) {
       allClusters.push(c)
       if (c.seenInN > 1) collapsedCount += c.seenInN - 1
+      const clusterTags = buildClusterSurfaceTags(c)
+      if ((clusterTags.cluster_langs ?? '').includes(',')) multiLangSurvivors++
       const tagged: MemoryEntry = {
         ...c.primary,
         tags: {
           ...c.primary.tags,
-          seen_in_N: String(c.seenInN),
-          cluster_id: c.clusterId,
-          ...(c.seenInN > 1
-            ? {
-                cluster_members: c.members
-                  .map((m) => m.id)
-                  .filter((id) => id !== c.primary.id)
-                  .join(','),
-              }
-            : {}),
+          ...clusterTags,
         },
       }
       out.push(tagged)
     }
   }
 
-  return { entries: out, collapsedCount, clusters: allClusters }
+  return { entries: out, collapsedCount, clusters: allClusters, multiLangSurvivors }
 }

--- a/core/memory/substrate-health.ts
+++ b/core/memory/substrate-health.ts
@@ -92,7 +92,10 @@ export function computeSubstrateHealth(
     if (v.action !== 'accept') {
       precisionFail++
       if (e.type === 'gotcha' && v.reasonCode === 'gotcha_open_narration') unshapedGotcha++
-      if (e.type === 'spec' && (v.reasonCode === 'empty_spec_mirror' || v.reasonCode === 'bare_id_body')) {
+      if (
+        e.type === 'spec' &&
+        (v.reasonCode === 'empty_spec_mirror' || v.reasonCode === 'bare_id_body')
+      ) {
         emptySpec++
       }
       if (v.reasonCode === 'junk' || v.reasonCode === 'inbox_no_substance') junkLike++

--- a/core/memory/substrate-health.ts
+++ b/core/memory/substrate-health.ts
@@ -1,0 +1,303 @@
+/**
+ * Substrate health + capture density — honesty metrics for living memory.
+ *
+ * Pure over MemoryEntry[]. Used by insights quality / memory doctor and as a
+ * compact-brief coverage footer so consumers never confuse "listed risks"
+ * with "complete knowledge of the zone".
+ *
+ * Metrics (contract for future intake):
+ *   signal_ratio · unshaped_gotcha_rate · empty_spec_rate · junk_like_rate
+ *   recency bands · blind_spots[] · score 0–100
+ */
+
+import type { MemoryEntry } from './entries'
+import { classifyCapturePrecision } from './precision-classifier'
+import { clusterMemoryEntries, extractKeyEntities } from './semantic-cluster'
+
+/** Types that carry judgment authority on briefs. */
+export const JUDGMENT_TYPES = new Set([
+  'decision',
+  'gotcha',
+  'learning',
+  'fact',
+  'feedback',
+  'pattern',
+  'anti-pattern',
+  'red-herring',
+  'spec',
+  'shipped',
+])
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface DensityBand {
+  d7: number
+  d30: number
+  older: number
+}
+
+export interface BlindSpot {
+  kind: 'type' | 'entity' | 'recency' | 'empty'
+  label: string
+  reason: string
+}
+
+export interface SubstrateHealth {
+  live: number
+  judgment: number
+  /** 0–1: share of judgment rows that pass precision as-typed. */
+  signalRatio: number
+  unshapedGotchaRate: number
+  emptySpecRate: number
+  junkLikeRate: number
+  /** Entries that would collapse under semantic cluster (within-type). */
+  clusterCollapsedEstimate: number
+  byType: Record<string, number>
+  recency: DensityBand
+  blindSpots: BlindSpot[]
+  /** 0–100 composite for doctor / gates. */
+  score: number
+  issues: string[]
+}
+
+function ageMs(e: MemoryEntry, now: number): number {
+  const t = Date.parse(e.rememberedAt)
+  return Number.isFinite(t) ? Math.max(0, now - t) : Number.POSITIVE_INFINITY
+}
+
+/**
+ * Compute substrate health for a vault slice (full index or recall set).
+ */
+export function computeSubstrateHealth(
+  entries: MemoryEntry[],
+  nowMs: number = Date.now()
+): SubstrateHealth {
+  const live = entries.length
+  const byType: Record<string, number> = {}
+  for (const e of entries) {
+    byType[e.type] = (byType[e.type] ?? 0) + 1
+  }
+
+  const judgment = entries.filter((e) => JUDGMENT_TYPES.has(e.type))
+  let unshapedGotcha = 0
+  let emptySpec = 0
+  let junkLike = 0
+  let precisionFail = 0
+
+  const gotchas = judgment.filter((e) => e.type === 'gotcha')
+  const specs = judgment.filter((e) => e.type === 'spec')
+
+  for (const e of judgment) {
+    const v = classifyCapturePrecision(e.content, e.type)
+    if (v.action !== 'accept') {
+      precisionFail++
+      if (e.type === 'gotcha' && v.reasonCode === 'gotcha_open_narration') unshapedGotcha++
+      if (e.type === 'spec' && (v.reasonCode === 'empty_spec_mirror' || v.reasonCode === 'bare_id_body')) {
+        emptySpec++
+      }
+      if (v.reasonCode === 'junk' || v.reasonCode === 'inbox_no_substance') junkLike++
+    }
+  }
+
+  const unshapedGotchaRate = gotchas.length === 0 ? 0 : unshapedGotcha / gotchas.length
+  const emptySpecRate = specs.length === 0 ? 0 : emptySpec / specs.length
+  const junkLikeRate = judgment.length === 0 ? 0 : junkLike / judgment.length
+  const signalRatio =
+    judgment.length === 0 ? 1 : Math.max(0, Math.min(1, 1 - precisionFail / judgment.length))
+
+  // Cluster estimate within judgment types only
+  let clusterCollapsedEstimate = 0
+  const byJType = new Map<string, MemoryEntry[]>()
+  for (const e of judgment) {
+    const list = byJType.get(e.type) ?? []
+    list.push(e)
+    byJType.set(e.type, list)
+  }
+  for (const group of byJType.values()) {
+    if (group.length < 2) continue
+    const clusters = clusterMemoryEntries(group)
+    for (const c of clusters) {
+      if (c.seenInN > 1) clusterCollapsedEstimate += c.seenInN - 1
+    }
+  }
+
+  const recency: DensityBand = { d7: 0, d30: 0, older: 0 }
+  for (const e of entries) {
+    const age = ageMs(e, nowMs)
+    if (age <= 7 * DAY_MS) recency.d7++
+    else if (age <= 30 * DAY_MS) recency.d30++
+    else recency.older++
+  }
+
+  const blindSpots: BlindSpot[] = []
+  if (live === 0) {
+    blindSpots.push({
+      kind: 'empty',
+      label: 'vault',
+      reason: 'no live memory — every zone is a blind spot',
+    })
+  }
+  if (judgment.length > 0 && recency.d30 === 0 && recency.d7 === 0) {
+    blindSpots.push({
+      kind: 'recency',
+      label: 'stale-vault',
+      reason: 'no captures in the last 30 days — knowledge may be rotten',
+    })
+  }
+  // Judgment types missing entirely but others present
+  for (const need of ['decision', 'gotcha'] as const) {
+    if (live >= 8 && (byType[need] ?? 0) === 0) {
+      blindSpots.push({
+        kind: 'type',
+        label: need,
+        reason: `no ${need} entries in a non-empty vault — risk surface is incomplete`,
+      })
+    }
+  }
+
+  // Entity density: entities that appear only once and only in old entries
+  // are thin — surface top thin anchors when judgment exists.
+  if (judgment.length >= 3) {
+    const entityHits = new Map<string, { count: number; fresh: number }>()
+    for (const e of judgment) {
+      const fresh = ageMs(e, nowMs) <= 30 * DAY_MS ? 1 : 0
+      for (const ent of extractKeyEntities(e.content)) {
+        if (ent.length < 6 && !['rls', 'jwt', 'csrf'].includes(ent)) continue
+        const cur = entityHits.get(ent) ?? { count: 0, fresh: 0 }
+        cur.count++
+        cur.fresh += fresh
+        entityHits.set(ent, cur)
+      }
+    }
+    // Prefer reporting lack of multi-capture on high-signal single-hit entities
+    // only when we have enough data that sparsity is meaningful.
+    let thin = 0
+    for (const [ent, h] of entityHits) {
+      if (h.count === 1 && h.fresh === 0) {
+        thin++
+        if (blindSpots.filter((b) => b.kind === 'entity').length < 3) {
+          blindSpots.push({
+            kind: 'entity',
+            label: ent,
+            reason: `single stale capture for "${ent}" — validate before trusting`,
+          })
+        }
+      }
+    }
+    if (thin > 3) {
+      blindSpots.push({
+        kind: 'entity',
+        label: `${thin} thin anchors`,
+        reason: `${thin} entities appear only once in stale captures — density is low`,
+      })
+    }
+  }
+
+  const issues: string[] = []
+  if (unshapedGotcha > 0) {
+    issues.push(`${unshapedGotcha} open-narration gotcha(s) fail precision (should be context).`)
+  }
+  if (emptySpec > 0) {
+    issues.push(`${emptySpec} empty-spec mirror(s) still live.`)
+  }
+  if (junkLike > 0) {
+    issues.push(`${junkLike} junk-like judgment row(s) should be forgotten.`)
+  }
+  if (clusterCollapsedEstimate > 0) {
+    issues.push(
+      `${clusterCollapsedEstimate} near-duplicate(s) would collapse on brief (semantic cluster).`
+    )
+  }
+  for (const b of blindSpots) {
+    if (b.kind !== 'entity' || blindSpots.filter((x) => x.kind === 'entity').indexOf(b) < 2) {
+      issues.push(`Blind spot (${b.kind}): ${b.reason}`)
+    }
+  }
+
+  // Score: start 100, penalize precision failures and blind spots
+  let score = 100
+  score -= Math.round((1 - signalRatio) * 40)
+  score -= Math.min(20, Math.round(unshapedGotchaRate * 20))
+  score -= Math.min(15, Math.round(emptySpecRate * 15))
+  score -= Math.min(15, blindSpots.length * 3)
+  score = Math.max(0, Math.min(100, score))
+
+  return {
+    live,
+    judgment: judgment.length,
+    signalRatio,
+    unshapedGotchaRate,
+    emptySpecRate,
+    junkLikeRate,
+    clusterCollapsedEstimate,
+    byType,
+    recency,
+    blindSpots,
+    score,
+    issues,
+  }
+}
+
+/**
+ * One-line coverage footer for compact memory surfaces (honest density).
+ */
+export function formatCoverageFooter(entries: MemoryEntry[], nowMs: number = Date.now()): string {
+  if (entries.length === 0) {
+    return '_Coverage: empty set — full blind spot; do not treat absence of risks as safety._'
+  }
+  const h = computeSubstrateHealth(entries, nowMs)
+  const density =
+    h.recency.d7 + h.recency.d30 >= Math.max(3, Math.ceil(entries.length * 0.4))
+      ? 'dense'
+      : h.recency.d7 + h.recency.d30 >= 1
+        ? 'mixed'
+        : 'thin/stale'
+  const topTypes = Object.entries(h.byType)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([t, n]) => `${t}:${n}`)
+    .join(' ')
+  const blind =
+    h.blindSpots.length === 0
+      ? 'no structural blind spots in this slice'
+      : `${h.blindSpots.length} blind-spot signal(s) — not complete coverage`
+  return `_Coverage: ${entries.length} shown · density=${density} · signal≈${Math.round(h.signalRatio * 100)}% · ${topTypes} · ${blind}_`
+}
+
+/**
+ * Markdown block for memory doctor / insights quality.
+ */
+export function formatSubstrateHealthMd(h: SubstrateHealth): string {
+  const lines = [
+    '## Substrate health',
+    '',
+    `| Metric | Value |`,
+    `|---|---:|`,
+    `| Score | ${h.score}/100 |`,
+    `| Live | ${h.live} |`,
+    `| Judgment | ${h.judgment} |`,
+    `| Signal ratio | ${Math.round(h.signalRatio * 100)}% |`,
+    `| Unshaped gotcha rate | ${Math.round(h.unshapedGotchaRate * 100)}% |`,
+    `| Empty-spec rate | ${Math.round(h.emptySpecRate * 100)}% |`,
+    `| Cluster collapse estimate | ${h.clusterCollapsedEstimate} |`,
+    `| Recency 7d / 30d / older | ${h.recency.d7} / ${h.recency.d30} / ${h.recency.older} |`,
+    '',
+  ]
+  if (h.issues.length === 0) {
+    lines.push('- No substrate precision issues detected in this slice.')
+  } else {
+    lines.push('### Issues')
+    for (const i of h.issues) lines.push(`- ${i}`)
+  }
+  if (h.blindSpots.length > 0) {
+    lines.push('', '### Blind spots')
+    for (const b of h.blindSpots) {
+      lines.push(`- **${b.label}** (${b.kind}): ${b.reason}`)
+    }
+  }
+  lines.push(
+    '',
+    '_This is captured knowledge only — absence of a risk is not proof it does not exist._'
+  )
+  return lines.join('\n')
+}

--- a/core/services/land-synthesis.ts
+++ b/core/services/land-synthesis.ts
@@ -101,6 +101,8 @@ export function buildLandHandoffContent(input: LandSynthesisInput): string | nul
     parts.push('Session close: no open work cycle — landed repo + capture signals only.')
   }
 
+  // Store still uses living-v2 field shape for parsers; lead sentence is the
+  // synthesis value without relying on the label as the only scannable text.
   parts.push(
     'Context synthesis: Passive land hand-off from durable signals (cycle, journal, commits, auto-captures). Not a model essay.'
   )

--- a/core/services/retention/capture-gate.ts
+++ b/core/services/retention/capture-gate.ts
@@ -26,6 +26,7 @@ import { buildReferenceModel } from './reference-model'
 const ALWAYS_ACCEPT = new Set([
   'decision',
   'gotcha',
+  'red-herring',
   'learning',
   'fact',
   'feedback',

--- a/core/services/retention/capture-gate.ts
+++ b/core/services/retention/capture-gate.ts
@@ -15,6 +15,7 @@
  */
 
 import type { MemoryEntry, MemoryType } from '../../memory/entries'
+import { classifyCapturePrecision } from '../../memory/precision-classifier'
 import { projectMemory } from '../../memory/project-memory'
 import { isJunkCaptureContent } from '../capture-junk'
 import { buildReferenceIndex, CAPTURE_MIN_EXCESS, excessAgainstIndex } from './excess'
@@ -69,6 +70,22 @@ export function captureGate(
   const junk = isJunkCaptureContent(trimmed, type)
   if (junk.junk) {
     return { accept: false, reason: `junk capture: ${junk.reason}` }
+  }
+
+  // Precision classifier (pure, no I/O): empty specs, open-narration gotchas,
+  // sub-substance inbox. Demote is not accept-as-typed — caller (remember)
+  // rewrites type; gate rejects the original public type.
+  const precision = classifyCapturePrecision(trimmed, type, {
+    force: tags?.force === 'true' || tags?.['precision:force'] === 'true',
+  })
+  if (precision.action === 'refuse') {
+    return { accept: false, reason: `precision: ${precision.reason}` }
+  }
+  if (precision.action === 'demote') {
+    return {
+      accept: false,
+      reason: `precision demote→${precision.demoteTo ?? 'context'}: ${precision.reason}`,
+    }
   }
 
   const auto = isAutoSource(tags?.source)

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -18,10 +18,10 @@
 import { loadIndex as loadBm25Index } from '../../domain/bm25'
 import { memoryFingerprint } from '../../memory/content-fingerprint'
 import { collectSupersededIds, isModelMemory, type MemoryEntry } from '../../memory/entries'
+import { classifyCapturePrecision } from '../../memory/precision-classifier'
 import { projectMemory } from '../../memory/project-memory'
 import { archiveStorage } from '../../storage/archive-storage'
 import prjctDb from '../../storage/database'
-import { classifyCapturePrecision } from '../../memory/precision-classifier'
 import { isJunkCaptureContent } from '../capture-junk'
 import { isIrrelevantGeneratedContext } from '../context-quality-service'
 import { extractCorrectionIds, usefulnessService } from '../usefulness'
@@ -502,15 +502,7 @@ export function forgetJunkCaptures(
   const max = options.max ?? 50
   // Include gotcha/spec so precision shape failures (open narration, empty
   // mirrors) leave living surfaces on dream — not only low-stakes junk.
-  const types = options.types ?? [
-    'inbox',
-    'context',
-    'idea',
-    'todo',
-    'question',
-    'gotcha',
-    'spec',
-  ]
+  const types = options.types ?? ['inbox', 'context', 'idea', 'todo', 'question', 'gotcha', 'spec']
   let forgotten = 0
   const samples: string[] = []
   try {
@@ -529,9 +521,7 @@ export function forgetJunkCaptures(
       if (forgetEntry(projectId, e.id)) {
         forgotten++
         if (samples.length < 8) {
-          samples.push(
-            `${e.id}:${j.junk ? j.reason : precision.reasonCode}`
-          )
+          samples.push(`${e.id}:${j.junk ? j.reason : precision.reasonCode}`)
         }
       }
     }

--- a/core/services/retention/index.ts
+++ b/core/services/retention/index.ts
@@ -21,6 +21,7 @@ import { collectSupersededIds, isModelMemory, type MemoryEntry } from '../../mem
 import { projectMemory } from '../../memory/project-memory'
 import { archiveStorage } from '../../storage/archive-storage'
 import prjctDb from '../../storage/database'
+import { classifyCapturePrecision } from '../../memory/precision-classifier'
 import { isJunkCaptureContent } from '../capture-junk'
 import { isIrrelevantGeneratedContext } from '../context-quality-service'
 import { extractCorrectionIds, usefulnessService } from '../usefulness'
@@ -499,7 +500,17 @@ export function forgetJunkCaptures(
   options: { max?: number; types?: string[] } = {}
 ): { forgotten: number; samples: string[] } {
   const max = options.max ?? 50
-  const types = options.types ?? ['inbox', 'context', 'idea', 'todo', 'question']
+  // Include gotcha/spec so precision shape failures (open narration, empty
+  // mirrors) leave living surfaces on dream — not only low-stakes junk.
+  const types = options.types ?? [
+    'inbox',
+    'context',
+    'idea',
+    'todo',
+    'question',
+    'gotcha',
+    'spec',
+  ]
   let forgotten = 0
   const samples: string[] = []
   try {
@@ -508,10 +519,20 @@ export function forgetJunkCaptures(
       if (forgotten >= max) break
       if (!types.includes(e.type)) continue
       const j = isJunkCaptureContent(e.content, e.type)
-      if (!j.junk) continue
+      const precision = classifyCapturePrecision(e.content, e.type)
+      const drop =
+        j.junk ||
+        precision.action === 'refuse' ||
+        // Historical open-narration gotchas: drop from living judgment surface
+        (e.type === 'gotcha' && precision.action === 'demote')
+      if (!drop) continue
       if (forgetEntry(projectId, e.id)) {
         forgotten++
-        if (samples.length < 8) samples.push(`${e.id}:${j.reason}`)
+        if (samples.length < 8) {
+          samples.push(
+            `${e.id}:${j.junk ? j.reason : precision.reasonCode}`
+          )
+        }
       }
     }
   } catch {

--- a/core/services/skill-generator/prjct-skill-body.ts
+++ b/core/services/skill-generator/prjct-skill-body.ts
@@ -129,6 +129,7 @@ export function buildPrjctSkillReference(): string {
     '| a non-trivial choice just got resolved (+ its why) | `prjct remember decision "<choice + one-line why>"` | 1 |',
     '| an insight / "aha" / new mental model | `prjct remember learning "<insight>"` | 1 |',
     '| a non-obvious trap surfaced (+ how to avoid) | `prjct remember gotcha "<trap + how to avoid>"` | 1 |',
+    '| discarded cause / not-the-cause (negative knowledge) | `prjct remember red-herring "<what it was NOT + real cause>"` | 1 |',
     '| vault noisy / long-running project — consolidate memory + rebuild L0 index | `prjct dream [--force] [--dry-run]` | 1 |',
     '| resolved inbox/signal should leave rotation | `prjct close <id> --reason "…"` | 1 |',
     '| delete a bad memory by id | `prjct forget <id>` | 1 |',

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -61,6 +61,14 @@ class SpecService {
   ): Promise<Spec> {
     const projectId = await this.requireProjectId(projectPath)
 
+    // Precision gate: empty specs (goal===title, bare id lookup) must not
+    // graduate. Fail loud — a silent draft is worse than a refused create.
+    const { classifySpecCreate } = await import('../memory/precision-classifier')
+    const precision = classifySpecCreate(args.title, args.content.goal)
+    if (precision.action === 'refuse') {
+      throw new Error(`Cannot create empty spec (${precision.reasonCode}): ${precision.reason}`)
+    }
+
     // Auto-context inference (B-CTX): only if `notes` is empty and the
     // caller didn't opt out. The composer reads `findRelevantFiles` +
     // `projectMemory.recall` and returns a tentative Markdown block.

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -61,9 +61,12 @@ class SpecService {
   ): Promise<Spec> {
     const projectId = await this.requireProjectId(projectPath)
 
-    // Precision gate: empty specs (goal===title, bare id lookup) must not
-    // graduate. Fail loud — a silent draft is worse than a refused create.
-    const { classifySpecCreate } = await import('../memory/precision-classifier')
+    // Hard refuse lookup-only goals (bare UUID). Draft seeds with goal=title
+    // are allowed in the specs table; memory mirror is gated separately so
+    // empty mirrors never pollute living type=spec surfaces.
+    const { classifySpecCreate, shouldMirrorSpecToMemory } = await import(
+      '../memory/precision-classifier'
+    )
     const precision = classifySpecCreate(args.title, args.content.goal)
     if (precision.action === 'refuse') {
       throw new Error(`Cannot create empty spec (${precision.reasonCode}): ${precision.reason}`)
@@ -104,14 +107,17 @@ class SpecService {
       tags: args.tags,
     })
 
-    // Mirror to memory event stream so `prjct context memory spec` finds it.
-    await projectMemory.remember(projectPath, {
-      type: 'spec',
-      content: `${spec.title}\n\nGoal: ${spec.content.goal}`,
-      tags: { ...(args.tags ?? {}), spec_id: spec.id, status: spec.status },
-      source: spec.id,
-      provenance: 'declared',
-    })
+    // Mirror only when goal is substantive — draft seeds (goal===title) stay
+    // in the specs table without polluting `prjct context memory spec`.
+    if (shouldMirrorSpecToMemory(spec.title, spec.content.goal)) {
+      await projectMemory.remember(projectPath, {
+        type: 'spec',
+        content: `${spec.title}\n\nGoal: ${spec.content.goal}`,
+        tags: { ...(args.tags ?? {}), spec_id: spec.id, status: spec.status },
+        source: spec.id,
+        provenance: 'declared',
+      })
+    }
 
     return spec
   }

--- a/core/tools/context/index.ts
+++ b/core/tools/context/index.ts
@@ -171,7 +171,7 @@ async function runMemoryTool(
 
   // `learnings` is a typed slice of memory focused on what the project
   // has *learned* the hard way. Everything else comes through `memory`.
-  const LEARNINGS_TYPES: MemoryType[] = ['learning', 'anti-pattern', 'gotcha']
+  const LEARNINGS_TYPES: MemoryType[] = ['learning', 'anti-pattern', 'gotcha', 'red-herring']
   const types = opts.kind === 'learnings' ? LEARNINGS_TYPES : undefined
 
   // The full pipeline (FTS-first, recall backfill, semantic blend,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.63.2",
+  "version": "3.64.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

Phase 0 substrate quality so living memory is honest, dense, and auditable — no intake/PRD UI.

- **Precision classifier** before public graduation: empty specs, open-narration gotchas (demote → context), sub-substance inbox refuse; wired into capture-gate, remember, spec create, dream.
- **Semantic cluster** on compact brief: keep fullest + `seen_in_N` as importance; entity gate anti over-collapse.
- **T1 post-cluster audit**: `cluster_sources` = all mem_ids (primary first); compact shows `sources=…` so corroborators stay openable.
- **Language**: store-original; multi-lang tags + explicit defer of surface normalize to product layer (no DB rewrite).
- **red-herring** first-class + auto-retype from closed not-the-cause language.
- **Substrate health** in memory doctor + coverage footer (absence ≠ proof of safety).

## Test plan

- [x] `bun test core/__tests__/memory/precision-classifier.test.ts`
- [x] `bun test core/__tests__/memory/semantic-cluster.test.ts` (T1 sources, multi-lang defer, demote isolation)
- [x] `bun test core/__tests__/memory/substrate-health.test.ts`
- [x] `bun test core/__tests__/services/capture-junk.test.ts`
- [x] `bun run typecheck`

## Out of scope (follow-up PR)

- Brief language unify at product/intake layer
- Write-side soft cluster persistence / seen_in_N ledger
- Intake / PRD product surface