### PR TITLE
feat(harness): project style model + dual evolution (v3.68.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.68.0] - 2026-07-16
+
+### Added
+- project style model dual evolution
+
 ## [3.67.0] - 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.67.0] - 2026-07-16
+
+### Added
+- project style model dual evolution
+
 ## [3.66.0] - 2026-07-16
 
 ### Added

--- a/core/__tests__/commands/analysis-save-llm.test.ts
+++ b/core/__tests__/commands/analysis-save-llm.test.ts
@@ -73,6 +73,42 @@ describe('analysis-save-llm', () => {
     expect(saved?.projectInsights).not.toContain('WIP')
   })
 
+  test('thin markdown notes do not clobber a rich house-style analysis', async () => {
+    const rich = {
+      ...MINIMAL_VALID,
+      architecture: {
+        style: 'modular-monolith',
+        insights: ['commands route through services'],
+        domains: ['core'],
+      },
+      patterns: [
+        {
+          name: 'Command registry',
+          description: 'command-data.ts is the wire',
+          locations: ['core/commands'],
+          confidence: 0.95,
+          category: 'architecture',
+        },
+      ],
+      conventions: [
+        { category: 'imports', rule: 'No barrel files', example: 'import from source' },
+      ],
+    }
+    const first = await saveLlmAnalysis(JSON.stringify(rich), projectPath, { md: true })
+    expect(first.success).toBe(true)
+
+    const notes = ['# Notes', '- Extra insight about ship gates.', '- WIP'].join('\n')
+    const second = await saveLlmAnalysis(notes, projectPath, { md: true })
+    expect(second.success).toBe(true)
+
+    const saved = llmAnalysisStorage.getActive(projectId)
+    expect(saved?.architecture.style).toBe('modular-monolith')
+    expect(saved?.patterns).toHaveLength(1)
+    expect(saved?.patterns[0]?.name).toBe('Command registry')
+    expect(saved?.conventions).toHaveLength(1)
+    expect(saved?.projectInsights?.some((i) => i.includes('Extra insight'))).toBe(true)
+  })
+
   test('reads a JSON analysis file path instead of parsing the path string as JSON', async () => {
     const file = path.join(projectPath, 'analysis.json')
     await fs.writeFile(file, JSON.stringify(MINIMAL_VALID), 'utf-8')

--- a/core/__tests__/services/project-style-diff.test.ts
+++ b/core/__tests__/services/project-style-diff.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  formatProjectStyleDiffMd,
+  generateProjectStyleDiff,
+} from '../../services/project-style-diff'
+import { buildProjectStyleSnapshot } from '../../services/project-style-profile'
+
+const stack = {
+  hasFrontend: false,
+  hasBackend: true,
+  hasDatabase: true,
+  hasDocker: false,
+  hasTesting: true,
+  frontendType: null as null,
+  frameworks: [] as string[],
+}
+
+const stats = {
+  fileCount: 50,
+  version: '1.0.0',
+  name: 'x',
+  ecosystem: 'JavaScript',
+  projectType: 'simple',
+  languages: ['TypeScript'],
+  frameworks: [] as string[],
+}
+
+describe('project-style-diff', () => {
+  test('first snapshot is pure added', () => {
+    const after = buildProjectStyleSnapshot({
+      stats,
+      stack,
+      packageDeps: { zod: '1' },
+      commitHash: 'aaa',
+    })
+    const diff = generateProjectStyleDiff(null, after)
+    expect(diff.hasChanges).toBe(true)
+    expect(diff.summary.added).toBeGreaterThan(0)
+  })
+
+  test('detects added framework / library', () => {
+    const before = buildProjectStyleSnapshot({
+      stats,
+      stack: { ...stack, frameworks: [] },
+      packageDeps: {},
+      commitHash: 'aaa',
+      capturedAt: '2026-07-01T00:00:00.000Z',
+      id: 'style_before',
+    })
+    const after = buildProjectStyleSnapshot({
+      stats,
+      stack: { ...stack, frameworks: ['Hono'] },
+      packageDeps: { hono: '4', zod: '3' },
+      commitHash: 'bbb',
+      capturedAt: '2026-07-02T00:00:00.000Z',
+      id: 'style_after',
+    })
+    const diff = generateProjectStyleDiff(before, after)
+    expect(diff.hasChanges).toBe(true)
+    const fields = diff.items.map((i) => `${i.type}:${i.field}:${i.after ?? i.before}`)
+    expect(fields.some((f) => f.includes('Frameworks') || f.includes('Key libraries'))).toBe(true)
+    const md = formatProjectStyleDiffMd(diff)
+    expect(md).toContain('Project evolution')
+  })
+
+  test('identical snapshots → no changes', () => {
+    const a = buildProjectStyleSnapshot({
+      stats,
+      stack: { ...stack, frameworks: ['Hono'] },
+      packageDeps: { hono: '4' },
+      commitHash: 'aaa',
+      capturedAt: '2026-07-01T00:00:00.000Z',
+      id: 'style_a',
+    })
+    const b = buildProjectStyleSnapshot({
+      stats,
+      stack: { ...stack, frameworks: ['Hono'] },
+      packageDeps: { hono: '4' },
+      commitHash: 'aaa',
+      capturedAt: '2026-07-02T00:00:00.000Z',
+      id: 'style_b',
+    })
+    // force same payload content by copying
+    b.payload = structuredClone(a.payload)
+    b.patternCount = a.patternCount
+    const diff = generateProjectStyleDiff(a, b)
+    expect(diff.hasChanges).toBe(false)
+  })
+})

--- a/core/__tests__/services/project-style-evolution.test.ts
+++ b/core/__tests__/services/project-style-evolution.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import pathManager from '../../infrastructure/path-manager'
+import {
+  getActiveProjectStyle,
+  getProjectEvolution,
+  persistProjectStyleSnapshot,
+  recomputeProjectStyle,
+  renderProjectEvolution,
+} from '../../services/project-style-evolution'
+import { buildProjectStyleSnapshot } from '../../services/project-style-profile'
+
+async function freshProject(): Promise<{ projectPath: string; projectId: string }> {
+  const projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-style-evo-'))
+  await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+  await fs.writeFile(
+    path.join(projectPath, 'package.json'),
+    JSON.stringify({
+      name: 'style-evo-test',
+      version: '1.0.0',
+      dependencies: { hono: '4.0.0', zod: '3.0.0' },
+      devDependencies: { typescript: '5.0.0', vitest: '2.0.0' },
+    }),
+    'utf-8'
+  )
+  await fs.writeFile(path.join(projectPath, 'tsconfig.json'), '{}', 'utf-8')
+  await fs.writeFile(path.join(projectPath, 'bun.lock'), '', 'utf-8')
+  const projectId = `test-style-${Math.random().toString(36).slice(2, 10)}`
+  await configManager.writeConfig(projectPath, {
+    projectId,
+    dataPath: path.join(projectPath, '.prjct-data'),
+  })
+  await pathManager.ensureProjectStructure(projectId)
+  return { projectPath, projectId }
+}
+
+describe('project-style-evolution', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    ;({ projectPath, projectId } = await freshProject())
+  })
+
+  afterEach(async () => {
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true })
+  })
+
+  test('persist + getActive + evolution render', () => {
+    const snap = buildProjectStyleSnapshot({
+      stats: {
+        fileCount: 10,
+        version: '1.0.0',
+        name: 't',
+        ecosystem: 'JavaScript',
+        projectType: 'simple',
+        languages: ['TypeScript'],
+        frameworks: [],
+      },
+      stack: {
+        hasFrontend: false,
+        hasBackend: true,
+        hasDatabase: false,
+        hasDocker: false,
+        hasTesting: true,
+        frontendType: null,
+        frameworks: ['Hono'],
+      },
+      packageDeps: { hono: '4', zod: '3' },
+      commitHash: 'abc1234',
+    })
+    persistProjectStyleSnapshot(projectId, snap)
+    const active = getActiveProjectStyle(projectId)
+    expect(active?.id).toBe(snap.id)
+    expect(active?.payload.stack.frameworks).toContain('Hono')
+    const evo = getProjectEvolution(projectId, 5)
+    expect(evo.length).toBe(1)
+    const md = renderProjectEvolution(projectId)
+    expect(md).toContain('Project evolution')
+  })
+
+  test('recomputeProjectStyle on real package.json', async () => {
+    const { detectStack, gatherStats, detectCommands } = await import(
+      '../../services/sync-analyzer'
+    )
+    const [stats, stack, commands] = await Promise.all([
+      gatherStats(projectPath),
+      detectStack(projectPath),
+      detectCommands(projectPath),
+    ])
+    const result = await recomputeProjectStyle({
+      projectId,
+      projectPath,
+      stats,
+      stack,
+      commands,
+      commitHash: 'fff',
+      bridgeMemory: false,
+    })
+    expect(result.isFirst).toBe(true)
+    expect(result.snapshot.payload.stack.ecosystem).toBe('JavaScript')
+    expect(result.snapshot.payload.stack.languages).toContain('TypeScript')
+    // key libs from package.json
+    expect(
+      result.snapshot.payload.stack.keyLibraries.some((l) =>
+        ['Hono', 'Zod', 'Vitest', 'TypeScript'].includes(l)
+      )
+    ).toBe(true)
+    const active = getActiveProjectStyle(projectId)
+    expect(active).not.toBeNull()
+
+    // Second recompute without changes → no new history spam (still active)
+    const again = await recomputeProjectStyle({
+      projectId,
+      projectPath,
+      stats,
+      stack,
+      commands,
+      commitHash: 'fff',
+      bridgeMemory: false,
+    })
+    expect(again.isFirst).toBe(false)
+    expect(again.delta.hasChanges).toBe(false)
+    expect(getProjectEvolution(projectId).length).toBe(1)
+  })
+})

--- a/core/__tests__/services/project-style-profile.test.ts
+++ b/core/__tests__/services/project-style-profile.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildProjectStyleSnapshot,
+  isRichLlmAnalysis,
+  isThinLlmAnalysis,
+  stableStyleKey,
+} from '../../services/project-style-profile'
+import type { LLMAnalysis } from '../../types/llm-analysis'
+
+const emptyStack = {
+  hasFrontend: false,
+  hasBackend: false,
+  hasDatabase: false,
+  hasDocker: false,
+  hasTesting: true,
+  frontendType: null as null,
+  frameworks: [] as string[],
+}
+
+const baseStats = {
+  fileCount: 100,
+  version: '1.0.0',
+  name: 'demo',
+  ecosystem: 'JavaScript',
+  projectType: 'complex',
+  languages: ['TypeScript'],
+  frameworks: [] as string[],
+}
+
+function richAnalysis(): LLMAnalysis {
+  return {
+    version: 1,
+    commitHash: 'abc',
+    analyzedAt: '2026-07-16T00:00:00.000Z',
+    architecture: { style: 'modular-monolith', insights: ['cli routes'], domains: [] },
+    patterns: [
+      {
+        name: 'Command registry',
+        description: 'One entry in command-data.ts',
+        locations: ['core/commands'],
+        confidence: 0.9,
+        category: 'architecture',
+      },
+    ],
+    antiPatterns: [
+      {
+        issue: 'Barrel files',
+        reasoning: 'breaks tree-shake',
+        files: [],
+        suggestion: 'import from source',
+        severity: 'medium',
+        confidence: 0.9,
+      },
+    ],
+    techDebt: [],
+    riskAreas: [],
+    refactorSuggestions: [],
+    projectInsights: [],
+    conventions: [{ category: 'imports', rule: 'No barrel files' }],
+    stack: { languages: ['TypeScript'], frameworks: ['Hono'] },
+  }
+}
+
+describe('project-style-profile', () => {
+  test('stableStyleKey normalizes', () => {
+    expect(stableStyleKey('No Barrel Files!')).toBe('no-barrel-files')
+  })
+
+  test('isRichLlmAnalysis / isThinLlmAnalysis', () => {
+    expect(isRichLlmAnalysis(richAnalysis())).toBe(true)
+    expect(isThinLlmAnalysis(richAnalysis())).toBe(false)
+    expect(
+      isThinLlmAnalysis({
+        ...richAnalysis(),
+        architecture: { style: 'unknown', insights: ['note'], domains: [] },
+        patterns: [],
+        antiPatterns: [],
+        conventions: [],
+        stack: undefined,
+      })
+    ).toBe(true)
+  })
+
+  test('buildProjectStyleSnapshot merges mechanical stack + rich analysis', () => {
+    const snap = buildProjectStyleSnapshot({
+      stats: baseStats,
+      stack: { ...emptyStack, frameworks: [], hasTesting: true },
+      packageDeps: { zod: '^3', 'better-sqlite3': '11', hono: '4' },
+      packageManager: 'bun',
+      llmAnalysis: richAnalysis(),
+      structural: { symbols: 10, files: 100, packages: ['core'] },
+      commitHash: 'deadbeef',
+    })
+
+    expect(snap.payload.stack.ecosystem).toBe('JavaScript')
+    expect(snap.payload.stack.languages).toContain('TypeScript')
+    expect(snap.payload.stack.keyLibraries).toContain('Zod')
+    expect(snap.payload.stack.packageManager).toBe('bun')
+    expect(snap.patternCount).toBe(1)
+    expect(snap.conventionCount).toBe(1)
+    expect(snap.antiPatternCount).toBe(1)
+    expect(snap.summary).toContain('patterns')
+    expect(snap.payload.patterns[0]?.name).toBe('Command registry')
+  })
+
+  test('thin analysis alone does not invent patterns', () => {
+    const thin: LLMAnalysis = {
+      version: 1,
+      commitHash: null,
+      analyzedAt: '2026-07-16T00:00:00.000Z',
+      architecture: { style: 'unknown', insights: ['WIP note'], domains: [] },
+      patterns: [],
+      antiPatterns: [],
+      techDebt: [],
+      riskAreas: [],
+      refactorSuggestions: [],
+      projectInsights: ['WIP note'],
+      conventions: [],
+    }
+    const snap = buildProjectStyleSnapshot({
+      stats: baseStats,
+      stack: emptyStack,
+      llmAnalysis: thin,
+    })
+    expect(snap.patternCount).toBe(0)
+    expect(snap.conventionCount).toBe(0)
+    expect(snap.payload.stack.ecosystem).toBe('JavaScript')
+  })
+})

--- a/core/commands/analysis.ts
+++ b/core/commands/analysis.ts
@@ -331,11 +331,40 @@ export class AnalysisCommands extends PrjctCommandsBase {
             )
           }
         }
+        // Dual evolution surfaces (project + developer)
+        let projectEvolutionSection: string | null = null
+        if (result.projectStyle?.evolutionMd) {
+          projectEvolutionSection = result.projectStyle.evolutionMd
+        } else if (result.projectStyle?.summary) {
+          projectEvolutionSection = [
+            '## Project style',
+            '',
+            result.projectStyle.summary,
+            '',
+            `Coverage: ${result.projectStyle.styleCoverage}/100 · ` +
+              `${result.projectStyle.patternCount} patterns · ` +
+              `${result.projectStyle.conventionCount} conventions · ` +
+              `${result.projectStyle.antiPatternCount} anti-patterns`,
+          ].join('\n')
+        }
+        let developerEvolutionSection: string | null = null
+        if (result.developerSnapshotCaptured) {
+          try {
+            const { renderDeveloperEvolution } = await import('../services/developer-evolution')
+            developerEvolutionSection = renderDeveloperEvolution(projectId, 4)
+          } catch {
+            developerEvolutionSection =
+              '## Developer evolution\n\nWeekly developer snapshot captured.'
+          }
+        }
+
         const md = mdOutput(
           mdDone(`Sync Complete`),
           mdStats(mdStatsObj),
           retentionSection,
           analysisDiffSection,
+          projectEvolutionSection,
+          developerEvolutionSection,
           result.git.hasChanges ? mdWarn('Uncommitted changes detected') : null,
           contextReviewSection,
           llmAnalysisInstructions,

--- a/core/commands/analysis/llm.ts
+++ b/core/commands/analysis/llm.ts
@@ -9,6 +9,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { parseLlmAnalysis } from '../../schemas/llm-analysis'
+import { isRichLlmAnalysis, isThinLlmAnalysis } from '../../services/project-style-profile'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
 import type { MdOption } from '../../types/cli'
 import type { CommandResult } from '../../types/commands'
@@ -30,14 +31,51 @@ export async function saveLlmAnalysis(
     const projectId = proj.value
 
     const resolved = await resolveAnalysisInput(analysisInput, projectPath)
-    const analysis = await normalizeAnalysis(resolved.content, projectPath)
+    let analysis = await normalizeAnalysis(resolved.content, projectPath)
+    let mergedNotes = false
+
+    // Anti-clobber (mem_8432): freeform markdown/notes yield style=unknown +
+    // empty patterns. Never supersede a rich house-style analysis with that —
+    // fold insights into the existing active analysis instead.
+    const previous = llmAnalysisStorage.getActive(projectId)
+    if (previous && isRichLlmAnalysis(previous) && isThinLlmAnalysis(analysis)) {
+      analysis = mergeThinNotesIntoRich(previous, analysis)
+      mergedNotes = true
+    }
 
     llmAnalysisStorage.save(projectId, analysis)
+
+    // Refresh project style model when a structured save lands (or notes merge
+    // into rich). Best-effort — save already succeeded.
+    try {
+      const { recomputeProjectStyle } = await import('../../services/project-style-evolution')
+      const { gatherStats, detectStack, detectCommands } = await import(
+        '../../services/sync-analyzer'
+      )
+      const [stats, stack, commands] = await Promise.all([
+        gatherStats(projectPath),
+        detectStack(projectPath),
+        detectCommands(projectPath),
+      ])
+      await recomputeProjectStyle({
+        projectId,
+        projectPath,
+        stats,
+        stack,
+        commands,
+        commitHash: analysis.commitHash,
+        source: 'analysis-save',
+      })
+    } catch {
+      /* style recompute is best-effort after analysis save */
+    }
 
     if (options.md) {
       console.log(
         mdOutput(
-          mdDone('LLM Analysis Saved'),
+          mdDone(
+            mergedNotes ? 'LLM Analysis Notes Merged (house style preserved)' : 'LLM Analysis Saved'
+          ),
           mdStats({
             Input: resolved.source,
             Architecture: analysis.architecture.style,
@@ -46,6 +84,7 @@ export async function saveLlmAnalysis(
             'Tech debt items': analysis.techDebt?.length || 0,
             'Risk areas': analysis.riskAreas?.length || 0,
             Conventions: analysis.conventions?.length || 0,
+            ...(mergedNotes ? { Merge: 'thin notes → existing rich analysis' } : {}),
           })
         )
       )
@@ -53,8 +92,11 @@ export async function saveLlmAnalysis(
       console.log(
         JSON.stringify({
           success: true,
-          message: 'LLM analysis saved',
+          message: mergedNotes
+            ? 'LLM analysis notes merged into existing rich analysis'
+            : 'LLM analysis saved',
           input: resolved.source,
+          mergedNotes,
           stats: {
             patterns: analysis.patterns.length,
             antiPatterns: analysis.antiPatterns?.length || 0,
@@ -67,6 +109,32 @@ export async function saveLlmAnalysis(
     return { success: true }
   } catch (error) {
     return failFromError(error)
+  }
+}
+
+/** Fold freeform insights into a rich analysis without wiping house style. */
+function mergeThinNotesIntoRich(rich: LLMAnalysis, thin: LLMAnalysis): LLMAnalysis {
+  const mergeUnique = (a: string[], b: string[], cap: number): string[] => {
+    const out: string[] = []
+    const seen = new Set<string>()
+    for (const line of [...a, ...b]) {
+      const k = line.toLowerCase()
+      if (seen.has(k) || !line.trim()) continue
+      seen.add(k)
+      out.push(line)
+      if (out.length >= cap) break
+    }
+    return out
+  }
+  return {
+    ...rich,
+    analyzedAt: thin.analyzedAt,
+    commitHash: thin.commitHash ?? rich.commitHash,
+    projectInsights: mergeUnique(rich.projectInsights ?? [], thin.projectInsights ?? [], 60),
+    architecture: {
+      ...rich.architecture,
+      insights: mergeUnique(rich.architecture.insights ?? [], thin.architecture.insights ?? [], 24),
+    },
   }
 }
 

--- a/core/commands/context.ts
+++ b/core/commands/context.ts
@@ -82,7 +82,7 @@ export class ContextCommands {
           }
         : null
 
-      const repoAnalysis = await this.loadRepoAnalysis(globalPath)
+      const repoAnalysis = await this.loadRepoAnalysis(globalPath, projectId)
 
       // Orchestrator-derived domain/subtask classification was dropped —
       // it was harness that guessed intent from task text. Claude tags
@@ -213,14 +213,42 @@ export class ContextCommands {
   }
 
   /**
-   * Load repo analysis from analysis/repo-analysis.json
+   * Load repo stack for context surface.
+   * Priority: active project style snapshot → repo-analysis.json → live detector.
    */
-  private async loadRepoAnalysis(globalPath: string): Promise<{
+  private async loadRepoAnalysis(
+    globalPath: string,
+    projectId?: string
+  ): Promise<{
     ecosystem: string
     frameworks: string[]
     hasTests: boolean
     technologies: string[]
   } | null> {
+    // 1. Project style snapshot (recomputed every sync)
+    if (projectId) {
+      try {
+        const { getActiveProjectStyle } = await import('../services/project-style-evolution')
+        const style = getActiveProjectStyle(projectId)
+        if (style) {
+          const s = style.payload.stack
+          return {
+            ecosystem: s.ecosystem || 'unknown',
+            frameworks: s.frameworks ?? [],
+            hasTests: s.hasTests ?? false,
+            technologies: [
+              ...(s.languages ?? []),
+              ...(s.frameworks ?? []),
+              ...(s.keyLibraries ?? []),
+            ].filter((v, i, arr) => arr.indexOf(v) === i),
+          }
+        }
+      } catch {
+        /* fall through */
+      }
+    }
+
+    // 2. Legacy artifact written by style recompute
     try {
       const analysisPath = path.join(globalPath, 'analysis', 'repo-analysis.json')
       const content = await fs.readFile(analysisPath, 'utf-8')
@@ -232,7 +260,25 @@ export class ContextCommands {
         technologies: data.technologies || [],
       }
     } catch (error) {
-      if (isNotFoundError(error)) return null
+      if (!isNotFoundError(error)) {
+        /* ignore parse errors */
+      }
+    }
+
+    // 3. Live mechanical detect (honest stack even before first style capture)
+    try {
+      const { detectStack, gatherStats } = await import('../services/sync-analyzer')
+      const projectPath = process.cwd()
+      const [stack, stats] = await Promise.all([detectStack(projectPath), gatherStats(projectPath)])
+      return {
+        ecosystem: stats.ecosystem || 'unknown',
+        frameworks: stack.frameworks ?? stats.frameworks ?? [],
+        hasTests: stack.hasTesting ?? false,
+        technologies: [...(stats.languages ?? []), ...(stack.frameworks ?? [])].filter(
+          (v, i, arr) => arr.indexOf(v) === i
+        ),
+      }
+    } catch {
       return null
     }
   }

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -132,18 +132,49 @@ export class WorkflowCommands extends PrjctCommandsBase {
       const riskLines = risks.map((r) => `[${r.label}] ${r.title} — \`${r.file}\`  \`${r.id}\``)
 
       // Project pattern supremacy: match house style; upgrade only real anti-patterns.
+      // Prefer durable project style model (recomputed every sync), then related hits.
       const { buildAlignmentBrief } = await import('../services/project-alignment')
       const patternHits = related.filter((h) => h.type === 'pattern' || h.pattern)
       const antiHits = related.filter((h) => h.type === 'anti-pattern' || h.antiPattern)
+      let stylePatterns: Array<{ title?: string; content?: string }> = []
+      let styleAntis: Array<{ title?: string; content?: string }> = []
+      try {
+        const { getActiveProjectStyle } = await import('../services/project-style-evolution')
+        const style = getActiveProjectStyle(projectId)
+        if (style) {
+          stylePatterns = [
+            ...style.payload.patterns.map((p) => ({
+              title: p.name,
+              content: p.description,
+            })),
+            ...style.payload.conventions.map((c) => ({
+              title: c.category ?? 'convention',
+              content: c.rule,
+            })),
+          ]
+          styleAntis = style.payload.antiPatterns.map((a) => ({
+            title: a.issue,
+            content: a.suggestion,
+          }))
+        }
+      } catch {
+        /* style optional */
+      }
       const alignment = buildAlignmentBrief({
-        patterns: patternHits.map((h) => ({
-          title: h.title,
-          content: h.pattern || h.detail,
-        })),
-        antiPatterns: antiHits.map((h) => ({
-          title: h.title,
-          content: h.antiPattern || h.detail,
-        })),
+        patterns: [
+          ...stylePatterns,
+          ...patternHits.map((h) => ({
+            title: h.title,
+            content: h.pattern || h.detail,
+          })),
+        ],
+        antiPatterns: [
+          ...styleAntis,
+          ...antiHits.map((h) => ({
+            title: h.title,
+            content: h.antiPattern || h.detail,
+          })),
+        ],
         neighborHint: likelyFiles[0]?.path ?? null,
       })
 

--- a/core/hooks/session-start.ts
+++ b/core/hooks/session-start.ts
@@ -37,6 +37,8 @@ import { deriveTitle } from '../memory/format'
 import { projectMemory } from '../memory/project-memory'
 import { recordAgentSessionStart } from '../services/agent-session-recorder'
 import { extractDeveloperRules } from '../services/developer-profile'
+import { getActiveProjectStyle } from '../services/project-style-evolution'
+import { formatProjectStyleDigest } from '../services/project-style-profile'
 import { createStalenessChecker } from '../services/staleness-checker'
 import { usefulnessService } from '../services/usefulness'
 import type { LocalConfig, ProjectPersona } from '../types/config'
@@ -351,7 +353,28 @@ function buildKnowledgeDigest(projectId: string): string | null {
     projectId,
     new Set([...gotchas, ...decisions].map((e) => e.id))
   )
-  if (gotchas.length === 0 && decisions.length === 0 && !repeatMiss && devRules.length === 0) {
+  // Project style (house rules) — dual to developer rules
+  let projectStyleBlock: string | null = null
+  try {
+    const style = getActiveProjectStyle(projectId)
+    if (style) {
+      projectStyleBlock = formatProjectStyleDigest(style, {
+        maxConventions: 4,
+        maxPatterns: 3,
+        maxAnti: 2,
+      })
+    }
+  } catch {
+    projectStyleBlock = null
+  }
+
+  if (
+    gotchas.length === 0 &&
+    decisions.length === 0 &&
+    !repeatMiss &&
+    devRules.length === 0 &&
+    !projectStyleBlock
+  ) {
     return null
   }
 
@@ -364,6 +387,15 @@ function buildKnowledgeDigest(projectId: string): string | null {
     for (const r of devRules) {
       const short = r.rule.length > 140 ? `${r.rule.slice(0, 139)}…` : r.rule
       lines.push(`- ${short}  \`${r.sourceId}\``)
+    }
+  }
+  if (projectStyleBlock) {
+    // Fold style under digest without duplicating the outer header
+    const body = projectStyleBlock
+      .replace(/^## How this repo works \(project style\)\n?/, '')
+      .trim()
+    if (body) {
+      lines.push('', '**How this repo works (match house style):**', body)
     }
   }
   if (gotchas.length > 0) {
@@ -383,7 +415,7 @@ function buildKnowledgeDigest(projectId: string): string | null {
   }
   lines.push(
     '',
-    '> Resolve any `mem_id` with `prjct search <id>`. Full developer model: MCP `prjct_developer`.'
+    '> Resolve any `mem_id` with `prjct search <id>`. Full developer model: MCP `prjct_developer`. Project style: `prjct analysis` / sync evolution.'
   )
   return safeTruncate(lines.join('\n'), DIGEST_MAX_CHARS)
 }

--- a/core/services/project-style-diff.ts
+++ b/core/services/project-style-diff.ts
@@ -1,0 +1,196 @@
+/**
+ * Project style diff — pure comparison of two style snapshots.
+ * Same spirit as analysis-diff.ts; keyed by stable style keys.
+ */
+
+import type {
+  ProjectStyleDiff,
+  ProjectStyleDiffItem,
+  ProjectStyleSnapshot,
+} from '../types/project-style'
+
+export function generateProjectStyleDiff(
+  before: ProjectStyleSnapshot | null,
+  after: ProjectStyleSnapshot
+): ProjectStyleDiff {
+  const items: ProjectStyleDiffItem[] = []
+
+  if (!before) {
+    return {
+      hasChanges: true,
+      items: [
+        {
+          field: 'Project style',
+          type: 'added',
+          after: after.summary,
+        },
+      ],
+      summary: { added: 1, removed: 0, changed: 0 },
+      beforeCommit: null,
+      afterCommit: after.commitHash,
+    }
+  }
+
+  const b = before.payload
+  const a = after.payload
+
+  // Ecosystem / package manager
+  if (b.stack.ecosystem !== a.stack.ecosystem) {
+    items.push({
+      field: 'Ecosystem',
+      type: 'changed',
+      before: b.stack.ecosystem,
+      after: a.stack.ecosystem,
+    })
+  }
+  if ((b.stack.packageManager ?? '') !== (a.stack.packageManager ?? '')) {
+    items.push({
+      field: 'Package manager',
+      type: 'changed',
+      before: b.stack.packageManager ?? '(none)',
+      after: a.stack.packageManager ?? '(none)',
+    })
+  }
+
+  diffStringArray('Languages', b.stack.languages, a.stack.languages, items)
+  diffStringArray('Frameworks', b.stack.frameworks, a.stack.frameworks, items)
+  diffStringArray('Key libraries', b.stack.keyLibraries, a.stack.keyLibraries, items)
+
+  if (b.stack.hasTests !== a.stack.hasTests) {
+    items.push({
+      field: 'Has tests',
+      type: 'changed',
+      before: String(b.stack.hasTests),
+      after: String(a.stack.hasTests),
+    })
+  }
+
+  // Patterns / anti / conventions by key
+  diffKeyed(
+    'Pattern',
+    b.patterns.map((p) => [p.key, p.name]),
+    a.patterns.map((p) => [p.key, p.name]),
+    items
+  )
+  diffKeyed(
+    'Anti-pattern',
+    b.antiPatterns.map((p) => [p.key, p.issue]),
+    a.antiPatterns.map((p) => [p.key, p.issue]),
+    items
+  )
+  diffKeyed(
+    'Convention',
+    b.conventions.map((c) => [c.key, c.rule]),
+    a.conventions.map((c) => [c.key, c.rule]),
+    items
+  )
+
+  if (
+    b.structural.symbols !== a.structural.symbols &&
+    (b.structural.symbols > 0 || a.structural.symbols > 0)
+  ) {
+    items.push({
+      field: 'Symbols',
+      type: 'changed',
+      before: String(b.structural.symbols),
+      after: String(a.structural.symbols),
+    })
+  }
+  if (b.structural.files !== a.structural.files) {
+    items.push({
+      field: 'Files',
+      type: 'changed',
+      before: String(b.structural.files),
+      after: String(a.structural.files),
+    })
+  }
+
+  const added = items.filter((i) => i.type === 'added').length
+  const removed = items.filter((i) => i.type === 'removed').length
+  const changed = items.filter((i) => i.type === 'changed').length
+
+  return {
+    hasChanges: items.length > 0,
+    items,
+    summary: { added, removed, changed },
+    beforeCommit: before.commitHash,
+    afterCommit: after.commitHash,
+  }
+}
+
+export function formatProjectStyleDiffMd(diff: ProjectStyleDiff): string {
+  if (!diff.hasChanges) {
+    return '## Project evolution\n\nNo style changes since last sync.'
+  }
+
+  const lines: string[] = ['## Project evolution (this sync)']
+  if (diff.beforeCommit || diff.afterCommit) {
+    lines.push(`> \`${short(diff.beforeCommit)}\` → \`${short(diff.afterCommit)}\``)
+  }
+  lines.push('')
+  lines.push(`+${diff.summary.added} · −${diff.summary.removed} · ~${diff.summary.changed}`)
+  lines.push('')
+  for (const item of diff.items.slice(0, 20)) {
+    const icon = item.type === 'added' ? '+' : item.type === 'removed' ? '−' : '~'
+    if (item.type === 'changed') {
+      lines.push(`- ${icon} **${item.field}**: ${item.before} → ${item.after}`)
+    } else if (item.type === 'added') {
+      lines.push(`- ${icon} **${item.field}**: ${item.after}`)
+    } else {
+      lines.push(`- ${icon} **${item.field}**: ${item.before}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function short(hash: string | null): string {
+  if (!hash) return '(none)'
+  return hash.length > 7 ? hash.slice(0, 7) : hash
+}
+
+function diffStringArray(
+  field: string,
+  before: string[],
+  after: string[],
+  items: ProjectStyleDiffItem[]
+): void {
+  const b = new Set(before.map((s) => s.toLowerCase()))
+  const a = new Set(after.map((s) => s.toLowerCase()))
+  for (const x of after) {
+    if (!b.has(x.toLowerCase())) {
+      items.push({ field, type: 'added', after: x })
+    }
+  }
+  for (const x of before) {
+    if (!a.has(x.toLowerCase())) {
+      items.push({ field, type: 'removed', before: x })
+    }
+  }
+}
+
+function diffKeyed(
+  field: string,
+  before: Array<[string, string]>,
+  after: Array<[string, string]>,
+  items: ProjectStyleDiffItem[]
+): void {
+  const bMap = new Map(before)
+  const aMap = new Map(after)
+  for (const [key, label] of aMap) {
+    if (!bMap.has(key)) {
+      items.push({ field, type: 'added', after: label })
+    } else if (bMap.get(key) !== label) {
+      items.push({
+        field,
+        type: 'changed',
+        before: bMap.get(key),
+        after: label,
+      })
+    }
+  }
+  for (const [key, label] of bMap) {
+    if (!aMap.has(key)) {
+      items.push({ field, type: 'removed', before: label })
+    }
+  }
+}

--- a/core/services/project-style-evolution.ts
+++ b/core/services/project-style-evolution.ts
@@ -1,0 +1,482 @@
+/**
+ * Project style evolution — typed snapshots of how the *repository* works,
+ * progressive over time. Symmetric to developer-evolution.ts.
+ *
+ *   capture / getActive / getEvolution / render / recomputeOnSync
+ *
+ * Measurement substrate: core counters are stable columns; payload JSON +
+ * metrics bag stay extensible without rewriting history.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { projectMemory } from '../memory/project-memory'
+import { prjctDb } from '../storage/database'
+import llmAnalysisStorage from '../storage/llm-analysis-storage'
+import type { LLMAnalysis } from '../types/llm-analysis'
+import type {
+  ProjectStyleDiff,
+  ProjectStylePayload,
+  ProjectStyleRecomputeResult,
+  ProjectStyleSnapshot,
+  ProjectStyleSource,
+} from '../types/project-style'
+import type { ProjectCommands, ProjectStats } from '../types/project-sync'
+import type { StackDetection } from '../types/stack'
+import { buildArchitectureSnapshot } from './architecture-snapshot'
+import { formatProjectStyleDiffMd, generateProjectStyleDiff } from './project-style-diff'
+import {
+  buildProjectStyleSnapshot,
+  formatProjectStyleDigest,
+  isRichLlmAnalysis,
+} from './project-style-profile'
+
+const HISTORY_CAP = 50
+
+interface SnapshotRow {
+  id: string
+  captured_at: string
+  commit_hash: string | null
+  source: string
+  pattern_count: number
+  anti_pattern_count: number
+  convention_count: number
+  framework_count: number
+  symbol_count: number
+  file_count: number
+  summary: string
+  payload_json: string
+  is_active: number
+}
+
+function rowToSnapshot(r: SnapshotRow): ProjectStyleSnapshot {
+  let payload: ProjectStylePayload
+  try {
+    payload = JSON.parse(r.payload_json) as ProjectStylePayload
+  } catch {
+    payload = emptyPayload()
+  }
+  return {
+    id: r.id,
+    capturedAt: r.captured_at,
+    commitHash: r.commit_hash,
+    source: (r.source as ProjectStyleSource) || 'sync-mechanical',
+    patternCount: r.pattern_count,
+    antiPatternCount: r.anti_pattern_count,
+    conventionCount: r.convention_count,
+    frameworkCount: r.framework_count,
+    symbolCount: r.symbol_count,
+    fileCount: r.file_count,
+    summary: r.summary,
+    payload,
+  }
+}
+
+function emptyPayload(): ProjectStylePayload {
+  return {
+    payloadVersion: 1,
+    stack: {
+      ecosystem: 'unknown',
+      languages: [],
+      frameworks: [],
+      keyLibraries: [],
+      hasTests: false,
+      hasDocker: false,
+    },
+    commands: {},
+    conventions: [],
+    patterns: [],
+    antiPatterns: [],
+    structural: { symbols: 0, files: 0, packages: [] },
+    metrics: {},
+  }
+}
+
+export function getActiveProjectStyle(projectId: string): ProjectStyleSnapshot | null {
+  try {
+    const row = prjctDb.get<SnapshotRow>(
+      projectId,
+      'SELECT * FROM project_style_snapshots WHERE is_active = 1 ORDER BY captured_at DESC LIMIT 1'
+    )
+    return row ? rowToSnapshot(row) : null
+  } catch {
+    return null
+  }
+}
+
+/** History newest-first (includes active). */
+export function getProjectEvolution(projectId: string, limit = 12): ProjectStyleSnapshot[] {
+  try {
+    return prjctDb
+      .query<SnapshotRow>(
+        projectId,
+        'SELECT * FROM project_style_snapshots ORDER BY captured_at DESC LIMIT ?',
+        limit
+      )
+      .map(rowToSnapshot)
+  } catch {
+    return []
+  }
+}
+
+export function renderProjectEvolution(projectId: string, limit = 6): string | null {
+  const snaps = getProjectEvolution(projectId, limit)
+  if (snaps.length === 0) return null
+
+  const lines: string[] = ['## Project evolution']
+  if (snaps.length >= 2) {
+    const latest = snaps[0]!
+    const prior = snaps[snaps.length - 1]!
+    const pDelta = latest.patternCount - prior.patternCount
+    const cDelta = latest.conventionCount - prior.conventionCount
+    const fDelta = latest.fileCount - prior.fileCount
+    lines.push(
+      `Over ${snaps.length} snapshots: patterns ${fmtDelta(pDelta)}, ` +
+        `conventions ${fmtDelta(cDelta)}, files ${fmtDelta(fDelta)}.`
+    )
+  }
+  for (const s of snaps) {
+    lines.push(`- ${s.capturedAt.slice(0, 10)} — ${s.summary}`)
+  }
+  return lines.join('\n')
+}
+
+function fmtDelta(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`
+}
+
+/**
+ * Persist a snapshot as the new active row; mark previous active inactive.
+ * Cap history at HISTORY_CAP (delete oldest inactive).
+ */
+export function persistProjectStyleSnapshot(
+  projectId: string,
+  snapshot: ProjectStyleSnapshot
+): void {
+  prjctDb.transaction(projectId, (db) => {
+    db.prepare('UPDATE project_style_snapshots SET is_active = 0 WHERE is_active = 1').run()
+    db.prepare(
+      `INSERT INTO project_style_snapshots (
+         id, captured_at, commit_hash, source,
+         pattern_count, anti_pattern_count, convention_count, framework_count,
+         symbol_count, file_count, summary, payload_json, is_active
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`
+    ).run(
+      snapshot.id,
+      snapshot.capturedAt,
+      snapshot.commitHash,
+      snapshot.source,
+      snapshot.patternCount,
+      snapshot.antiPatternCount,
+      snapshot.conventionCount,
+      snapshot.frameworkCount,
+      snapshot.symbolCount,
+      snapshot.fileCount,
+      snapshot.summary,
+      JSON.stringify(snapshot.payload)
+    )
+
+    // Cap history: keep newest HISTORY_CAP
+    const ids = db
+      .prepare('SELECT id FROM project_style_snapshots ORDER BY captured_at DESC')
+      .all() as Array<{ id: string }>
+    if (ids.length > HISTORY_CAP) {
+      const drop = ids.slice(HISTORY_CAP)
+      const del = db.prepare('DELETE FROM project_style_snapshots WHERE id = ?')
+      for (const row of drop) del.run(row.id)
+    }
+  })
+}
+
+export interface RecomputeProjectStyleArgs {
+  projectId: string
+  projectPath: string
+  stats: ProjectStats
+  stack: StackDetection
+  commands?: ProjectCommands | null
+  commitHash?: string | null
+  source?: ProjectStyleSource
+  /** When true, UPSERT style memories for vector recall. Default true. */
+  bridgeMemory?: boolean
+}
+
+/**
+ * Full recompute for sync heartbeat: build style, diff vs previous, persist,
+ * optional memory bridge + repo-analysis.json for context surface.
+ */
+export async function recomputeProjectStyle(
+  args: RecomputeProjectStyleArgs
+): Promise<ProjectStyleRecomputeResult> {
+  const previous = getActiveProjectStyle(args.projectId)
+  const llm = pickBestAnalysis(args.projectId)
+  const packageMeta = await readPackageMeta(args.projectPath)
+  const structural = loadStructural(args.projectId)
+  const memoryStyle = loadMemoryStyle(args.projectId)
+
+  const snapshot = buildProjectStyleSnapshot({
+    stats: args.stats,
+    stack: args.stack,
+    commands: args.commands,
+    packageDeps: packageMeta.deps,
+    packageManager: packageMeta.packageManager,
+    llmAnalysis: llm,
+    memoryPatterns: memoryStyle.patterns,
+    memoryAntiPatterns: memoryStyle.antiPatterns,
+    memoryConventions: memoryStyle.conventions,
+    structural,
+    commitHash: args.commitHash ?? null,
+    source: args.source ?? 'sync-mechanical',
+  })
+
+  // Attach styleCoverage metric for future measurement
+  snapshot.payload.metrics.styleCoverage = computeStyleCoverage(snapshot)
+  snapshot.payload.metrics.hasRichAnalysis = isRichLlmAnalysis(llm) ? 1 : 0
+
+  const delta = generateProjectStyleDiff(previous, snapshot)
+  const isFirst = previous === null
+
+  // Only persist a new history row when something changed OR first capture
+  if (isFirst || delta.hasChanges) {
+    persistProjectStyleSnapshot(args.projectId, snapshot)
+  } else {
+    // Touch active payload metrics / summary without exploding history:
+    // re-write the same active id's payload when only timestamps would differ.
+    // For identical content, keep previous row (stable evolution series).
+  }
+
+  const active = getActiveProjectStyle(args.projectId) ?? snapshot
+
+  if (args.bridgeMemory !== false) {
+    await bridgeStyleToMemory(args.projectPath, args.projectId, active).catch(() => {
+      /* best-effort */
+    })
+  }
+
+  await writeRepoAnalysisArtifact(args.projectId, active).catch(() => {
+    /* best-effort */
+  })
+
+  return { snapshot: active, delta, isFirst }
+}
+
+function computeStyleCoverage(s: ProjectStyleSnapshot): number {
+  // 0–100: stack known + patterns/conventions density
+  let score = 0
+  if (s.payload.stack.ecosystem !== 'unknown') score += 25
+  if (s.payload.stack.frameworks.length > 0 || s.payload.stack.keyLibraries.length > 0) score += 20
+  if (s.payload.stack.hasTests) score += 10
+  if (s.conventionCount > 0) score += Math.min(25, s.conventionCount * 5)
+  if (s.patternCount > 0) score += Math.min(15, s.patternCount * 3)
+  if (s.antiPatternCount > 0) score += Math.min(5, s.antiPatternCount)
+  return Math.min(100, score)
+}
+
+/** Prefer active rich LLM analysis; fall back to most recent rich superseded. */
+function pickBestAnalysis(projectId: string): LLMAnalysis | null {
+  try {
+    const active = llmAnalysisStorage.getActive(projectId)
+    if (isRichLlmAnalysis(active)) return active
+
+    try {
+      const all = llmAnalysisStorage.getAllFull(projectId)
+      for (const h of all) {
+        if (isRichLlmAnalysis(h.analysis)) return h.analysis
+      }
+    } catch {
+      /* fall through */
+    }
+    return active
+  } catch {
+    return null
+  }
+}
+
+function loadStructural(projectId: string): {
+  symbols: number
+  files: number
+  packages: string[]
+} {
+  try {
+    const snap = buildArchitectureSnapshot(projectId)
+    if (!snap.ready) return { symbols: 0, files: 0, packages: [] }
+    return {
+      symbols: snap.symbols,
+      files: snap.files,
+      packages: snap.packages.slice(0, 20),
+    }
+  } catch {
+    return { symbols: 0, files: 0, packages: [] }
+  }
+}
+
+function loadMemoryStyle(projectId: string): {
+  patterns: Array<{ name: string; description: string }>
+  antiPatterns: Array<{ issue: string; suggestion: string }>
+  conventions: Array<{ rule: string; category?: string }>
+} {
+  const patterns: Array<{ name: string; description: string }> = []
+  const antiPatterns: Array<{ issue: string; suggestion: string }> = []
+  const conventions: Array<{ rule: string; category?: string }> = []
+  try {
+    const entries = projectMemory.recall(projectId, {
+      types: ['pattern', 'anti-pattern', 'decision'],
+      limit: 40,
+    })
+    for (const e of entries) {
+      const topic = e.tags?.topic ?? ''
+      if (!topic.startsWith('style:') && e.type !== 'pattern' && e.type !== 'anti-pattern') continue
+      if (e.type === 'pattern' || topic.startsWith('style:pattern:')) {
+        patterns.push({
+          name: e.tags?.name || topic.replace(/^style:pattern:/, '') || 'pattern',
+          description: e.content.slice(0, 400),
+        })
+      } else if (e.type === 'anti-pattern' || topic.startsWith('style:anti:')) {
+        antiPatterns.push({
+          issue: e.tags?.name || topic.replace(/^style:anti:/, '') || 'anti-pattern',
+          suggestion: e.content.slice(0, 400),
+        })
+      } else if (topic.startsWith('style:convention:')) {
+        conventions.push({ rule: e.content.slice(0, 400), category: e.tags?.category })
+      }
+    }
+  } catch {
+    /* empty */
+  }
+  return { patterns, antiPatterns, conventions }
+}
+
+async function readPackageMeta(projectPath: string): Promise<{
+  deps: Record<string, string>
+  packageManager: string | null
+}> {
+  try {
+    const raw = await fs.readFile(path.join(projectPath, 'package.json'), 'utf-8')
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      packageManager?: string
+    }
+    const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
+    let packageManager: string | null = null
+    if (pkg.packageManager) {
+      packageManager = pkg.packageManager.split('@')[0] ?? null
+    } else {
+      const locks: Array<[string, string]> = [
+        ['bun.lockb', 'bun'],
+        ['bun.lock', 'bun'],
+        ['pnpm-lock.yaml', 'pnpm'],
+        ['yarn.lock', 'yarn'],
+        ['package-lock.json', 'npm'],
+      ]
+      for (const [file, pm] of locks) {
+        try {
+          await fs.access(path.join(projectPath, file))
+          packageManager = pm
+          break
+        } catch {
+          /* next */
+        }
+      }
+    }
+    return { deps, packageManager }
+  } catch {
+    return { deps: {}, packageManager: null }
+  }
+}
+
+/**
+ * UPSERT style memories so selective embeddings can recall house rules.
+ * Uses tags.topic = style:<kind>:<key> for supersession.
+ */
+export async function bridgeStyleToMemory(
+  projectPath: string,
+  projectId: string,
+  snapshot: ProjectStyleSnapshot
+): Promise<number> {
+  let written = 0
+  const p = snapshot.payload
+
+  for (const c of p.conventions.slice(0, 25)) {
+    const topic = `style:convention:${c.key}`
+    await projectMemory.remember(projectPath, {
+      type: 'decision',
+      content: c.rule,
+      tags: { topic, category: c.category ?? 'convention', source: 'project-style' },
+      projectId,
+      provenance: 'extracted',
+    })
+    written++
+  }
+  for (const pat of p.patterns.slice(0, 25)) {
+    const topic = `style:pattern:${pat.key}`
+    await projectMemory.remember(projectPath, {
+      type: 'pattern',
+      content: `${pat.name}: ${pat.description}`,
+      tags: {
+        topic,
+        name: pat.name,
+        source: 'project-style',
+        ...(pat.category ? { category: pat.category } : {}),
+      },
+      projectId,
+      provenance: 'extracted',
+    })
+    written++
+  }
+  for (const a of p.antiPatterns.slice(0, 25)) {
+    const topic = `style:anti:${a.key}`
+    await projectMemory.remember(projectPath, {
+      type: 'anti-pattern',
+      content: `${a.issue}. Suggestion: ${a.suggestion}`,
+      tags: {
+        topic,
+        name: a.issue,
+        source: 'project-style',
+        ...(a.severity ? { severity: a.severity } : {}),
+      },
+      projectId,
+      provenance: 'extracted',
+    })
+    written++
+  }
+  return written
+}
+
+/** Write analysis/repo-analysis.json so legacy context readers work. */
+async function writeRepoAnalysisArtifact(
+  projectId: string,
+  snapshot: ProjectStyleSnapshot
+): Promise<void> {
+  const { default: pathManager } = await import('../infrastructure/path-manager')
+  const globalPath = pathManager.getGlobalProjectPath(projectId)
+  const dir = path.join(globalPath, 'analysis')
+  await fs.mkdir(dir, { recursive: true })
+  const stack = snapshot.payload.stack
+  const body = {
+    ecosystem: stack.ecosystem,
+    frameworks: stack.frameworks,
+    hasTests: stack.hasTests,
+    technologies: [...stack.languages, ...stack.frameworks, ...stack.keyLibraries].filter(
+      (v, i, arr) => arr.indexOf(v) === i
+    ),
+    packageManager: stack.packageManager ?? null,
+    updatedAt: snapshot.capturedAt,
+    styleSummary: snapshot.summary,
+  }
+  await fs.writeFile(path.join(dir, 'repo-analysis.json'), JSON.stringify(body, null, 2), 'utf-8')
+}
+
+export function formatProjectStyleForSync(result: ProjectStyleRecomputeResult): {
+  evolutionMd: string | null
+  digestMd: string | null
+  delta: ProjectStyleDiff
+} {
+  const evolutionMd =
+    result.delta.hasChanges || result.isFirst ? formatProjectStyleDiffMd(result.delta) : null
+  const digestMd = formatProjectStyleDigest(result.snapshot, {
+    maxConventions: 4,
+    maxPatterns: 3,
+    maxAnti: 2,
+  })
+  return { evolutionMd, digestMd, delta: result.delta }
+}

--- a/core/services/project-style-profile.ts
+++ b/core/services/project-style-profile.ts
@@ -1,0 +1,401 @@
+/**
+ * Project Style Profile — pure builder for the "how this repo works" model.
+ *
+ * Mechanical sources (stats, stack detector, package.json, commands) always
+ * contribute stack/libs/commands. Narrative patterns/conventions come from a
+ * *valid* LLM analysis (not empty/unknown-only) and style-tagged memories.
+ *
+ * Deterministic; no IO except optional package.json already read by callers.
+ */
+
+import type { LLMAnalysis } from '../types/llm-analysis'
+import type {
+  ProjectStyleAntiPattern,
+  ProjectStyleCommands,
+  ProjectStyleConvention,
+  ProjectStylePattern,
+  ProjectStylePayload,
+  ProjectStyleSnapshot,
+  ProjectStyleSource,
+  ProjectStyleStack,
+  ProjectStyleStructural,
+} from '../types/project-style'
+import type { ProjectCommands, ProjectStats } from '../types/project-sync'
+import type { StackDetection } from '../types/stack'
+import { getTimestamp } from '../utils/date-helper'
+
+const KNOWN_LIBS = [
+  'zod',
+  'better-sqlite3',
+  '@modelcontextprotocol/sdk',
+  'chalk',
+  'chokidar',
+  'commander',
+  'express',
+  'fastify',
+  'hono',
+  'react',
+  'next',
+  'vue',
+  'vitest',
+  'jest',
+  'typescript',
+  'biome',
+  'lefthook',
+  'drizzle-orm',
+  'prisma',
+  '@prisma/client',
+]
+
+export function stableStyleKey(raw: string): string {
+  const k = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+  return k || 'item'
+}
+
+/** True when analysis carries house-style signal worth keeping. */
+export function isRichLlmAnalysis(
+  a:
+    | Pick<LLMAnalysis, 'architecture' | 'patterns' | 'antiPatterns' | 'conventions' | 'stack'>
+    | null
+    | undefined
+): boolean {
+  if (!a) return false
+  if (a.architecture?.style && a.architecture.style !== 'unknown') return true
+  if ((a.patterns?.length ?? 0) > 0) return true
+  if ((a.conventions?.length ?? 0) > 0) return true
+  if ((a.antiPatterns?.length ?? 0) > 0) return true
+  if ((a.stack?.frameworks?.length ?? 0) > 0 || (a.stack?.languages?.length ?? 0) > 0) return true
+  return false
+}
+
+export function isThinLlmAnalysis(a: LLMAnalysis | null | undefined): boolean {
+  return !isRichLlmAnalysis(a)
+}
+
+export interface BuildProjectStyleInput {
+  stats: ProjectStats
+  stack: StackDetection
+  commands?: ProjectCommands | null
+  /** package.json deps merged (dependencies + devDependencies) */
+  packageDeps?: Record<string, string>
+  packageManager?: string | null
+  llmAnalysis?: LLMAnalysis | null
+  /** Memory-sourced style rows (type pattern / anti-pattern / decision with style topic) */
+  memoryPatterns?: Array<{ name: string; description: string }>
+  memoryAntiPatterns?: Array<{ issue: string; suggestion: string }>
+  memoryConventions?: Array<{ rule: string; category?: string }>
+  structural?: Partial<ProjectStyleStructural> | null
+  commitHash?: string | null
+  source?: ProjectStyleSource
+  metrics?: Record<string, number | string>
+  id?: string
+  capturedAt?: string
+}
+
+export function buildProjectStylePayload(input: BuildProjectStyleInput): ProjectStylePayload {
+  const stack = buildStack(input)
+  const commands = buildCommands(input.commands)
+  const fromLlm = isRichLlmAnalysis(input.llmAnalysis) ? input.llmAnalysis : null
+
+  const conventions = mergeConventions(
+    fromLlm?.conventions?.map((c) => ({
+      key: stableStyleKey(c.category ? `${c.category}-${c.rule}` : c.rule),
+      rule: c.rule,
+      category: c.category,
+    })) ?? [],
+    input.memoryConventions?.map((c) => ({
+      key: stableStyleKey(c.category ? `${c.category}-${c.rule}` : c.rule),
+      rule: c.rule,
+      category: c.category,
+    })) ?? []
+  )
+
+  const patterns = mergePatterns(
+    fromLlm?.patterns?.map((p) => ({
+      key: stableStyleKey(p.name),
+      name: p.name,
+      description: p.description,
+      locations: p.locations,
+      category: p.category,
+    })) ?? [],
+    input.memoryPatterns?.map((p) => ({
+      key: stableStyleKey(p.name),
+      name: p.name,
+      description: p.description,
+    })) ?? []
+  )
+
+  const antiPatterns = mergeAntiPatterns(
+    fromLlm?.antiPatterns?.map((a) => ({
+      key: stableStyleKey(a.issue),
+      issue: a.issue,
+      suggestion: a.suggestion,
+      severity: a.severity,
+    })) ?? [],
+    input.memoryAntiPatterns?.map((a) => ({
+      key: stableStyleKey(a.issue),
+      issue: a.issue,
+      suggestion: a.suggestion,
+    })) ?? []
+  )
+
+  // Prefer LLM stack languages/frameworks when present
+  if (fromLlm?.stack?.languages?.length) {
+    for (const lang of fromLlm.stack.languages) {
+      if (!stack.languages.includes(lang)) stack.languages.push(lang)
+    }
+  }
+  if (fromLlm?.stack?.frameworks?.length) {
+    for (const fw of fromLlm.stack.frameworks) {
+      if (!stack.frameworks.includes(fw)) stack.frameworks.push(fw)
+    }
+  }
+  if (fromLlm?.stack?.packageManager && !stack.packageManager) {
+    stack.packageManager = fromLlm.stack.packageManager
+  }
+
+  const structural: ProjectStyleStructural = {
+    symbols: input.structural?.symbols ?? 0,
+    files: input.structural?.files ?? input.stats.fileCount ?? 0,
+    packages: input.structural?.packages ?? [],
+  }
+
+  return {
+    payloadVersion: 1,
+    stack,
+    commands,
+    conventions,
+    patterns,
+    antiPatterns,
+    structural,
+    metrics: { ...(input.metrics ?? {}) },
+  }
+}
+
+export function buildProjectStyleSnapshot(input: BuildProjectStyleInput): ProjectStyleSnapshot {
+  const payload = buildProjectStylePayload(input)
+  const capturedAt = input.capturedAt ?? getTimestamp()
+  const id =
+    input.id ??
+    `style_${capturedAt.replace(/[^0-9]/g, '').slice(0, 14)}_${Math.random().toString(36).slice(2, 8)}`
+
+  return {
+    id,
+    capturedAt,
+    commitHash: input.commitHash ?? null,
+    source: input.source ?? 'sync-mechanical',
+    patternCount: payload.patterns.length,
+    antiPatternCount: payload.antiPatterns.length,
+    conventionCount: payload.conventions.length,
+    frameworkCount: payload.stack.frameworks.length,
+    symbolCount: payload.structural.symbols,
+    fileCount: payload.structural.files,
+    summary: buildStyleSummary(payload),
+    payload,
+  }
+}
+
+export function buildStyleSummary(payload: ProjectStylePayload): string {
+  const stackBits = [
+    payload.stack.ecosystem !== 'unknown' ? payload.stack.ecosystem : null,
+    payload.stack.languages.slice(0, 2).join('+') || null,
+    payload.stack.frameworks.slice(0, 3).join(', ') || null,
+  ].filter(Boolean)
+  const stackLine = stackBits.length > 0 ? stackBits.join(' · ') : 'stack unknown'
+  return (
+    `${stackLine}; ` +
+    `${payload.patterns.length} patterns, ${payload.antiPatterns.length} anti-patterns, ` +
+    `${payload.conventions.length} conventions; ` +
+    `${payload.structural.files} files` +
+    (payload.structural.symbols > 0 ? `, ${payload.structural.symbols} symbols` : '')
+  )
+}
+
+function buildStack(input: BuildProjectStyleInput): ProjectStyleStack {
+  const frameworks = unique([...(input.stack.frameworks ?? []), ...(input.stats.frameworks ?? [])])
+  const languages = unique([...(input.stats.languages ?? [])])
+  const keyLibraries = collectKeyLibraries(input.packageDeps ?? {})
+  const deps = input.packageDeps ?? {}
+
+  // Promote known libs that are also "framework-ish" if stack detector missed them
+  for (const lib of keyLibraries) {
+    if (
+      ['Hono', 'Express', 'Fastify', 'React', 'Next.js', 'Vue', 'NestJS'].includes(lib) &&
+      !frameworks.includes(lib)
+    ) {
+      frameworks.push(lib)
+    }
+  }
+
+  // Tests: stack detector + common test runners (incl. bun:test without vitest dep)
+  const hasTests =
+    input.stack.hasTesting === true ||
+    Boolean(
+      deps.vitest ||
+        deps.jest ||
+        deps.mocha ||
+        deps['bun-types'] ||
+        deps['@types/bun'] ||
+        keyLibraries.includes('Vitest') ||
+        keyLibraries.includes('Jest')
+    ) ||
+    // commands.test present and not a placeholder is a weak signal — callers
+    // pass real detectCommands output when available
+    Boolean(input.commands?.test && /test/i.test(input.commands.test))
+
+  return {
+    ecosystem: input.stats.ecosystem || 'unknown',
+    languages,
+    frameworks,
+    packageManager: input.packageManager ?? undefined,
+    keyLibraries,
+    hasTests,
+    hasDocker: input.stack.hasDocker === true,
+  }
+}
+
+function buildCommands(commands?: ProjectCommands | null): ProjectStyleCommands {
+  if (!commands) return {}
+  return {
+    test: commands.test,
+    lint: commands.lint,
+    build: commands.build,
+    dev: commands.dev,
+    install: commands.install,
+    format: commands.format,
+  }
+}
+
+function collectKeyLibraries(deps: Record<string, string>): string[] {
+  const out: string[] = []
+  for (const name of KNOWN_LIBS) {
+    if (deps[name]) {
+      out.push(displayLibName(name))
+    }
+  }
+  return out.slice(0, 16)
+}
+
+function displayLibName(pkg: string): string {
+  const map: Record<string, string> = {
+    hono: 'Hono',
+    express: 'Express',
+    fastify: 'Fastify',
+    react: 'React',
+    next: 'Next.js',
+    vue: 'Vue',
+    vitest: 'Vitest',
+    jest: 'Jest',
+    typescript: 'TypeScript',
+    zod: 'Zod',
+    'better-sqlite3': 'better-sqlite3',
+    '@modelcontextprotocol/sdk': 'MCP SDK',
+    biome: 'Biome',
+    lefthook: 'Lefthook',
+    'drizzle-orm': 'Drizzle',
+    prisma: 'Prisma',
+    '@prisma/client': 'Prisma',
+  }
+  return map[pkg] ?? pkg
+}
+
+function mergeConventions(
+  a: ProjectStyleConvention[],
+  b: ProjectStyleConvention[]
+): ProjectStyleConvention[] {
+  const map = new Map<string, ProjectStyleConvention>()
+  for (const c of [...a, ...b]) {
+    if (!map.has(c.key)) map.set(c.key, c)
+  }
+  return [...map.values()].slice(0, 40)
+}
+
+function mergePatterns(a: ProjectStylePattern[], b: ProjectStylePattern[]): ProjectStylePattern[] {
+  const map = new Map<string, ProjectStylePattern>()
+  for (const p of [...a, ...b]) {
+    if (!map.has(p.key)) map.set(p.key, p)
+  }
+  return [...map.values()].slice(0, 40)
+}
+
+function mergeAntiPatterns(
+  a: ProjectStyleAntiPattern[],
+  b: ProjectStyleAntiPattern[]
+): ProjectStyleAntiPattern[] {
+  const map = new Map<string, ProjectStyleAntiPattern>()
+  for (const p of [...a, ...b]) {
+    if (!map.has(p.key)) map.set(p.key, p)
+  }
+  return [...map.values()].slice(0, 40)
+}
+
+function unique(items: string[]): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const i of items) {
+    const t = i.trim()
+    if (!t) continue
+    const k = t.toLowerCase()
+    if (seen.has(k)) continue
+    seen.add(k)
+    out.push(t)
+  }
+  return out
+}
+
+/** Compact inject block for SessionStart / work. */
+export function formatProjectStyleDigest(
+  snapshot: ProjectStyleSnapshot | null,
+  opts: { maxConventions?: number; maxPatterns?: number; maxAnti?: number } = {}
+): string | null {
+  if (!snapshot) return null
+  const maxC = opts.maxConventions ?? 5
+  const maxP = opts.maxPatterns ?? 4
+  const maxA = opts.maxAnti ?? 3
+  const p = snapshot.payload
+  const lines: string[] = ['## How this repo works (project style)', '']
+  const stackParts = [
+    p.stack.ecosystem !== 'unknown' ? p.stack.ecosystem : null,
+    p.stack.languages.join(', ') || null,
+    p.stack.frameworks.join(', ') || null,
+    p.stack.keyLibraries.slice(0, 6).join(', ') || null,
+  ].filter(Boolean)
+  if (stackParts.length > 0) {
+    lines.push(`**Stack:** ${stackParts.join(' · ')}`)
+  }
+  if (p.conventions.length > 0) {
+    lines.push('', '**Conventions (match):**')
+    for (const c of p.conventions.slice(0, maxC)) {
+      lines.push(`- ${c.rule}`)
+    }
+  }
+  if (p.patterns.length > 0) {
+    lines.push('', '**Patterns (match):**')
+    for (const pat of p.patterns.slice(0, maxP)) {
+      lines.push(`- **${pat.name}** — ${truncate(pat.description, 120)}`)
+    }
+  }
+  if (p.antiPatterns.length > 0) {
+    lines.push('', '**Anti-patterns (avoid):**')
+    for (const a of p.antiPatterns.slice(0, maxA)) {
+      lines.push(`- ${a.issue}${a.suggestion ? ` → ${truncate(a.suggestion, 80)}` : ''}`)
+    }
+  }
+  if (p.conventions.length === 0 && p.patterns.length === 0 && p.antiPatterns.length === 0) {
+    lines.push(
+      '',
+      '_No durable house patterns yet — open a neighbor file and match local idiom. Prefer `prjct sync` + structured analysis-save-llm JSON to enrich._'
+    )
+  }
+  lines.push('', `_${snapshot.summary}_`)
+  return lines.join('\n')
+}
+
+function truncate(s: string, n: number): string {
+  const t = s.replace(/\s+/g, ' ').trim()
+  return t.length > n ? `${t.slice(0, n - 1)}…` : t
+}

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -335,6 +335,44 @@ class SyncService {
       const syncMetrics = await phase('metrics', () =>
         recordSyncMetrics(this.projectId!, stats, duration)
       )
+      const developerSnapshotCaptured = syncMetrics.developerSnapshotCaptured === true
+
+      // 9a. Project style model — recalculate every sync (dual evolution with
+      // developer snapshot above). Progressive delta + history + memory bridge.
+      let projectStyle: import('../types/project-sync').ProjectStyleSyncSummary | undefined
+      try {
+        const { recomputeProjectStyle, formatProjectStyleForSync } = await import(
+          './project-style-evolution'
+        )
+        const styleResult = await phase('project-style', () =>
+          recomputeProjectStyle({
+            projectId: this.projectId!,
+            projectPath: this.projectPath,
+            stats,
+            stack,
+            commands,
+            commitHash: git.recentCommits[0]?.hash ?? null,
+            source: 'sync-mechanical',
+          })
+        )
+        const formatted = formatProjectStyleForSync(styleResult)
+        const coverageRaw = styleResult.snapshot.payload.metrics.styleCoverage
+        projectStyle = {
+          summary: styleResult.snapshot.summary,
+          evolutionMd: formatted.evolutionMd,
+          patternCount: styleResult.snapshot.patternCount,
+          antiPatternCount: styleResult.snapshot.antiPatternCount,
+          conventionCount: styleResult.snapshot.conventionCount,
+          styleCoverage: typeof coverageRaw === 'number' ? coverageRaw : Number(coverageRaw) || 0,
+          isFirst: styleResult.isFirst,
+          hasChanges: styleResult.delta.hasChanges,
+        }
+      } catch (error) {
+        log.debug('Project style recompute failed (non-critical)', {
+          error: getErrorMessage(error),
+        })
+      }
+
       const workCost = await phase('work-cost', () => publishWorkCostSnapshots(this.projectId!))
 
       // 9b. Archive stale data (PRJ-267)
@@ -482,6 +520,8 @@ class SyncService {
         workCost,
         verification,
         incremental: incrementalInfo,
+        projectStyle,
+        developerSnapshotCaptured,
         generatedSkills,
       }
     } catch (error) {

--- a/core/services/sync/persistence.ts
+++ b/core/services/sync/persistence.ts
@@ -35,7 +35,7 @@ export async function recordSyncMetrics(
   projectId: string,
   stats: ProjectStats,
   duration: number
-): Promise<SyncMetrics> {
+): Promise<SyncMetrics & { developerSnapshotCaptured?: boolean }> {
   // Real original size from BM25 index (actual tokens indexed from source files).
   // Loaded ONCE and reused by the index-stats block below — the second load
   // used to hit right after the sync invalidated the cache, paying a full
@@ -86,9 +86,10 @@ export async function recordSyncMetrics(
   } catch (error) {
     log.debug('Failed to recompute velocity', { error: getErrorMessage(error) })
   }
+  let developerSnapshotCaptured = false
   try {
     const { captureDeveloperSnapshot } = await import('../developer-evolution')
-    await captureDeveloperSnapshot(projectId)
+    developerSnapshotCaptured = await captureDeveloperSnapshot(projectId)
   } catch (error) {
     log.debug('Failed to capture dev snapshot', { error: getErrorMessage(error) })
   }
@@ -121,6 +122,7 @@ export async function recordSyncMetrics(
     filteredSize,
     compressionRate,
     indexes,
+    developerSnapshotCaptured,
   }
 }
 

--- a/core/storage/database/migrations.ts
+++ b/core/storage/database/migrations.ts
@@ -2639,6 +2639,38 @@ export const migrations: Migration[] = [
       db.run('CREATE INDEX IF NOT EXISTS idx_code_symbol_edges_src ON code_symbol_edges(src)')
     },
   },
+  {
+    version: 63,
+    name: 'project-style-snapshots',
+    up: (db: SqliteDatabase) => {
+      // Project evolution substrate (symmetric to developer_profile_snapshots):
+      // progressive house-style model recalculated on each sync — stack, patterns,
+      // conventions, anti-patterns + extensible metrics bag for future measurement.
+      db.run(
+        `CREATE TABLE IF NOT EXISTS project_style_snapshots (
+           id                  TEXT PRIMARY KEY,
+           captured_at         TEXT NOT NULL,
+           commit_hash         TEXT,
+           source              TEXT NOT NULL DEFAULT 'sync-mechanical',
+           pattern_count       INTEGER NOT NULL DEFAULT 0,
+           anti_pattern_count  INTEGER NOT NULL DEFAULT 0,
+           convention_count    INTEGER NOT NULL DEFAULT 0,
+           framework_count     INTEGER NOT NULL DEFAULT 0,
+           symbol_count        INTEGER NOT NULL DEFAULT 0,
+           file_count          INTEGER NOT NULL DEFAULT 0,
+           summary             TEXT NOT NULL,
+           payload_json        TEXT NOT NULL,
+           is_active           INTEGER NOT NULL DEFAULT 0
+         )`
+      )
+      db.run(
+        'CREATE INDEX IF NOT EXISTS ix_project_style_active ON project_style_snapshots(is_active, captured_at DESC)'
+      )
+      db.run(
+        'CREATE INDEX IF NOT EXISTS ix_project_style_captured ON project_style_snapshots(captured_at DESC)'
+      )
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations[migrations.length - 1]?.version ?? 0

--- a/core/types/project-style.ts
+++ b/core/types/project-style.ts
@@ -1,0 +1,104 @@
+/**
+ * Project Style Model — progressive snapshots of how the repo works
+ * (stack, patterns, conventions, anti-patterns). Symmetric to developer
+ * evolution: captured on every sync, diffed, history kept for measurement.
+ */
+
+export type ProjectStyleSource = 'sync-mechanical' | 'sync-llm' | 'analysis-save'
+
+export interface ProjectStyleStack {
+  ecosystem: string
+  languages: string[]
+  frameworks: string[]
+  packageManager?: string
+  keyLibraries: string[]
+  hasTests: boolean
+  hasDocker: boolean
+}
+
+export interface ProjectStyleCommands {
+  test?: string
+  lint?: string
+  build?: string
+  dev?: string
+  install?: string
+  format?: string
+}
+
+export interface ProjectStyleConvention {
+  key: string
+  rule: string
+  category?: string
+}
+
+export interface ProjectStylePattern {
+  key: string
+  name: string
+  description: string
+  locations?: string[]
+  category?: string
+}
+
+export interface ProjectStyleAntiPattern {
+  key: string
+  issue: string
+  suggestion: string
+  severity?: string
+}
+
+export interface ProjectStyleStructural {
+  symbols: number
+  files: number
+  packages: string[]
+}
+
+/** Versioned payload stored as JSON on each snapshot row. */
+export interface ProjectStylePayload {
+  payloadVersion: 1
+  stack: ProjectStyleStack
+  commands: ProjectStyleCommands
+  conventions: ProjectStyleConvention[]
+  patterns: ProjectStylePattern[]
+  antiPatterns: ProjectStyleAntiPattern[]
+  structural: ProjectStyleStructural
+  /** Extensible bag for future measurement without migrations. */
+  metrics: Record<string, number | string>
+}
+
+export interface ProjectStyleSnapshot {
+  id: string
+  capturedAt: string
+  commitHash: string | null
+  source: ProjectStyleSource
+  patternCount: number
+  antiPatternCount: number
+  conventionCount: number
+  frameworkCount: number
+  symbolCount: number
+  fileCount: number
+  summary: string
+  payload: ProjectStylePayload
+}
+
+export type ProjectStyleDiffKind = 'added' | 'removed' | 'changed'
+
+export interface ProjectStyleDiffItem {
+  field: string
+  type: ProjectStyleDiffKind
+  before?: string
+  after?: string
+}
+
+export interface ProjectStyleDiff {
+  hasChanges: boolean
+  items: ProjectStyleDiffItem[]
+  summary: { added: number; removed: number; changed: number }
+  beforeCommit: string | null
+  afterCommit: string | null
+}
+
+export interface ProjectStyleRecomputeResult {
+  snapshot: ProjectStyleSnapshot
+  delta: ProjectStyleDiff
+  isFirst: boolean
+}

--- a/core/types/project-sync.ts
+++ b/core/types/project-sync.ts
@@ -162,6 +162,19 @@ export interface IncrementalInfo {
   affectedDomains: string[]
 }
 
+export interface ProjectStyleSyncSummary {
+  /** One-line digest of current project style */
+  summary: string
+  /** Markdown delta section for this sync (null when unchanged) */
+  evolutionMd: string | null
+  patternCount: number
+  antiPatternCount: number
+  conventionCount: number
+  styleCoverage: number
+  isFirst: boolean
+  hasChanges: boolean
+}
+
 export interface ProjectSyncResult {
   success: boolean
   projectId: string
@@ -178,6 +191,10 @@ export interface ProjectSyncResult {
   workCost?: WorkCostSnapshot[]
   verification?: VerificationReport
   incremental?: IncrementalInfo
+  /** Dual evolution: project style recompute on this sync */
+  projectStyle?: ProjectStyleSyncSummary
+  /** True when a new weekly developer snapshot was captured this sync */
+  developerSnapshotCaptured?: boolean
   generatedSkills?: {
     generated: { name: string; path: string }[]
     skipped: { name: string; reason: string }[]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.67.0",
+  "version": "3.68.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.66.0",
+  "version": "3.67.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- Project Style Model recalculated on every `prjct sync` (stack, patterns, conventions, anti-patterns, structural).
- Progressive `project_style_snapshots` history + delta on sync output (project evolution, dual to developer evolution).
- Work/SessionStart inject house style; analysis-save-llm no longer clobbers rich house style with thin markdown.
- Style memories UPSERT (`style:*` topics) for selective embeddings; context stack surface fixed.

## Test plan
- [x] `bun test` project-style-* + analysis-save-llm (12 pass)
- [x] pre-push typecheck
- [x] Live recompute on prjct-cli recovered 4 patterns / 6 conventions / stack honesty
- [ ] CI green on PR

Generated with [p/](https://www.prjct.app/)