### PR TITLE
feat(harness): OpenCode native MCP + Pi skill surface (v3.70.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.70.0] - 2026-07-16
+
+### Added
+- OpenCode native MCP installer (`mcp.prjct`) + Pi skill surface on install/doctor
+
 ## [3.69.1] - 2026-07-17
 
 ### Bug Fixes

--- a/core/__tests__/infrastructure/agent-runtime-registry.test.ts
+++ b/core/__tests__/infrastructure/agent-runtime-registry.test.ts
@@ -22,6 +22,7 @@ describe('agent runtime registry', () => {
 
     const expectedRuntimes: AgentRuntimeId[] = [
       'opencode',
+      'pi',
       'qwen-code',
       'kimi-cli',
       'grok',
@@ -50,6 +51,23 @@ describe('agent runtime registry', () => {
     const writable = (kimi.mcpTargets ?? []).filter((target) => target.writable)
     expect(writable.length).toBeGreaterThan(0)
     expect(writable[0]?.pathHint).toContain('.kimi/mcp.json')
+  })
+
+  it('exposes a writable OpenCode MCP target and full support for Pi skill path', () => {
+    const opencode = getAgentRuntime('opencode')
+    expect(opencode.supports.mcp).toBe(true)
+    expect(opencode.supports.skills).toBe(true)
+    const writable = (opencode.mcpTargets ?? []).filter((t) => t.writable)
+    expect(writable.length).toBeGreaterThan(0)
+    expect(writable[0]?.pathHint).toContain('opencode')
+
+    const pi = getAgentRuntime('pi')
+    expect(pi.kind).toBe('cli')
+    expect(pi.status).toBe('stable')
+    expect(pi.supports.agentsMd).toBe(true)
+    expect(pi.supports.skills).toBe(true)
+    expect(pi.supports.mcp).toBe(false)
+    expect(pi.detectsBy?.commands).toContain('pi')
   })
 
   it('registers xAI Grok Build with native writable ~/.grok/config.toml MCP', () => {
@@ -98,6 +116,8 @@ describe('agent runtime registry', () => {
       expect(byId.get('aider')?.supportLevel).toBe('baseline')
       expect(byId.get('grok')?.supportLevel).toBe('full')
       expect(byId.get('claude')?.supportLevel).toBe('full')
+      expect(byId.get('opencode')?.supportLevel).toBe('full')
+      expect(byId.get('pi')?.supportLevel).toBe('full')
       expect(byId.get('codex')?.supportLevel).toBe('full')
       expect(byId.get('gemini')?.supportLevel).toBe('full')
       expect(byId.get('opencode')?.supportLevel).toBe('full')

--- a/core/__tests__/infrastructure/harness-surfaces.test.ts
+++ b/core/__tests__/infrastructure/harness-surfaces.test.ts
@@ -14,11 +14,25 @@ describe('harness surfaces matrix', () => {
       'gemini',
       'grok',
       'opencode',
+      'pi',
       'cursor',
       'cline',
     ] as const) {
       expect(ids).toContain(id)
     }
+  })
+
+  it('documents OpenCode MCP as native and Pi skill as native (no MCP)', () => {
+    const opencode = getHarnessSurface('opencode')
+    expect(opencode).toBeDefined()
+    expect(opencode!.mcp.prjct).toBe('native')
+    expect(opencode!.hooks.prjct).toBe('none')
+
+    const pi = getHarnessSurface('pi')
+    expect(pi).toBeDefined()
+    expect(pi!.skills.prjct).toBe('native')
+    expect(pi!.mcp.prjct).toBe('none')
+    expect(pi!.legibility).toMatch(/skill/i)
   })
 
   it('documents Grok as native MCP+skills+plugin with hooks inherits-claude', () => {

--- a/core/__tests__/infrastructure/pi-skill.test.ts
+++ b/core/__tests__/infrastructure/pi-skill.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Pi skill installer — ~/.pi/agent/skills/prjct/SKILL.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  buildPiSkillContent,
+  getPiSkillInstallPath,
+  installPiSkill,
+} from '../../infrastructure/pi-skill'
+
+const PREV_HOME = process.env.HOME
+const PREV_TEST = process.env.PRJCT_TEST_MODE
+
+let home: string
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-pi-skill-test-'))
+  process.env.HOME = home
+  process.env.PRJCT_TEST_MODE = '1'
+})
+
+afterEach(async () => {
+  if (PREV_HOME === undefined) delete process.env.HOME
+  else process.env.HOME = PREV_HOME
+  if (PREV_TEST === undefined) delete process.env.PRJCT_TEST_MODE
+  else process.env.PRJCT_TEST_MODE = PREV_TEST
+  await fs.rm(home, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('installPiSkill', () => {
+  it('creates SKILL.md under the Pi skills path', async () => {
+    const r = await installPiSkill()
+    expect(r.success).toBe(true)
+    expect(r.action).toBe('created')
+    const skillPath = getPiSkillInstallPath()
+    expect(r.path).toBe(skillPath)
+    const body = await fs.readFile(skillPath, 'utf-8')
+    expect(body).toContain('name: prjct')
+    expect(body).toContain('prjct work')
+    expect(body).toContain('prjct-pi-skill')
+  })
+
+  it('is idempotent when content matches', async () => {
+    await installPiSkill()
+    const r = await installPiSkill()
+    expect(r.success).toBe(true)
+    expect(r.action).toBe('unchanged')
+  })
+
+  it('buildPiSkillContent stamps metadata hash', () => {
+    const built = buildPiSkillContent('# prjct\n\nRun verbs.\n')
+    expect(built.templateHash).toHaveLength(12)
+    expect(built.content).toContain('prjct-pi-skill')
+  })
+})

--- a/core/__tests__/services/harness-coverage.test.ts
+++ b/core/__tests__/services/harness-coverage.test.ts
@@ -28,10 +28,64 @@ describe('harness coverage (organic multi-runtime board)', () => {
 
   it('reports absent when no runtimes are wired', async () => {
     const report = await probeHarnessCoverage(home)
-    expect(report.runtimes.length).toBe(5)
+    // Claude, Codex, Gemini, Cursor, Grok, OpenCode, Pi
+    expect(report.runtimes.length).toBe(7)
+    expect(report.runtimes.map((r) => r.id)).toEqual(
+      expect.arrayContaining(['opencode', 'pi', 'claude', 'grok'])
+    )
     // Without CLIs on PATH in a fresh HOME, detected may still be 0
     expect(report.organicPct).toBeGreaterThanOrEqual(0)
     expect(report.grade).toBeGreaterThanOrEqual(1)
+  })
+
+  it('marks OpenCode full when mcp.prjct is present and Pi full when skill is present', async () => {
+    const ocDir = path.join(home, '.prjct-tests', 'opencode')
+    await fs.mkdir(ocDir, { recursive: true })
+    await fs.writeFile(
+      path.join(ocDir, 'opencode.json'),
+      JSON.stringify({
+        mcp: {
+          prjct: {
+            type: 'local',
+            command: ['npx', '-y', 'prjct-cli@latest', 'mcp-server'],
+            enabled: true,
+          },
+        },
+      }),
+      'utf-8'
+    )
+    // Detect via ~/.config/opencode in real path — PRJCT_TEST_MODE uses .prjct-tests.
+    // Create home config dir so detection fires, and ensure MCP path is test path.
+    await fs.mkdir(path.join(home, '.config', 'opencode'), { recursive: true })
+    await fs.writeFile(
+      path.join(home, '.config', 'opencode', 'opencode.json'),
+      JSON.stringify({
+        mcp: {
+          prjct: {
+            type: 'local',
+            command: ['npx', '-y', 'prjct-cli@latest', 'mcp-server'],
+            enabled: true,
+          },
+        },
+      }),
+      'utf-8'
+    )
+
+    const piSkillDir = path.join(home, '.prjct-tests', 'pi', 'agent', 'skills', 'prjct')
+    await fs.mkdir(piSkillDir, { recursive: true })
+    await fs.writeFile(path.join(piSkillDir, 'SKILL.md'), '# prjct\n', 'utf-8')
+    await fs.mkdir(path.join(home, '.pi', 'agent'), { recursive: true })
+
+    const report = await probeHarnessCoverage(home)
+    const oc = report.runtimes.find((r) => r.id === 'opencode')
+    expect(oc?.detected).toBe(true)
+    // Probe reads getOpenCodeConfigPath() which under PRJCT_TEST_MODE is .prjct-tests/opencode
+    expect(oc?.mcpLive).toBe(true)
+    expect(oc?.organic).toBe('full')
+
+    const pi = report.runtimes.find((r) => r.id === 'pi')
+    expect(pi?.detected).toBe(true)
+    expect(pi?.organic).toBe('full')
   })
 
   it('marks Claude full when settings + mcp.json have prjct wire', async () => {
@@ -80,6 +134,8 @@ describe('harness coverage (organic multi-runtime board)', () => {
     expect(md).toContain('Organic multi-runtime board')
     expect(md).toContain('Claude Code')
     expect(md).toContain('Grok Build')
+    expect(md).toContain('OpenCode')
+    expect(md).toContain('Pi')
     expect(md).toContain('Moat')
   })
 

--- a/core/__tests__/utils/opencode-mcp.test.ts
+++ b/core/__tests__/utils/opencode-mcp.test.ts
@@ -1,0 +1,121 @@
+/**
+ * OpenCode MCP wiring — mcp.prjct local entry in opencode.json / JSONC.
+ *
+ * Pins:
+ *   1. Missing config → creates with $schema + mcp.prjct
+ *   2. Existing user mcp servers preserved
+ *   3. JSONC comments preserved on modify
+ *   4. Idempotent re-run
+ *   5. Shape: type local + command array including mcp-server
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  ensureOpenCodeMcpServer,
+  hasOpenCodePrjctMcp,
+  toOpenCodeLocalMcp,
+} from '../../utils/opencode-mcp'
+
+let dir: string
+let configPath: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-opencode-mcp-test-'))
+  configPath = path.join(dir, 'opencode.json')
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+})
+
+describe('toOpenCodeLocalMcp', () => {
+  it('maps command+args into a local command array', () => {
+    const entry = toOpenCodeLocalMcp({
+      command: 'npx',
+      args: ['-y', 'prjct-cli@latest', 'mcp-server'],
+      env: { PATH: '/usr/bin' },
+    })
+    expect(entry.type).toBe('local')
+    expect(entry.enabled).toBe(true)
+    expect(entry.command).toEqual(['npx', '-y', 'prjct-cli@latest', 'mcp-server'])
+    expect(entry.environment?.PATH).toBe('/usr/bin')
+  })
+})
+
+describe('ensureOpenCodeMcpServer', () => {
+  it('creates opencode.json with mcp.prjct when missing', async () => {
+    const r = await ensureOpenCodeMcpServer(configPath)
+    expect(r.changed).toBe(true)
+    expect(r.path).toBe(configPath)
+
+    const raw = await fs.readFile(configPath, 'utf-8')
+    expect(hasOpenCodePrjctMcp(raw)).toBe(true)
+    const config = JSON.parse(raw) as {
+      $schema?: string
+      mcp?: { prjct?: { type?: string; command?: string[]; enabled?: boolean } }
+    }
+    expect(config.$schema).toContain('opencode.ai')
+    expect(config.mcp?.prjct?.type).toBe('local')
+    expect(config.mcp?.prjct?.enabled).toBe(true)
+    expect(config.mcp?.prjct?.command?.some((c) => c.includes('mcp-server') || c.includes('prjct'))).toBe(
+      true
+    )
+  })
+
+  it('preserves user-defined MCP servers while upserting prjct', async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          mcp: {
+            mine: { type: 'local', command: ['echo', 'hi'], enabled: true },
+          },
+        },
+        null,
+        2
+      )}\n`,
+      'utf-8'
+    )
+
+    const r = await ensureOpenCodeMcpServer(configPath)
+    expect(r.changed).toBe(true)
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf-8')) as {
+      mcp: Record<string, { command?: string[] }>
+    }
+    expect(config.mcp.mine?.command).toEqual(['echo', 'hi'])
+    expect(config.mcp.prjct?.command).toBeTruthy()
+  })
+
+  it('preserves JSONC comments when modifying', async () => {
+    const jsoncPath = path.join(dir, 'opencode.jsonc')
+    await fs.writeFile(
+      jsoncPath,
+      `{
+  // user theme note
+  "theme": "opencode",
+  "mcp": {
+    "other": { "type": "local", "command": ["true"], "enabled": true }
+  }
+}
+`,
+      'utf-8'
+    )
+
+    const r = await ensureOpenCodeMcpServer(jsoncPath)
+    expect(r.changed).toBe(true)
+    const raw = await fs.readFile(jsoncPath, 'utf-8')
+    expect(raw).toContain('// user theme note')
+    expect(hasOpenCodePrjctMcp(raw)).toBe(true)
+    expect(raw).toContain('"other"')
+  })
+
+  it('is idempotent on re-run', async () => {
+    await ensureOpenCodeMcpServer(configPath)
+    const second = await ensureOpenCodeMcpServer(configPath)
+    expect(second.changed).toBe(false)
+  })
+})

--- a/core/commands/install.ts
+++ b/core/commands/install.ts
@@ -10,6 +10,7 @@
 import { detectAgentRuntimes } from '../infrastructure/agent-runtime-registry'
 import configManager from '../infrastructure/config-manager'
 import { installGrokSkill } from '../infrastructure/grok-skill'
+import { installPiSkill } from '../infrastructure/pi-skill'
 import { probeHarnessCoverage, renderHarnessCoverageMd } from '../services/harness-coverage'
 import { writeProjectAgentSurfaces } from '../services/project-agent-surfaces'
 import {
@@ -28,6 +29,7 @@ import { installGeminiSettings, uninstallGeminiSettings } from '../utils/gemini-
 import { ensureGrokMcpServer } from '../utils/grok-mcp'
 import { installGrokPlugin } from '../utils/grok-plugin'
 import { ensureKimiMcpServer } from '../utils/kimi-mcp'
+import { ensureOpenCodeMcpServer } from '../utils/opencode-mcp'
 import { failFromError, failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
@@ -64,6 +66,10 @@ export class InstallCommands extends PrjctCommandsBase {
       const grokConfig = grokDetected ? await ensureGrokMcpServer() : null
       const grokSkill = grokDetected ? await installGrokSkill() : null
       const grokPlugin = grokDetected ? await installGrokPlugin() : null
+      const opencodeDetected = detected.some((runtime) => runtime.runtime.id === 'opencode')
+      const opencodeConfig = opencodeDetected ? await ensureOpenCodeMcpServer() : null
+      const piDetected = detected.some((runtime) => runtime.runtime.id === 'pi')
+      const piSkill = piDetected ? await installPiSkill() : null
       const coverage = await probeHarnessCoverage(projectPath)
       const total = PRJCT_HOOKS.length
       const prunedNote = result.hooksPruned > 0 ? `, ${result.hooksPruned} retired removed` : ''
@@ -75,6 +81,8 @@ export class InstallCommands extends PrjctCommandsBase {
         cursorHooks ? 'cursor' : null,
         kimiConfig ? 'kimi' : null,
         grokConfig || grokSkill?.success || grokPlugin?.success ? 'grok' : null,
+        opencodeConfig ? 'opencode' : null,
+        piSkill?.success ? 'pi' : null,
         'claude',
       ].filter((x): x is string => Boolean(x))
       let deltaLine: string | null = null
@@ -164,6 +172,16 @@ export class InstallCommands extends PrjctCommandsBase {
                   `- Grok plugin: ${grokPlugin.changed ? `updated (${grokPlugin.files.join(', ') || 'files'})` : 'already ready'} → \`${grokPlugin.path}\``,
                 ]
               : []),
+            ...(opencodeConfig
+              ? [
+                  `- OpenCode MCP: ${opencodeConfig.changed ? 'updated' : 'already ready'} → \`${opencodeConfig.path}\``,
+                ]
+              : []),
+            ...(piSkill?.success
+              ? [
+                  `- Pi skill: ${piSkill.action ?? 'ready'}${piSkill.path ? ` → \`${piSkill.path}\`` : ''}`,
+                ]
+              : []),
             ``,
             `## Claude hooks adapter`,
             `Wrote to \`${result.settingsPath}\`.`,
@@ -180,8 +198,8 @@ export class InstallCommands extends PrjctCommandsBase {
             ``,
             renderHarnessCoverageMd(coverage),
             `> One install · one SQLite brain · every agent surface. That is the moat — not more skills.`,
-            `> Grok: native MCP + skill; hooks still via Claude compat. Codex/Gemini/Cursor get native adapters.`,
-            `> Gaps? \`prjct doctor --fix\`. Only \`_prjctManaged: true\` entries were touched.`,
+            `> OpenCode: native MCP. Pi: native skill (no MCP). Grok: MCP+skill; hooks via Claude compat. Codex/Gemini/Cursor: native adapters.`,
+            `> Gaps? \`prjct doctor --fix\`. Only managed entries were touched.`,
           ].join('\n')
         )
       } else {
@@ -243,6 +261,16 @@ export class InstallCommands extends PrjctCommandsBase {
         if (grokPlugin?.success) {
           out.info(
             `Grok plugin: ${grokPlugin.changed ? 'updated' : 'already ready'} → ${grokPlugin.path}`
+          )
+        }
+        if (opencodeConfig) {
+          out.info(
+            `OpenCode MCP: ${opencodeConfig.changed ? 'updated' : 'already ready'} → ${opencodeConfig.path}`
+          )
+        }
+        if (piSkill?.success) {
+          out.info(
+            `Pi skill: ${piSkill.action ?? 'ready'}${piSkill.path ? ` → ${piSkill.path}` : ''}`
           )
         }
         out.info(

--- a/core/infrastructure/agent-runtime-registry.ts
+++ b/core/infrastructure/agent-runtime-registry.ts
@@ -12,6 +12,7 @@ export type AgentRuntimeId =
   | 'gemini'
   | 'antigravity'
   | 'opencode'
+  | 'pi'
   | 'qwen-code'
   | 'kimi-cli'
   | 'grok'
@@ -227,17 +228,47 @@ export const AGENT_RUNTIME_REGISTRY: readonly AgentRuntimeDefinition[] = [
       commands: ['opencode'],
     },
     contextFiles: ['AGENTS.md', 'opencode.json', 'opencode.jsonc'],
-    mcpTargets: [{ format: 'opencode-json', pathHint: 'opencode.jsonc mcp', writable: false }],
+    mcpTargets: [
+      {
+        format: 'opencode-json',
+        pathHint: '~/.config/opencode/opencode.json mcp.prjct',
+        writable: true,
+      },
+    ],
     supports: {
       agentsMd: true,
       mcp: true,
-      skills: false,
+      // Claude-compat skills (~/.claude/skills) when OPENCODE_DISABLE_CLAUDE_CODE unset.
+      skills: true,
       hooks: false,
       acp: false,
       projectRules: true,
     },
     notes:
-      'Benchmark-tier open-source CLI (2026-07): most-starred multi-provider agent. AGENTS.md + plugins + MCP.',
+      'Benchmark-tier open-source CLI (2026-07): most-starred multi-provider agent. AGENTS.md + prjct install writes mcp.prjct; Claude skill/CLAUDE.md compat.',
+  },
+  {
+    id: 'pi',
+    displayName: 'Pi',
+    kind: 'cli',
+    status: 'stable',
+    detectsBy: {
+      homeDirs: ['.pi', path.join('.pi', 'agent')],
+      projectDirs: ['.pi'],
+      commands: ['pi'],
+    },
+    contextFiles: ['AGENTS.md', 'CLAUDE.md', 'SYSTEM.md', 'APPEND_SYSTEM.md'],
+    supports: {
+      agentsMd: true,
+      // No built-in MCP — skills + CLI --md are the contract (pi.dev design).
+      mcp: false,
+      skills: true,
+      hooks: false,
+      acp: false,
+      projectRules: false,
+    },
+    notes:
+      'Benchmark-tier minimal harness (2026-07): AGENTS.md + prjct skill at ~/.pi/agent/skills/prjct. MCP only via optional extensions — do not require it.',
   },
   {
     id: 'qwen-code',
@@ -729,6 +760,7 @@ const FULL_SUPPORT_RUNTIME_IDS = new Set<AgentRuntimeId>([
   'codex',
   'gemini',
   'opencode',
+  'pi',
   'cursor',
   'cline',
   'grok',

--- a/core/infrastructure/harness-surfaces.ts
+++ b/core/infrastructure/harness-surfaces.ts
@@ -283,27 +283,64 @@ export const BENCHMARK_HARNESS_SURFACES: readonly HarnessSurfaceEntry[] = [
     displayName: 'OpenCode',
     product: 'OpenCode (OSS multi-provider)',
     instructions: {
-      files: ['AGENTS.md', 'opencode.json(c)'],
-      loadOrder: 'project agents + AGENTS.md',
+      files: ['AGENTS.md', 'opencode.json(c)', 'CLAUDE.md (compat)'],
+      loadOrder: 'project AGENTS.md → global ~/.config/opencode/AGENTS.md; Claude fallbacks',
       prjct: 'portable',
     },
     mcp: {
-      configPaths: ['opencode.jsonc mcp section'],
-      format: 'JSONC project config',
-      prjct: 'planned',
+      configPaths: [
+        '~/.config/opencode/opencode.json mcp.prjct',
+        '~/.config/opencode/opencode.jsonc',
+        'project opencode.json(c)',
+      ],
+      format: 'JSONC mcp.<name> = { type:local, command:[...], enabled }',
+      prjct: 'native',
+      notes: 'prjct install → ensureOpenCodeMcpServer() upserts mcp.prjct (jsonc-safe merge)',
     },
     skills: {
-      paths: ['plugins / project agents'],
-      prjct: 'portable',
+      paths: ['.opencode/skills/', '~/.claude/skills/ (Claude Code compat)'],
+      prjct: 'inherits-claude',
+      notes: 'Claude skill install covers OpenCode when Claude compat is enabled',
     },
     hooks: {
       configPaths: [],
       events: [],
       format: 'plugin/extension dependent',
       prjct: 'none',
-      contract: 'No Claude-parity hook pack assumed; use MCP + AGENTS.md',
+      contract: 'No Claude-parity hook pack; MCP + AGENTS.md is the organic wire',
     },
-    legibility: 'Portable AGENTS.md + MCP CLI. Prefer model-agnostic tools over Claude-only hooks.',
+    legibility:
+      'Native MCP on prjct install when OpenCode is detected. AGENTS.md portable; Claude skills/CLAUDE.md as fallback.',
+  },
+  {
+    runtimeId: 'pi',
+    displayName: 'Pi',
+    product: 'Pi coding agent (minimal harness)',
+    instructions: {
+      files: ['AGENTS.md', 'CLAUDE.md', '~/.pi/agent/AGENTS.md', 'SYSTEM.md / APPEND_SYSTEM.md'],
+      loadOrder: '~/.pi/agent → parents → cwd',
+      prjct: 'portable',
+    },
+    mcp: {
+      configPaths: [],
+      format: 'none built-in (extension-only)',
+      prjct: 'none',
+      notes: 'Pi intentionally has no native MCP; do not require it for full wire',
+    },
+    skills: {
+      paths: ['~/.pi/agent/skills/prjct/SKILL.md', 'pi packages'],
+      prjct: 'native',
+      notes: 'prjct install → installPiSkill() at ~/.pi/agent/skills/prjct/SKILL.md',
+    },
+    hooks: {
+      configPaths: [],
+      events: [],
+      format: 'extension event hooks only',
+      prjct: 'none',
+      contract: 'Skill + AGENTS.md + prjct CLI --md; no lifecycle hook pack',
+    },
+    legibility:
+      'Native skill on prjct install when Pi is detected. AGENTS.md portable. MCP is optional via community extensions only.',
   },
   {
     runtimeId: 'cursor',

--- a/core/infrastructure/pi-skill.ts
+++ b/core/infrastructure/pi-skill.ts
@@ -1,0 +1,103 @@
+/**
+ * Pi coding-agent skill installer.
+ *
+ * Writes `~/.pi/agent/skills/prjct/SKILL.md` from the compact multi-host skill
+ * (same CONTRACT as Codex/Grok). Pi has no built-in MCP — skills + AGENTS.md
+ * are the portable contract. See pi.dev docs: AGENTS.md from ~/.pi/agent/,
+ * parents, cwd; skills via skill dirs / packages.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { getTemplateContent } from '../agentic/template-loader'
+import { getErrorMessage } from '../types/fs'
+import { fileExists } from '../utils/file-helper'
+import { sha256 } from '../utils/hash'
+import log from '../utils/logger'
+import { VERSION } from '../utils/version'
+import { resolveUserPath } from './user-home'
+
+const PI_SKILL_META_MARKER = 'prjct-pi-skill'
+
+function getPiSkillPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'pi', 'agent', 'skills', 'prjct', 'SKILL.md')
+  }
+  return resolveUserPath('.pi', 'agent', 'skills', 'prjct', 'SKILL.md')
+}
+
+export function getPiSkillInstallPath(): string {
+  return getPiSkillPath()
+}
+
+function getPiSkillMetadata(templateHash: string): string {
+  return `<!-- ${PI_SKILL_META_MARKER}: ${JSON.stringify({
+    v: VERSION,
+    h: templateHash,
+  })} -->`
+}
+
+function hashContent(content: string): string {
+  return sha256(content).slice(0, 12)
+}
+
+async function loadPiSkillTemplate(): Promise<string | null> {
+  // Prefer Pi-specific template when present; fall back to compact Codex skill
+  // (same CONTRACT lines — multi-host parity).
+  return getTemplateContent('pi/SKILL.md') ?? getTemplateContent('codex/SKILL.md')
+}
+
+export function buildPiSkillContent(templateContent: string): {
+  content: string
+  templateHash: string
+} {
+  const normalized = templateContent.trimEnd()
+  const templateHash = hashContent(normalized)
+  const metadata = getPiSkillMetadata(templateHash)
+  return {
+    content: `${normalized}\n\n${metadata}\n`,
+    templateHash,
+  }
+}
+
+/**
+ * Install prjct as a skill for Pi (`~/.pi/agent/skills/prjct/`).
+ */
+export async function installPiSkill(): Promise<{
+  success: boolean
+  action: string | null
+  path?: string
+}> {
+  try {
+    const skillMdPath = getPiSkillPath()
+    await fs.mkdir(path.dirname(skillMdPath), { recursive: true })
+
+    const skillExists = await fileExists(skillMdPath)
+
+    const templateContent = await loadPiSkillTemplate()
+    if (!templateContent) {
+      log.warn('Pi SKILL.md template not found')
+      return { success: false, action: null }
+    }
+
+    const built = buildPiSkillContent(templateContent)
+
+    if (skillExists) {
+      const existing = await fs.readFile(skillMdPath, 'utf-8').catch(() => '')
+      if (existing === built.content) {
+        return { success: true, action: 'unchanged', path: skillMdPath }
+      }
+    }
+
+    await fs.writeFile(skillMdPath, built.content, 'utf-8')
+
+    return {
+      success: true,
+      action: skillExists ? 'updated' : 'created',
+      path: skillMdPath,
+    }
+  } catch (error) {
+    log.warn(`Pi skill warning: ${getErrorMessage(error)}`)
+    return { success: false, action: null }
+  }
+}

--- a/core/infrastructure/setup.ts
+++ b/core/infrastructure/setup.ts
@@ -266,6 +266,24 @@ export async function run(): Promise<SetupResults> {
         )
       }
     }
+    const opencodeDetected = runtimes.some((r) => r.runtime.id === 'opencode' && r.detected)
+    if (opencodeDetected) {
+      const { ensureOpenCodeMcpServer } = await import('../utils/opencode-mcp')
+      const oc = await ensureOpenCodeMcpServer()
+      console.log(
+        `   ${chalk.green('✓')} OpenCode MCP ${oc.changed ? 'installed' : 'ready'} → ${oc.path}`
+      )
+    }
+    const piDetected = runtimes.some((r) => r.runtime.id === 'pi' && r.detected)
+    if (piDetected) {
+      const { installPiSkill } = await import('./pi-skill')
+      const pi = await installPiSkill()
+      if (pi.success) {
+        console.log(
+          `   ${chalk.green('✓')} Pi skill ${pi.action ?? 'ready'}${pi.path ? ` → ${pi.path}` : ''}`
+        )
+      }
+    }
   } catch {
     /* best-effort — install.ts is the primary wire path */
   }

--- a/core/services/agent-identity.ts
+++ b/core/services/agent-identity.ts
@@ -25,6 +25,7 @@ const KNOWN_AGENTS = new Set([
   'grok',
   'cursor',
   'opencode',
+  'pi',
   'windsurf',
   'antigravity',
   'unknown',
@@ -53,6 +54,12 @@ export function detectRuntimeAgent(): string {
   }
   if (process.env.GROK_API_KEY || process.env.XAI_API_KEY || process.env.GROK_SESSION) {
     return 'grok'
+  }
+  if (process.env.OPENCODE || process.env.OPENCODE_SESSION || process.env.OPENCODE_CONFIG) {
+    return 'opencode'
+  }
+  if (process.env.PI_CODING_AGENT_DIR || process.env.PI_SESSION || process.env.PI_AGENT) {
+    return 'pi'
   }
   return 'unknown'
 }
@@ -83,6 +90,8 @@ export function normalizeAgentName(raw: string): string {
   if (t === 'openai' || t === 'oai') return 'codex'
   if (t === 'google') return 'gemini'
   if (t === 'xai' || t === 'grok-build') return 'grok'
+  if (t === 'opencode-ai' || t === 'open-code') return 'opencode'
+  if (t === 'pi-coding-agent' || t === 'pi-agent') return 'pi'
   return t.slice(0, 32)
 }
 

--- a/core/services/doctor-heal.ts
+++ b/core/services/doctor-heal.ts
@@ -195,6 +195,14 @@ export async function applyDoctorHeal(
           await installGrokSkill()
           await installGrokPlugin()
         }
+        if (detected.some((r) => r.runtime.id === 'opencode')) {
+          const { ensureOpenCodeMcpServer } = await import('../utils/opencode-mcp')
+          await ensureOpenCodeMcpServer()
+        }
+        if (detected.some((r) => r.runtime.id === 'pi')) {
+          const { installPiSkill } = await import('../infrastructure/pi-skill')
+          await installPiSkill()
+        }
         // Always ensure Claude hooks too when multi-runtime runs
         await installHooks()
         applied.push(action.id)

--- a/core/services/harness-coverage.ts
+++ b/core/services/harness-coverage.ts
@@ -13,6 +13,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { getGrokSkillInstallPath } from '../infrastructure/grok-skill'
+import { getPiSkillInstallPath } from '../infrastructure/pi-skill'
 import { resolveUserHome } from '../infrastructure/user-home'
 import { getCodexHooksJsonPath } from '../utils/codex-hooks'
 import { getCodexConfigTomlPath } from '../utils/codex-mcp'
@@ -20,6 +21,11 @@ import { getCursorHooksJsonPath } from '../utils/cursor-hooks'
 import { getGeminiSettingsPath } from '../utils/gemini-settings'
 import { getGrokConfigTomlPath } from '../utils/grok-mcp'
 import { getGrokPluginRoot } from '../utils/grok-plugin'
+import {
+  getOpenCodeConfigPath,
+  getOpenCodeJsoncConfigPath,
+  hasOpenCodePrjctMcp,
+} from '../utils/opencode-mcp'
 import { commandOnPathAsync } from '../utils/which'
 
 export type OrganicLevel = 'full' | 'partial' | 'inherited' | 'none' | 'absent'
@@ -133,12 +139,22 @@ export async function probeHarnessCoverage(
   const grokSkill = getGrokSkillInstallPath()
   const grokPluginJson = path.join(getGrokPluginRoot(), 'plugin.json')
   const projectCursor = path.join(projectPath, '.cursor')
+  const opencodeJson = getOpenCodeConfigPath()
+  const opencodeJsonc = getOpenCodeJsoncConfigPath()
+  const opencodeHome = path.join(home, '.config', 'opencode')
+  const projectOpencode = path.join(projectPath, '.opencode')
+  const piHome = path.join(home, '.pi')
+  const piAgent = path.join(home, '.pi', 'agent')
+  const piSkill = getPiSkillInstallPath()
+  const projectPi = path.join(projectPath, '.pi')
 
   const [
     claudeCmd,
     codexCmd,
     geminiCmd,
     grokCmd,
+    opencodeCmd,
+    piCmd,
     claudeSettingsText,
     claudeMcpText,
     codexHooksText,
@@ -150,11 +166,21 @@ export async function probeHarnessCoverage(
     grokPluginExists,
     grokDir,
     cursorDir,
+    opencodeJsonText,
+    opencodeJsoncText,
+    opencodeDir,
+    projectOpencodeDir,
+    piDir,
+    piAgentDir,
+    piSkillExists,
+    projectPiDir,
   ] = await Promise.all([
     commandOnPathAsync('claude'),
     commandOnPathAsync('codex'),
     commandOnPathAsync('gemini'),
     commandOnPathAsync('grok'),
+    commandOnPathAsync('opencode'),
+    commandOnPathAsync('pi'),
     readText(claudeSettings),
     readText(claudeMcp),
     readText(codexHooks),
@@ -166,6 +192,14 @@ export async function probeHarnessCoverage(
     fileExists(grokPluginJson),
     fileExists(grokHome),
     fileExists(projectCursor),
+    readText(opencodeJson),
+    readText(opencodeJsonc),
+    fileExists(opencodeHome),
+    fileExists(projectOpencode),
+    fileExists(piHome),
+    fileExists(piAgent),
+    fileExists(piSkill),
+    fileExists(projectPi),
   ])
 
   const claudeDetected = claudeCmd || (await fileExists(path.join(home, '.claude')))
@@ -193,6 +227,13 @@ export async function probeHarnessCoverage(
   // Hooks still fire via Claude-compat settings; MCP can be native and/or Claude.
   const grokHooksLive = Boolean(claudeHooks)
   const grokMcpLive = grokNativeMcp || claudeMcpLive
+
+  const opencodeDetected = Boolean(opencodeCmd || opencodeDir || projectOpencodeDir)
+  const opencodeMcpLive =
+    hasOpenCodePrjctMcp(opencodeJsonText) || hasOpenCodePrjctMcp(opencodeJsoncText)
+
+  const piDetected = Boolean(piCmd || piDir || piAgentDir || projectPiDir)
+  const piSkillLive = Boolean(piSkillExists)
 
   const runtimes: RuntimeCoverage[] = [
     {
@@ -283,6 +324,34 @@ export async function probeHarnessCoverage(
                 : 'detected — run prjct install'
         : 'not installed',
     },
+    {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      detected: opencodeDetected,
+      hooksLive: false, // no Claude-parity hook pack
+      mcpLive: opencodeMcpLive,
+      // MCP-only is full for OpenCode (same model as Cursor hooks-only).
+      organic: !opencodeDetected ? 'absent' : opencodeMcpLive ? 'full' : 'none',
+      evidence: opencodeMcpLive
+        ? '~/.config/opencode/opencode.json mcp.prjct'
+        : opencodeDetected
+          ? 'detected — run prjct install for OpenCode MCP'
+          : 'not installed',
+    },
+    {
+      id: 'pi',
+      displayName: 'Pi',
+      detected: piDetected,
+      hooksLive: false,
+      mcpLive: false, // Pi has no native MCP
+      // Skill-only is full for Pi (anti-MCP-by-default design).
+      organic: !piDetected ? 'absent' : piSkillLive ? 'full' : 'none',
+      evidence: piSkillLive
+        ? '~/.pi/agent/skills/prjct/SKILL.md'
+        : piDetected
+          ? 'detected — run prjct install for Pi skill'
+          : 'not installed',
+    },
   ]
 
   const detected = runtimes.filter((r) => r.detected)
@@ -294,7 +363,7 @@ export async function probeHarnessCoverage(
 
   const summary =
     detectedCount === 0
-      ? 'No benchmark CLI/IDE detected — install Claude, Codex, Gemini, Cursor, or Grok, then `prjct install`.'
+      ? 'No benchmark CLI/IDE detected — install Claude, Codex, Gemini, Cursor, OpenCode, Pi, or Grok, then `prjct install`.'
       : liveCount === detectedCount
         ? `Organic full board: ${liveCount}/${detectedCount} detected runtimes live (${organicPct}%). Same SQLite brain, multi-surface wire.`
         : `Organic board ${liveCount}/${detectedCount} live (${organicPct}%). Run \`prjct install\` to close gaps — one command, all surfaces.`
@@ -321,7 +390,7 @@ export function renderHarnessCoverageMd(report: HarnessCoverageReport): string {
   ]
   for (const r of report.runtimes) {
     lines.push(
-      `| ${r.displayName} | ${r.detected ? 'yes' : '—'} | ${r.hooksLive ? '●' : '○'} | ${r.mcpLive ? '●' : r.id === 'cursor' ? 'IDE' : '○'} | \`${r.organic}\` | ${r.evidence} |`
+      `| ${r.displayName} | ${r.detected ? 'yes' : '—'} | ${r.hooksLive ? '●' : '○'} | ${r.mcpLive ? '●' : r.id === 'cursor' ? 'IDE' : r.id === 'pi' ? 'skill' : '○'} | \`${r.organic}\` | ${r.evidence} |`
     )
   }
   lines.push('', report.summary, '')

--- a/core/types/workflows.ts
+++ b/core/types/workflows.ts
@@ -23,6 +23,7 @@ export type AIAgent =
   | 'codex'
   | 'antigravity'
   | 'opencode'
+  | 'pi'
   | 'qwen-code'
   | 'goose'
   | 'aider'

--- a/core/utils/opencode-mcp.ts
+++ b/core/utils/opencode-mcp.ts
@@ -1,0 +1,188 @@
+/**
+ * OpenCode MCP wiring — ensures `~/.config/opencode/opencode.json` carries
+ * a managed `mcp.prjct` local server entry.
+ *
+ * OpenCode uses a different shape than Claude's mcpServers JSON:
+ *   mcp.<name> = { type: "local", command: [bin, ...args], enabled, environment? }
+ *
+ * We merge via jsonc-parser so JSONC comments on existing configs are
+ * preserved when possible. Prefer global config (user-wide) so every project
+ * gets prjct tools without per-repo commits.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import * as jsonc from 'jsonc-parser'
+import type { MCPServerConfig } from '../types/utils.js'
+import { resolveUserPath } from '../infrastructure/user-home'
+import { MCP_SERVER_PRESETS } from './mcp-config'
+
+export interface OpenCodeLocalMcp {
+  type: 'local'
+  command: string[]
+  enabled: boolean
+  environment?: Record<string, string>
+}
+
+export function getOpenCodeConfigPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'opencode', 'opencode.json')
+  }
+  return resolveUserPath('.config', 'opencode', 'opencode.json')
+}
+
+/** Alternate JSONC path — only used when opencode.json is missing but .jsonc exists. */
+export function getOpenCodeJsoncConfigPath(): string {
+  if (process.env.PRJCT_TEST_MODE === '1') {
+    return path.join(resolveUserPath('.prjct-tests'), 'opencode', 'opencode.jsonc')
+  }
+  return resolveUserPath('.config', 'opencode', 'opencode.jsonc')
+}
+
+/**
+ * Map prjct MCPServerConfig → OpenCode local MCP entry.
+ */
+export function toOpenCodeLocalMcp(
+  server: MCPServerConfig = MCP_SERVER_PRESETS.prjct
+): OpenCodeLocalMcp {
+  const command = [server.command, ...(server.args ?? [])]
+  const entry: OpenCodeLocalMcp = {
+    type: 'local',
+    command,
+    enabled: true,
+  }
+  if (server.env && Object.keys(server.env).length > 0) {
+    entry.environment = { ...server.env }
+  }
+  return entry
+}
+
+async function resolveWritePath(preferred = getOpenCodeConfigPath()): Promise<string> {
+  // Prefer explicit preferred path (tests pass this). Otherwise prefer existing
+  // jsonc over creating a new .json when only jsonc is present.
+  try {
+    await fs.access(preferred)
+    return preferred
+  } catch {
+    /* fall through */
+  }
+  if (preferred === getOpenCodeConfigPath()) {
+    const jsoncPath = getOpenCodeJsoncConfigPath()
+    try {
+      await fs.access(jsoncPath)
+      return jsoncPath
+    } catch {
+      /* create preferred */
+    }
+  }
+  return preferred
+}
+
+function parseOpenCodeConfig(raw: string): Record<string, unknown> {
+  if (!raw.trim()) return {}
+  const errors: jsonc.ParseError[] = []
+  const result = jsonc.parse(raw, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  })
+  if (errors.length > 0) {
+    // Fall back to empty object only on total failure; prefer partial?
+    // Hard-fail so we never clobber a broken file silently.
+    const first = errors[0]
+    throw new SyntaxError(
+      `OpenCode config parse error at offset ${first.offset}: ${jsonc.printParseErrorCode(first.error)}`
+    )
+  }
+  if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+    return {}
+  }
+  return result as Record<string, unknown>
+}
+
+/**
+ * Idempotently install/refresh mcp.prjct in OpenCode global config.
+ */
+export async function ensureOpenCodeMcpServer(
+  configPath?: string,
+  server: MCPServerConfig = MCP_SERVER_PRESETS.prjct
+): Promise<{ path: string; changed: boolean }> {
+  const target = configPath ?? (await resolveWritePath())
+  await fs.mkdir(path.dirname(target), { recursive: true })
+
+  let existingRaw = ''
+  try {
+    existingRaw = await fs.readFile(target, 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  const entry = toOpenCodeLocalMcp(server)
+
+  if (!existingRaw.trim()) {
+    const fresh = {
+      $schema: 'https://opencode.ai/config.json',
+      mcp: {
+        prjct: entry,
+      },
+    }
+    await fs.writeFile(target, `${JSON.stringify(fresh, null, 2)}\n`, 'utf-8')
+    return { path: target, changed: true }
+  }
+
+  const parsed = parseOpenCodeConfig(existingRaw)
+  const mcp = (parsed.mcp ?? {}) as Record<string, unknown>
+  const previous = mcp.prjct
+  const changed = JSON.stringify(previous) !== JSON.stringify(entry)
+  if (!changed) {
+    return { path: target, changed: false }
+  }
+
+  // Use jsonc modify so comments / trailing commas are preserved when possible.
+  let next = existingRaw
+  const formatting = { tabSize: 2, insertSpaces: true } as const
+  if (!parsed.mcp || typeof parsed.mcp !== 'object') {
+    next = jsonc.applyEdits(
+      next,
+      jsonc.modify(next, ['mcp'], {}, { formattingOptions: formatting })
+    )
+  }
+  next = jsonc.applyEdits(
+    next,
+    jsonc.modify(next, ['mcp', 'prjct'], entry, { formattingOptions: formatting })
+  )
+  // Ensure schema hint for editors when missing
+  if (!parsed.$schema) {
+    next = jsonc.applyEdits(
+      next,
+      jsonc.modify(next, ['$schema'], 'https://opencode.ai/config.json', {
+        formattingOptions: formatting,
+        isArrayInsertion: false,
+      })
+    )
+  }
+
+  await fs.writeFile(target, next.endsWith('\n') ? next : `${next}\n`, 'utf-8')
+  return { path: target, changed: true }
+}
+
+/** True iff config has a local mcp.prjct entry (any shape with command/mcp-server). */
+export function hasOpenCodePrjctMcp(raw: string | null | undefined): boolean {
+  if (!raw) return false
+  try {
+    const parsed = parseOpenCodeConfig(raw)
+    const mcp = parsed.mcp as Record<string, unknown> | undefined
+    const prjct = mcp?.prjct as Record<string, unknown> | undefined
+    if (!prjct) return false
+    const command = prjct.command
+    if (Array.isArray(command)) {
+      return command.some((c) => typeof c === 'string' && (c.includes('prjct') || c.includes('mcp-server')))
+    }
+    if (typeof command === 'string') {
+      return command.includes('prjct') || command.includes('mcp-server')
+    }
+    // Heuristic for partially-written configs
+    return JSON.stringify(prjct).includes('mcp-server') || JSON.stringify(prjct).includes('prjct')
+  } catch {
+    return raw.includes('"prjct"') && (raw.includes('mcp-server') || raw.includes('type'))
+  }
+}

--- a/core/workflows/onboarding/detection.ts
+++ b/core/workflows/onboarding/detection.ts
@@ -44,6 +44,7 @@ export const AI_AGENTS: { value: AIAgent; title: string; description: string }[]
   { value: 'gemini', title: 'Gemini CLI', description: "Google's Gemini in terminal" },
   { value: 'codex', title: 'OpenAI Codex', description: "OpenAI's coding agent in terminal" },
   { value: 'opencode', title: 'OpenCode', description: 'Open-source terminal coding agent' },
+  { value: 'pi', title: 'Pi', description: 'Minimal terminal coding harness (skills + AGENTS.md)' },
   { value: 'qwen-code', title: 'Qwen Code', description: 'Qwen-family coding runtime' },
   { value: 'goose', title: 'Goose', description: 'Open-source coding agent with extensions' },
   { value: 'aider', title: 'Aider', description: 'Terminal pair-programming agent' },
@@ -113,6 +114,12 @@ export async function detectInstalledAgents(projectPath: string): Promise<AIAgen
     agents.push('antigravity')
   }
   if (await dirExists(path.join(projectPath, '.opencode'))) agents.push('opencode')
+  if (
+    (await dirExists(path.join(projectPath, '.pi'))) ||
+    (await dirExists(path.join(os.homedir(), '.pi')))
+  ) {
+    agents.push('pi')
+  }
   if (await dirExists(path.join(projectPath, '.qwen'))) agents.push('qwen-code')
   if (await dirExists(path.join(projectPath, '.goose'))) agents.push('goose')
   if (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.69.1",
+  "version": "3.70.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- **OpenCode**: native MCP installer (`ensureOpenCodeMcpServer`) → `~/.config/opencode/opencode.json` `mcp.prjct` (JSONC-safe). Organic board: MCP-only = full.
- **Pi**: registry + `installPiSkill` → `~/.pi/agent/skills/prjct/SKILL.md`. No native MCP (by design); skill = full wire.
- Wired into `prjct install`, `doctor --fix`, setup, harness surfaces, organic coverage.

**Release: v3.70.0** (bumped from main’s 3.69.1 — no collision with 3.69.0).

## Test plan

- [x] Unit tests: opencode-mcp, pi-skill, registry, harness-surfaces, harness-coverage
- [ ] With OpenCode: `prjct install` writes `mcp.prjct`
- [ ] With Pi: `prjct install` writes skill
- [ ] `prjct doctor --fix` re-wires both when detected

Generated with [p/](https://www.prjct.app/)