### PR TITLE
fix(upgrade): install only npm registry version (v3.69.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [3.69.1] - 2026-07-17
+
+### Bug Fixes
+
+- upgrade installs only npm registry version (never monorepo/local)
+
 ## [3.69.0] - 2026-07-16
 
 ### Added

--- a/core/__tests__/commands/update-registry-only.test.ts
+++ b/core/__tests__/commands/update-registry-only.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Upgrade must install ONLY the npm registry package — never monorepo/local.
+ * Doctrine mem_9174: install from outside (registry), never link / local tree.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import os from 'node:os'
+import {
+  MANAGERS,
+  registryInstallArgs,
+  registryInstallCwd,
+} from '../../commands/update/package-managers'
+
+describe('upgrade installs from npm registry only', () => {
+  it('registryInstallCwd is a neutral directory (never monorepo)', () => {
+    const cwd = registryInstallCwd()
+    expect(cwd).toBe(os.tmpdir())
+    expect(cwd).not.toContain('prjct-cli')
+  })
+
+  it('registryInstallArgs pin exact prjct-cli@X.Y.Z for every manager', () => {
+    const pin = 'prjct-cli@3.69.0'
+    for (const pm of [MANAGERS.npm, MANAGERS.pnpm, MANAGERS.bun, MANAGERS.yarn]) {
+      const args = registryInstallArgs(pm, pin)
+      expect(args.some((a) => a === pin)).toBe(true)
+      expect(args.some((a) => a === 'prjct-cli@latest')).toBe(false)
+      // Never a path or bare package name without version pin when pin provided
+      expect(args.some((a) => a === '.' || a.startsWith('/') || a.startsWith('file:'))).toBe(false)
+    }
+  })
+
+  it('npm/pnpm prefer online registry over local cache', () => {
+    expect(MANAGERS.npm.installArgs).toContain('--prefer-online')
+    expect(MANAGERS.pnpm.installArgs).toContain('--prefer-online')
+  })
+
+  it('installArgs always name the registry package prjct-cli@…', () => {
+    for (const pm of Object.values(MANAGERS)) {
+      expect(pm.installArgs.some((a) => a.startsWith('prjct-cli@'))).toBe(true)
+    }
+  })
+})

--- a/core/commands/update.ts
+++ b/core/commands/update.ts
@@ -17,7 +17,6 @@ import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
 import { failFromError } from '../utils/md-aware'
 import out from '../utils/output'
-import { VERSION } from '../utils/version'
 import { PrjctCommandsBase } from './base'
 import { type CleanupMode, consolidateInstalls } from './update/cleanup-installs'
 import { formatMdOutput, formatTerminalOutput, type PhaseResult } from './update/output'
@@ -27,6 +26,8 @@ import {
   isOnPath,
   type PkgManager,
   redirectToInstalledPackage,
+  registryInstallArgs,
+  registryInstallCwd,
   selectPackageManager,
 } from './update/package-managers'
 
@@ -108,10 +109,12 @@ export class UpdateCommands extends PrjctCommandsBase {
       results.phase3 = await this.phaseDaemonRestart(dryRun)
       if (!md) out.stop()
 
-      // ── Post-update: stamp version + clear cache ──
+      // ── Post-update: stamp INSTALLED (npm) version + clear cache ──
+      // Never stamp the running process VERSION — that can be monorepo source.
       if (!dryRun) {
         try {
-          await editorsConfig.updateVersion(VERSION)
+          const installed = getAllInstalledLocations()[0]?.version
+          if (installed) await editorsConfig.updateVersion(installed)
         } catch {
           // Non-blocking
         }
@@ -191,18 +194,36 @@ export class UpdateCommands extends PrjctCommandsBase {
         targets = [selectPackageManager()]
       }
 
-      // Resolve the TRUE latest from the npm registry and PIN it. `@latest`
-      // is resolved by each PM from its own metadata cache — pnpm's is
-      // frequently stale and silently resolves an OLD version, so a plain
-      // `pnpm add -g prjct-cli@latest` can *downgrade* the install. Pinning
-      // the exact registry version makes the upgrade deterministic.
+      // Source of truth is ALWAYS registry.npmjs.org — never monorepo package.json,
+      // never npm-link, never the running binary's baked VERSION (mem_9174).
+      // Pin exact version so PM metadata caches cannot downgrade the install.
+      let registryVersion: string | null = null
       let pinnedSpec: string | null = null
       try {
         const v = (await new UpdateChecker().getLatestVersion())?.trim()
-        if (v && /^\d+\.\d+\.\d+/.test(v)) pinnedSpec = `prjct-cli@${v}`
-      } catch {
-        // registry unreachable — fall back to each PM's @latest
+        if (v && /^\d+\.\d+\.\d+/.test(v)) {
+          registryVersion = v
+          pinnedSpec = `prjct-cli@${v}`
+        }
+      } catch (err) {
+        result.errors.push(
+          `npm registry unreachable — refuse to install from local tree: ${getErrorMessage(err)}`
+        )
+        result.success = false
+        return result
       }
+
+      if (!pinnedSpec || !registryVersion) {
+        result.success = false
+        result.errors.push('npm registry did not return a valid prjct-cli version')
+        return result
+      }
+
+      result.details.push(`registry.npmjs.org latest = ${registryVersion}`)
+
+      // Neutral cwd: running `npm install -g prjct-cli@…` from inside the monorepo
+      // can resolve the local package instead of the published tarball.
+      const installCwd = registryInstallCwd()
 
       for (const pm of targets) {
         if (!isOnPath(pm.name)) {
@@ -213,19 +234,15 @@ export class UpdateCommands extends PrjctCommandsBase {
           continue
         }
         try {
-          // Pin the exact registry latest (bypasses semver ranges AND each
-          // PM's stale @latest cache — see pinnedSpec above).
-          const args = pinnedSpec
-            ? pm.installArgs.map((a) => (a === 'prjct-cli@latest' ? pinnedSpec : a))
-            : pm.installArgs
-          execFileSync(pm.name, args, { stdio: 'pipe' })
-          result.details.push(`${pm.name} install complete${pinnedSpec ? ` (${pinnedSpec})` : ''}`)
+          const args = registryInstallArgs(pm, pinnedSpec)
+          execFileSync(pm.name, args, { stdio: 'pipe', cwd: installCwd })
+          result.details.push(`${pm.name} install complete (${pinnedSpec} from npm registry)`)
         } catch (err) {
           result.errors.push(`${pm.name}: ${getErrorMessage(err)}`)
         }
       }
 
-      // Per-install version transitions
+      // Per-install version transitions + verify each matches registry
       const installsAfter = getAllInstalledLocations()
       const beforeMap = new Map(installsBefore.map((i) => [i.pm.name, i.version]))
       const transitions: string[] = []
@@ -236,16 +253,23 @@ export class UpdateCommands extends PrjctCommandsBase {
           transitions.push(`${pm.name}: ${before} → ${version}`)
         } else if (!before) {
           transitions.push(`${pm.name}: installed v${version}`)
+        } else {
+          transitions.push(`${pm.name}: v${version} (matches registry)`)
+        }
+        if (version !== registryVersion) {
+          result.errors.push(
+            `${pm.name} install is v${version} but registry latest is ${registryVersion} — ` +
+              `global install did not apply npm package (check PATH / npm root -g)`
+          )
         }
       }
 
-      if (transitions.length > 1) {
-        for (const t of transitions) result.details.push(t)
-      } else if (transitions.length === 1) {
-        result.details.push(transitions[0]!)
-      } else if (installsAfter.length > 0) {
-        result.details.push(`v${installsAfter[0]!.version} (already latest)`)
+      for (const t of transitions) result.details.push(t)
+
+      if (installsAfter.length === 0) {
+        result.errors.push('No global prjct-cli install found after registry install')
       }
+      if (result.errors.length > 0) result.success = false
     } catch (err) {
       result.success = false
       result.errors.push(getErrorMessage(err))

--- a/core/commands/update/package-managers.ts
+++ b/core/commands/update/package-managers.ts
@@ -96,7 +96,9 @@ export function registryInstallCwd(): string {
  */
 export function registryInstallArgs(pm: PkgManager, pinnedSpec: string | null): string[] {
   const target = pinnedSpec ?? 'prjct-cli@latest'
-  return pm.installArgs.map((a) => (a === 'prjct-cli@latest' || a.startsWith('prjct-cli@') ? target : a))
+  return pm.installArgs.map((a) =>
+    a === 'prjct-cli@latest' || a.startsWith('prjct-cli@') ? target : a
+  )
 }
 
 export function isHomebrewInstall(): boolean {

--- a/core/commands/update/package-managers.ts
+++ b/core/commands/update/package-managers.ts
@@ -28,10 +28,16 @@ export interface InstalledLocation {
 
 const HOME = os.homedir()
 
+/**
+ * Global install args always pin the npm registry package name.
+ * Never pass a relative path / `.` / monorepo root — that installs LOCAL source
+ * (user doctrine mem_9174: install from registry only).
+ */
 export const MANAGERS: Record<PkgManagerName, PkgManager> = {
   npm: {
     name: 'npm',
-    installArgs: ['install', '-g', 'prjct-cli@latest'],
+    // --prefer-online: bypass stale local npm cache of old tarballs
+    installArgs: ['install', '-g', 'prjct-cli@latest', '--prefer-online'],
     getInstallRoot: () => {
       try {
         return execFileSync('npm', ['root', '-g'], {
@@ -45,7 +51,7 @@ export const MANAGERS: Record<PkgManagerName, PkgManager> = {
   },
   pnpm: {
     name: 'pnpm',
-    installArgs: ['add', '-g', 'prjct-cli@latest'],
+    installArgs: ['add', '-g', 'prjct-cli@latest', '--prefer-online'],
     getInstallRoot: () => {
       try {
         return execFileSync('pnpm', ['root', '-g'], {
@@ -77,6 +83,20 @@ export const MANAGERS: Record<PkgManagerName, PkgManager> = {
       }
     },
   },
+}
+
+/** Neutral cwd for global installs — never monorepo (avoids npm linking local package). */
+export function registryInstallCwd(): string {
+  return os.tmpdir()
+}
+
+/**
+ * Rewrite install args so the package spec is always the exact npm registry
+ * pin (`prjct-cli@X.Y.Z`). Falls back to `@latest` only when pin is null.
+ */
+export function registryInstallArgs(pm: PkgManager, pinnedSpec: string | null): string[] {
+  const target = pinnedSpec ?? 'prjct-cli@latest'
+  return pm.installArgs.map((a) => (a === 'prjct-cli@latest' || a.startsWith('prjct-cli@') ? target : a))
 }
 
 export function isHomebrewInstall(): boolean {

--- a/core/infrastructure/update-checker.ts
+++ b/core/infrastructure/update-checker.ts
@@ -53,17 +53,21 @@ class UpdateChecker {
   }
 
   /**
-   * Fetch latest version from npm registry
+   * Fetch latest version from npm registry (never from monorepo / local package.json).
+   * Cache-busting query + no-cache headers so upgrade always sees the published dist-tag.
    */
   async getLatestVersion(): Promise<string> {
     return new Promise((resolve, reject) => {
+      const bust = Date.now()
       const options = {
         hostname: 'registry.npmjs.org',
-        path: `/${this.packageName}/latest`,
+        path: `/${this.packageName}/latest?prjct_bust=${bust}`,
         method: 'GET',
         headers: {
           'User-Agent': 'prjct-cli-update-checker',
           Accept: 'application/json',
+          'Cache-Control': 'no-cache, no-store',
+          Pragma: 'no-cache',
         },
       }
 
@@ -78,7 +82,12 @@ class UpdateChecker {
           try {
             if (res.statusCode === 200) {
               const packageData = JSON.parse(data)
-              resolve(packageData.version)
+              const version = typeof packageData.version === 'string' ? packageData.version.trim() : ''
+              if (!/^\d+\.\d+\.\d+/.test(version)) {
+                reject(new Error(`npm registry returned invalid version: ${version || '(empty)'}`))
+                return
+              }
+              resolve(version)
             } else {
               reject(new Error(`npm registry returned status ${res.statusCode}`))
             }

--- a/core/infrastructure/update-checker.ts
+++ b/core/infrastructure/update-checker.ts
@@ -82,7 +82,8 @@ class UpdateChecker {
           try {
             if (res.statusCode === 200) {
               const packageData = JSON.parse(data)
-              const version = typeof packageData.version === 'string' ? packageData.version.trim() : ''
+              const version =
+                typeof packageData.version === 'string' ? packageData.version.trim() : ''
               if (!/^\d+\.\d+\.\d+/.test(version)) {
                 reject(new Error(`npm registry returned invalid version: ${version || '(empty)'}`))
                 return

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prjct-cli",
-  "version": "3.69.0",
+  "version": "3.69.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prjct-cli",
-      "version": "3.69.0",
+      "version": "3.69.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.69.0",
+  "version": "3.69.1",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary
- `prjct upgrade` installs **only** from `registry.npmjs.org` — never monorepo, never link, never baked process `VERSION`.
- Pin exact latest from registry (cache-bust + no-cache headers).
- Global install runs from **tmpdir** with `--prefer-online`.
- Post-install verifies each PM matches registry version; refuse when registry is unreachable.
- Bump to **3.69.1** (3.69.0 already published for agent-contract).

## Test plan
- [x] `bun test` update-registry-only + update-cleanup
- [ ] CI green
- [ ] After merge/publish: `prjct upgrade` lands on npm latest

Generated with [p/](https://www.prjct.app/)