### PR TITLE
feat(harness): WS1 typed process chokepoint (v3.71.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## [Unreleased]
 
+## [3.71.0] - 2026-07-19
+
+### Added
+- WS1 chokepoint superiority: close gaps vs gentle-ai typed process errors
+
 ## [3.70.1] - 2026-07-17
 
 ### Bug Fixes
 
 - full graph upload — remove 400/900 caps (#587)
 - ship full structural graph to cloud — no caps
-
 
 ## [3.70.0] - 2026-07-16
 

--- a/core/__tests__/services/content-bound-stamp.test.ts
+++ b/core/__tests__/services/content-bound-stamp.test.ts
@@ -1,15 +1,22 @@
 /**
  * Content-bound stamp — pure hash + drift verdict (Dynasty D2).
+ * Plus the ship-safety rule: git infra must not collapse to "unverified → pass".
  */
 
 import { describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import {
   BLOB_MISSING,
   buildTreeHash,
   contentBoundDriftVerdict,
+  currentTreeHashForStamp,
   hashBlobContent,
+  resolveStampPaths,
   stampFromContents,
 } from '../../services/content-bound-stamp'
+import { GitInfraError } from '../../utils/exec'
 
 describe('content-bound-stamp', () => {
   it('hashes blob content deterministically', () => {
@@ -111,5 +118,50 @@ describe('content-bound-stamp', () => {
     })
     expect(u.blocked).toBe(false)
     expect(u.reason).toBe('unverified')
+  })
+})
+
+/**
+ * PATH-hijack: empty dir as PATH → git spawn ENOENT (real infra failure).
+ */
+async function withBrokenGit<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-no-git-'))
+  const oldPath = process.env.PATH
+  process.env.PATH = dir
+  try {
+    return await fn()
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH
+    else process.env.PATH = oldPath
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+describe('content-bound stamp — git infra must not fail-open', () => {
+  it('resolveStampPaths throws GitInfraError when git cannot spawn', async () => {
+    if (process.platform === 'win32') return
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-stamp-'))
+    try {
+      await withBrokenGit(async () => {
+        await expect(resolveStampPaths(dir, null)).rejects.toBeInstanceOf(GitInfraError)
+      })
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  it('currentTreeHashForStamp rethrows GitInfraError (empty-path fallback)', async () => {
+    if (process.platform === 'win32') return
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-stamp-'))
+    try {
+      // Empty paths force resolveStampPaths → git. A pure stamp with no
+      // recorded paths is the fail-open footgun if git collapses to null.
+      const stamp = stampFromContents([], { stampedAt: 't0' })
+      await withBrokenGit(async () => {
+        await expect(currentTreeHashForStamp(dir, stamp)).rejects.toBeInstanceOf(GitInfraError)
+      })
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
   })
 })

--- a/core/__tests__/services/detect-changes.test.ts
+++ b/core/__tests__/services/detect-changes.test.ts
@@ -11,6 +11,7 @@ import { indexSymbols } from '../../domain/symbol-graph'
 import pathManager from '../../infrastructure/path-manager'
 import { detectChanges } from '../../services/detect-changes'
 import prjctDb from '../../storage/database'
+import { GitInfraError } from '../../utils/exec'
 
 describe('detect-changes', () => {
   let testDir: string
@@ -65,5 +66,39 @@ describe('detect-changes', () => {
     })
     expect(result.changes[0]?.risk).toBe('critical')
     expect(result.summary.critical).toBe(1)
+  })
+})
+
+
+/**
+ * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
+ * fails with a real ENOENT — exercises the infra-failure path without mocks.
+ */
+async function withBrokenGit<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-no-git-'))
+  const oldPath = process.env.PATH
+  process.env.PATH = dir
+  try {
+    return await fn()
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH
+    else process.env.PATH = oldPath
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+describe('detect-changes — typed git failures (WS1)', () => {
+  it('git infra failure rejects with GitInfraError instead of a fake clean tree', async () => {
+    if (process.platform === 'win32') return
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-dc-nogit-'))
+    try {
+      await withBrokenGit(async () => {
+        await expect(
+          detectChanges(dir, 'test-dc-nogit', { source: 'working-tree' })
+        ).rejects.toBeInstanceOf(GitInfraError)
+      })
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
   })
 })

--- a/core/__tests__/services/staleness-checker.test.ts
+++ b/core/__tests__/services/staleness-checker.test.ts
@@ -190,3 +190,51 @@ describe('StalenessChecker', () => {
     })
   })
 })
+
+
+/**
+ * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
+ * fails with a real ENOENT — exercises the infra-failure path without mocks.
+ */
+async function withBrokenGit<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-no-git-'))
+  const oldPath = process.env.PATH
+  process.env.PATH = dir
+  try {
+    return await fn()
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH
+    else process.env.PATH = oldPath
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+describe('typed git failures (WS1)', () => {
+  it('reports "history changed" ONLY on a typed exit (sync commit really gone)', async () => {
+    prjctDb.setDoc(testProjectId, 'project', {
+      lastSyncCommit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      lastSync: new Date().toISOString(),
+    })
+
+    const checker = createStalenessChecker(process.cwd())
+    const status = await checker.check(testProjectId)
+
+    expect(status.isStale).toBe(true)
+    expect(status.reason).toContain('history changed')
+  })
+
+  it('git infra failure (spawn) → staleness unknown, NEVER "history changed"', async () => {
+    if (process.platform === 'win32') return
+    prjctDb.setDoc(testProjectId, 'project', {
+      lastSyncCommit: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      lastSync: new Date().toISOString(),
+    })
+
+    await withBrokenGit(async () => {
+      const status = await createStalenessChecker(process.cwd()).check(testProjectId)
+      expect(status.isStale).toBe(false)
+      expect(status.reason).toContain('unknown')
+      expect(status.reason).not.toContain('history changed')
+    })
+  })
+})

--- a/core/__tests__/services/task-harness.test.ts
+++ b/core/__tests__/services/task-harness.test.ts
@@ -119,3 +119,33 @@ describe('detectKind — word-aware matching (no mid-word false positives)', () 
     expect(buildTaskHarness('improve the implement flow for exports').kind).toBe('feature')
   })
 })
+
+
+/**
+ * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
+ * fails with a real ENOENT — exercises the infra-failure path without mocks.
+ */
+async function withBrokenGit<T>(fn: () => Promise<T>): Promise<T> {
+  const noGitDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-no-git-'))
+  const oldPath = process.env.PATH
+  process.env.PATH = noGitDir
+  try {
+    return await fn()
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH
+    else process.env.PATH = oldPath
+    await fs.rm(noGitDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+describe('evaluateHarnessCompletion — typed git failures (WS1)', () => {
+  test('git infra failure → "evidence unavailable", never a fabricated missing-test warning', async () => {
+    if (process.platform === 'win32') return
+    const task = await currentTask('bug en codex no se instala el statusbar eso es un must')
+    await withBrokenGit(async () => {
+      const result = await evaluateHarnessCompletion(dir, task)
+      expect(result.warnings.some((w) => w.includes('evidence unavailable'))).toBe(true)
+      expect(result.warnings.some((w) => w.includes('no test file changed'))).toBe(false)
+    })
+  })
+})

--- a/core/__tests__/services/version-service.test.ts
+++ b/core/__tests__/services/version-service.test.ts
@@ -164,3 +164,54 @@ describe('VersionService.bump (idempotency)', () => {
     expect(next).toBe('0.1.1')
   })
 })
+
+
+/**
+ * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
+ * fails with a real ENOENT — exercises the infra-failure path without mocks.
+ */
+async function withBrokenGit<T>(fn: () => Promise<T>): Promise<T> {
+  const noGitDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-no-git-'))
+  const oldPath = process.env.PATH
+  process.env.PATH = noGitDir
+  try {
+    return await fn()
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH
+    else process.env.PATH = oldPath
+    await fs.rm(noGitDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+describe('VersionService — typed git failures (WS1)', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-version-nogit-'))
+    await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: dir })
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+    await execFileAsync('git', ['config', 'user.name', 'Test'], { cwd: dir })
+    await execFileAsync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir })
+  })
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('bump rejects on git infra failure instead of treating the tree as fresh', async () => {
+    if (process.platform === 'win32') return
+    await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify({ version: '1.2.3' }))
+    await execFileAsync('git', ['add', 'package.json'], { cwd: dir })
+    await execFileAsync('git', ['commit', '-q', '-m', 'v1.2.3'], { cwd: dir })
+
+    await withBrokenGit(async () => {
+      await expect(new VersionService(dir).bump()).rejects.toThrow(/git (timeout|spawn) failure/)
+    })
+
+    // The transient failure must NOT have touched the version.
+    const pkg = JSON.parse(await fs.readFile(path.join(dir, 'package.json'), 'utf-8')) as {
+      version: string
+    }
+    expect(pkg.version).toBe('1.2.3')
+  })
+})

--- a/core/__tests__/services/workspace-id.test.ts
+++ b/core/__tests__/services/workspace-id.test.ts
@@ -90,3 +90,36 @@ describe('deriveWorkspace', () => {
     expect(ws.isMain).toBe(true)
   })
 })
+
+
+/**
+ * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
+ * fails with a real ENOENT — exercises the infra-failure path without mocks.
+ */
+async function withBrokenGit<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-no-git-'))
+  const oldPath = process.env.PATH
+  process.env.PATH = dir
+  try {
+    return await fn()
+  } finally {
+    if (oldPath === undefined) delete process.env.PATH
+    else process.env.PATH = oldPath
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+describe('deriveWorkspace — degraded identity (WS1)', () => {
+  test('git infra failure → main sentinel FLAGGED with gitError (write paths refuse)', async () => {
+    if (process.platform === 'win32') return
+    // Fresh path — deriveWorkspace memoizes per cwd for 5s.
+    const fresh = path.join(wtA, 'fresh-sub')
+    await fs.mkdir(fresh, { recursive: true })
+    await withBrokenGit(async () => {
+      const ws = await deriveWorkspace(fresh)
+      expect(ws.workspaceId).toBe(MAIN_WORKSPACE_ID)
+      expect(ws.isMain).toBe(true)
+      expect(ws.gitError).toBe('spawn')
+    })
+  })
+})

--- a/core/__tests__/utils/proc.test.ts
+++ b/core/__tests__/utils/proc.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Typed process chokepoint (core/utils/exec.ts).
+ *
+ * Superiority contract vs gentle-ai v2.1.8 typed process errors:
+ *   - deadline FIRST (timeoutMs + AbortSignal), then spawn, then overflow, then exit
+ *   - only exitCodeMeans(code≥0) is a domain negative
+ *   - overflow is INFRA (never synthetic exit -1)
+ *   - envelopes sanitized ≤240; full cause stays in-process
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { ChildProcess, spawn } from 'node:child_process'
+import { exec as execCallback } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import {
+  exitCodeMeans,
+  GitInfraError,
+  gitInfraErrorOf,
+  gitStdout,
+  isProcInfra,
+  matchProc,
+  PROC_ENVELOPE_MAX,
+  type ProcResult,
+  procErrorOf,
+  runProc,
+  sanitizeProcEnvelope,
+  throwProc,
+} from '../../utils/exec'
+
+const execAsync = promisify(execCallback)
+const NODE = process.execPath
+
+/** A spawn double whose process never produces output or exits. */
+function hangingSpawn(): typeof spawn {
+  return (() => {
+    const child = new EventEmitter() as ChildProcess
+    ;(child as { stdout: unknown }).stdout = new EventEmitter()
+    ;(child as { stderr: unknown }).stderr = new EventEmitter()
+    ;(child as { pid: number }).pid = 999_999_999
+    ;(child as { kill: () => boolean }).kill = () => true
+    return child
+  }) as unknown as typeof spawn
+}
+
+describe('runProc classification', () => {
+  test('ok result captures stdout/stderr + durationMs', async () => {
+    const res = await runProc(NODE, ['-e', 'console.log("out"); console.error("err")'])
+    expect(res.ok).toBe(true)
+    if (res.ok) {
+      expect(res.stdout.trim()).toBe('out')
+      expect(res.stderr.trim()).toBe('err')
+      expect(res.durationMs).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  test('non-zero exit → kind exit with code, signal null, and streams', async () => {
+    const res = await runProc(NODE, ['-e', 'console.error("boom"); process.exit(7)'])
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.kind).toBe('exit')
+      if (res.kind === 'exit') {
+        expect(res.code).toBe(7)
+        expect(res.signal).toBeNull()
+        expect(res.stderr).toContain('boom')
+      }
+    }
+  })
+
+  test('missing binary → kind spawn with OS cause + code (never an exit)', async () => {
+    const res = await runProc('prjct-definitely-not-a-real-binary-xyz', [])
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.kind).toBe('spawn')
+      if (res.kind === 'spawn') {
+        expect(res.cause.message).toMatch(/ENOENT|not found/i)
+        expect(res.code === undefined || res.code === 'ENOENT').toBe(true)
+      }
+    }
+  })
+
+  test('deadline → kind timeout carrying budget + budgetSource:timeout', async () => {
+    const res = await runProc(NODE, ['-e', 'setTimeout(() => {}, 5000)'], { timeoutMs: 150 })
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.kind).toBe('timeout')
+      if (res.kind === 'timeout') {
+        expect(res.budgetMs).toBe(150)
+        expect(res.budgetSource).toBe('timeout')
+      }
+    }
+  })
+
+  test('AbortSignal (caller budget) wins without waiting the full timeoutMs', async () => {
+    const ac = new AbortController()
+    const pending = runProc(NODE, ['-e', 'setTimeout(() => {}, 5000)'], {
+      timeoutMs: 10_000,
+      signal: ac.signal,
+    })
+    setTimeout(() => ac.abort(), 50)
+    const res = await pending
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.kind).toBe('timeout')
+      if (res.kind === 'timeout') expect(res.budgetSource).toBe('abort')
+    }
+  })
+
+  test('already-aborted signal never spawns', async () => {
+    const ac = new AbortController()
+    ac.abort()
+    const res = await runProc(NODE, ['-e', 'console.log("should-not-run")'], {
+      signal: ac.signal,
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.kind).toBe('timeout')
+      if (res.kind === 'timeout') {
+        expect(res.budgetSource).toBe('abort')
+        expect(res.budgetMs).toBe(0)
+      }
+    }
+  })
+
+  test('deadline precedence: timeout wins even when the process never closes cleanly', async () => {
+    const res = await runProc(
+      NODE,
+      ['-e', 'process.on("SIGTERM", () => {}); setTimeout(() => {}, 5000)'],
+      { timeoutMs: 150 }
+    )
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.kind).toBe('timeout')
+  })
+
+  test('timeout kills the whole process tree — grandchildren cannot escape', async () => {
+    if (process.platform === 'win32') return
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-proc-tree-'))
+    const marker = path.join(dir, 'grandchild-survived')
+    try {
+      const res = await runProc('sh', ['-c', `(sleep 1; touch "${marker}") & sleep 30`], {
+        timeoutMs: 200,
+      })
+      expect(res.ok).toBe(false)
+      if (!res.ok) expect(res.kind).toBe('timeout')
+      await new Promise((resolve) => setTimeout(resolve, 1400))
+      const exists = await fs
+        .access(marker)
+        .then(() => true)
+        .catch(() => false)
+      expect(exists).toBe(false)
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('maxBuffer overflow is INFRA (kind overflow) — never synthetic exit -1', async () => {
+    const res = await runProc(NODE, ['-e', 'console.log("x".repeat(2_000_000))'], {
+      maxBuffer: 1024,
+    })
+    expect(res.ok).toBe(false)
+    if (!res.ok) {
+      expect(res.kind).toBe('overflow')
+      if (res.kind === 'overflow') {
+        expect(res.maxBuffer).toBe(1024)
+        expect(isProcInfra(res)).toBe(true)
+        // Domain-negative footgun must stay shut:
+        expect(exitCodeMeans(res, -1)).toBe(false)
+      }
+    }
+  })
+
+  test('overflow settles immediately (does not wait for close/timeout)', async () => {
+    const t0 = Date.now()
+    const res = await runProc(
+      NODE,
+      ['-e', 'console.log("x".repeat(5_000_000)); setTimeout(()=>{}, 30_000)'],
+      {
+        maxBuffer: 512,
+        timeoutMs: 30_000,
+      }
+    )
+    const elapsed = Date.now() - t0
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.kind).toBe('overflow')
+    // Must not wait for the 30s timeout — hang regression guard.
+    expect(elapsed).toBeLessThan(5_000)
+  })
+})
+
+describe('exitCodeMeans / gitInfraErrorOf / procErrorOf / matchProc', () => {
+  const ok: ProcResult = { ok: true, stdout: '', stderr: '', durationMs: 1 }
+  const exit1: ProcResult = {
+    ok: false,
+    kind: 'exit',
+    code: 1,
+    signal: null,
+    stderr: 'no match',
+    stdout: '',
+    args: ['git', 'grep'],
+    durationMs: 1,
+  }
+  const exitNeg: ProcResult = {
+    ok: false,
+    kind: 'exit',
+    code: -1,
+    signal: 'SIGKILL',
+    stderr: '',
+    stdout: '',
+    args: ['git'],
+    durationMs: 1,
+  }
+  const timeout: ProcResult = {
+    ok: false,
+    kind: 'timeout',
+    budgetMs: 10,
+    budgetSource: 'timeout',
+    args: ['git'],
+    stdout: '',
+    stderr: '',
+    durationMs: 1,
+  }
+  const spawnFail: ProcResult = {
+    ok: false,
+    kind: 'spawn',
+    cause: new Error('ENOENT'),
+    code: 'ENOENT',
+    args: ['git'],
+    durationMs: 1,
+  }
+  const overflow: ProcResult = {
+    ok: false,
+    kind: 'overflow',
+    maxBuffer: 10,
+    args: ['git'],
+    stdout: '',
+    stderr: 'maxBuffer',
+    durationMs: 1,
+  }
+
+  test('only a typed exit with a real code ≥ 0 is a domain negative', () => {
+    expect(exitCodeMeans(exit1, 1)).toBe(true)
+    expect(exitCodeMeans(exit1, 2)).toBe(false)
+    expect(exitCodeMeans(timeout, 1)).toBe(false)
+    expect(exitCodeMeans(spawnFail, 1)).toBe(false)
+    expect(exitCodeMeans(overflow, 1)).toBe(false)
+    // Synthetic / signal-only codes are never domain:
+    expect(exitCodeMeans(exitNeg, -1)).toBe(false)
+    expect(exitCodeMeans(exit1, -1)).toBe(false)
+  })
+
+  test('isProcInfra covers timeout/spawn/overflow only', () => {
+    expect(isProcInfra(ok)).toBe(false)
+    expect(isProcInfra(exit1)).toBe(false)
+    expect(isProcInfra(timeout)).toBe(true)
+    expect(isProcInfra(spawnFail)).toBe(true)
+    expect(isProcInfra(overflow)).toBe(true)
+  })
+
+  test('infra errors build GitInfraError; exit/ok build nothing', () => {
+    expect(gitInfraErrorOf(ok)).toBeNull()
+    expect(gitInfraErrorOf(exit1)).toBeNull()
+    const infra = gitInfraErrorOf(timeout)
+    expect(infra).toBeInstanceOf(GitInfraError)
+    expect(infra?.kind).toBe('timeout')
+    expect(gitInfraErrorOf(spawnFail)?.kind).toBe('spawn')
+    expect(gitInfraErrorOf(overflow)?.kind).toBe('overflow')
+  })
+
+  test('procErrorOf: null on ok; generic Error on exit; GitInfraError on infra', () => {
+    expect(procErrorOf(ok)).toBeNull()
+    const exitErr = procErrorOf(exit1)
+    expect(exitErr).toBeInstanceOf(Error)
+    expect(exitErr).not.toBeInstanceOf(GitInfraError)
+    expect(exitErr?.message).toMatch(/exit 1/)
+    expect(exitErr?.message).toContain('no match')
+    expect(procErrorOf(timeout)).toBeInstanceOf(GitInfraError)
+    expect(procErrorOf(spawnFail)).toBeInstanceOf(GitInfraError)
+    expect(procErrorOf(overflow)).toBeInstanceOf(GitInfraError)
+  })
+
+  test('throwProc never throws null — always a real Error', () => {
+    expect(() => throwProc(exit1)).toThrow(/exit 1/)
+    expect(() => throwProc(timeout)).toThrow(GitInfraError)
+    expect(() => throwProc(overflow)).toThrow(GitInfraError)
+    expect(() => throwProc(ok)).toThrow(/throwProc called on ok/)
+  })
+
+  test('matchProc is exhaustive and routes overflow away from exit', () => {
+    const label = (r: ProcResult) =>
+      matchProc(r, {
+        ok: () => 'ok',
+        exit: () => 'exit',
+        timeout: () => 'timeout',
+        spawn: () => 'spawn',
+        overflow: () => 'overflow',
+      })
+    expect(label(ok)).toBe('ok')
+    expect(label(exit1)).toBe('exit')
+    expect(label(timeout)).toBe('timeout')
+    expect(label(spawnFail)).toBe('spawn')
+    expect(label(overflow)).toBe('overflow')
+  })
+
+  test('sanitizeProcEnvelope caps length and strips path-like segments', () => {
+    const long = 'x'.repeat(500)
+    expect(sanitizeProcEnvelope(long).length).toBeLessThanOrEqual(PROC_ENVELOPE_MAX)
+    const withPath = 'failed reading /Users/jj/secret/repo/.git/config boom'
+    expect(sanitizeProcEnvelope(withPath)).not.toContain('/Users/jj')
+    expect(sanitizeProcEnvelope(withPath)).toContain('…')
+  })
+
+  test('GitInfraError.message is envelope-sanitized; detail keeps full text', () => {
+    const detail = `exceeded while reading /Users/jj/secret/project/.git`
+    const err = new GitInfraError('timeout', ['git', 'status'], detail)
+    expect(err.message.length).toBeLessThanOrEqual(PROC_ENVELOPE_MAX)
+    expect(err.message).not.toContain('/Users/jj')
+    expect(err.detail).toBe(detail)
+  })
+})
+
+describe('gitStdout', () => {
+  test('returns trimmed stdout on success', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-gitstdout-'))
+    try {
+      await execAsync('git init -q', { cwd: dir })
+      const out = await gitStdout(dir, ['rev-parse', '--is-inside-work-tree'])
+      expect(out).toBe('true')
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('typed exit (missing ref) → null, the legitimate domain negative', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-gitstdout-'))
+    try {
+      await execAsync('git init -q', { cwd: dir })
+      const out = await gitStdout(dir, ['rev-parse', '--verify', '--quiet', 'no-such-ref'])
+      expect(out).toBeNull()
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  test('timeout → throws GitInfraError instead of collapsing to null', async () => {
+    await expect(
+      gitStdout(process.cwd(), ['status'], { spawnFn: hangingSpawn(), timeoutMs: 100 })
+    ).rejects.toBeInstanceOf(GitInfraError)
+  })
+
+  test('spawn failure → throws GitInfraError (never null domain negative)', async () => {
+    const spawnFn = (() => {
+      const child = new EventEmitter() as ChildProcess
+      ;(child as { stdout: unknown }).stdout = new EventEmitter()
+      ;(child as { stderr: unknown }).stderr = new EventEmitter()
+      ;(child as { pid: number }).pid = 1
+      ;(child as { kill: () => boolean }).kill = () => true
+      queueMicrotask(() =>
+        child.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))
+      )
+      return child
+    }) as unknown as typeof spawn
+    await expect(gitStdout(process.cwd(), ['status'], { spawnFn })).rejects.toBeInstanceOf(
+      GitInfraError
+    )
+  })
+})

--- a/core/commands/product.ts
+++ b/core/commands/product.ts
@@ -25,7 +25,7 @@ import type { SqliteBindings } from '../storage/database/sqlite-compat'
 import type { MdOption } from '../types/cli'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
-import { execFileAsync } from '../utils/exec'
+import { runGit, throwProc } from '../utils/exec'
 import { failHard } from '../utils/md-aware'
 import out from '../utils/output'
 import { PrjctCommandsBase } from './base'
@@ -818,27 +818,26 @@ async function buildGuardrails(projectId: string, projectPath: string) {
 
 async function changedFiles(projectPath: string): Promise<string[]> {
   const names = new Set<string>()
-  try {
-    const { stdout } = await execFileAsync('git', ['diff', '--name-only', 'HEAD'], {
-      cwd: projectPath,
-    })
-    for (const line of stdout.split('\n')) {
+  const diff = await runGit(['diff', '--name-only', 'HEAD'], { cwd: projectPath })
+  if (diff.ok) {
+    for (const line of diff.stdout.split('\n')) {
       const value = line.trim()
       if (value) names.add(value)
     }
-  } catch {
-    return []
+  } else if (diff.kind !== 'exit') {
+    // Typed exit → no diff answer; still collect untracked below.
+    throwProc(diff)
   }
-  try {
-    const { stdout } = await execFileAsync('git', ['ls-files', '--others', '--exclude-standard'], {
-      cwd: projectPath,
-    })
-    for (const line of stdout.split('\n')) {
+  const untracked = await runGit(['ls-files', '--others', '--exclude-standard'], {
+    cwd: projectPath,
+  })
+  if (untracked.ok) {
+    for (const line of untracked.stdout.split('\n')) {
       const value = line.trim()
       if (value) names.add(value)
     }
-  } catch {
-    // ignore untracked lookup failure
+  } else if (untracked.kind !== 'exit') {
+    throwProc(untracked)
   }
   return [...names].sort()
 }

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -25,6 +25,7 @@ import { getErrorMessage } from '../types/fs'
 import type { WorkflowRule } from '../types/storage/extended'
 import type { WorkflowRunContext } from '../types/workflow.js'
 import * as dateHelper from '../utils/date-helper'
+import { GitInfraError } from '../utils/exec'
 import { failFromError } from '../utils/md-aware'
 import { mdDone, mdList, mdNextSteps, mdOutput, mdSection } from '../utils/md-formatter'
 import { getNextSteps, showNextSteps } from '../utils/next-steps'
@@ -176,12 +177,12 @@ export class ShippingCommands extends PrjctCommandsBase {
       }
 
       // Delivery geometry at ship — large committed diffs need an explicit strategy.
+      const geomMode = shipConfig?.deliveryGeometry?.mode ?? 'off'
       try {
         const { computeCommittedChangeset, shipGeometryVerdict } = await import(
           '../services/delivery-geometry'
         )
         const cs = await computeCommittedChangeset(projectPath)
-        const geomMode = shipConfig?.deliveryGeometry?.mode ?? 'off'
         const gv = shipGeometryVerdict({
           changeset: cs,
           mode: geomMode,
@@ -192,7 +193,16 @@ export class ShippingCommands extends PrjctCommandsBase {
           return { success: false, error: gv.message ?? 'Delivery geometry gate blocked ship.' }
         }
         if (gv.message) console.log(gv.message)
-      } catch {
+      } catch (err) {
+        // Strict mode must not fail open when the changeset is unevaluable:
+        // a git infra failure blocks with the cause instead of silently
+        // passing the gate. Advisory/off stay best-effort.
+        if (geomMode === 'strict' && err instanceof GitInfraError) {
+          return {
+            success: false,
+            error: `Delivery geometry gate unevaluable: ${err.message}. Re-run when git is healthy, or ship with explicit \`--geometry\`.`,
+          }
+        }
         /* geometry best-effort */
       }
 
@@ -222,7 +232,12 @@ export class ShippingCommands extends PrjctCommandsBase {
             }
           }
         }
-      } catch {
+      } catch (err) {
+        // Advisory cue stays fail-open, but a git infra failure is surfaced
+        // — never a silent "no structural risk" on a sick git.
+        if (err instanceof GitInfraError) {
+          console.log(`⚠️  Structural risk cue unavailable: ${err.message}`)
+        }
         /* structural risk best-effort */
       }
 
@@ -230,6 +245,8 @@ export class ShippingCommands extends PrjctCommandsBase {
       // auto-ship). Intensity standard|full hard-blocks without ledger.approved.
       // Override: --no-judgment-gate only (consent-scoped; not --no-spec-gate).
       // code-strict pack forces dual-blind (full) intensity when quality applies.
+      const packs = shipConfig?.persona?.packs ?? []
+      const isCodeStrictPack = packs.includes('code-strict')
       try {
         const { intensityFromChangeset, judgmentShipVerdict } = await import(
           '../services/precision-judgment'
@@ -246,8 +263,6 @@ export class ShippingCommands extends PrjctCommandsBase {
           { files: cs?.files ?? 0, loc: cs?.loc ?? 0 },
           signals
         )
-        const packs = shipConfig?.persona?.packs ?? []
-        const isCodeStrictPack = packs.includes('code-strict')
         // SUPERIOR: code-strict ALWAYS dual-blind (full) — even trivial diffs.
         // Ship-grade packs never skip the judgment ledger.
         if (isCodeStrictPack) {
@@ -285,11 +300,28 @@ export class ShippingCommands extends PrjctCommandsBase {
               return { success: false, error: cv.message }
             }
             if (cv.message) console.log(cv.message)
-          } catch {
-            /* content-bound best-effort */
+          } catch (err) {
+            // Git infra must not fail-open the content-bound gate under
+            // code-strict packs (null treeHash used to mean "unverified → pass").
+            if (codeStrict && err instanceof GitInfraError) {
+              return {
+                success: false,
+                error: `Content-bound stamp unevaluable: ${err.message}. Re-run when git is healthy, or override with \`--no-judgment-gate\`.`,
+              }
+            }
+            /* non-strict / non-infra: best-effort */
           }
         }
-      } catch {
+      } catch (err) {
+        // A hard judgment gate (code-strict pack) must not fail open when
+        // the changeset is unevaluable — block with the cause. Everything
+        // else stays best-effort and never crashes ship on lookup.
+        if (isCodeStrictPack && err instanceof GitInfraError) {
+          return {
+            success: false,
+            error: `Judgment ship gate unevaluable: ${err.message}. Re-run when git is healthy, or override with \`--no-judgment-gate\`.`,
+          }
+        }
         /* judgment gate is best-effort — never crash ship on lookup */
       }
 

--- a/core/commands/team.ts
+++ b/core/commands/team.ts
@@ -23,10 +23,8 @@
  * with deterministic file writes only.
  */
 
-import { exec } from 'node:child_process'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { promisify } from 'node:util'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
 import {
@@ -36,14 +34,13 @@ import {
 } from '../storage/team-enrollment-storage'
 import type { CommandResult } from '../types/commands'
 import { getErrorMessage } from '../types/fs'
+import { execAsync } from '../utils/exec'
 import { writeFileAtomic } from '../utils/file-helper'
 import { failHard, failWith } from '../utils/md-aware'
 import { mdOutput, mdSection } from '../utils/md-formatter'
 import out from '../utils/output'
 import { VERSION } from '../utils/version'
 import { PrjctCommandsBase } from './base'
-
-const execP = promisify(exec)
 
 const CLAUDE_MD_START = '<!-- prjct-team:start - DO NOT REMOVE THIS MARKER -->'
 const CLAUDE_MD_END = '<!-- prjct-team:end - DO NOT REMOVE THIS MARKER -->'
@@ -148,7 +145,7 @@ export class TeamCommands extends PrjctCommandsBase {
       let staged = false
       const stagedPaths = [teamPath, claudeMdPath]
       try {
-        await execP('git rev-parse --show-toplevel', { cwd: projectPath })
+        await execAsync('git rev-parse --show-toplevel', { cwd: projectPath })
 
         // 4a. Optional: install pre-commit hook that blocks commits
         // when team.json says required:true and prjct isn't on PATH.
@@ -161,11 +158,11 @@ export class TeamCommands extends PrjctCommandsBase {
           await fs.mkdir(path.dirname(hookPath), { recursive: true })
           await fs.writeFile(hookPath, PRE_COMMIT_HOOK_BODY, 'utf-8')
           await fs.chmod(hookPath, 0o755)
-          await execP('git config core.hooksPath .githooks', { cwd: projectPath })
+          await execAsync('git config core.hooksPath .githooks', { cwd: projectPath })
           stagedPaths.push(hookPath)
         }
 
-        await execP(`git add ${stagedPaths.map((p) => JSON.stringify(p)).join(' ')}`, {
+        await execAsync(`git add ${stagedPaths.map((p) => JSON.stringify(p)).join(' ')}`, {
           cwd: projectPath,
         })
         staged = true

--- a/core/services/agent-switch.ts
+++ b/core/services/agent-switch.ts
@@ -199,6 +199,13 @@ async function rebindTaskOwner(
   }
 ): Promise<void> {
   const ws = await deriveWorkspace(projectPath)
+  if (ws.gitError) {
+    // Degraded identity — writing task fields keyed on the main fallback
+    // could corrupt another workspace's cycle. Refuse loudly.
+    throw new Error(
+      `git ${ws.gitError}: workspace identity unknown — refusing to update task fields on the main fallback.`
+    )
+  }
   // null → delete key inside updateCurrentTask / updateWorkspaceTask
   const patch = fields as Partial<import('../schemas/state').CurrentTask> & Record<string, unknown>
 
@@ -237,6 +244,12 @@ export async function switchAgent(
   const fromIdentity = task.ownerIdentity || caller.identity
 
   const ws = await deriveWorkspace(projectPath)
+  if (ws.gitError) {
+    return {
+      ok: false,
+      error: `git ${ws.gitError}: workspace identity unknown — refusing to switch agents on the main fallback. Re-run when git is healthy.`,
+    }
+  }
   const cfg = await configManager.readConfig(projectPath).catch(() => null)
   const evidence = await buildEvidence(projectId, projectPath, task.id, task.startedAt)
   const reason = composeReason(options.reason, evidence, task.description)

--- a/core/services/auto-updater.ts
+++ b/core/services/auto-updater.ts
@@ -9,16 +9,14 @@
  * remote installer script in the background.
  */
 
-import { execFile, execFileSync, spawn } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
-import { promisify } from 'node:util'
 import { resolveCliHome } from '../infrastructure/cli-home'
 import { compareSemver } from '../schemas/model'
+import { execFileAsync } from '../utils/exec'
 import { getConfig, setConfig } from './global-config'
 import { fetchLatestVersion } from './update-checker'
-
-const execFileP = promisify(execFile)
 
 // Per call — honors PRJCT_CLI_HOME (see cli-home.ts).
 const stateDir = (): string => path.join(resolveCliHome(), 'state')
@@ -122,13 +120,13 @@ async function applyUpgrade(source: InstallSource, _targetVersion: string): Prom
     return
   }
   if (source === 'bun') {
-    await execFileP('bun', ['install', '-g', 'prjct-cli@latest'], {
+    await execFileAsync('bun', ['install', '-g', 'prjct-cli@latest'], {
       timeout: 120_000,
     })
     return
   }
   if (source === 'npm' || source === 'unknown') {
-    await execFileP('npm', ['install', '-g', 'prjct-cli@latest'], {
+    await execFileAsync('npm', ['install', '-g', 'prjct-cli@latest'], {
       timeout: 120_000,
     })
     return

--- a/core/services/cbm-bridge.ts
+++ b/core/services/cbm-bridge.ts
@@ -6,12 +6,9 @@
  * making it a hard dependency.
  */
 
-import { execFile } from 'node:child_process'
 import { access } from 'node:fs/promises'
 import path from 'node:path'
-import { promisify } from 'node:util'
-
-const execFileAsync = promisify(execFile)
+import { execFileAsync } from '../utils/exec'
 
 export interface CbmStatus {
   available: boolean

--- a/core/services/content-bound-stamp.ts
+++ b/core/services/content-bound-stamp.ts
@@ -10,7 +10,7 @@
 import { createHash } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { execFileAsync } from '../utils/exec'
+import { GitInfraError, gitStdout } from '../utils/exec'
 
 /** Missing / deleted path sentinel — still contributes to treeHash. */
 export const BLOB_MISSING = 'missing' as const
@@ -163,13 +163,13 @@ export function shortHash(h: string): string {
   return h.slice(0, 12)
 }
 
+/**
+ * Git for stamp path resolution. Typed exit → null (domain: no paths / no
+ * HEAD). Infra (timeout/spawn) throws GitInfraError — never collapse to null,
+ * or ship would treat an unevaluable tree as "unverified → pass".
+ */
 async function safeGit(projectPath: string, args: string[]): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync('git', args, { cwd: projectPath })
-    return stdout.trim()
-  } catch {
-    return null
-  }
+  return gitStdout(projectPath, args, { timeoutMs: 5_000 })
 }
 
 /**
@@ -259,7 +259,10 @@ export async function currentTreeHashForStamp(
       headSha: stamp.headSha,
     })
     return next.treeHash
-  } catch {
+  } catch (err) {
+    // IO / parse failures → null (unverified advisory). Git infra must
+    // propagate so code-strict ship can refuse instead of fail-open.
+    if (err instanceof GitInfraError) throw err
     return null
   }
 }

--- a/core/services/delivery-geometry.ts
+++ b/core/services/delivery-geometry.ts
@@ -3,7 +3,7 @@
  * Shared by `prjct review-risk` (advisory) and work-start gates (strict packs).
  */
 
-import { execFileAsync } from '../utils/exec'
+import { gitStdout } from '../utils/exec'
 
 export type DeliveryTier = 'trivial' | 'normal' | 'large'
 export type DeliveryGeometry = 'direct' | 'single' | 'split'
@@ -35,13 +35,12 @@ export function geometryOf(tier: DeliveryTier): DeliveryGeometry {
   return 'split'
 }
 
+// Typed chokepoint: exit codes stay domain negatives (null — e.g. no default
+// branch, no merge-base); git timeout/spawn throws GitInfraError so a strict
+// geometry gate can refuse instead of silently passing (callers catch and
+// decide the polarity of their gate).
 async function safeGit(projectPath: string, args: string[]): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync('git', args, { cwd: projectPath })
-    return stdout.trim()
-  } catch {
-    return null
-  }
+  return gitStdout(projectPath, args)
 }
 
 function parseShortstat(shortstat: string): { files: number; loc: number } {

--- a/core/services/detect-changes.ts
+++ b/core/services/detect-changes.ts
@@ -7,15 +7,13 @@
 import { loadGraph } from '../domain/import-graph'
 import { fileFanIn, filesCallingInto, hasSymbolIndex, symbolsInFile } from '../domain/symbol-graph'
 import type { ChangeRisk, DetectChangesResult, DetectedChange } from '../types/domain.js'
-import { execFileAsync } from '../utils/exec'
+import { gitStdout } from '../utils/exec'
 
+// Typed chokepoint: exit codes stay domain negatives (null — e.g. missing ref,
+// not a repo); git timeout/spawn throws GitInfraError so a broken git can
+// never masquerade as "no changes" on the ship path.
 async function safeGit(projectPath: string, args: string[]): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync('git', args, { cwd: projectPath })
-    return stdout.trim()
-  } catch {
-    return null
-  }
+  return gitStdout(projectPath, args)
 }
 
 async function listWorkingTreeFiles(projectPath: string): Promise<string[]> {

--- a/core/services/git-context.ts
+++ b/core/services/git-context.ts
@@ -4,9 +4,13 @@
  * answer "who touched this / what changed during that task?" WITHOUT making the
  * agent read all of `git blame`. All best-effort: a non-repo or a missing piece
  * just omits that field.
+ *
+ * Uses the typed chokepoint for bounded timeout (no hang) and no shell.
+ * Best-effort semantics: infra and typed exit both omit the field — these
+ * tags must never block remember/ship.
  */
 
-import { execFileAsync } from '../utils/exec'
+import { runGit } from '../utils/exec'
 
 export interface GitContext {
   /** Short HEAD sha at capture time. */
@@ -17,13 +21,12 @@ export interface GitContext {
   files?: string[]
 }
 
+const GIT_CTX_TIMEOUT_MS = 5_000
+
 async function git(cwd: string, args: string[]): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync('git', args, { cwd })
-    return stdout.trim() || undefined
-  } catch {
-    return undefined
-  }
+  const res = await runGit(args, { cwd, timeoutMs: GIT_CTX_TIMEOUT_MS })
+  if (!res.ok) return undefined
+  return res.stdout.trim() || undefined
 }
 
 export async function deriveGitContext(projectPath: string): Promise<GitContext> {

--- a/core/services/judgment-orchestrator.ts
+++ b/core/services/judgment-orchestrator.ts
@@ -78,7 +78,7 @@ export async function resolveWorkIntensity(
       }
     }
   } catch {
-    /* no git — intensity from signals only */
+    /* no git / git infra failure — intensity from signals only (advisory) */
   }
   const { intensity } = intensityFromChangeset({ files, loc }, signals)
   return { intensity, files, loc }

--- a/core/services/lean-detector.ts
+++ b/core/services/lean-detector.ts
@@ -17,13 +17,10 @@
  *   - Conservative: only flags growth >= threshold, never on first run.
  */
 
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
 import type { LocalConfig } from '../types/config'
-
-const execFileP = promisify(execFile)
+import { exitCodeMeans, runGit, throwProc } from '../utils/exec'
 
 const LEAN_DEBT_SOURCE_TAG = 'lean-detector'
 const LEAN_DEBT_PATTERN_TAG = 'lean-debt-growth'
@@ -113,25 +110,24 @@ export async function detectAndPersistLeanDebt(
  * comparison stays meaningful turn-over-turn.
  */
 async function measureLeanMarkers(projectPath: string): Promise<number> {
-  try {
-    const { stdout } = await execFileP('git', ['grep', '-cI', '-e', 'lean:'], {
-      cwd: projectPath,
-      maxBuffer: 16 * 1024 * 1024,
-    })
-    let total = 0
-    for (const line of stdout.split('\n')) {
-      // `git grep -c` emits "<file>:<count>" per file.
-      const idx = line.lastIndexOf(':')
-      if (idx <= 0) continue
-      const num = Number.parseInt(line.slice(idx + 1), 10)
-      if (Number.isFinite(num)) total += num
-    }
-    return total
-  } catch (err) {
-    // git grep exits 1 when there are no matches — treat as zero.
-    if ((err as { code?: number }).code === 1) return 0
-    throw err
+  const res = await runGit(['grep', '-cI', '-e', 'lean:'], {
+    cwd: projectPath,
+    maxBuffer: 16 * 1024 * 1024,
+  })
+  if (!res.ok) {
+    // git grep exit 1 = no matches — the one legitimate domain negative.
+    if (exitCodeMeans(res, 1)) return 0
+    throwProc(res)
   }
+  let total = 0
+  for (const line of res.stdout.split('\n')) {
+    // `git grep -c` emits "<file>:<count>" per file.
+    const idx = line.lastIndexOf(':')
+    if (idx <= 0) continue
+    const num = Number.parseInt(line.slice(idx + 1), 10)
+    if (Number.isFinite(num)) total += num
+  }
+  return total
 }
 
 interface DebtMemoryRow {

--- a/core/services/pattern-detector.ts
+++ b/core/services/pattern-detector.ts
@@ -23,14 +23,11 @@
  *     precision over recall.
  */
 
-import { execFile } from 'node:child_process'
 import path from 'node:path'
-import { promisify } from 'node:util'
 import configManager from '../infrastructure/config-manager'
 import { projectMemory } from '../memory/project-memory'
 import type { LocalConfig } from '../types/config'
-
-const execFileP = promisify(execFile)
+import { exitCodeMeans, runGit, throwProc } from '../utils/exec'
 
 const HOT_FILE_PATTERN_TAG = 'hot-file'
 const HOT_FILE_SOURCE_TAG = 'pattern-detector-auto'
@@ -228,14 +225,19 @@ async function detectHotFiles(projectPath: string): Promise<HotFile[]> {
   // -z: NUL-separate paths inside each commit; --name-only without
   //   --diff-filter so we count any change (add/modify/rename).
   // --pretty=format:: empty so each commit emits only its file list.
-  const { stdout } = await execFileP(
-    'git',
+  // Typed chokepoint: timeout/spawn throw into the outer try (Stop stays
+  // best-effort); typed exit → empty list (no history), never a hang.
+  const res = await runGit(
     ['log', `--since=${WINDOW_DAYS}.days.ago`, '--name-only', '--pretty=format:', '-z'],
-    { cwd: projectPath, maxBuffer: 16 * 1024 * 1024 }
+    { cwd: projectPath, maxBuffer: 16 * 1024 * 1024, timeoutMs: 15_000 }
   )
+  if (!res.ok) {
+    if (res.kind === 'exit') return []
+    throwProc(res)
+  }
 
   const counts = new Map<string, number>()
-  for (const raw of stdout.split('\0')) {
+  for (const raw of res.stdout.split('\0')) {
     const file = raw.trim()
     if (!file) continue
     if (isIgnored(file)) continue
@@ -333,26 +335,24 @@ interface DebtSnapshot {
  * comparison meaningful turn-over-turn.
  */
 async function measureTechDebt(projectPath: string): Promise<DebtSnapshot> {
-  try {
-    const { stdout } = await execFileP('git', ['grep', '-cE', '\\b(TODO|FIXME|XXX)\\b'], {
-      cwd: projectPath,
-      maxBuffer: 16 * 1024 * 1024,
-    })
-    let total = 0
-    for (const line of stdout.split('\n')) {
-      // git grep -c emits "<file>:<count>" per file
-      const idx = line.lastIndexOf(':')
-      if (idx <= 0) continue
-      const num = Number.parseInt(line.slice(idx + 1), 10)
-      if (Number.isFinite(num)) total += num
-    }
-    return { totalCount: total }
-  } catch (err) {
-    // git grep exits non-zero when no matches — treat as 0
-    const code = (err as { code?: number }).code
-    if (code === 1) return { totalCount: 0 }
-    throw err
+  const res = await runGit(['grep', '-cE', '\\b(TODO|FIXME|XXX)\\b'], {
+    cwd: projectPath,
+    maxBuffer: 16 * 1024 * 1024,
+  })
+  if (!res.ok) {
+    // git grep exit 1 = no matches — the one legitimate domain negative.
+    if (exitCodeMeans(res, 1)) return { totalCount: 0 }
+    throwProc(res)
   }
+  let total = 0
+  for (const line of res.stdout.split('\n')) {
+    // git grep -c emits "<file>:<count>" per file
+    const idx = line.lastIndexOf(':')
+    if (idx <= 0) continue
+    const num = Number.parseInt(line.slice(idx + 1), 10)
+    if (Number.isFinite(num)) total += num
+  }
+  return { totalCount: total }
 }
 
 interface DebtMemoryRow {

--- a/core/services/staleness-checker.ts
+++ b/core/services/staleness-checker.ts
@@ -10,7 +10,7 @@
 import { prjctDb } from '../storage/database'
 import { getErrorMessage } from '../types/fs'
 import type { SessionInfo, StalenessConfig, StalenessStatus } from '../types/services.js'
-import { execAsync } from '../utils/exec'
+import { runGit } from '../utils/exec'
 import { sessionTracker } from './session-tracker'
 
 const DEFAULT_CONFIG: StalenessConfig = {
@@ -77,17 +77,18 @@ class StalenessChecker {
       const lastSync = projectJson.lastSync as string
 
       // Get current HEAD commit (bounded)
-      try {
-        const { stdout } = await execAsync('git rev-parse --short HEAD', {
-          cwd: this.projectPath,
-          timeout: 3000,
-        })
-        status.currentCommit = stdout.trim()
-      } catch {
-        // Not a git repo
-        status.reason = 'Not a git repository'
+      const head = await runGit(['rev-parse', '--short', 'HEAD'], {
+        cwd: this.projectPath,
+        timeoutMs: 3000,
+      })
+      if (!head.ok) {
+        // Typed exit = genuinely not a git repo; timeout/spawn = git is
+        // broken — report unknown, never confuse the two.
+        status.reason =
+          head.kind === 'exit' ? 'Not a git repository' : `git ${head.kind} — staleness unknown`
         return status
       }
+      status.currentCommit = head.stdout.trim()
 
       // If no last sync commit, we can't compare
       if (!status.lastSyncCommit) {
@@ -105,19 +106,26 @@ class StalenessChecker {
       // Bounded git (timeouts match land-synthesis ~3s). Count first —
       // name lists only when needed for significant-file detection.
       const cwd = this.projectPath
-      const gitOpts = { cwd, timeout: 3000, maxBuffer: 1024 * 256 }
-      const revListResult = await execAsync(
-        `git rev-list --count ${status.lastSyncCommit}..HEAD`,
+      const gitOpts = { cwd, timeoutMs: 3000, maxBuffer: 1024 * 256 }
+      const revList = await runGit(
+        ['rev-list', '--count', `${status.lastSyncCommit}..HEAD`],
         gitOpts
-      ).catch(() => null)
+      )
 
-      if (!revListResult) {
-        status.isStale = true
-        status.reason = 'Sync commit no longer exists (history changed). Run `prjct sync`.'
+      if (!revList.ok) {
+        if (revList.kind === 'exit') {
+          // Bad revision range = the recorded sync commit is really gone.
+          status.isStale = true
+          status.reason = 'Sync commit no longer exists (history changed). Run `prjct sync`.'
+        } else {
+          // A git timeout/spawn is NOT a history rewrite — never report
+          // staleness from an infra failure.
+          status.reason = `git ${revList.kind} reading history — staleness unknown. Retry shortly.`
+        }
         return status
       }
 
-      status.commitsSinceSync = parseInt(revListResult.stdout.trim(), 10) || 0
+      status.commitsSinceSync = parseInt(revList.stdout.trim(), 10) || 0
 
       // Calculate days since sync
       if (lastSync) {
@@ -134,14 +142,11 @@ class StalenessChecker {
       const needNames =
         status.commitsSinceSync > 0 && status.commitsSinceSync < this.config.commitThreshold
       if (needNames) {
-        const diffResult = await execAsync(
-          `git diff --name-only ${status.lastSyncCommit}..HEAD`,
-          gitOpts
-        ).catch(() => null)
+        const diff = await runGit(['diff', '--name-only', `${status.lastSyncCommit}..HEAD`], gitOpts)
         // Cap name list so a huge range cannot blow SessionStart memory.
-        const names = diffResult
-          ? diffResult.stdout.trim().split('\n').filter(Boolean).slice(0, 200)
-          : []
+        // Any failure (exit or infra) degrades to an empty list — the
+        // count-based verdict above already stands on its own.
+        const names = diff.ok ? diff.stdout.trim().split('\n').filter(Boolean).slice(0, 200) : []
         status.changedFiles = names
         status.significantChanges = names.filter((file) =>
           this.config.significantFiles.some((sig) => file.endsWith(sig) || file.includes(sig))

--- a/core/services/sync/project-identity.ts
+++ b/core/services/sync/project-identity.ts
@@ -11,12 +11,9 @@
  * so the caller falls back to a random UUID for those.
  */
 
-import { execFile } from 'node:child_process'
 import crypto from 'node:crypto'
-import { promisify } from 'node:util'
+import { execFileAsync } from '../../utils/exec'
 import { parseRemote } from './project-meta'
-
-const execFileAsync = promisify(execFile)
 
 // Fixed namespace for prjct project ids (a constant random UUID). Changing this
 // would re-key every derived id, so it must stay stable forever.

--- a/core/services/task-harness.ts
+++ b/core/services/task-harness.ts
@@ -8,7 +8,7 @@ import type {
   TaskHarness,
 } from '../schemas/state'
 import { getTimestamp } from '../utils/date-helper'
-import { execFileAsync } from '../utils/exec'
+import { GitInfraError, runGit, throwProc } from '../utils/exec'
 
 const PUBLIC_SURFACE_TERMS = [
   'cli',
@@ -101,9 +101,29 @@ export async function evaluateHarnessCompletion(
     return { changedFiles: [], observedEvidence: [], warnings: [], diffSize: 0 }
   }
 
-  const changedFiles = await readChangedFiles(projectPath)
+  // Evidence is advisory. A typed git EXIT is a valid answer ("no diff");
+  // a git INFRA failure (timeout/spawn) must not fabricate "0 files / no
+  // tests changed" — it surfaces as its own warning instead.
+  let changedFiles: string[] = []
+  let diffSize = 0
+  let gitUnavailable: GitInfraError | null = null
+  try {
+    changedFiles = await readChangedFiles(projectPath)
+    diffSize = await readDiffSize(projectPath)
+  } catch (err) {
+    if (err instanceof GitInfraError) gitUnavailable = err
+    else throw err
+  }
+
   const observedEvidence = observedEvidenceFromFiles(changedFiles)
   const warnings: string[] = []
+
+  if (gitUnavailable) {
+    warnings.push(
+      `git ${gitUnavailable.kind}: change evidence unavailable — completion checks skipped, not failed.`
+    )
+    return { changedFiles, observedEvidence, warnings, diffSize }
+  }
 
   if (
     harness.expectedEvidence.includes('regression-test') &&
@@ -120,7 +140,6 @@ export async function evaluateHarnessCompletion(
     warnings.push('Public-facing files changed; no README/docs/changelog file changed.')
   }
 
-  const diffSize = await readDiffSize(projectPath)
   if (diffSize > 400) {
     warnings.push(`Diff is ${diffSize} changed lines; consider splitting or justify the scope.`)
   }
@@ -306,40 +325,38 @@ function touchesPublicSurface(files: string[]): boolean {
 
 async function readChangedFiles(projectPath: string): Promise<string[]> {
   const files = new Set<string>()
-  try {
-    const { stdout } = await execFileAsync('git', ['diff', '--name-only', 'HEAD'], {
-      cwd: projectPath,
-    })
-    for (const line of stdout.split('\n')) {
+  const diff = await runGit(['diff', '--name-only', 'HEAD'], { cwd: projectPath })
+  if (diff.ok) {
+    for (const line of diff.stdout.split('\n')) {
       const value = line.trim()
       if (value) files.add(value)
     }
-  } catch {
-    return []
+  } else if (diff.kind !== 'exit') {
+    // Typed exit → no diff answer; still collect untracked below.
+    throwProc(diff)
   }
-  try {
-    const { stdout } = await execFileAsync('git', ['ls-files', '--others', '--exclude-standard'], {
-      cwd: projectPath,
-    })
-    for (const line of stdout.split('\n')) {
+  const untracked = await runGit(['ls-files', '--others', '--exclude-standard'], {
+    cwd: projectPath,
+  })
+  if (untracked.ok) {
+    for (const line of untracked.stdout.split('\n')) {
       const value = line.trim()
       if (value) files.add(value)
     }
-  } catch {
-    // ignore untracked lookup failure
+  } else if (untracked.kind !== 'exit') {
+    throwProc(untracked)
   }
   return [...files].sort()
 }
 
 async function readDiffSize(projectPath: string): Promise<number> {
-  try {
-    const { stdout } = await execFileAsync('git', ['diff', '--shortstat', 'HEAD'], {
-      cwd: projectPath,
-    })
-    const insertions = Number.parseInt(stdout.match(/(\d+) insertions?/)?.[1] ?? '0', 10)
-    const deletions = Number.parseInt(stdout.match(/(\d+) deletions?/)?.[1] ?? '0', 10)
-    return insertions + deletions
-  } catch {
-    return 0
+  const res = await runGit(['diff', '--shortstat', 'HEAD'], { cwd: projectPath })
+  if (!res.ok) {
+    // Typed exit = no diff info (fresh repo) → 0; infra failure propagates.
+    if (res.kind === 'exit') return 0
+    throwProc(res)
   }
+  const insertions = Number.parseInt(res.stdout.match(/(\d+) insertions?/)?.[1] ?? '0', 10)
+  const deletions = Number.parseInt(res.stdout.match(/(\d+) deletions?/)?.[1] ?? '0', 10)
+  return insertions + deletions
 }

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -27,6 +27,7 @@ import { getGitBranch } from '../session/git-helpers'
 import { stateStorage } from '../storage/state-storage'
 import { upsertTaskPipelineState } from '../storage/task-pipeline-storage'
 import * as dateHelper from '../utils/date-helper'
+import { GitInfraError } from '../utils/exec'
 import { executeWorkflowRules } from '../workflow-engine/workflow-engine'
 import { type LikelyFileHit, rankLikelyFiles } from './file-cue'
 import { buildLivingContextPrompt, parseLivingContextFields } from './living-context-contract'
@@ -322,8 +323,17 @@ export async function startTask(
         return { ok: false, blocked: ig.message ?? 'Delivery geometry required at intent.' }
       }
       if (ig.message) console.log(ig.message)
-    } catch {
-      /* geometry is best-effort — never block on git errors */
+    } catch (err) {
+      /* geometry is best-effort — never block on git errors …
+         …EXCEPT in strict mode: there the gate is a hard contract, and a
+         git infra failure makes it unevaluable — block with the cause
+         instead of failing open. */
+      if (err instanceof GitInfraError && mode === 'strict') {
+        return {
+          ok: false,
+          blocked: `Delivery geometry gate unevaluable: ${err.message}. Re-run when git is healthy, or pass \`--geometry\` explicitly.`,
+        }
+      }
     }
   }
 
@@ -415,6 +425,14 @@ export async function startTask(
   }
 
   const ws = await deriveWorkspace(effectivePath)
+  if (ws.gitError) {
+    // Degraded identity (git timeout/spawn): keying a new task on the main
+    // sentinel could bleed a linked worktree's state into main — refuse.
+    return {
+      ok: false,
+      blocked: `git ${ws.gitError}: workspace identity unknown — refusing to start work on the main fallback. Re-run when git is healthy.`,
+    }
+  }
   const workspaceId = ws.isMain ? MAIN_WORKSPACE_ID : ws.workspaceId
   const taskFields = {
     id: taskId,
@@ -737,6 +755,15 @@ export async function setTaskStatus(
   // task in activeTasks[], isolated from other worktrees. The main worktree
   // keeps the singular currentTask path below.
   const ws = await deriveWorkspace(projectPath)
+  if (ws.gitError) {
+    // Degraded identity — a status write keyed on the main fallback could
+    // hit the wrong workspace's task. Refuse with the cause.
+    return {
+      ok: false,
+      reason: 'unsupported',
+      message: `git ${ws.gitError}: workspace identity unknown — refusing to change task status on the main fallback. Re-run when git is healthy.`,
+    }
+  }
   if (!ws.isMain) {
     const wsTask = await stateStorage.getCurrentTaskForWorkspace(projectId, ws.workspaceId)
     if (!wsTask) return { ok: false, reason: 'no-active-task' }
@@ -875,6 +902,9 @@ export async function resolveActiveTask(
   projectPath: string
 ): Promise<CurrentTask | null> {
   const ws = await deriveWorkspace(projectPath)
+  // Degraded identity: returning main's task could bleed another worktree's
+  // operations into main's cycle — "no active task" is the safe answer.
+  if (ws.gitError) return null
   if (ws.isMain) return stateStorage.getCurrentTask(projectId)
   return stateStorage.getCurrentTaskForWorkspace(projectId, ws.workspaceId)
 }
@@ -925,6 +955,9 @@ export async function completeActiveTask(
   feedback?: TaskFeedback
 ): Promise<CurrentTask | null> {
   const ws = await deriveWorkspace(projectPath)
+  // Degraded identity: never complete MAIN's task from what might be a
+  // linked worktree with a sick git.
+  if (ws.gitError) return null
   if (ws.isMain) return stateStorage.completeTask(projectId, feedback)
   return stateStorage.completeTaskInWorkspace(projectId, ws.workspaceId, feedback)
 }

--- a/core/services/version-service.ts
+++ b/core/services/version-service.ts
@@ -17,7 +17,7 @@
 
 import path from 'node:path'
 import type { VersionInfo } from '../types/services/extracted'
-import { execAsync, execFileAsync } from '../utils/exec'
+import { execFileAsync, runGit, throwProc } from '../utils/exec'
 import * as fileHelper from '../utils/file-helper'
 
 // VersionService
@@ -89,16 +89,22 @@ export class VersionService {
   /**
    * Read the version of `file` as it exists at `git HEAD`. Returns null
    * when the file is untracked, the repo is fresh, or git is unavailable.
+   * Throws GitInfraError on git timeout/spawn — a transient git failure
+   * must NOT be read as "fresh", or a version bump could reset the version.
    */
   private async readVersionFromGitHead(
     file: string,
     format: VersionInfo['format']
   ): Promise<string | null> {
+    const relPath = path.relative(this.projectPath, file)
+    const res = await runGit(['show', `HEAD:${relPath}`], { cwd: this.projectPath })
+    if (!res.ok) {
+      // Typed exit = file not in HEAD / not a git repo → treat as fresh.
+      if (res.kind === 'exit') return null
+      throwProc(res)
+    }
     try {
-      const relPath = path.relative(this.projectPath, file)
-      const { stdout } = await execFileAsync('git', ['show', `HEAD:${relPath}`], {
-        cwd: this.projectPath,
-      })
+      const stdout = res.stdout
       if (format === 'json') {
         const parsed = JSON.parse(stdout) as { version?: string }
         return parsed.version ?? null
@@ -115,7 +121,7 @@ export class VersionService {
       }
       return null
     } catch {
-      // file not in HEAD, not a git repo, or git missing — treat as fresh
+      // HEAD content exists but doesn't parse as the expected format.
       return null
     }
   }
@@ -218,25 +224,25 @@ export class VersionService {
   }
 
   private async fromGitTag(): Promise<VersionInfo | null> {
-    try {
-      const { stdout } = await execAsync('git tag --sort=-v:refname', {
-        cwd: this.projectPath,
-      })
+    const res = await runGit(['tag', '--sort=-v:refname'], { cwd: this.projectPath })
+    if (!res.ok) {
+      // Typed exit = not a git repo / no tags → next detector. Infra
+      // failure (timeout/spawn) throws — never skip detectors silently.
+      if (res.kind === 'exit') return null
+      throwProc(res)
+    }
 
-      const tags = stdout.trim().split('\n')
-      for (const tag of tags) {
-        const cleaned = tag.trim().replace(/^v/, '')
-        if (isSemver(cleaned)) {
-          return {
-            current: cleaned,
-            next: bumpPatch(cleaned),
-            file: null,
-            format: 'git-tag',
-          }
+    const tags = res.stdout.trim().split('\n')
+    for (const tag of tags) {
+      const cleaned = tag.trim().replace(/^v/, '')
+      if (isSemver(cleaned)) {
+        return {
+          current: cleaned,
+          next: bumpPatch(cleaned),
+          file: null,
+          format: 'git-tag',
         }
       }
-    } catch {
-      // Not a git repo or git not available
     }
 
     return null

--- a/core/services/workspace-id.ts
+++ b/core/services/workspace-id.ts
@@ -22,7 +22,7 @@
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { execFileAsync } from '../utils/exec'
+import { runGit } from '../utils/exec'
 import { sha256Short } from '../utils/hash'
 
 /** Sentinel id for the main worktree (and any non-worktree path). */
@@ -41,6 +41,13 @@ export interface WorkspaceContext {
   isMain: boolean
   /** Output-contract label, e.g. `fdf22d · feat/foo` or `main · trunk`. */
   label: string
+  /**
+   * Set when git itself failed (timeout/spawn/overflow) and the identity above
+   * is a DEGRADED main-sentinel fallback, not a verified main worktree. Write
+   * paths MUST refuse to key state on it — a transient git error must never
+   * bleed a linked worktree's task state into main.
+   */
+  gitError?: 'timeout' | 'spawn' | 'overflow'
 }
 
 /** Realpath a path, falling back to the input when it can't be resolved. */
@@ -74,7 +81,9 @@ const CACHE_TTL_MS = 5000
 /**
  * Derive the workspace context for a given path (cwd or an MCP `projectPath`).
  * Never throws — degrades to the main sentinel on any git/fs failure so the
- * caller can always fall back to singular behavior.
+ * caller can always fall back to singular behavior. When git ITSELF failed
+ * (timeout/spawn) the degraded fallback carries `gitError`: write paths must
+ * refuse it (see WorkspaceContext.gitError), read-only paths may degrade.
  *
  * Uses a SINGLE `git rev-parse` invocation (multiple flags → multiple output
  * lines) instead of several sequential forks, to stay cheap on the hot path.
@@ -90,24 +99,17 @@ export async function deriveWorkspace(cwd: string): Promise<WorkspaceContext> {
 }
 
 async function computeWorkspace(cwd: string): Promise<WorkspaceContext> {
-  let toplevel = ''
-  let gitDir = ''
-  let commonDir = ''
-  let branch: string | undefined
-  try {
-    // One fork: rev-parse prints one line per flag, in order.
-    const { stdout } = await execFileAsync(
-      'git',
-      ['rev-parse', '--show-toplevel', '--git-dir', '--git-common-dir', '--abbrev-ref', 'HEAD'],
-      { cwd }
-    )
-    const [tl = '', gd = '', cd = '', br = ''] = stdout.trim().split('\n')
-    toplevel = tl.trim()
-    gitDir = gd.trim()
-    commonDir = cd.trim()
-    branch = br.trim() && br.trim() !== 'HEAD' ? br.trim() : undefined
-  } catch {
-    // Not a git repo / git missing → main sentinel on the raw path.
+  // One fork: rev-parse prints one line per flag, in order.
+  const result = await runGit(
+    ['rev-parse', '--show-toplevel', '--git-dir', '--git-common-dir', '--abbrev-ref', 'HEAD'],
+    { cwd }
+  )
+
+  if (!result.ok) {
+    // Typed exit = genuinely not a git repo → main sentinel on the raw path
+    // (normal, documented behavior). timeout/spawn = git is broken: the
+    // sentinel is then a DEGRADED guess — flag it so write paths refuse to
+    // key task state on an identity that could belong to a linked worktree.
     const worktreePath = await safeRealpath(cwd)
     return {
       workspaceId: MAIN_WORKSPACE_ID,
@@ -115,8 +117,19 @@ async function computeWorkspace(cwd: string): Promise<WorkspaceContext> {
       shortId: MAIN_WORKSPACE_ID,
       isMain: true,
       label: buildLabel(MAIN_WORKSPACE_ID),
+      ...(result.kind === 'exit' ? {} : { gitError: result.kind }),
     }
   }
+
+  let toplevel = ''
+  let gitDir = ''
+  let commonDir = ''
+  let branch: string | undefined
+  const [tl = '', gd = '', cd = '', br = ''] = result.stdout.trim().split('\n')
+  toplevel = tl.trim()
+  gitDir = gd.trim()
+  commonDir = cd.trim()
+  branch = br.trim() && br.trim() !== 'HEAD' ? br.trim() : undefined
 
   // A child worktree has a per-worktree git-dir distinct from the shared
   // common-dir; in the main worktree they resolve to the same directory.

--- a/core/session/git-helpers.ts
+++ b/core/session/git-helpers.ts
@@ -3,41 +3,56 @@
  *
  * Extracted from session-snapshot.ts to eliminate duplication
  * across session files that need basic git state.
+ *
+ * Best-effort READ helpers: typed exit and infra both degrade to
+ * empty/undefined (labels must never crash ship/session). Value over
+ * raw promisify(exec): bounded timeout + no shell + no hang.
  */
 
-import { execAsync } from '../utils/exec'
+import { runGit } from '../utils/exec'
+
+const HELPER_TIMEOUT_MS = 5_000
 
 /**
  * Get current git branch name.
- * Returns undefined if not in a git repo or on a detached HEAD.
+ * Returns undefined if not in a git repo, detached HEAD, or git is unhealthy.
  */
 export async function getGitBranch(projectPath: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execAsync('git branch --show-current', {
-      cwd: projectPath,
-    })
-    return stdout.trim() || undefined
-  } catch {
-    return undefined
-  }
+  const res = await runGit(['branch', '--show-current'], {
+    cwd: projectPath,
+    timeoutMs: HELPER_TIMEOUT_MS,
+  })
+  if (!res.ok) return undefined
+  return res.stdout.trim() || undefined
 }
 
 /**
  * Get list of modified files (tracked, uncommitted changes).
  * Falls back to unstaged diff if HEAD comparison fails (e.g., empty repo).
+ * Bounded + shell-free (no `2>/dev/null ||` pipelines).
  */
 export async function getModifiedFiles(projectPath: string, limit = 20): Promise<string[]> {
-  try {
-    const { stdout } = await execAsync(
-      'git diff --name-only HEAD 2>/dev/null || git diff --name-only 2>/dev/null',
-      { cwd: projectPath }
-    )
-    return stdout
+  const parse = (stdout: string): string[] =>
+    stdout
       .trim()
       .split('\n')
       .filter((f) => f.length > 0)
       .slice(0, limit)
-  } catch {
-    return []
+
+  const vsHead = await runGit(['diff', '--name-only', 'HEAD'], {
+    cwd: projectPath,
+    timeoutMs: HELPER_TIMEOUT_MS,
+  })
+  if (vsHead.ok) {
+    const files = parse(vsHead.stdout)
+    if (files.length > 0) return files
   }
+
+  // Fresh repo / no HEAD: unstaged working-tree names only.
+  const unstaged = await runGit(['diff', '--name-only'], {
+    cwd: projectPath,
+    timeoutMs: HELPER_TIMEOUT_MS,
+  })
+  if (!unstaged.ok) return []
+  return parse(unstaged.stdout)
 }

--- a/core/utils/exec.ts
+++ b/core/utils/exec.ts
@@ -1,4 +1,428 @@
-import { exec as execCallback, execFile as execFileCallback } from 'node:child_process'
+import {
+  type ChildProcess,
+  exec as execCallback,
+  execFile as execFileCallback,
+  spawn,
+} from 'node:child_process'
 import { promisify } from 'node:util'
 export const execAsync = promisify(execCallback)
 export const execFileAsync = promisify(execFileCallback)
+
+/**
+ * Typed process chokepoint — preferred path for subprocesses, required for
+ * any call site where a failure must NOT be reclassified as a domain negative
+ * (clean tree / not a repo / no matches / stamp unverified).
+ *
+ * Contract:
+ *   - `runProc` never rejects. Outcomes are a `ProcResult` union.
+ *   - Precedence: abort/deadline → spawn → overflow → exit.
+ *   - Only `exitCodeMeans(result, code≥0)` may treat failure as domain negative.
+ *   - Infra (timeout|spawn|overflow) → `GitInfraError` via `gitStdout` / `throwProc`.
+ *   - Tree-kill on timeout/overflow (process group / taskkill /T).
+ */
+export type ProcInfraKind = 'timeout' | 'spawn' | 'overflow'
+export type ProcBudgetSource = 'timeout' | 'abort'
+
+export type ProcResult =
+  | { ok: true; stdout: string; stderr: string; durationMs: number }
+  | {
+      ok: false
+      kind: 'timeout'
+      budgetMs: number
+      budgetSource: ProcBudgetSource
+      args: string[]
+      stdout: string
+      stderr: string
+      durationMs: number
+    }
+  | {
+      ok: false
+      kind: 'spawn'
+      cause: Error
+      /** OS errno / Node error code when present (ENOENT, EACCES, …). */
+      code?: string
+      args: string[]
+      durationMs: number
+    }
+  | {
+      ok: false
+      kind: 'overflow'
+      maxBuffer: number
+      args: string[]
+      stdout: string
+      stderr: string
+      durationMs: number
+    }
+  | {
+      ok: false
+      kind: 'exit'
+      code: number
+      /** Set when the process died from a signal rather than exit(n). */
+      signal: NodeJS.Signals | null
+      stdout: string
+      stderr: string
+      args: string[]
+      durationMs: number
+    }
+
+export interface RunProcOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  /** Per-command whole-run budget. Default 10s. */
+  timeoutMs?: number
+  /**
+   * Caller cancellation. Already-aborted → no spawn. Later abort → timeout
+   * with budgetSource:'abort' (checked with the same precedence as deadline).
+   */
+  signal?: AbortSignal
+  /** Combined stdout+stderr cap. Default 1 MiB. Overflow is INFRA, not exit. */
+  maxBuffer?: number
+  /** Test seam — defaults to node:child_process spawn. */
+  spawnFn?: typeof spawn
+}
+
+const DEFAULT_BUDGET_MS = 10_000
+const DEFAULT_MAX_BUFFER = 1024 * 1024
+/** Cap on messages that may leave the process (logs, memory, ship notes). */
+export const PROC_ENVELOPE_MAX = 240
+
+/**
+ * Kill the whole process tree. `detached: true` (unix) made the child a
+ * process-group leader, so a group kill reaches grandchildren that a plain
+ * `child.kill()` would orphan.
+ */
+function killProcessTree(child: ChildProcess): void {
+  try {
+    if (process.platform === 'win32') {
+      if (child.pid !== undefined) {
+        spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' }).unref()
+      }
+    } else if (child.pid !== undefined) {
+      process.kill(-child.pid, 'SIGKILL')
+    }
+  } catch {
+    // Group kill failed — direct kill fallback below.
+  }
+  try {
+    child.kill('SIGKILL')
+  } catch {
+    /* already reaped */
+  }
+}
+
+function joinChunks(chunks: Buffer[], maxLen: number): string {
+  if (chunks.length === 0) return ''
+  const total = Buffer.concat(chunks)
+  const slice = total.length > maxLen ? total.subarray(0, maxLen) : total
+  return slice.toString('utf8')
+}
+
+function nodeErrorCode(err: Error): string | undefined {
+  const code = (err as NodeJS.ErrnoException).code
+  return typeof code === 'string' ? code : undefined
+}
+
+/**
+ * Spawn `cmd` and classify the outcome. Never rejects.
+ * Precedence: caller abort / deadline > spawn failure > overflow > exit code.
+ */
+export function runProc(
+  cmd: string,
+  args: string[],
+  opts: RunProcOptions = {}
+): Promise<ProcResult> {
+  const budgetMs = opts.timeoutMs ?? DEFAULT_BUDGET_MS
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER
+  const retainCap = maxBuffer
+  const spawnImpl = opts.spawnFn ?? spawn
+  const argv = [cmd, ...args]
+  const started = Date.now()
+  const duration = (): number => Date.now() - started
+
+  // Caller budget already expired — never spawn.
+  if (opts.signal?.aborted) {
+    return Promise.resolve({
+      ok: false,
+      kind: 'timeout',
+      budgetMs: 0,
+      budgetSource: 'abort',
+      args: argv,
+      stdout: '',
+      stderr: '',
+      durationMs: 0,
+    })
+  }
+
+  return new Promise<ProcResult>((resolve) => {
+    let settled = false
+    const outChunks: Buffer[] = []
+    const errChunks: Buffer[] = []
+    let outLen = 0
+    let errLen = 0
+    let overflow = false
+
+    const child = spawnImpl(cmd, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    const finish = (result: ProcResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      opts.signal?.removeEventListener('abort', onAbort)
+      resolve(result)
+    }
+
+    const partials = (): { stdout: string; stderr: string } => ({
+      stdout: joinChunks(outChunks, retainCap),
+      stderr: joinChunks(errChunks, retainCap),
+    })
+
+    const finishTimeout = (budgetSource: ProcBudgetSource, ms: number): void => {
+      killProcessTree(child)
+      const { stdout, stderr } = partials()
+      finish({
+        ok: false,
+        kind: 'timeout',
+        budgetMs: ms,
+        budgetSource,
+        args: argv,
+        stdout,
+        stderr,
+        durationMs: duration(),
+      })
+    }
+
+    const finishOverflow = (): void => {
+      killProcessTree(child)
+      const { stdout, stderr } = partials()
+      // Finish NOW — do not wait for `close`. A process that ignores kill
+      // would otherwise hang the Promise until the separate timeout fires.
+      finish({
+        ok: false,
+        kind: 'overflow',
+        maxBuffer,
+        args: argv,
+        stdout,
+        stderr: stderr || `maxBuffer exceeded (${maxBuffer} bytes)`,
+        durationMs: duration(),
+      })
+    }
+
+    const timer = setTimeout(() => finishTimeout('timeout', budgetMs), budgetMs)
+
+    const onAbort = (): void => finishTimeout('abort', budgetMs)
+    opts.signal?.addEventListener('abort', onAbort, { once: true })
+
+    const onChunk = (chunk: Buffer, isErr: boolean): void => {
+      if (settled) return
+      if (isErr) {
+        errChunks.push(chunk)
+        errLen += chunk.length
+      } else {
+        outChunks.push(chunk)
+        outLen += chunk.length
+      }
+      if (!overflow && outLen + errLen > maxBuffer) {
+        overflow = true
+        finishOverflow()
+      }
+    }
+    child.stdout?.on('data', (c: Buffer) => onChunk(c, false))
+    child.stderr?.on('data', (c: Buffer) => onChunk(c, true))
+
+    child.on('error', (cause: Error) => {
+      finish({
+        ok: false,
+        kind: 'spawn',
+        cause,
+        code: nodeErrorCode(cause),
+        args: argv,
+        durationMs: duration(),
+      })
+    })
+
+    child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+      // Overflow/timeout already settled — ignore the late close.
+      if (settled) return
+      const { stdout, stderr } = partials()
+      if (code === 0) {
+        finish({ ok: true, stdout, stderr, durationMs: duration() })
+      } else {
+        finish({
+          ok: false,
+          kind: 'exit',
+          code: code ?? -1,
+          signal,
+          stdout,
+          stderr: stderr.trim(),
+          args: argv,
+          durationMs: duration(),
+        })
+      }
+    })
+  })
+}
+
+/** `git` through the typed chokepoint. `args` are everything after `git`. */
+export function runGit(args: string[], opts: RunProcOptions = {}): Promise<ProcResult> {
+  return runProc('git', args, opts)
+}
+
+/** True when the failure is infrastructure (never a domain negative). */
+export function isProcInfra(
+  result: ProcResult
+): result is Extract<ProcResult, { ok: false; kind: ProcInfraKind }> {
+  return (
+    !result.ok &&
+    (result.kind === 'timeout' || result.kind === 'spawn' || result.kind === 'overflow')
+  )
+}
+
+/**
+ * The ONLY sanctioned way to read an exit code as a domain negative
+ * (e.g. `git grep` exit 1 = "no matches"). Requires a real OS exit code ≥ 0.
+ */
+export function exitCodeMeans(result: ProcResult, code: number): boolean {
+  if (!Number.isInteger(code) || code < 0) return false
+  return !result.ok && result.kind === 'exit' && result.code === code
+}
+
+/** Cap length + collapse whitespace for anything that may leave the process. */
+export function sanitizeProcEnvelope(text: string, max = PROC_ENVELOPE_MAX): string {
+  const oneLine = text
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  // Soft path scrub: common absolute roots (not a full secret redactor).
+  const scrubbed = oneLine
+    .replace(/(?:[A-Za-z]:)?(?:\/|\\)(?:Users|home|tmp|var|private|Users)(?:\/|\\)[^\s]*/gi, '…')
+    .replace(/\/(?:Users|home|tmp|var|private)\/[^\s]*/gi, '…')
+  if (scrubbed.length <= max) return scrubbed
+  return `${scrubbed.slice(0, Math.max(0, max - 1))}…`
+}
+
+/**
+ * Infrastructure failure (timeout / spawn / overflow). Thrown so write/ship
+ * paths fail loudly instead of fabricating "clean / not a repo / unverified".
+ *
+ * `.message` is envelope-capped; `.detail` keeps full text in-process only.
+ */
+export class GitInfraError extends Error {
+  readonly kind: ProcInfraKind
+  readonly args: string[]
+  readonly detail: string
+  readonly budgetSource?: ProcBudgetSource
+
+  constructor(
+    kind: ProcInfraKind,
+    args: string[],
+    detail: string,
+    extras?: { budgetSource?: ProcBudgetSource }
+  ) {
+    super(sanitizeProcEnvelope(`git ${kind} failure (${args.join(' ')}): ${detail}`))
+    this.name = 'GitInfraError'
+    this.kind = kind
+    this.args = args
+    this.detail = detail
+    this.budgetSource = extras?.budgetSource
+  }
+}
+
+/** Build a GitInfraError unless `result` is ok or a typed exit (then null). */
+export function gitInfraErrorOf(result: ProcResult): GitInfraError | null {
+  if (result.ok || result.kind === 'exit') return null
+  if (result.kind === 'timeout') {
+    return new GitInfraError(
+      'timeout',
+      result.args,
+      result.budgetSource === 'abort'
+        ? 'aborted by caller signal'
+        : `exceeded ${result.budgetMs}ms`,
+      { budgetSource: result.budgetSource }
+    )
+  }
+  if (result.kind === 'overflow') {
+    return new GitInfraError('overflow', result.args, `maxBuffer ${result.maxBuffer} bytes`)
+  }
+  return new GitInfraError('spawn', result.args, result.cause.message)
+}
+
+/**
+ * Error for any failed ProcResult (exit included). Null only when `result.ok`.
+ * Prefer `throwProc` at call sites — it never throws null.
+ */
+export function procErrorOf(result: ProcResult): Error | null {
+  if (result.ok) return null
+  if (result.kind === 'exit') {
+    const detail = result.stderr ? ` — ${sanitizeProcEnvelope(result.stderr, 120)}` : ''
+    const signal = result.signal ? ` signal=${result.signal}` : ''
+    return new Error(
+      sanitizeProcEnvelope(
+        `command failed (exit ${result.code}${signal}): ${result.args.join(' ')}${detail}`
+      )
+    )
+  }
+  return gitInfraErrorOf(result)
+}
+
+/**
+ * Throw a non-null Error for a failed ProcResult. Use after handling the
+ * domain exit codes you care about via `exitCodeMeans`. Never throws null.
+ */
+export function throwProc(result: ProcResult): never {
+  if (result.ok) {
+    throw new Error('throwProc called on ok result')
+  }
+  throw procErrorOf(result) ?? new Error(`process failed (${result.kind})`)
+}
+
+/**
+ * Exhaustive consumer dispatch — forces every kind to be handled so infra
+ * cannot silently fall through into a domain branch.
+ */
+export function matchProc<T>(
+  result: ProcResult,
+  handlers: {
+    ok: (r: Extract<ProcResult, { ok: true }>) => T
+    exit: (r: Extract<ProcResult, { kind: 'exit' }>) => T
+    timeout: (r: Extract<ProcResult, { kind: 'timeout' }>) => T
+    spawn: (r: Extract<ProcResult, { kind: 'spawn' }>) => T
+    overflow: (r: Extract<ProcResult, { kind: 'overflow' }>) => T
+  }
+): T {
+  if (result.ok) return handlers.ok(result)
+  switch (result.kind) {
+    case 'exit':
+      return handlers.exit(result)
+    case 'timeout':
+      return handlers.timeout(result)
+    case 'spawn':
+      return handlers.spawn(result)
+    case 'overflow':
+      return handlers.overflow(result)
+    default: {
+      const _exhaustive: never = result
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Trimmed stdout on success; `null` on typed exit (domain negative).
+ * Timeout / spawn / overflow throw `GitInfraError` — never collapse to null.
+ */
+export async function gitStdout(
+  cwd: string,
+  args: string[],
+  opts: RunProcOptions = {}
+): Promise<string | null> {
+  const result = await runGit(args, { ...opts, cwd })
+  if (result.ok) return result.stdout.trim()
+  const infra = gitInfraErrorOf(result)
+  if (infra) throw infra
+  return null
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.70.1",
+  "version": "3.71.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

- Add a single typed spawn chokepoint (`runProc` / `runGit` / `gitStdout`) with `ProcResult` union: ok | timeout | spawn | overflow | exit
- Dual budget (`timeoutMs` + `AbortSignal`), process-group tree-kill, overflow as **infra** (never synthetic exit -1)
- Migrate worst silent-git consumers so infra failures cannot be reclassified as domain negatives (clean tree / not a repo / unverified stamp)
- Content-bound stamp + code-strict ship: **fail-closed** on `GitInfraError` (was fail-open via null → unverified → pass)

## Why

gentle-ai v2.1.8 typed process errors: only a typed exit may be a domain negative. prjct had raw `promisify(exec)` collapses that could:
- reset version bumps on git hang
- report false "history changed" staleness
- pass ship with an unevaluable content-bound stamp under code-strict

## Real product value

| Path | Before | After |
|------|--------|-------|
| version bump | git hang → treat as fresh | throws `GitInfraError` |
| staleness | timeout → "history changed" | unknown, not rewritten |
| workspace-id | broken git → silent main | `gitError` flagged (writes refuse) |
| content-bound ship | infra → unverified → pass | code-strict blocks |
| harness evidence | missing tests fabricated | "evidence unavailable" |

## Test plan

- [x] `bun test core/__tests__/utils/proc.test.ts` (classification, tree-kill, overflow settle, AbortSignal, throwProc)
- [x] WS1 regressions: workspace-id, staleness, version, task-harness, detect-changes, content-bound fail-open
- [x] `bun run typecheck`
- [x] `bun run test:unit` — 2519 pass / 0 fail

Generated with [p/](https://www.prjct.app/)