### PR TITLE
feat(harness): native Grok host wire + plan ceremony

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.66.0] - 2026-07-16
+
+### Added
+- Native Grok host wire + plan ceremony
+
 ## [3.65.0] - 2026-07-16
 
 ### Added

--- a/core/__tests__/commands/plan-ceremony.test.ts
+++ b/core/__tests__/commands/plan-ceremony.test.ts
@@ -1,0 +1,50 @@
+/**
+ * prjct plan ceremony — draft → write → approve host contract
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { CeremonyCommands } from '../../commands/ceremonies'
+
+let dir: string
+const cmd = new CeremonyCommands()
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-plan-ceremony-'))
+  await fs.mkdir(path.join(dir, '.prjct'), { recursive: true })
+  await fs.writeFile(
+    path.join(dir, '.prjct/prjct.config.json'),
+    JSON.stringify({ projectId: `plan-ceremony-${Date.now()}` })
+  )
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('prjct plan ceremony', () => {
+  it('starts draft, writes body, approves', async () => {
+    const started = await cmd.plan('Add rate limiting', dir, { md: true })
+    expect(started.success).toBe(true)
+    expect(started.status).toBe('draft')
+
+    const written = await cmd.plan(
+      'write "# Plan: rate limit\n\n## Context\n\nAPI abuse.\n"',
+      dir,
+      { md: true }
+    )
+    expect(written.success).toBe(true)
+    expect(written.written).toBe(true)
+
+    const approved = await cmd.plan('approve', dir, { md: true })
+    expect(approved.success).toBe(true)
+    expect(approved.status).toBe('approved')
+  })
+
+  it('show fails when no plan', async () => {
+    const r = await cmd.plan('show', dir, { md: true })
+    expect(r.success).toBe(false)
+  })
+})

--- a/core/__tests__/commands/removed-verbs.test.ts
+++ b/core/__tests__/commands/removed-verbs.test.ts
@@ -22,7 +22,8 @@ describe('REMOVED_VERBS', () => {
       'jira',
       'tokens',
       'velocity',
-      'plan',
+      // 'plan' left this list in 2026-07: returned as plan-mode ceremony
+      // (draft → approve) under ceremonies.plan — a live verb again.
       // 'next' left this list in v3.26: it returned as the work-graph
       // frontier selector (prjct next) — a live verb again.
       // Removed later, with the vault/wiki feature deletion — must get the
@@ -62,6 +63,7 @@ describe('isRemovedVerb', () => {
     expect(isRemovedVerb('task')).toBe(false)
     expect(isRemovedVerb('status')).toBe(false)
     expect(isRemovedVerb('capture')).toBe(false)
+    expect(isRemovedVerb('plan')).toBe(false)
   })
 
   it('returns false for unknown verbs', () => {

--- a/core/__tests__/infrastructure/agent-runtime-registry.test.ts
+++ b/core/__tests__/infrastructure/agent-runtime-registry.test.ts
@@ -52,7 +52,7 @@ describe('agent runtime registry', () => {
     expect(writable[0]?.pathHint).toContain('.kimi/mcp.json')
   })
 
-  it('registers xAI Grok Build as AGENTS.md + Claude-compat MCP/skills/hooks CLI', () => {
+  it('registers xAI Grok Build with native writable ~/.grok/config.toml MCP', () => {
     const grok = getAgentRuntime('grok')
 
     expect(grok.kind).toBe('cli')
@@ -62,8 +62,8 @@ describe('agent runtime registry', () => {
     expect(grok.supports.skills).toBe(true)
     expect(grok.supports.hooks).toBe(true)
     expect(grok.detectsBy?.commands).toContain('grok')
-    // Grok inherits Claude MCP — writable path is ~/.claude/mcp.json (compat).
     const writable = (grok.mcpTargets ?? []).filter((target) => target.writable)
+    expect(writable.some((t) => t.pathHint.includes('.grok/config.toml'))).toBe(true)
     expect(writable.some((t) => t.pathHint.includes('.claude/mcp.json'))).toBe(true)
   })
 

--- a/core/__tests__/infrastructure/grok-skill.test.ts
+++ b/core/__tests__/infrastructure/grok-skill.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Grok skill installer — ~/.grok/skills/prjct/SKILL.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  buildGrokSkillContent,
+  getGrokSkillInstallPath,
+  installGrokSkill,
+} from '../../infrastructure/grok-skill'
+
+const PREV_HOME = process.env.HOME
+const PREV_TEST = process.env.PRJCT_TEST_MODE
+
+let home: string
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-grok-skill-test-'))
+  process.env.HOME = home
+  process.env.PRJCT_TEST_MODE = '1'
+})
+
+afterEach(async () => {
+  if (PREV_HOME === undefined) delete process.env.HOME
+  else process.env.HOME = PREV_HOME
+  if (PREV_TEST === undefined) delete process.env.PRJCT_TEST_MODE
+  else process.env.PRJCT_TEST_MODE = PREV_TEST
+  await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('installGrokSkill', () => {
+  it('creates SKILL.md under the Grok skills path', async () => {
+    const r = await installGrokSkill()
+    expect(r.success).toBe(true)
+    expect(r.action).toBe('created')
+    const skillPath = getGrokSkillInstallPath()
+    expect(r.path).toBe(skillPath)
+    const body = await fs.readFile(skillPath, 'utf-8')
+    expect(body).toContain('name: prjct')
+    expect(body).toContain('prjct work')
+    expect(body).toContain('prjct-grok-skill')
+  })
+
+  it('is idempotent when content matches', async () => {
+    await installGrokSkill()
+    const r = await installGrokSkill()
+    expect(r.success).toBe(true)
+    expect(r.action).toBe('unchanged')
+  })
+
+  it('buildGrokSkillContent stamps metadata hash', () => {
+    const built = buildGrokSkillContent('# prjct\n\nRun verbs.\n')
+    expect(built.templateHash).toHaveLength(12)
+    expect(built.content).toContain('prjct-grok-skill')
+  })
+})

--- a/core/__tests__/infrastructure/harness-surfaces.test.ts
+++ b/core/__tests__/infrastructure/harness-surfaces.test.ts
@@ -21,12 +21,14 @@ describe('harness surfaces matrix', () => {
     }
   })
 
-  it('documents Grok as inherits-claude for hooks and MCP', () => {
+  it('documents Grok as native MCP+skills+plugin with hooks inherits-claude', () => {
     const grok = getHarnessSurface('grok')
     expect(grok).toBeDefined()
     expect(grok!.hooks.prjct).toBe('inherits-claude')
-    expect(grok!.mcp.prjct).toBe('inherits-claude')
-    expect(grok!.legibility).toMatch(/Claude/i)
+    expect(grok!.mcp.prjct).toBe('native')
+    expect(grok!.skills.prjct).toBe('native')
+    expect(grok!.plugins?.prjct).toBe('native')
+    expect(grok!.legibility).toMatch(/native MCP/i)
   })
 
   it('documents Claude as fully native', () => {

--- a/core/__tests__/services/harness-rigs.test.ts
+++ b/core/__tests__/services/harness-rigs.test.ts
@@ -57,4 +57,17 @@ describe('steal-a-rig — adopt a base rig', () => {
   it('returns undefined for an unknown rig', () => {
     expect(findRig('does-not-exist')).toBeUndefined()
   })
+
+  it('resolves grok-build with Body/Brain organs (no agent-loop port)', () => {
+    const rig = findRig('grok-build')
+    expect(rig).toBeDefined()
+    expect(rig!.source).toContain('xai-org/grok-build')
+    const plan = renderRigAdoption(rig!)
+    expect(plan).toContain('skills-commands')
+    expect(plan).toContain('knowledge-base')
+    expect(plan).toContain('prjct remember')
+    expect(plan).toContain('prjct crew')
+    // Sovereignty: patterns only — never the Rust runtime
+    expect(rig!.description).toMatch(/not the Rust agent loop/i)
+  })
 })

--- a/core/__tests__/services/superiority-gates.test.ts
+++ b/core/__tests__/services/superiority-gates.test.ts
@@ -260,6 +260,8 @@ describe('multi-runtime signal + skill parity (installer-derived)', () => {
     expect(report.codexHasLoop).toBe(true)
     expect(report.geminiHasLoop).toBe(true)
     expect(report.grokInheritsClaude).toBe(true)
+    expect(report.grokMcpNative).toBe(true)
+    expect(report.grokSkillsNative).toBe(true)
   })
 
   it('Codex + Gemini surfaces carry loop-discipline CONTRACT', () => {

--- a/core/__tests__/services/weak-model-bench.test.ts
+++ b/core/__tests__/services/weak-model-bench.test.ts
@@ -48,6 +48,7 @@ describe('weak-model A/B release gate', () => {
     expect(md).toContain('codex hooks+MCP native')
     expect(md).toContain('gemini hooks+MCP native')
     expect(md).toContain('cursor hooks native')
-    expect(md).toContain('grok inherits-claude')
+    expect(md).toContain('grok mcp+skills native')
+    expect(md).toContain('grok hooks inherits-claude')
   })
 })

--- a/core/__tests__/storage/plan-storage.test.ts
+++ b/core/__tests__/storage/plan-storage.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Plan-mode SQLite storage
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { prjctDb } from '../../storage/database'
+import { emptyPlanTemplate, planStorage } from '../../storage/plan-storage'
+
+let tempProjectsDir: string
+let prevProjectsDir: string | undefined
+let projectId: string
+
+beforeEach(() => {
+  tempProjectsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-plan-storage-'))
+  prevProjectsDir = process.env.PRJCT_PROJECTS_DIR
+  process.env.PRJCT_PROJECTS_DIR = tempProjectsDir
+  projectId = `plan-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  prjctDb.get(projectId, 'SELECT 1')
+})
+
+afterEach(() => {
+  if (prevProjectsDir === undefined) delete process.env.PRJCT_PROJECTS_DIR
+  else process.env.PRJCT_PROJECTS_DIR = prevProjectsDir
+  // Leave the temp dir for the open SQLite handle; process exit cleans /tmp.
+  // Deleting while bun:sqlite still holds the file causes disk I/O errors.
+})
+
+describe('planStorage', () => {
+  it('starts a draft with Grok-style sections', () => {
+    const plan = planStorage.start(projectId, 'Add caching')
+    expect(plan.status).toBe('draft')
+    expect(plan.title).toBe('Add caching')
+    expect(plan.content).toContain('## Context')
+    expect(plan.content).toContain('## Recommended approach')
+    expect(plan.content).toContain('## Critical files')
+    expect(plan.content).toContain('## Reuse')
+    expect(plan.content).toContain('## Verification')
+    expect(planStorage.get(projectId)?.title).toBe('Add caching')
+  })
+
+  it('writeContent only works on draft', () => {
+    planStorage.start(projectId, 'X')
+    const body = emptyPlanTemplate('X').replace('Why this change is needed.', 'Need Redis')
+    const written = planStorage.writeContent(projectId, body)
+    expect(written?.content).toContain('Need Redis')
+
+    planStorage.approve(projectId)
+    expect(planStorage.writeContent(projectId, 'nope')).toBeNull()
+  })
+
+  it('approve transitions draft → approved', () => {
+    planStorage.start(projectId, 'Auth')
+    const approved = planStorage.approve(projectId)
+    expect(approved?.status).toBe('approved')
+    expect(approved?.approvedAt).toBeTruthy()
+    expect(planStorage.approve(projectId)).toBeNull()
+  })
+
+  it('clear removes the row', () => {
+    planStorage.start(projectId, 'Tmp')
+    planStorage.clear(projectId)
+    expect(planStorage.get(projectId)).toBeNull()
+  })
+})

--- a/core/__tests__/utils/grok-mcp.test.ts
+++ b/core/__tests__/utils/grok-mcp.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Grok MCP wiring — `[mcp_servers.prjct]` in ~/.grok/config.toml.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { ensureGrokMcpServer, grokHasPrjctMcpServer } from '../../utils/grok-mcp'
+
+let dir: string
+let configPath: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-grok-mcp-test-'))
+  configPath = path.join(dir, 'config.toml')
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('ensureGrokMcpServer', () => {
+  it('creates config.toml with the prjct server when missing', async () => {
+    const r = await ensureGrokMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('[mcp_servers.prjct]')
+    expect(body).toContain('# prjct:mcp:start')
+    expect(body).toContain('# prjct:mcp:end')
+    expect(body).toMatch(/command = "/)
+  })
+
+  it('appends to an existing config without touching user content', async () => {
+    const user = '[models]\ndefault = "grok-build"\n'
+    await fs.writeFile(configPath, user, 'utf-8')
+
+    const r = await ensureGrokMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('default = "grok-build"')
+    expect(body.indexOf('[models]')).toBeLessThan(body.indexOf('[mcp_servers.prjct]'))
+  })
+
+  it('replaces a stale managed block in place', async () => {
+    await ensureGrokMcpServer(configPath)
+    const before = await fs.readFile(configPath, 'utf-8')
+    const stale = before.replace(/command = "[^"]*"/, 'command = "old-binary"')
+    await fs.writeFile(configPath, stale, 'utf-8')
+
+    const r = await ensureGrokMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    const after = await fs.readFile(configPath, 'utf-8')
+    expect(after).not.toContain('old-binary')
+    expect(after.split('[mcp_servers.prjct]').length - 1).toBe(1)
+  })
+
+  it('is idempotent — second run reports unchanged', async () => {
+    await ensureGrokMcpServer(configPath)
+    const first = await fs.readFile(configPath, 'utf-8')
+    const r = await ensureGrokMcpServer(configPath)
+    expect(r.changed).toBe(false)
+    expect(await fs.readFile(configPath, 'utf-8')).toBe(first)
+  })
+
+  it('preserves a user-managed [mcp_servers.prjct] entry', async () => {
+    const user = '[mcp_servers.prjct]\ncommand = "my-custom-wrapper"\nargs = []\n'
+    await fs.writeFile(configPath, user, 'utf-8')
+
+    const r = await ensureGrokMcpServer(configPath)
+    expect(r.changed).toBe(false)
+    expect(r.skipped).toBe('user-managed')
+    const body = await fs.readFile(configPath, 'utf-8')
+    expect(body).toContain('command = "my-custom-wrapper"')
+    expect(body).not.toContain('# prjct:mcp:start')
+  })
+
+  it('grokHasPrjctMcpServer detects managed block', async () => {
+    expect(await grokHasPrjctMcpServer(configPath)).toBe(false)
+    await ensureGrokMcpServer(configPath)
+    expect(await grokHasPrjctMcpServer(configPath)).toBe(true)
+  })
+})

--- a/core/__tests__/utils/grok-plugin.test.ts
+++ b/core/__tests__/utils/grok-plugin.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Grok host-plugin materializer — ~/.grok/plugins/prjct
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { getGrokPluginRoot, grokPluginInstalled, installGrokPlugin } from '../../utils/grok-plugin'
+
+const PREV_HOME = process.env.HOME
+const PREV_TEST = process.env.PRJCT_TEST_MODE
+
+let home: string
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-grok-plugin-test-'))
+  process.env.HOME = home
+  process.env.PRJCT_TEST_MODE = '1'
+})
+
+afterEach(async () => {
+  if (PREV_HOME === undefined) delete process.env.HOME
+  else process.env.HOME = PREV_HOME
+  if (PREV_TEST === undefined) delete process.env.PRJCT_TEST_MODE
+  else process.env.PRJCT_TEST_MODE = PREV_TEST
+  await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('installGrokPlugin', () => {
+  it('materializes plugin.json, skill, and plan command', async () => {
+    const r = await installGrokPlugin()
+    expect(r.success).toBe(true)
+    expect(r.changed).toBe(true)
+    expect(r.path).toBe(getGrokPluginRoot())
+
+    const pluginJson = await fs.readFile(path.join(r.path, 'plugin.json'), 'utf-8')
+    expect(JSON.parse(pluginJson).name).toBe('prjct')
+
+    const skill = await fs.readFile(path.join(r.path, 'skills', 'prjct', 'SKILL.md'), 'utf-8')
+    expect(skill).toContain('prjct work')
+
+    const planCmd = await fs.readFile(path.join(r.path, 'commands', 'plan.md'), 'utf-8')
+    expect(planCmd).toContain('prjct plan')
+    expect(await grokPluginInstalled()).toBe(true)
+  })
+
+  it('is idempotent', async () => {
+    await installGrokPlugin()
+    const r = await installGrokPlugin()
+    expect(r.success).toBe(true)
+    expect(r.changed).toBe(false)
+  })
+})

--- a/core/commands/ceremonies.ts
+++ b/core/commands/ceremonies.ts
@@ -12,6 +12,8 @@
  *   prjct replan "<what changed>"    cascading drift repair: re-plan
  *                                    directive over downstream open items +
  *                                    automatic decision memory of the pivot
+ *   prjct plan …                     plan-mode ceremony (read-only until
+ *                                    approve) — Grok-style gate before edits
  *   prjct prime [--md]               session-open bundle: cycle + frontier +
  *                                    traps + budget in one pull
  *   prjct land [--md]                session-close checklist ("land the
@@ -27,6 +29,7 @@ import { orchestrationFor } from '../services/task-orchestration'
 import { collectActiveTasks } from '../services/task-overview'
 import { workGraph } from '../services/work-graph'
 import { prjctDb } from '../storage/database'
+import { planStorage, type WorkPlan } from '../storage/plan-storage'
 import { queueStorage } from '../storage/queue-storage'
 import type { CommandResult } from '../types/commands'
 import out from '../utils/output'
@@ -220,6 +223,207 @@ export class CeremonyCommands extends PrjctCommandsBase {
     lines.push('', '_The pivot was already captured as a decision memory._')
     console.log(lines.join('\n'))
     return { success: true, items: ready.length }
+  }
+
+  /**
+   * Plan-mode ceremony (Grok Build pattern, harness-layer):
+   *
+   *   prjct plan ["title"]           start draft (or show active) + host contract
+   *   prjct plan show                print active plan
+   *   prjct plan write "<markdown>"  update draft body only
+   *   prjct plan approve             exit plan mode; persist decision memory
+   *   prjct plan clear|abandon       drop / abandon plan
+   *
+   * While status=draft the host must treat source as read-only; only this verb
+   * mutates the plan artifact in SQLite (not a free-form plan.md on disk).
+   */
+  async plan(
+    input: string | null = null,
+    projectPath: string = process.cwd(),
+    options: CeremonyOptions = {}
+  ): Promise<CommandResult> {
+    const proj = await requireProject(projectPath, options)
+    if (!proj.ok) return proj.result
+
+    const raw = (input ?? '').trim()
+    const parts = raw.split(/\s+/).filter(Boolean)
+    const sub = (parts[0] ?? '').toLowerCase()
+    const rest = parts.slice(1).join(' ').trim()
+
+    if (!sub || sub === 'show' || sub === 'status') {
+      return this.planShowOrStart(proj.value, projectPath, raw, options)
+    }
+    if (sub === 'write' || sub === 'set') {
+      return this.planWrite(proj.value, rest || null, options)
+    }
+    if (sub === 'approve' || sub === 'ok') {
+      return this.planApprove(proj.value, projectPath, options)
+    }
+    if (sub === 'clear' || sub === 'abandon' || sub === 'quit') {
+      return this.planClear(proj.value, sub === 'clear', options)
+    }
+    // Bare title after first word that isn't a known sub — treat full input as start title
+    if (['start', 'new', 'enter'].includes(sub)) {
+      return this.planStart(proj.value, projectPath, rest || 'Untitled plan', options)
+    }
+    // `prjct plan "Add auth"` — title is the whole input
+    return this.planStart(proj.value, projectPath, raw, options)
+  }
+
+  private async planShowOrStart(
+    projectId: string,
+    projectPath: string,
+    titleOrEmpty: string,
+    options: CeremonyOptions
+  ): Promise<CommandResult> {
+    const existing = planStorage.get(projectId)
+    if (existing) {
+      this.printPlan(existing, options)
+      return { success: true, status: existing.status, title: existing.title }
+    }
+    if (!titleOrEmpty || ['show', 'status'].includes(titleOrEmpty.toLowerCase())) {
+      return this.fail(
+        'No active plan. Start one: `prjct plan "<title>"` then fill sections; approve with `prjct plan approve`.',
+        options
+      )
+    }
+    return this.planStart(projectId, projectPath, titleOrEmpty, options)
+  }
+
+  private async planStart(
+    projectId: string,
+    projectPath: string,
+    title: string,
+    options: CeremonyOptions
+  ): Promise<CommandResult> {
+    const existing = planStorage.get(projectId)
+    if (existing?.status === 'draft') {
+      this.printPlan(existing, options)
+      return {
+        success: true,
+        status: existing.status,
+        title: existing.title,
+        message: 'draft already active',
+      }
+    }
+
+    let taskId: string | null = null
+    try {
+      const overview = await collectActiveTasks(projectId, projectPath)
+      taskId = overview?.current?.id ?? null
+    } catch {
+      taskId = null
+    }
+
+    const plan = planStorage.start(projectId, title, taskId)
+    this.printPlan(plan, options)
+    return { success: true, status: plan.status, title: plan.title, created: true }
+  }
+
+  private planWrite(
+    projectId: string,
+    content: string | null,
+    options: CeremonyOptions
+  ): CommandResult {
+    if (!content) {
+      return this.fail(
+        'Usage: prjct plan write "<markdown plan body>" — only allowed while status is draft.',
+        options
+      )
+    }
+    const updated = planStorage.writeContent(projectId, content)
+    if (!updated) {
+      return this.fail(
+        'No draft plan to update. Start with `prjct plan "<title>"` or approve/clear the current plan.',
+        options
+      )
+    }
+    this.printPlan(updated, options)
+    return { success: true, status: updated.status, title: updated.title, written: true }
+  }
+
+  private async planApprove(
+    projectId: string,
+    projectPath: string,
+    options: CeremonyOptions
+  ): Promise<CommandResult> {
+    const approved = planStorage.approve(projectId)
+    if (!approved) {
+      return this.fail(
+        'No draft plan to approve. Start with `prjct plan "<title>"` and fill the sections first.',
+        options
+      )
+    }
+    await projectMemory.remember(projectPath, {
+      type: 'decision',
+      content: `Plan approved: ${approved.title}\n\n${approved.content.slice(0, 2000)}`,
+      tags: { topic: 'plan-mode', status: 'approved' },
+      provenance: 'declared',
+    })
+    this.printPlan(approved, options)
+    if (options.md) {
+      console.log('\n> Plan approved. Source edits are allowed. Implement against the plan.')
+    } else {
+      out.done('Plan approved — implement against the plan')
+    }
+    return { success: true, status: approved.status, title: approved.title, approved: true }
+  }
+
+  private planClear(
+    projectId: string,
+    hardClear: boolean,
+    options: CeremonyOptions
+  ): CommandResult {
+    const cur = planStorage.get(projectId)
+    if (!cur) return this.fail('No active plan to clear.', options)
+    if (hardClear) planStorage.clear(projectId)
+    else planStorage.abandon(projectId)
+    const msg = hardClear ? 'Plan cleared from SQLite.' : `Plan abandoned (${cur.title}).`
+    if (options.md) console.log(`> ${msg}`)
+    else out.done(msg)
+    return { success: true, cleared: hardClear, abandoned: !hardClear }
+  }
+
+  private printPlan(plan: WorkPlan, options: CeremonyOptions): void {
+    const hostContract =
+      plan.status === 'draft'
+        ? [
+            '## Host contract (draft — read-only)',
+            '',
+            '- Do **not** edit project source files until `prjct plan approve`.',
+            '- Only mutate the plan via `prjct plan write "<markdown>"`.',
+            '- Fill: Context · Recommended approach · Critical files · Reuse · Verification.',
+            '- When ready, ask the user; then `prjct plan approve --md`.',
+            '',
+          ]
+        : plan.status === 'approved'
+          ? [
+              '## Host contract (approved)',
+              '',
+              '- Source edits allowed. Implement against this plan.',
+              '- Persist decisions/learnings with `prjct remember`.',
+              '',
+            ]
+          : ['## Host contract (abandoned)', '']
+
+    const lines = [
+      `# Plan — ${plan.status}`,
+      '',
+      `**Title:** ${plan.title}`,
+      `**Updated:** ${plan.updatedAt}`,
+      plan.taskId ? `**Work cycle:** \`${plan.taskId.slice(0, 8)}\`` : null,
+      '',
+      ...hostContract,
+      '## Plan body',
+      '',
+      plan.content.trimEnd(),
+      '',
+    ].filter((x): x is string => x !== null)
+
+    console.log(lines.join('\n'))
+    if (!options.md && plan.status === 'draft') {
+      out.info('Plan mode: draft — no source edits until approve')
+    }
   }
 
   /**

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -1088,6 +1088,28 @@ export const COMMANDS: CommandMeta[] = [
     usage: { claude: 'p. replan "auth moved to JWT"', terminal: 'prjct replan "<what changed>"' },
   },
   {
+    name: 'plan',
+    group: 'ceremonies',
+    surface: 'ai-agile',
+    requiresProject: true,
+    implemented: true,
+    hasTemplate: false,
+    routing: { group: 'ceremonies', method: 'plan' },
+    optionSchema: {},
+    params: '["title"] | show | write "<md>" | approve | clear',
+    description:
+      'Plan-mode ceremony (read-only until approve): SQLite-backed plan with Context/Approach/Files/Reuse/Verification. Host must not edit source while status is draft.',
+    usage: {
+      claude: 'p. plan "Add auth"',
+      terminal: 'prjct plan ["title"] | show | write "..." | approve | clear [--md]',
+    },
+    features: [
+      'Grok Build plan-mode pattern at the harness layer (no TUI ownership)',
+      'draft → write → approve; approve persists a decision memory',
+      'Single SoT in kv_store work-plan:active',
+    ],
+  },
+  {
     name: 'prime',
     group: 'ceremonies',
     surface: 'ai-agile',

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -9,6 +9,7 @@
 
 import { detectAgentRuntimes } from '../infrastructure/agent-runtime-registry'
 import configManager from '../infrastructure/config-manager'
+import { installGrokSkill } from '../infrastructure/grok-skill'
 import { probeHarnessCoverage, renderHarnessCoverageMd } from '../services/harness-coverage'
 import { writeProjectAgentSurfaces } from '../services/project-agent-surfaces'
 import {
@@ -24,6 +25,8 @@ import { installCodexHooks, uninstallCodexHooks } from '../utils/codex-hooks'
 import { ensureCodexMcpServer } from '../utils/codex-mcp'
 import { installCursorHooks, uninstallCursorHooks } from '../utils/cursor-hooks'
 import { installGeminiSettings, uninstallGeminiSettings } from '../utils/gemini-settings'
+import { ensureGrokMcpServer } from '../utils/grok-mcp'
+import { installGrokPlugin } from '../utils/grok-plugin'
 import { ensureKimiMcpServer } from '../utils/kimi-mcp'
 import { failFromError, failHard } from '../utils/md-aware'
 import out from '../utils/output'
@@ -57,6 +60,10 @@ export class InstallCommands extends PrjctCommandsBase {
       const cursorHooks = cursorDetected ? await installCursorHooks() : null
       const kimiDetected = detected.some((runtime) => runtime.runtime.id === 'kimi-cli')
       const kimiConfig = kimiDetected ? await ensureKimiMcpServer() : null
+      const grokDetected = detected.some((runtime) => runtime.runtime.id === 'grok')
+      const grokConfig = grokDetected ? await ensureGrokMcpServer() : null
+      const grokSkill = grokDetected ? await installGrokSkill() : null
+      const grokPlugin = grokDetected ? await installGrokPlugin() : null
       const coverage = await probeHarnessCoverage(projectPath)
       const total = PRJCT_HOOKS.length
       const prunedNote = result.hooksPruned > 0 ? `, ${result.hooksPruned} retired removed` : ''
@@ -67,6 +74,7 @@ export class InstallCommands extends PrjctCommandsBase {
         geminiConfig ? 'gemini' : null,
         cursorHooks ? 'cursor' : null,
         kimiConfig ? 'kimi' : null,
+        grokConfig || grokSkill?.success || grokPlugin?.success ? 'grok' : null,
         'claude',
       ].filter((x): x is string => Boolean(x))
       let deltaLine: string | null = null
@@ -135,6 +143,27 @@ export class InstallCommands extends PrjctCommandsBase {
             ...(kimiConfig
               ? [`- Kimi config: ${kimiConfig.changed ? 'updated' : 'already ready'}`]
               : []),
+            ...(grokConfig
+              ? [
+                  `- Grok MCP: ${
+                    grokConfig.skipped === 'user-managed'
+                      ? 'user-managed preserved'
+                      : grokConfig.changed
+                        ? 'updated'
+                        : 'already ready'
+                  } → \`${grokConfig.path}\``,
+                ]
+              : []),
+            ...(grokSkill?.success
+              ? [
+                  `- Grok skill: ${grokSkill.action ?? 'ready'}${grokSkill.path ? ` → \`${grokSkill.path}\`` : ''}`,
+                ]
+              : []),
+            ...(grokPlugin?.success
+              ? [
+                  `- Grok plugin: ${grokPlugin.changed ? `updated (${grokPlugin.files.join(', ') || 'files'})` : 'already ready'} → \`${grokPlugin.path}\``,
+                ]
+              : []),
             ``,
             `## Claude hooks adapter`,
             `Wrote to \`${result.settingsPath}\`.`,
@@ -151,7 +180,7 @@ export class InstallCommands extends PrjctCommandsBase {
             ``,
             renderHarnessCoverageMd(coverage),
             `> One install · one SQLite brain · every agent surface. That is the moat — not more skills.`,
-            `> Grok inherits Claude. Codex/Gemini/Cursor get native adapters. Trust Codex hooks once via \`/hooks\`.`,
+            `> Grok: native MCP + skill; hooks still via Claude compat. Codex/Gemini/Cursor get native adapters.`,
             `> Gaps? \`prjct doctor --fix\`. Only \`_prjctManaged: true\` entries were touched.`,
           ].join('\n')
         )
@@ -196,6 +225,25 @@ export class InstallCommands extends PrjctCommandsBase {
         }
         if (kimiConfig) {
           out.info(`Kimi config: ${kimiConfig.changed ? 'updated' : 'already ready'}`)
+        }
+        if (grokConfig) {
+          const action =
+            grokConfig.skipped === 'user-managed'
+              ? 'user-managed MCP preserved'
+              : grokConfig.changed
+                ? 'updated'
+                : 'already ready'
+          out.info(`Grok MCP: ${action} → ${grokConfig.path}`)
+        }
+        if (grokSkill?.success) {
+          out.info(
+            `Grok skill: ${grokSkill.action ?? 'ready'}${grokSkill.path ? ` → ${grokSkill.path}` : ''}`
+          )
+        }
+        if (grokPlugin?.success) {
+          out.info(
+            `Grok plugin: ${grokPlugin.changed ? 'updated' : 'already ready'} → ${grokPlugin.path}`
+          )
         }
         out.info(
           `Organic board: ${coverage.liveCount}/${coverage.detectedCount} live (${coverage.organicPct}%)`
@@ -260,6 +308,26 @@ export class InstallCommands extends PrjctCommandsBase {
           ? {
               path: kimiConfig.path,
               changed: kimiConfig.changed,
+            }
+          : null,
+        grokConfig: grokConfig
+          ? {
+              path: grokConfig.path,
+              changed: grokConfig.changed,
+              skipped: grokConfig.skipped,
+            }
+          : null,
+        grokSkill: grokSkill?.success
+          ? {
+              action: grokSkill.action,
+              path: grokSkill.path,
+            }
+          : null,
+        grokPlugin: grokPlugin?.success
+          ? {
+              path: grokPlugin.path,
+              changed: grokPlugin.changed,
+              files: grokPlugin.files,
             }
           : null,
       }

--- a/core/commands/removed-verbs.ts
+++ b/core/commands/removed-verbs.ts
@@ -69,10 +69,8 @@ export const REMOVED_VERBS: Readonly<Record<string, RemovedVerb>> = {
     replacement: 'prjct status',
     note: 'Velocity reports were removed in v2.',
   },
-  plan: {
-    replacement: 'prjct init',
-    note: 'Planning is now part of init/task flow.',
-  },
+  // `plan` returned in 2026-07 as the plan-mode ceremony (draft → approve).
+  // Tombstone removed so the registered ceremonies.plan verb can dispatch.
   vault: {
     replacement: 'prjct search / prjct context memory / MCP prjct_*',
     note: 'The Obsidian/markdown vault was removed. Agents read project knowledge through tools now.',

--- a/core/infrastructure/agent-runtime-registry.ts
+++ b/core/infrastructure/agent-runtime-registry.ts
@@ -283,12 +283,15 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
     status: 'stable',
     detectsBy: { homeDirs: ['.grok'], commands: ['grok'] },
     contextFiles: ['AGENTS.md', 'CLAUDE.md'],
-    // Grok natively loads Claude MCP/settings — no separate writer required.
     mcpTargets: [
-      { format: 'generic', pathHint: '~/.grok config/plugins (MCP)', writable: false },
+      {
+        format: 'codex-toml',
+        pathHint: '~/.grok/config.toml',
+        writable: true,
+      },
       {
         format: 'claude-json',
-        pathHint: '~/.claude/mcp.json (Grok Claude-compat)',
+        pathHint: '~/.claude/mcp.json (Grok Claude-compat fallback)',
         writable: true,
       },
     ],
@@ -301,7 +304,7 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       projectRules: false,
     },
     notes:
-      'Benchmark-tier CLI (2026-07): Grok Build. AGENTS.md + native Claude Code compat (CLAUDE.md, skills, MCP, hooks). prjct install covers Grok via inherits-claude — see harness-surfaces.',
+      'Benchmark-tier CLI (2026-07): Grok Build. Native MCP + skill via prjct install (~/.grok/config.toml + ~/.grok/skills/prjct). Hooks still Claude-compat. See harness-surfaces.',
   },
   {
     id: 'goose',

--- a/core/infrastructure/grok-skill.ts
+++ b/core/infrastructure/grok-skill.ts
@@ -1,0 +1,103 @@
+/**
+ * Grok Build skill installer.
+ *
+ * Writes `~/.grok/skills/prjct/SKILL.md` from the compact multi-host skill
+ * (same CONTRACT as Codex). Grok has no hard byte cap, but keeping the
+ * surface compact avoids drift and matches the Body/Brain split: skill points
+ * at verbs; SQLite memory lives in prjct.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { getTemplateContent } from '../agentic/template-loader'
+import { getErrorMessage } from '../types/fs'
+import { fileExists } from '../utils/file-helper'
+import { sha256 } from '../utils/hash'
+import log from '../utils/logger'
+import { VERSION } from '../utils/version'
+import { resolveUserPath } from './user-home'
+
+const GROK_SKILL_META_MARKER = 'prjct-grok-skill'
+
+function getGrokSkillPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'grok', 'skills', 'prjct', 'SKILL.md')
+  }
+  return resolveUserPath('.grok', 'skills', 'prjct', 'SKILL.md')
+}
+
+export function getGrokSkillInstallPath(): string {
+  return getGrokSkillPath()
+}
+
+function getGrokSkillMetadata(templateHash: string): string {
+  return `<!-- ${GROK_SKILL_META_MARKER}: ${JSON.stringify({
+    v: VERSION,
+    h: templateHash,
+  })} -->`
+}
+
+function hashContent(content: string): string {
+  return sha256(content).slice(0, 12)
+}
+
+async function loadGrokSkillTemplate(): Promise<string | null> {
+  // Prefer Grok-specific template when present; fall back to compact Codex skill
+  // (same CONTRACT lines — multi-host parity).
+  return getTemplateContent('grok/SKILL.md') ?? getTemplateContent('codex/SKILL.md')
+}
+
+export function buildGrokSkillContent(templateContent: string): {
+  content: string
+  templateHash: string
+} {
+  const normalized = templateContent.trimEnd()
+  const templateHash = hashContent(normalized)
+  const metadata = getGrokSkillMetadata(templateHash)
+  return {
+    content: `${normalized}\n\n${metadata}\n`,
+    templateHash,
+  }
+}
+
+/**
+ * Install prjct as a skill for xAI Grok Build (`~/.grok/skills/prjct/`).
+ */
+export async function installGrokSkill(): Promise<{
+  success: boolean
+  action: string | null
+  path?: string
+}> {
+  try {
+    const skillMdPath = getGrokSkillPath()
+    await fs.mkdir(path.dirname(skillMdPath), { recursive: true })
+
+    const skillExists = await fileExists(skillMdPath)
+
+    const templateContent = await loadGrokSkillTemplate()
+    if (!templateContent) {
+      log.warn('Grok SKILL.md template not found')
+      return { success: false, action: null }
+    }
+
+    const built = buildGrokSkillContent(templateContent)
+
+    if (skillExists) {
+      const existing = await fs.readFile(skillMdPath, 'utf-8').catch(() => '')
+      if (existing === built.content) {
+        return { success: true, action: 'unchanged', path: skillMdPath }
+      }
+    }
+
+    await fs.writeFile(skillMdPath, built.content, 'utf-8')
+
+    return {
+      success: true,
+      action: skillExists ? 'updated' : 'created',
+      path: skillMdPath,
+    }
+  } catch (error) {
+    log.warn(`Grok skill warning: ${getErrorMessage(error)}`)
+    return { success: false, action: null }
+  }
+}

--- a/core/infrastructure/harness-surfaces.ts
+++ b/core/infrastructure/harness-surfaces.ts
@@ -60,6 +60,7 @@ export interface HarnessSurfaceEntry {
   plugins?: {
     paths: string[]
     prjct: PrjctWireStatus
+    notes?: string
   }
   /** One-line "what makes prjct legible here" */
   legibility: string
@@ -218,24 +219,25 @@ export const BENCHMARK_HARNESS_SURFACES: readonly HarnessSurfaceEntry[] = [
     },
     mcp: {
       configPaths: [
-        '~/.grok/config.toml + plugins',
-        '~/.claude/mcp.json (read natively)',
-        'Claude plugins/MCPs',
+        '~/.grok/config.toml [mcp_servers.prjct]',
+        '~/.claude/mcp.json (Claude compat fallback)',
+        'plugins .mcp.json',
       ],
-      format: 'Grok plugins/MCP + Claude MCP JSON (compat)',
-      prjct: 'inherits-claude',
-      notes: 'Zero-config Claude Code MCP/skills/hooks compatibility — prjct install covers Grok',
+      format: 'TOML mcp_servers (same shape as Codex) + Claude MCP JSON (compat)',
+      prjct: 'native',
+      notes:
+        'prjct install → ensureGrokMcpServer() writes managed [mcp_servers.prjct] into ~/.grok/config.toml; Claude MCP remains a fallback',
     },
     skills: {
       paths: [
         './.grok/skills/',
-        '~/.grok/skills/',
+        '~/.grok/skills/prjct/SKILL.md',
         '~/.agents/skills/',
         '.claude/skills/ (compat)',
         'plugin skills/',
       ],
-      prjct: 'inherits-claude',
-      notes: 'Also discovers ~/.agents/skills and Claude skills',
+      prjct: 'native',
+      notes: 'prjct install → installGrokSkill() at ~/.grok/skills/prjct/SKILL.md',
     },
     hooks: {
       configPaths: [
@@ -264,14 +266,17 @@ export const BENCHMARK_HARNESS_SURFACES: readonly HarnessSurfaceEntry[] = [
       prjct: 'inherits-claude',
       contract:
         'PreToolUse is the only blocking event (decision deny or exit 2). Fail-open on errors. Project hooks need trust.',
-      notes: 'prjct Claude hooks already fire under Grok via Claude compat — no second installer',
+      notes:
+        'Hooks still via Claude/Cursor compat (no second Grok hook writer yet). MCP + skill are native.',
     },
     plugins: {
-      paths: ['./.grok/plugins/', '~/.grok/plugins/', 'marketplaces'],
-      prjct: 'none',
+      paths: ['./.grok/plugins/', '~/.grok/plugins/prjct/', 'marketplaces'],
+      prjct: 'native',
+      notes:
+        'prjct install → installGrokPlugin() at ~/.grok/plugins/prjct (skill + /plan command; MCP stays in config.toml)',
     },
     legibility:
-      'Best free lunch: Claude-compatible. prjct install (Claude hooks + MCP) makes Grok fully legible without a Grok-specific writer.',
+      'Native MCP + skill + user plugin on prjct install when Grok is detected; PreToolUse/Session hooks still fire via Claude-compat settings. Plan ceremony: `prjct plan`. Grok is Brain; prjct SQLite is Body.',
   },
   {
     runtimeId: 'opencode',

--- a/core/infrastructure/setup.ts
+++ b/core/infrastructure/setup.ts
@@ -31,6 +31,7 @@ import { getErrorMessage, isNotFoundError } from '../types/fs'
 import type { AIProviderConfig, AIProviderName } from '../types/provider'
 import { getTimeout } from '../utils/constants'
 import { fileExists } from '../utils/file-helper'
+import { ensureGrokMcpServer } from '../utils/grok-mcp'
 import log from '../utils/logger'
 import { VERSION } from '../utils/version'
 import {
@@ -43,6 +44,7 @@ import {
 import { installCodexSkill, verifyCodexPRouterReady } from './codex-skill'
 import installer from './command-installer'
 import editorsConfig from './editors-config'
+import { installGrokSkill } from './grok-skill'
 import { mergeWithMarkers } from './ide-project-installer'
 import pathManager from './path-manager'
 import { installStatusLine } from './statusline-installer'
@@ -244,6 +246,28 @@ export async function run(): Promise<SetupResults> {
 
     console.log(`   ${chalk.green('✓')} Codex skill installed`)
     console.log(`   ${chalk.green('✓')} Codex p. router ready`)
+  }
+
+  // Step 2d: Install for Grok Build if detected (~/.grok or `grok` on PATH)
+  try {
+    const { detectAgentRuntimes } = await import('./agent-runtime-registry')
+    const runtimes = await detectAgentRuntimes(process.cwd())
+    const grokDetected = runtimes.some((r) => r.runtime.id === 'grok' && r.detected)
+    if (grokDetected) {
+      const { installGrokPlugin } = await import('../utils/grok-plugin')
+      const grokMcp = await ensureGrokMcpServer()
+      const grokSkill = await installGrokSkill()
+      const grokPlugin = await installGrokPlugin()
+      if (grokSkill.success || grokPlugin.success) {
+        console.log(
+          `   ${chalk.green('✓')} Grok skill/plugin ${grokSkill.action ?? 'ready'}${
+            grokMcp.changed ? ' + MCP' : ''
+          }${grokPlugin.changed ? ' + plugin' : ''}`
+        )
+      }
+    }
+  } catch {
+    /* best-effort — install.ts is the primary wire path */
   }
 
   // Step 3: Save version in editors-config

--- a/core/services/doctor-heal.ts
+++ b/core/services/doctor-heal.ts
@@ -187,6 +187,14 @@ export async function applyDoctorHeal(
           const { ensureKimiMcpServer } = await import('../utils/kimi-mcp')
           await ensureKimiMcpServer()
         }
+        if (detected.some((r) => r.runtime.id === 'grok')) {
+          const { ensureGrokMcpServer } = await import('../utils/grok-mcp')
+          const { installGrokSkill } = await import('../infrastructure/grok-skill')
+          const { installGrokPlugin } = await import('../utils/grok-plugin')
+          await ensureGrokMcpServer()
+          await installGrokSkill()
+          await installGrokPlugin()
+        }
         // Always ensure Claude hooks too when multi-runtime runs
         await installHooks()
         applied.push(action.id)

--- a/core/services/harness-coverage.ts
+++ b/core/services/harness-coverage.ts
@@ -3,8 +3,8 @@
  *
  * Competitors can ship AGENTS.md pointers. What they cannot cheaply copy is
  * a single install that leaves *working* hooks + MCP across Claude, Codex,
- * Gemini, Cursor (and Grok via Claude inherit) while SQLite judgment memory
- * and code gates stay the same brain underneath.
+ * Gemini, Cursor, and Grok (native MCP/skill + Claude-compat hooks) while
+ * SQLite judgment memory and code gates stay the same brain underneath.
  *
  * This module probes real config files (not capability claims) so install,
  * agents doctor, and harness score report the same truth.
@@ -12,11 +12,14 @@
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { getGrokSkillInstallPath } from '../infrastructure/grok-skill'
 import { resolveUserHome } from '../infrastructure/user-home'
 import { getCodexHooksJsonPath } from '../utils/codex-hooks'
 import { getCodexConfigTomlPath } from '../utils/codex-mcp'
 import { getCursorHooksJsonPath } from '../utils/cursor-hooks'
 import { getGeminiSettingsPath } from '../utils/gemini-settings'
+import { getGrokConfigTomlPath } from '../utils/grok-mcp'
+import { getGrokPluginRoot } from '../utils/grok-plugin'
 import { commandOnPathAsync } from '../utils/which'
 
 export type OrganicLevel = 'full' | 'partial' | 'inherited' | 'none' | 'absent'
@@ -126,6 +129,9 @@ export async function probeHarnessCoverage(
   const geminiSettings = getGeminiSettingsPath()
   const cursorHooks = getCursorHooksJsonPath()
   const grokHome = path.join(home, '.grok')
+  const grokToml = getGrokConfigTomlPath()
+  const grokSkill = getGrokSkillInstallPath()
+  const grokPluginJson = path.join(getGrokPluginRoot(), 'plugin.json')
   const projectCursor = path.join(projectPath, '.cursor')
 
   const [
@@ -139,6 +145,9 @@ export async function probeHarnessCoverage(
     codexTomlText,
     geminiText,
     cursorHooksText,
+    grokTomlText,
+    grokSkillExists,
+    grokPluginExists,
     grokDir,
     cursorDir,
   ] = await Promise.all([
@@ -152,6 +161,9 @@ export async function probeHarnessCoverage(
     readText(codexToml),
     readText(geminiSettings),
     readText(cursorHooks),
+    readText(grokToml),
+    fileExists(grokSkill),
+    fileExists(grokPluginJson),
     fileExists(grokHome),
     fileExists(projectCursor),
   ])
@@ -174,8 +186,13 @@ export async function probeHarnessCoverage(
     hasPrjctManagedJson(cursorHooksText) || hasPrjctHookCommand(cursorHooksText)
 
   const grokDetected = grokCmd || grokDir
-  // Grok inherits Claude hooks/MCP when those are live.
-  const grokInherited = Boolean(claudeHooks || claudeMcpLive)
+  const grokNativeMcp = hasPrjctMcpToml(grokTomlText)
+  const grokNativeSkill = Boolean(grokSkillExists)
+  const grokNativePlugin = Boolean(grokPluginExists)
+  const grokHasNative = grokNativeMcp || grokNativeSkill || grokNativePlugin
+  // Hooks still fire via Claude-compat settings; MCP can be native and/or Claude.
+  const grokHooksLive = Boolean(claudeHooks)
+  const grokMcpLive = grokNativeMcp || claudeMcpLive
 
   const runtimes: RuntimeCoverage[] = [
     {
@@ -245,13 +262,25 @@ export async function probeHarnessCoverage(
       id: 'grok',
       displayName: 'xAI Grok Build',
       detected: Boolean(grokDetected),
-      hooksLive: grokInherited && claudeHooks,
-      mcpLive: grokInherited && claudeMcpLive,
-      organic: organicOf(Boolean(grokDetected), grokInherited, grokInherited, true),
+      hooksLive: grokHooksLive,
+      mcpLive: grokMcpLive,
+      // Native MCP/skill → full/partial; Claude-only fallback → inherited.
+      organic: organicOf(
+        Boolean(grokDetected),
+        grokHooksLive,
+        grokMcpLive,
+        !grokHasNative && (claudeHooks || claudeMcpLive)
+      ),
       evidence: grokDetected
-        ? grokInherited
-          ? 'inherits Claude hooks+MCP (zero extra install)'
-          : 'detected — run prjct install (Claude wire unlocks Grok)'
+        ? grokNativeMcp && (grokNativeSkill || grokNativePlugin)
+          ? `~/.grok/config.toml MCP + ${grokNativePlugin ? 'plugins/prjct' : 'skills/prjct'} (hooks via Claude compat)`
+          : grokNativeMcp
+            ? '~/.grok/config.toml MCP (hooks via Claude compat)'
+            : grokNativeSkill || grokNativePlugin
+              ? `${grokNativePlugin ? 'plugins/prjct' : 'skills/prjct'} (MCP via Claude compat or missing)`
+              : claudeHooks || claudeMcpLive
+                ? 'Claude-compat only — run prjct install for native Grok MCP+skill+plugin'
+                : 'detected — run prjct install'
         : 'not installed',
     },
   ]

--- a/core/services/harness-rigs.ts
+++ b/core/services/harness-rigs.ts
@@ -110,6 +110,34 @@ export const RIGS: readonly RigTemplate[] = [
       { organ: 'stop-slop', install: 'prjct workflow gate ship "verify:auto".' },
     ],
   },
+  {
+    name: 'grok-build',
+    description:
+      'Grok as Brain, prjct as Body: multi-host skill/MCP projection, plan-mode approval gate, crew checkpoints, and SQLite memory (Grok memory is experimental). Steal patterns from the open Grok Build harness — not the Rust agent loop.',
+    source: 'https://github.com/xai-org/grok-build',
+    organs: [
+      {
+        organ: 'skills-commands',
+        install:
+          'prjct install — native ~/.grok/config.toml MCP + ~/.grok/skills/prjct + ~/.grok/plugins/prjct; hooks still via Claude compat. Keep AGENTS.md + MCP prjct_* as the portable contract.',
+      },
+      {
+        organ: 'knowledge-base',
+        install:
+          'prjct remember decision/learning/gotcha — prjct SQLite is the durable memory plane; do not rely on Grok experimental memory alone.',
+      },
+      {
+        organ: 'agent-catalog',
+        install:
+          'prjct crew install + `prjct plan` ceremony (draft read-only until `prjct plan approve`) before implementer edits on ambiguous work.',
+      },
+      {
+        organ: 'stop-slop',
+        install:
+          'prjct crew checkpoints set + `prjct workflow gate ship "verify:auto"`; map delivery-geometry tier to host permission mode advice (default/dontAsk/acceptEdits) without owning OS sandbox.',
+      },
+    ],
+  },
 ]
 
 export function findRig(name: string): RigTemplate | undefined {

--- a/core/services/multi-runtime-signals.ts
+++ b/core/services/multi-runtime-signals.ts
@@ -5,7 +5,7 @@
  *   1. PRJCT_HOOKS install set (Claude source of truth)
  *   2. Host mappers (Codex/Gemini/Cursor) including pre-package + prompt
  *   3. Compact skill CONTRACT.loop on Codex/Gemini surfaces
- *   4. Grok inherits Claude surfaces (harness-surfaces)
+ *   4. Grok native MCP + skill; hooks still inherit Claude (harness-surfaces)
  *
  * Not hardcoded prose theater — derived from real installers.
  */
@@ -38,6 +38,8 @@ export function multiRuntimeInstallParityReport(): {
   codexHasLoop: boolean
   geminiHasLoop: boolean
   grokInheritsClaude: boolean
+  grokMcpNative: boolean
+  grokSkillsNative: boolean
 } {
   const missing: string[] = []
   const hooks = PRJCT_HOOKS.map((h) => h.subcommand)
@@ -106,9 +108,12 @@ export function multiRuntimeInstallParityReport(): {
   }
 
   const grok = BENCHMARK_HARNESS_SURFACES.find((s) => s.runtimeId === 'grok')
-  const grokInheritsClaude =
-    grok?.hooks?.prjct === 'inherits-claude' || grok?.mcp?.prjct === 'inherits-claude'
-  if (!grokInheritsClaude) missing.push('grok does not inherit Claude surfaces')
+  const grokInheritsClaude = grok?.hooks?.prjct === 'inherits-claude'
+  const grokMcpNative = grok?.mcp?.prjct === 'native'
+  const grokSkillsNative = grok?.skills?.prjct === 'native'
+  if (!grokInheritsClaude) missing.push('grok hooks should inherit Claude PreToolUse/Session')
+  if (!grokMcpNative) missing.push('grok mcp not native')
+  if (!grokSkillsNative) missing.push('grok skills not native')
 
   for (const id of CORE_SUPERIORITY_RUNTIMES) {
     if (!BENCHMARK_HARNESS_SURFACES.some((s) => s.runtimeId === id)) {
@@ -123,6 +128,8 @@ export function multiRuntimeInstallParityReport(): {
     codexHasLoop,
     geminiHasLoop,
     grokInheritsClaude: Boolean(grokInheritsClaude),
+    grokMcpNative: Boolean(grokMcpNative),
+    grokSkillsNative: Boolean(grokSkillsNative),
   }
 }
 

--- a/core/services/weak-model-bench.ts
+++ b/core/services/weak-model-bench.ts
@@ -178,9 +178,14 @@ export function runWeakModelBench(): WeakBenchReport {
   )
   push('cursor hooks native', cursor?.hooks.prjct === 'native', `hooks=${cursor?.hooks.prjct}`)
   push(
-    'grok inherits-claude',
-    grok?.hooks.prjct === 'inherits-claude' && grok?.mcp.prjct === 'inherits-claude',
-    `hooks=${grok?.hooks.prjct} mcp=${grok?.mcp.prjct}`
+    'grok mcp+skills native',
+    grok?.mcp.prjct === 'native' && grok?.skills.prjct === 'native',
+    `mcp=${grok?.mcp.prjct} skills=${grok?.skills.prjct}`
+  )
+  push(
+    'grok hooks inherits-claude',
+    grok?.hooks.prjct === 'inherits-claude',
+    `hooks=${grok?.hooks.prjct}`
   )
 
   const surfaceIds = new Set(listHarnessSurfaces().map((s) => s.runtimeId))

--- a/core/storage/plan-storage.ts
+++ b/core/storage/plan-storage.ts
@@ -1,0 +1,121 @@
+/**
+ * Active work-plan storage (plan-mode ceremony).
+ *
+ * One kv_store row per project at key `work-plan:active`. Status draft means
+ * the host agent should treat the workspace as read-only except for plan
+ * updates via `prjct plan write`. Approve clears the hard contract and
+ * persists a decision memory (caller).
+ */
+
+import { z } from 'zod'
+import { getTimestamp } from '../utils/date-helper'
+import prjctDb from './database'
+
+export const PLAN_KEY = 'work-plan:active'
+
+export const WorkPlanSchema = z.object({
+  status: z.enum(['draft', 'approved', 'abandoned']),
+  title: z.string().min(1),
+  content: z.string(),
+  taskId: z.string().nullable().optional(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+  approvedAt: z.string().nullable().optional(),
+})
+
+export type WorkPlan = z.infer<typeof WorkPlanSchema>
+
+/** Canonical plan skeleton (Grok plan-mode sections). */
+export function emptyPlanTemplate(title: string): string {
+  return [
+    `# Plan: ${title}`,
+    '',
+    '## Context',
+    '',
+    'Why this change is needed.',
+    '',
+    '## Recommended approach',
+    '',
+    'The path we will take (not every alternative).',
+    '',
+    '## Critical files',
+    '',
+    '- `path/to/file` — why',
+    '',
+    '## Reuse',
+    '',
+    'Existing functions/utilities to match (file:line when known).',
+    '',
+    '## Verification',
+    '',
+    'How to test end-to-end after implementation.',
+    '',
+  ].join('\n')
+}
+
+class PlanStorage {
+  get(projectId: string): WorkPlan | null {
+    const raw = prjctDb.getDoc<unknown>(projectId, PLAN_KEY)
+    if (raw === null) return null
+    const parsed = WorkPlanSchema.safeParse(raw)
+    return parsed.success ? parsed.data : null
+  }
+
+  set(projectId: string, plan: WorkPlan): WorkPlan {
+    const row = WorkPlanSchema.parse(plan)
+    prjctDb.setDoc(projectId, PLAN_KEY, row)
+    return row
+  }
+
+  start(projectId: string, title: string, taskId?: string | null): WorkPlan {
+    const now = getTimestamp()
+    const plan: WorkPlan = {
+      status: 'draft',
+      title: title.trim() || 'Untitled plan',
+      content: emptyPlanTemplate(title.trim() || 'Untitled plan'),
+      taskId: taskId ?? null,
+      createdAt: now,
+      updatedAt: now,
+      approvedAt: null,
+    }
+    return this.set(projectId, plan)
+  }
+
+  writeContent(projectId: string, content: string): WorkPlan | null {
+    const cur = this.get(projectId)
+    if (!cur || cur.status !== 'draft') return null
+    return this.set(projectId, {
+      ...cur,
+      content,
+      updatedAt: getTimestamp(),
+    })
+  }
+
+  approve(projectId: string): WorkPlan | null {
+    const cur = this.get(projectId)
+    if (!cur || cur.status !== 'draft') return null
+    const now = getTimestamp()
+    return this.set(projectId, {
+      ...cur,
+      status: 'approved',
+      updatedAt: now,
+      approvedAt: now,
+    })
+  }
+
+  abandon(projectId: string): WorkPlan | null {
+    const cur = this.get(projectId)
+    if (!cur) return null
+    return this.set(projectId, {
+      ...cur,
+      status: 'abandoned',
+      updatedAt: getTimestamp(),
+    })
+  }
+
+  clear(projectId: string): void {
+    prjctDb.deleteDoc(projectId, PLAN_KEY)
+  }
+}
+
+export const planStorage = new PlanStorage()

--- a/core/utils/grok-mcp.ts
+++ b/core/utils/grok-mcp.ts
@@ -1,0 +1,112 @@
+/**
+ * Grok Build config wiring — ensures `~/.grok/config.toml` carries the prjct
+ * MCP server entry.
+ *
+ * Grok uses the same TOML shape as Codex (`[mcp_servers.<name>]`). We manage
+ * our entry between `# prjct:mcp` comment markers so re-runs replace our block
+ * and never touch user content. If the user defined `[mcp_servers.prjct]`
+ * themselves (no markers), we leave their config alone.
+ *
+ * Hooks stay on the Claude-compat path (`inherits-claude`); this module is
+ * the native MCP wire so Grok users without a Claude install still get
+ * `prjct_*` tools.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { resolveUserPath } from '../infrastructure/user-home'
+import type { MCPServerConfig } from '../types/utils.js'
+import { buildPrjctMcpTomlBlock } from './codex-mcp'
+import { MCP_SERVER_PRESETS } from './mcp-config'
+
+const START_MARKER = '# prjct:mcp:start - managed by prjct, do not edit between markers'
+const END_MARKER = '# prjct:mcp:end'
+
+export function getGrokConfigTomlPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'grok', 'config.toml')
+  }
+  return resolveUserPath('.grok', 'config.toml')
+}
+
+/**
+ * Upsert a marker-delimited block into `existing`. Returns the new text plus
+ * whether a user-managed (marker-less) table of the same name was found — in
+ * which case we leave their config untouched.
+ */
+function upsertMarkedBlock(
+  existing: string,
+  block: string,
+  startMarker: string,
+  endMarker: string,
+  tableName: string
+): { next: string; skipped?: 'user-managed' } {
+  const startIdx = existing.indexOf(startMarker)
+  const endIdx = existing.indexOf(endMarker)
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx)
+    let after = existing.slice(endIdx + endMarker.length)
+    if (after.startsWith('\n')) after = after.slice(1)
+    return { next: before + block + after }
+  }
+  if (new RegExp(`^\\s*\\[mcp_servers\\.${tableName}\\]`, 'm').test(existing)) {
+    return { next: existing, skipped: 'user-managed' }
+  }
+  if (existing.trim().length > 0) {
+    return { next: `${existing.trimEnd()}\n\n${block}` }
+  }
+  return { next: block }
+}
+
+/**
+ * Idempotently install/refresh the prjct MCP server in Grok's config.toml.
+ *
+ * - No file → create it with managed MCP.
+ * - File with our markers → replace the MCP block in place.
+ * - File with a user-managed `[mcp_servers.prjct]` (no markers) → preserve it.
+ */
+export async function ensureGrokMcpServer(
+  configPath = getGrokConfigTomlPath(),
+  server: MCPServerConfig = MCP_SERVER_PRESETS.prjct
+): Promise<{
+  path: string
+  changed: boolean
+  skipped?: 'user-managed'
+}> {
+  let existing = ''
+  try {
+    existing = await fs.readFile(configPath, 'utf-8')
+  } catch {
+    // Missing file — we'll create it.
+  }
+
+  const block = buildPrjctMcpTomlBlock(server)
+  const upserted = upsertMarkedBlock(existing, block, START_MARKER, END_MARKER, 'prjct')
+  const next = upserted.next
+  const skipped = upserted.skipped
+
+  if (next === existing) {
+    return { path: configPath, changed: false, skipped }
+  }
+
+  await fs.mkdir(path.dirname(configPath), { recursive: true })
+  await fs.writeFile(configPath, next, 'utf-8')
+  return {
+    path: configPath,
+    changed: true,
+    skipped,
+  }
+}
+
+/** True iff config.toml carries a `[mcp_servers.prjct]` table (managed or user). */
+export async function grokHasPrjctMcpServer(
+  configPath = getGrokConfigTomlPath()
+): Promise<boolean> {
+  try {
+    const existing = await fs.readFile(configPath, 'utf-8')
+    return /^\s*\[mcp_servers\.prjct\]/m.test(existing) || existing.includes(START_MARKER)
+  } catch {
+    return false
+  }
+}

--- a/core/utils/grok-plugin.ts
+++ b/core/utils/grok-plugin.ts
@@ -1,0 +1,133 @@
+/**
+ * Grok Build host-plugin materializer.
+ *
+ * Installs a user-level plugin at `~/.grok/plugins/prjct/` (auto-trusted by
+ * Grok). Bundles skill + optional slash command; MCP stays in
+ * `~/.grok/config.toml` (ensureGrokMcpServer) so we never double-register
+ * `prjct_*` tools via both plugin `.mcp.json` and config.toml.
+ *
+ * Layout matches Grok plugin convention:
+ *   plugin.json
+ *   skills/prjct/SKILL.md
+ *   commands/plan.md   (slash-command → prjct plan ceremony)
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { getTemplateContent } from '../agentic/template-loader'
+import { buildGrokSkillContent } from '../infrastructure/grok-skill'
+import { resolveUserPath } from '../infrastructure/user-home'
+import { getErrorMessage } from '../types/fs'
+import log from './logger'
+import { VERSION } from './version'
+
+const PLUGIN_NAME = 'prjct'
+
+export function getGrokPluginRoot(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'grok', 'plugins', PLUGIN_NAME)
+  }
+  return resolveUserPath('.grok', 'plugins', PLUGIN_NAME)
+}
+
+function buildPluginJson(): string {
+  return `${JSON.stringify(
+    {
+      name: PLUGIN_NAME,
+      version: VERSION,
+      description:
+        'prjct agentic harness: SQLite work cycles, memory, guards. Grok is Brain; prjct is Body. Run prjct verbs / MCP prjct_*.',
+      author: { name: 'prjct.app' },
+    },
+    null,
+    2
+  )}\n`
+}
+
+function buildPlanCommandMarkdown(): string {
+  return `---
+description: Enter or manage prjct plan mode (read-only until approve). Use when the approach is ambiguous and you need a written plan before editing code.
+---
+
+# prjct plan
+
+Run this ceremony yourself (do not ask the user to type it):
+
+\`\`\`bash
+prjct plan "\${ARGUMENTS}" --md
+\`\`\`
+
+Follow the host contract printed by the CLI:
+
+- While plan status is **draft**, do not edit project source — only update the plan via \`prjct plan write\` / \`prjct plan\`.
+- When the plan is ready, ask the user to approve, then run \`prjct plan approve --md\`.
+- After approve, implement against the plan; persist decisions with \`prjct remember\`.
+`
+}
+
+async function loadSkillTemplate(): Promise<string | null> {
+  return getTemplateContent('grok/SKILL.md') ?? getTemplateContent('codex/SKILL.md')
+}
+
+async function writeIfChanged(filePath: string, content: string): Promise<boolean> {
+  try {
+    const existing = await fs.readFile(filePath, 'utf-8')
+    if (existing === content) return false
+  } catch {
+    // missing
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, 'utf-8')
+  return true
+}
+
+/**
+ * Idempotently install/refresh the user-level Grok plugin.
+ */
+export async function installGrokPlugin(pluginRoot = getGrokPluginRoot()): Promise<{
+  success: boolean
+  path: string
+  changed: boolean
+  files: string[]
+}> {
+  try {
+    const template = await loadSkillTemplate()
+    if (!template) {
+      log.warn('Grok plugin: skill template missing')
+      return { success: false, path: pluginRoot, changed: false, files: [] }
+    }
+
+    const skill = buildGrokSkillContent(template)
+    const targets: Array<{ rel: string; content: string }> = [
+      { rel: 'plugin.json', content: buildPluginJson() },
+      { rel: path.join('skills', 'prjct', 'SKILL.md'), content: skill.content },
+      { rel: path.join('commands', 'plan.md'), content: buildPlanCommandMarkdown() },
+    ]
+
+    const written: string[] = []
+    for (const t of targets) {
+      const abs = path.join(pluginRoot, t.rel)
+      if (await writeIfChanged(abs, t.content)) written.push(t.rel)
+    }
+
+    return {
+      success: true,
+      path: pluginRoot,
+      changed: written.length > 0,
+      files: written,
+    }
+  } catch (error) {
+    log.warn(`Grok plugin warning: ${getErrorMessage(error)}`)
+    return { success: false, path: pluginRoot, changed: false, files: [] }
+  }
+}
+
+/** True if the managed plugin directory exists with plugin.json. */
+export async function grokPluginInstalled(pluginRoot = getGrokPluginRoot()): Promise<boolean> {
+  try {
+    await fs.access(path.join(pluginRoot, 'plugin.json'))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.65.0",
+  "version": "3.66.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/grok/SKILL.md
+++ b/templates/grok/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: prjct
+description: prjct work cycles + memory; run prjct verbs, do not preload context. Use when the user wants project memory, work cycles, ships, guardrails, or performance.
+---
+
+# prjct
+
+Run `prjct <cmd> --md` and follow it. Grok is the Brain; prjct is the Body (SQLite memory + work cycles).
+
+- prjct is a RAG-backed project memory harness; do not preload project history.
+- `prjct work "<intent>" --md` is the single entrypoint — recognize intent and run the verb yourself.
+- Pull only what surfaces: `prjct search` / `context memory` / `guard` / MCP — not something to load wholesale.
+- Save synthesized memory in English: `prjct remember <decision|learning|gotcha|context> "<text>"`.
+- KB (`identity/voice/glossary/framework`): `remember <facet>` / `context memory <facet>` — on demand, never injected here.
+- Ship only after user OKs: `prjct ship --md`.
+- Loop: land; H2+ intent; tip→user SoT; close.
+- L0 portable; id=cwd.
+- Prefer MCP `prjct_*` tools when available; do not rely on Grok experimental memory alone.
+- Ambiguous approach → `prjct plan "<title>"` (read-only until `prjct plan approve`); do not edit source while plan is draft.
+
+Commit footer: `Generated with [p/](https://www.prjct.app/)`


### PR DESCRIPTION
## Summary

- **Native Grok Build host integration** when `grok` / `~/.grok` is detected: managed MCP in `~/.grok/config.toml`, skill at `~/.grok/skills/prjct/`, user plugin at `~/.grok/plugins/prjct/` (skill + `/plan` slash command). Hooks remain Claude-compat.
- **`prjct plan` ceremony** (draft → write → approve/clear): SQLite `work-plan:active` with Grok-style sections and a read-only host contract until approve; re-enables the verb (v2 tombstone removed).
- **Steal-a-rig `grok-build`**, harness-surfaces/coverage/parity updates, and install/setup/doctor-heal wiring.

## Test plan

- [x] `bun test` on grok-mcp, grok-plugin, grok-skill, plan-storage, plan-ceremony, removed-verbs, harness-surfaces, agent-runtime-registry, harness-rigs, weak-model-bench, superiority-gates (70 pass)
- [x] `tsc --noEmit` (pre-push)
- [ ] `prjct install` with Grok detected → MCP + skill + plugin present; `prjct agents doctor` / coverage shows Grok native
- [ ] `prjct plan "title"` → draft contract; `write` → `approve` → decision memory; `clear` resets
- [ ] Claude/Codex install paths unchanged (regression smoke)