### PR TITLE
fix(harness): context density not session kill; production MCP only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.65.0] - 2026-07-16
+
+### Added
+- context density not session kill; production MCP only
+
 ## [3.64.0] - 2026-07-16
 
 ### Added

--- a/core/__tests__/services/cycle-budget-card.test.ts
+++ b/core/__tests__/services/cycle-budget-card.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'bun:test'
 import { buildCycleBudgetCard } from '../../services/cycle-budget-card'
 
 describe('cycle-budget-card', () => {
-  it('prints turns and land cue at cycle open', () => {
+  it('prints turns and density cue at cycle open', () => {
     const c = buildCycleBudgetCard({
       turns: 0,
       turnLimit: 15,
@@ -17,11 +17,11 @@ describe('cycle-budget-card', () => {
     expect(c.line).toMatch(/Cycle budget/)
     expect(c.line).toContain('turns 0/15')
     expect(c.line).toContain('100000')
-    expect(c.line).toMatch(/land/i)
+    expect(c.line).toMatch(/signal density|session continues/i)
     expect(c.md).toContain('Cycle budget')
   })
 
-  it('escalates land cue under critical pressure', () => {
+  it('under critical pressure prefers compact work not session kill', () => {
     const c = buildCycleBudgetCard({
       turns: 12,
       turnLimit: 15,
@@ -29,7 +29,8 @@ describe('cycle-budget-card', () => {
       tokenBudget: 100_000,
       pressureLevel: 'critical',
     })
-    expect(c.line).toMatch(/LAND NOW/i)
+    expect(c.line).toMatch(/high-signal|compact|keep working/i)
+    expect(c.line).not.toMatch(/LAND NOW/i)
     expect(c.turnRatio).toBeCloseTo(0.8, 2)
   })
 })

--- a/core/__tests__/services/superiority-gates.test.ts
+++ b/core/__tests__/services/superiority-gates.test.ts
@@ -87,17 +87,17 @@ describe('package install parse (PreToolUse superiority)', () => {
   })
 })
 
-describe('context-pressure hard gate (expansion block)', () => {
-  it('critical blocks expansion; warn does not block ship but requires compact path', () => {
+describe('context-pressure density guard (no forced session kill)', () => {
+  it('default: never hard-blocks ship; compact preference only', () => {
     const crit = contextPressureVerdict(
       { maxTurnsPerCycle: 10 } as never,
       { turnCount: 8 } as never
     )
     expect(crit.level).toBe('critical')
-    expect(contextPressureBlocksExpansion(crit)).toBe(true)
+    expect(contextPressureBlocksExpansion(crit)).toBe(false)
     expect(contextPressureRequiresCompactPath(crit)).toBe(true)
-    expect(crit.cue).toMatch(/land/)
-    expect(contextPressureStatusLine(crit)).toMatch(/CRITICAL/)
+    expect(crit.cue).toMatch(/Session continues|density|compact/i)
+    expect(contextPressureStatusLine(crit)).toMatch(/density|compact/i)
 
     const warn = contextPressureVerdict(
       { maxTurnsPerCycle: 10 } as never,
@@ -106,8 +106,21 @@ describe('context-pressure hard gate (expansion block)', () => {
     expect(warn.level).toBe('warn')
     expect(contextPressureBlocksExpansion(warn)).toBe(false)
     expect(contextPressureRequiresCompactPath(warn)).toBe(true)
-    expect(warn.cue).toMatch(/compact path|prjct land/i)
-    expect(contextPressureStatusLine(warn)).toMatch(/land/)
+    expect(warn.cue).toMatch(/Keep the chat|compact|high-signal/i)
+    expect(contextPressureStatusLine(warn)).toMatch(/density|compact/i)
+  })
+
+  it('opt-in hardBlockShip only when configured', () => {
+    const crit = contextPressureVerdict(
+      { maxTurnsPerCycle: 10 } as never,
+      { turnCount: 8 } as never
+    )
+    expect(
+      contextPressureBlocksExpansion(crit, {
+        contextPressure: { hardBlockShip: true },
+      } as never)
+    ).toBe(true)
+    expect(contextPressureBlocksExpansion(crit, {} as never)).toBe(false)
   })
 })
 

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -148,7 +148,8 @@ export class ShippingCommands extends PrjctCommandsBase {
         /* package check is best-effort */
       }
 
-      // Context-pressure HARD gate — critical sessions must land/prime first.
+      // Context-density soft gate — default does NOT kill sessions or block ship.
+      // Opt-in hard block: config.contextPressure.hardBlockShip + critical.
       try {
         const { contextPressureBlocksExpansion, contextPressureVerdict } = await import(
           '../services/context-pressure'
@@ -159,15 +160,15 @@ export class ShippingCommands extends PrjctCommandsBase {
           tokensOut: currentTask?.tokensOut,
           description: currentTask?.description,
         })
-        if (contextPressureBlocksExpansion(pressure) && !options.forcePressure) {
+        if (contextPressureBlocksExpansion(pressure, shipConfig) && !options.forcePressure) {
           return {
             success: false,
             error:
               pressure.cue ??
-              'Context pressure critical — run `prjct land`, open a fresh window + `prjct prime`. Override only with `prjct ship --force-pressure` and explicit consent.',
+              'Context density hard-block is enabled (contextPressure.hardBlockShip). Soften injection or pass --force-pressure with consent.',
           }
         }
-        if (pressure.level === 'warn' && pressure.cue) {
+        if ((pressure.level === 'warn' || pressure.level === 'critical') && pressure.cue) {
           console.log(pressure.cue)
         }
       } catch {

--- a/core/services/context-pressure.ts
+++ b/core/services/context-pressure.ts
@@ -1,10 +1,15 @@
 /**
- * Context-pressure cues — beat GSD's context-window utilization guard without
- * needing proprietary host metrics.
+ * Context-pressure cues — signal-density guard, NOT a forced session killer.
  *
- * Uses turn count + optional token budget (already on the active task) as a
- * host-agnostic proxy. At 60%/70% of the cycle turn budget (or stuck threshold),
- * inject land/compact pressure so agents close the loop instead of rotting.
+ * Policy (product, 2026-07): long sessions are fine. What we protect is that
+ * the window does not fill with junk (broad Grep, re-research, padded recall).
+ * Hosts (Codex/Claude) already show real context % — when THAT hits 100%, the
+ * host may need a new window. prjct must not invent a second, earlier "you
+ * must land / clear" ritual that thrash-ends productive work.
+ *
+ * Uses turn count + optional token budget as a soft proxy only.
+ * Soft cues at 60%/70% of cycle budget. Ship hard-block is OFF by default
+ * (opt-in: LocalConfig.contextPressure.hardBlockShip === true).
  */
 
 import type { LocalConfig } from '../types/config'
@@ -34,7 +39,7 @@ export interface ContextPressureVerdict {
 
 /**
  * Prefer configured maxTurnsPerCycle; fall back to the stuck threshold so
- * projects without an explicit budget still get pressure cues.
+ * projects without an explicit budget still get soft density cues.
  */
 export function contextPressureVerdict(
   config: LocalConfig | null | undefined,
@@ -63,10 +68,11 @@ export function contextPressureVerdict(
       turns,
       limit,
       ratio: effective,
-      cue: `# prjct: CONTEXT PRESSURE (critical ~${Math.round(effective * 100)}%) — HARD GATE
-Session is full — STOP expanding scope. \`prjct ship\` is blocked until you \`prjct land\` then \`/clear\` or new window + \`prjct prime\`.
-Compact path (MUST): (1) finish or pause the open slice (2) \`prjct land\` (3) fresh window + \`prjct prime\` — do NOT re-research from zero.
-Fresh compound judgment (SQLite) beats GSD fresh-window thrash. Override ship only with explicit consent: \`prjct ship --force-pressure\`.`,
+      cue: `# prjct: context density (high ~${Math.round(effective * 100)}%)
+Session continues — do NOT force land/clear just because the cycle is long.
+Protect the window: no broad Grep/Glob thrash, no re-research from zero, pull memory by id (\`prjct context memory mem_N\`), prefer compact format.
+Persist durable signal with \`prjct remember\` / land when YOU choose hygiene — not as a kill switch.
+Host "Context 100%" is the real window limit; until then keep working with high-signal tools only.`,
     }
   }
 
@@ -76,40 +82,48 @@ Fresh compound judgment (SQLite) beats GSD fresh-window thrash. Override ship on
       turns,
       limit,
       ratio: effective,
-      cue: `# prjct: context pressure (~${Math.round(effective * 100)}%) — compact path
-Context budget low. Mandatory close plan THIS window:
-1. Finish the current slice only (no new exploration / no multi-file rabbit holes)
-2. \`prjct land\` before context dies
-3. Next window: \`prjct prime\` (not a blank chat)
-Do not open broad Grep/Glob or spawn research subagents until after land+prime.`,
+      cue: `# prjct: context density (~${Math.round(effective * 100)}%)
+Keep the chat — prefer high-signal tools only:
+1. Finish the current slice (no new rabbit holes)
+2. Recall compact / by-id — do not re-index the tree
+3. Optional hygiene later: \`prjct land\` then \`prjct prime\` if the HOST context is actually full
+Do not treat this as "session must end".`,
     }
   }
 
   return { level: 'ok', cue: null, turns, limit, ratio: effective }
 }
 
-/** Critical pressure blocks ship / expansion — superior to banner-only guards. */
-export function contextPressureBlocksExpansion(v: ContextPressureVerdict): boolean {
-  return v.level === 'critical'
+/**
+ * Ship hard-block. Default OFF — long sessions are valid.
+ * Opt-in per project: config.contextPressure.hardBlockShip === true AND critical.
+ */
+export function contextPressureBlocksExpansion(
+  v: ContextPressureVerdict,
+  config?: LocalConfig | null
+): boolean {
+  if (config?.contextPressure?.hardBlockShip === true && v.level === 'critical') {
+    return true
+  }
+  return false
 }
 
 /**
- * Host-agnostic one-liner for statusline / doctor / Codex status_line.
+ * Host-agnostic one-liner for statusline / doctor.
  * Empty string when ok (no noise on the chrome).
  */
 export function contextPressureStatusLine(v: ContextPressureVerdict): string {
   if (v.level === 'critical') {
-    return `ctx:${Math.round(v.ratio * 100)}% CRITICAL → land then prime`
+    return `ctx:${Math.round(v.ratio * 100)}% density — compact tools only`
   }
   if (v.level === 'warn') {
-    return `ctx:${Math.round(v.ratio * 100)}% → land/prime soon`
+    return `ctx:${Math.round(v.ratio * 100)}% density — prefer compact`
   }
   return ''
 }
 
 /**
- * True when agents MUST take the compact path (land → fresh → prime)
- * before expanding scope — warn OR critical.
+ * Prefer compact tool use (pull-by-id, no thrash) — NOT "must land/new window".
  */
 export function contextPressureRequiresCompactPath(v: ContextPressureVerdict): boolean {
   return v.level === 'warn' || v.level === 'critical'

--- a/core/services/cycle-budget-card.ts
+++ b/core/services/cycle-budget-card.ts
@@ -45,23 +45,23 @@ export function buildCycleBudgetCard(input: CycleBudgetInput): CycleBudgetCard {
       : tokensSpent > 0
         ? `tokens spent≈${tokensSpent} (no cycle budget set)`
         : 'tokens — (set maxTokensPerCycle to track)'
-  const landCue =
+  const densityCue =
     pressure === 'critical'
-      ? 'LAND NOW · prjct land then /clear'
+      ? 'keep working · high-signal tools only (no thrash)'
       : pressure === 'warn'
-        ? 'plan land soon · no more exploration'
-        : 'land before context dies · prjct land'
+        ? 'prefer compact recall · avoid junk injection'
+        : 'session continues · protect signal density'
 
-  const line = `Cycle budget: ${turnBit} · ${tokBit} · pressure=${pressure} · ${landCue}`
+  const line = `Cycle budget: ${turnBit} · ${tokBit} · pressure=${pressure} · ${densityCue}`
   const md = [
     '## Cycle budget (once per work cycle)',
     '',
     `- ${turnBit} (${Math.round(turnRatio * 100)}%)`,
     `- ${tokBit}${tokenBudget ? ` (${Math.round(tokenRatio * 100)}%)` : ''}`,
     `- pressure: **${pressure}**`,
-    `- close path: \`${landCue}\``,
+    `- density: \`${densityCue}\``,
     '',
-    '_Dynasty: cost-to-quality is a product feature — GSD thrash is not._',
+    '_Sessions may run long. Do not kill the chat for a turn proxy — starve junk injection instead._',
   ].join('\n')
 
   return { line, md, turnRatio, tokenRatio }

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -111,6 +111,15 @@ export interface LocalConfig {
    */
   maxTokensPerCycle?: number
   /**
+   * Context-density policy (not a session killer).
+   * Default: soft cues only — prefer compact tools, never force land/clear.
+   * hardBlockShip — opt-in only; when true, critical pressure blocks `prjct ship`
+   * unless `--force-pressure`. Most projects should leave this unset/false.
+   */
+  contextPressure?: {
+    hardBlockShip?: boolean
+  }
+  /**
    * Delivery-geometry gate at work start when the working tree is already large.
    *   - off — never
    *   - advisory — surface in work output (default for code pack)

--- a/core/utils/codex-mcp.ts
+++ b/core/utils/codex-mcp.ts
@@ -52,14 +52,21 @@ function buildMcpTomlBlock(
   endMarker: string
 ): string {
   const args = (server.args ?? []).map(tomlString).join(', ')
-  return [
+  const lines = [
     startMarker,
     `[mcp_servers.${name}]`,
     `command = ${tomlString(server.command)}`,
     `args = [${args}]`,
-    endMarker,
-    '',
-  ].join('\n')
+  ]
+  // Codex supports env tables for MCP servers (needed for sparse PATH hosts).
+  if (server.env && Object.keys(server.env).length > 0) {
+    const pairs = Object.entries(server.env)
+      .map(([k, v]) => `${k} = ${tomlString(v)}`)
+      .join(', ')
+    lines.push(`env = { ${pairs} }`)
+  }
+  lines.push(endMarker, '')
+  return lines.join('\n')
 }
 
 export function buildPrjctMcpTomlBlock(server: MCPServerConfig = MCP_SERVER_PRESETS.prjct): string {

--- a/core/utils/mcp-config.ts
+++ b/core/utils/mcp-config.ts
@@ -16,32 +16,104 @@ const PRJCT_MCP_DESCRIPTION =
   'prjct: agentic harness with project memory, workflow gates, intent briefs, and performance context. Use prjct_task_start as the MCP entrypoint for a work cycle; prjct retrieves focused context, persists evidence stations, and keeps humans in the loop for risky gates. Agents resume from prjct_task_status/workflow output, create or link reviewed intent/spec briefs when required, and persist synthesized learning instead of raw transcript fragments.'
 
 /**
- * Get the prjct MCP server config, resolving the path from the installed package.
+ * Get the prjct MCP server config for agent hosts (Codex/Claude/…).
+ *
+ * Production-only policy: never pin hosts to git worktrees, monorepo bins, or
+ * unbuilt trees. Prefer the published npm package (`prjct-cli`) with absolute
+ * `node` + `bin/prjct.cjs` so sparse-PATH hosts (Codex) can still spawn.
+ * Opt-in only: PRJCT_MCP_ALLOW_LOCAL=1 may use a local bin for prjct dogfood.
  */
 function getPrjctMcpConfig(): MCPServerConfig {
-  const localBin = resolveLocalPrjctBin()
-  if (localBin) {
-    return {
-      command: localBin,
-      args: ['mcp-server'],
-      description: PRJCT_MCP_DESCRIPTION,
+  const published = resolvePublishedPrjctMcpConfig()
+  if (published) return published
+
+  if (process.env.PRJCT_MCP_ALLOW_LOCAL === '1') {
+    const localBin = resolveLocalPrjctBin()
+    if (localBin) {
+      return {
+        command: localBin,
+        args: ['mcp-server'],
+        description: PRJCT_MCP_DESCRIPTION,
+      }
     }
   }
 
+  return {
+    command: 'npx',
+    args: ['-y', 'prjct-cli@latest', 'mcp-server'],
+    description: PRJCT_MCP_DESCRIPTION,
+  }
+}
+
+/** True if path is a git worktree or obvious monorepo source bin (not npm global). */
+function isNonProductionPrjctPath(resolved: string): boolean {
+  const norm = resolved.replace(/\\/g, '/')
+  if (norm.includes('/.worktrees/')) return true
+  // Unbuilt / source-tree bin without a package install layout
+  if (norm.includes('/prjct-cli/bin/prjct') && !norm.includes('/node_modules/prjct-cli/')) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Resolve published prjct-cli install for host MCP wiring.
+ * Uses require.resolve when available, else walks known npm global prefixes.
+ */
+function resolvePublishedPrjctMcpConfig(): MCPServerConfig | null {
+  const pkgDirs: string[] = []
   try {
-    const pkgDir = path.dirname(require.resolve('prjct-cli/package.json'))
-    return {
-      command: path.join(pkgDir, 'bin', 'prjct'),
-      args: ['mcp-server'],
-      description: PRJCT_MCP_DESCRIPTION,
-    }
+    pkgDirs.push(path.dirname(require.resolve('prjct-cli/package.json')))
   } catch {
+    /* not resolvable from this process */
+  }
+  // Common npm global layouts (nvm + homebrew node)
+  const home = os.homedir()
+  for (const prefix of [
+    process.env.NVM_BIN ? path.resolve(process.env.NVM_BIN, '..') : '',
+    path.join(home, '.nvm', 'versions', 'node', process.version, 'lib'),
+    '/opt/homebrew/lib',
+    '/usr/local/lib',
+  ].filter(Boolean)) {
+    pkgDirs.push(path.join(prefix, 'node_modules', 'prjct-cli'))
+  }
+
+  for (const pkgDir of pkgDirs) {
+    if (isNonProductionPrjctPath(pkgDir)) continue
+    const cjs = path.join(pkgDir, 'bin', 'prjct.cjs')
+    const distOk =
+      fsSync.existsSync(path.join(pkgDir, 'dist', 'bin', 'prjct.mjs')) ||
+      fsSync.existsSync(path.join(pkgDir, 'dist', 'bin', 'prjct-core.mjs'))
+    if (!fsSync.existsSync(cjs) || !distOk) continue
+
+    // Prefer absolute node next to the install so Codex sparse PATH works
+    // (prjct.cjs shebang is #!/usr/bin/env node).
+    const nodeCandidates = [
+      process.execPath,
+      path.join(path.dirname(process.execPath), 'node'),
+      path.join(pkgDir, '..', '..', 'bin', 'node'), // nvm: .../node/vX/lib/node_modules → .../bin/node
+    ]
+    let nodeBin = process.execPath
+    for (const n of nodeCandidates) {
+      if (n && fsSync.existsSync(n)) {
+        nodeBin = n
+        break
+      }
+    }
+    // nvm layout: pkgDir = .../node/vX/lib/node_modules/prjct-cli → bin/node at .../node/vX/bin/node
+    const nvmNode = path.resolve(pkgDir, '..', '..', '..', 'bin', 'node')
+    if (fsSync.existsSync(nvmNode)) nodeBin = nvmNode
+
     return {
-      command: 'npx',
-      args: ['-y', 'prjct-cli', 'mcp-server'],
+      command: nodeBin,
+      args: [cjs, 'mcp-server'],
+      env: {
+        PATH: `${path.dirname(nodeBin)}${path.delimiter}/usr/bin${path.delimiter}/bin`,
+      },
       description: PRJCT_MCP_DESCRIPTION,
     }
   }
+  return null
 }
 
 function resolveLocalPrjctBin(): string | null {
@@ -53,7 +125,15 @@ function resolveLocalPrjctBin(): string | null {
   ].filter(Boolean)
 
   for (const candidate of candidates) {
-    if (fsSync.existsSync(candidate)) return candidate
+    if (!fsSync.existsSync(candidate)) continue
+    let resolved = candidate
+    try {
+      resolved = fsSync.realpathSync(candidate)
+    } catch {
+      /* keep candidate */
+    }
+    if (isNonProductionPrjctPath(resolved)) continue
+    return resolved
   }
   return null
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.64.0",
+  "version": "3.65.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- **Context pressure** no longer forces land/clear/new session. Soft density cues only; ship hard-block is opt-in (`contextPressure.hardBlockShip`).
- **Cycle budget card** language: session continues, protect signal density.
- **Codex/MCP install**: prefer published `prjct-cli` (absolute `node` + `bin/prjct.cjs`); never pin git worktrees.

## Why

Long sessions are valid. What we protect is garbage injection, not chat length. Host `Context 100%` is the real window limit.

## Test plan

- [x] `bun test core/__tests__/services/superiority-gates.test.ts`
- [x] `bun test core/__tests__/services/cycle-budget-card.test.ts`
- [x] `bun test core/__tests__/utils/codex-mcp.test.ts core/__tests__/commands/setup-mcp.test.ts`
- [x] typecheck