### PR TITLE
fix(code-graph): full graph upload — remove 400/900 caps

### DIFF
--- a/core/__tests__/services/code-graph-cloud.test.ts
+++ b/core/__tests__/services/code-graph-cloud.test.ts
@@ -101,12 +101,26 @@ export function main() {
     expect(buildCloudCodeGraphSnapshot('no-such-project-xyz')).toBeNull()
   })
 
-  it('respects maxNodes cap', async () => {
+  it('optional maxNodes/maxLinks only apply when explicitly passed', async () => {
     await indexSymbols(sourceDir, testProjectId)
-    const snap = buildCloudCodeGraphSnapshot(testProjectId, { maxNodes: 3, maxLinks: 20 })
+    const full = buildCloudCodeGraphSnapshot(testProjectId)
+    const capped = buildCloudCodeGraphSnapshot(testProjectId, { maxNodes: 3, maxLinks: 20 })
+    expect(full).not.toBeNull()
+    expect(capped).not.toBeNull()
+    // Default ships the full index (no artificial 400/900 cloud caps)
+    expect(full!.nodes.length).toBeGreaterThanOrEqual(capped!.nodes.length)
+    // Opt-in cap still bounds picked symbols (+ file hubs)
+    expect(capped!.nodes.length).toBeLessThanOrEqual(10)
+    expect(capped!.links.length).toBeLessThanOrEqual(20)
+  })
+
+  it('default snapshot includes every indexed symbol as a node (no drop)', async () => {
+    await indexSymbols(sourceDir, testProjectId)
+    const snap = buildCloudCodeGraphSnapshot(testProjectId)
     expect(snap).not.toBeNull()
-    // File nodes are extra on top of picked symbols — total can be slightly over maxNodes
-    // but should stay bounded (picked ≤ 3 + file hubs ≤ 3)
-    expect(snap!.nodes.length).toBeLessThanOrEqual(10)
+    // symbolCount is the index size; nodes = symbols + File hubs (≥ symbolCount)
+    expect(snap!.nodes.length).toBeGreaterThanOrEqual(snap!.symbolCount)
+    const nonFile = snap!.nodes.filter((n) => n.kind !== 'File')
+    expect(nonFile.length).toBe(snap!.symbolCount)
   })
 })

--- a/core/commands/code.ts
+++ b/core/commands/code.ts
@@ -9,7 +9,7 @@
  *   prjct code architecture        → structural overview (one-shot)
  *   prjct code export              → cache under ~/.prjct-cli/projects/<id>/
  *   prjct code import              → restore SQLite from that per-project cache
- *   prjct code push-graph          → upload compact structural graph to cloud 3D
+ *   prjct code push-graph          → upload full structural graph to cloud 3D
  *   prjct code reindex             → rebuild symbol graph now
  *   prjct code dead                → zero-caller symbols (excl. entries)
  *   prjct code cbm [cli <tool> …]  → optional CBM bridge status / execute
@@ -342,7 +342,7 @@ export class CodeCommands extends PrjctCommandsBase {
         options
       )
     }
-    const msg = `Uploaded structural graph · ${res.nodes ?? 0} nodes · ${res.links ?? 0} links (Function/Class/File + CALLS)`
+    const msg = `Uploaded full structural graph · ${res.nodes ?? 0} nodes · ${res.links ?? 0} links (Function/Class/File + CALLS/IMPORTS — uncapped)`
     if (options.md) console.log(mdOutput('## Code graph cloud', `> ${msg}`))
     else out.success(msg)
     return { success: true, ...res }

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -461,7 +461,7 @@ export const COMMANDS: CommandMeta[] = [
       'Symbol index on sync; 4th work-scope signal; CALLS with enclosing + imports',
       'trace / impact (hunk-level) / architecture / dead one-shots',
       'Per-project cache under ~/.prjct-cli/projects/<id>/ (never in client repo)',
-      'push-graph: compact Function/Class/File + CALLS snapshot → cloud 3D',
+      'push-graph: full Function/Class/File + CALLS/IMPORTS graph → cloud 3D (no node/link caps)',
       'PreToolUse Grep|Glob augment; ship structural risk cue; optional CBM cli',
     ],
   },

--- a/core/services/code-graph-artifact.ts
+++ b/core/services/code-graph-artifact.ts
@@ -182,7 +182,7 @@ export async function maybeExportAfterIndex(projectId: string): Promise<void> {
   }
 }
 
-/** Build compact structural snapshot and POST to /sync/projects/{id}/code-graph. */
+/** Build full structural snapshot (no node/link caps) and POST to /sync/projects/{id}/code-graph. */
 export async function maybeUploadCodeGraphToCloud(
   projectId: string
 ): Promise<{ uploaded: boolean; nodes?: number; links?: number; reason?: string }> {

--- a/core/services/code-graph-cloud.ts
+++ b/core/services/code-graph-cloud.ts
@@ -1,21 +1,28 @@
 /**
- * Compact structural code-graph snapshot for cloud 3D visualization.
+ * Structural code-graph snapshot for cloud 3D visualization.
  *
  * Same domain as CBM / native symbol index:
  *   nodes = Function | Method | Class | Interface | Type | File | …
  *   links = CALLS | IMPORTS | DEFINES | HANDLES | TESTS
  *
- * NOT knowledge/contribution clusters. Cap size for API JSONB + SPA force-graph.
+ * NOT knowledge/contribution clusters.
+ *
+ * Default: ship the FULL index (every symbol, every structural edge, every
+ * file that holds a symbol). Optional maxNodes/maxLinks are opt-in only for
+ * tests or explicit callers — never applied by default.
  */
 
 import { hasSymbolIndex, listAllSymbols, loadMeta } from '../domain/symbol-graph'
 import prjctDb from '../storage/database'
 import type { CodeSymbolEdge, SymbolEdgeType } from '../types/domain.js'
 
-/** Max nodes shipped to cloud (force-graph stays interactive). */
-export const CLOUD_GRAPH_MAX_NODES = 400
-/** Max directed edges shipped with the node subset. */
-export const CLOUD_GRAPH_MAX_LINKS = 900
+/**
+ * @deprecated No default cloud caps. Kept as Infinity so any leftover import
+ * that treats these as ceilings stays uncapped.
+ */
+export const CLOUD_GRAPH_MAX_NODES = Number.POSITIVE_INFINITY
+/** @deprecated See CLOUD_GRAPH_MAX_NODES — no default link cap. */
+export const CLOUD_GRAPH_MAX_LINKS = Number.POSITIVE_INFINITY
 
 export type CloudGraphNodeKind =
   | 'Function'
@@ -97,9 +104,15 @@ function loadEdges(projectId: string): CodeSymbolEdge[] {
   }
 }
 
+function hasFiniteCap(n: number | undefined): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n >= 0
+}
+
 /**
- * Build a compact CBM-style structural graph from the local symbol index.
- * Scores symbols by structural degree (CALLS/IMPORTS) + export + kind weight.
+ * Build a CBM-style structural graph from the local symbol index.
+ *
+ * Default = full index. Pass maxNodes/maxLinks only when you intentionally
+ * want a truncated sample (tests).
  */
 export function buildCloudCodeGraphSnapshot(
   projectId: string,
@@ -107,15 +120,13 @@ export function buildCloudCodeGraphSnapshot(
 ): CloudCodeGraphSnapshot | null {
   if (!hasSymbolIndex(projectId)) return null
 
-  const maxNodes = opts.maxNodes ?? CLOUD_GRAPH_MAX_NODES
-  const maxLinks = opts.maxLinks ?? CLOUD_GRAPH_MAX_LINKS
   const symbols = listAllSymbols(projectId)
   if (symbols.length === 0) return null
 
   const edges = loadEdges(projectId)
   const meta = loadMeta(projectId)
 
-  // Degree from structural edges only
+  // Degree from structural edges only (ordering only — does not drop nodes)
   const degree = new Map<string, number>()
   for (const e of edges) {
     const w = EDGE_PRIORITY[e.edgeType] ?? 1
@@ -148,23 +159,25 @@ export function buildCloudCodeGraphSnapshot(
     })
     .sort((a, b) => b.score - a.score || a.s.name.localeCompare(b.s.name))
 
-  const picked = scored.slice(0, maxNodes).map((x) => x.s)
+  // Full set by default; optional opt-in cap for tests only
+  const picked = hasFiniteCap(opts.maxNodes)
+    ? scored.slice(0, opts.maxNodes).map((x) => x.s)
+    : scored.map((x) => x.s)
   const keep = new Set(picked.map((s) => s.id))
 
-  // File nodes for top files among picked symbols (CBM-style File layer)
+  // File nodes for every file among picked symbols (no "top N" slice)
   const fileCounts = new Map<string, number>()
   for (const s of picked) {
     fileCounts.set(s.file, (fileCounts.get(s.file) ?? 0) + 1)
   }
-  const topFiles = [...fileCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, Math.min(80, Math.floor(maxNodes / 5)))
+  const files = [...fileCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .map(([f]) => f)
 
   const fileNodeId = (file: string) => `file:${file}`
   const nodes: CloudGraphNode[] = []
 
-  for (const file of topFiles) {
+  for (const file of files) {
     const base = file.split('/').pop() || file
     nodes.push({
       id: fileNodeId(file),
@@ -186,11 +199,11 @@ export function buildCloudCodeGraphSnapshot(
     })
   }
 
-  // DEFINES: File → symbol for symbols in top files
+  // DEFINES: File → symbol for every picked symbol that has a file node
   const defineLinks: CloudGraphLink[] = []
-  const topFileSet = new Set(topFiles)
+  const fileSet = new Set(files)
   for (const s of picked) {
-    if (!topFileSet.has(s.file)) continue
+    if (!fileSet.has(s.file)) continue
     defineLinks.push({
       source: fileNodeId(s.file),
       target: s.id,
@@ -198,7 +211,7 @@ export function buildCloudCodeGraphSnapshot(
     })
   }
 
-  // Structural edges between kept symbol nodes
+  // Structural edges between kept symbol nodes (full set by default)
   const edgeCandidates = edges
     .filter((e) => keep.has(e.src) && keep.has(e.dst) && e.src !== e.dst)
     .map((e) => ({
@@ -212,17 +225,18 @@ export function buildCloudCodeGraphSnapshot(
 
   const seen = new Set<string>()
   const links: CloudGraphLink[] = []
+  const linkCap = hasFiniteCap(opts.maxLinks) ? opts.maxLinks : Number.POSITIVE_INFINITY
 
   for (const d of defineLinks) {
+    if (links.length >= linkCap) break
     const key = `${d.source}->${d.target}:${d.type}`
     if (seen.has(key)) continue
     seen.add(key)
     links.push({ source: d.source, target: d.target, type: d.type })
-    if (links.length >= maxLinks) break
   }
 
   for (const e of edgeCandidates) {
-    if (links.length >= maxLinks) break
+    if (links.length >= linkCap) break
     const key = `${e.source}->${e.target}:${e.type}`
     if (seen.has(key)) continue
     seen.add(key)


### PR DESCRIPTION
## Summary

- **Bug:** cloud 3D graph only showed ~480 nodes / 900 links / 5 kinds because CLI hard-capped `CLOUD_GRAPH_MAX_NODES=400`, `MAX_LINKS=900`, and top-80 files.
- **Fix:** default snapshot ships the **full** symbol index (every Function/Class/… + every File hub + every structural edge). Optional `maxNodes`/`maxLinks` are opt-in for tests only.
- After merge: reindex + `prjct code push-graph` (or next sync) to upload the full graph.

## Test plan

- [x] `bun test core/__tests__/services/code-graph-cloud.test.ts`
- [ ] On a large project: `prjct code reindex && prjct code push-graph` → node count ≥ symbolCount

Generated with [p/](https://www.prjct.app/)