### PR TITLE
fix(code-graph): real upload error details

### DIFF
--- a/core/services/code-graph-artifact.ts
+++ b/core/services/code-graph-artifact.ts
@@ -194,7 +194,14 @@ export async function maybeUploadCodeGraphToCloud(
   try {
     const { default: syncClient } = await import('../sync/sync-client')
     const res = await syncClient.uploadCodeGraph(projectId, snap)
-    if (!res.ok) return { uploaded: false, reason: 'upload failed or unauthenticated' }
+    if (!res.ok) {
+      return {
+        uploaded: false,
+        reason: res.reason ?? 'upload failed or unauthenticated',
+        nodes: snap.nodes.length,
+        links: snap.links.length,
+      }
+    }
     return {
       uploaded: true,
       nodes: res.nodes ?? snap.nodes.length,

--- a/core/sync/sync-client.ts
+++ b/core/sync/sync-client.ts
@@ -210,10 +210,10 @@ class SyncClient {
       }>
       links: Array<{ source: string; target: string; type: string }>
     }
-  ): Promise<{ ok: boolean; nodes?: number; links?: number }> {
+  ): Promise<{ ok: boolean; nodes?: number; links?: number; reason?: string }> {
     try {
       const { apiUrl, apiKey, deviceId } = await this.getAuthHeaders()
-      if (!apiKey) return { ok: false }
+      if (!apiKey) return { ok: false, reason: 'unauthenticated' }
       const response = await this.fetchWithRetry(
         `${apiUrl}/sync/projects/${projectId}/code-graph`,
         {
@@ -225,11 +225,21 @@ class SyncClient {
           body: JSON.stringify(graph),
         }
       )
-      if (!response.ok) return { ok: false }
+      if (!response.ok) {
+        let detail = `${response.status} ${response.statusText}`
+        try {
+          const errBody = (await response.json()) as { detail?: unknown }
+          if (typeof errBody.detail === 'string') detail = errBody.detail
+          else if (errBody.detail != null) detail = JSON.stringify(errBody.detail).slice(0, 300)
+        } catch {
+          /* ignore body parse */
+        }
+        return { ok: false, reason: detail }
+      }
       const body = (await response.json()) as { ok?: boolean; nodes?: number; links?: number }
       return { ok: body.ok !== false, nodes: body.nodes, links: body.links }
-    } catch {
-      return { ok: false }
+    } catch (e) {
+      return { ok: false, reason: e instanceof Error ? e.message : String(e) }
     }
   }
 


### PR DESCRIPTION
## Summary
- `uploadCodeGraph` returns `reason` from HTTP status/body instead of always mapping failure to "unauthenticated".

## Test plan
- [x] typecheck via normal CI

Generated with [p/](https://www.prjct.app/)