### PR TITLE
style: fix biome Quality Checks after WS1 merge (#589)

### DIFF
--- a/core/__tests__/services/detect-changes.test.ts
+++ b/core/__tests__/services/detect-changes.test.ts
@@ -69,7 +69,6 @@ describe('detect-changes', () => {
   })
 })
 
-
 /**
  * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
  * fails with a real ENOENT — exercises the infra-failure path without mocks.

--- a/core/__tests__/services/staleness-checker.test.ts
+++ b/core/__tests__/services/staleness-checker.test.ts
@@ -191,7 +191,6 @@ describe('StalenessChecker', () => {
   })
 })
 
-
 /**
  * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
  * fails with a real ENOENT — exercises the infra-failure path without mocks.

--- a/core/__tests__/services/task-harness.test.ts
+++ b/core/__tests__/services/task-harness.test.ts
@@ -120,7 +120,6 @@ describe('detectKind — word-aware matching (no mid-word false positives)', () 
   })
 })
 
-
 /**
  * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
  * fails with a real ENOENT — exercises the infra-failure path without mocks.

--- a/core/__tests__/services/version-service.test.ts
+++ b/core/__tests__/services/version-service.test.ts
@@ -165,7 +165,6 @@ describe('VersionService.bump (idempotency)', () => {
   })
 })
 
-
 /**
  * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
  * fails with a real ENOENT — exercises the infra-failure path without mocks.

--- a/core/__tests__/services/workspace-id.test.ts
+++ b/core/__tests__/services/workspace-id.test.ts
@@ -91,7 +91,6 @@ describe('deriveWorkspace', () => {
   })
 })
 
-
 /**
  * PATH-hijack: an empty dir as PATH means `git` resolves nowhere, so spawn
  * fails with a real ENOENT — exercises the infra-failure path without mocks.

--- a/core/domain/symbol-graph.ts
+++ b/core/domain/symbol-graph.ts
@@ -668,7 +668,7 @@ function applyTsPath(specifier: string, tsPaths: TsPathMap): string[] {
     if (pattern.endsWith('/*')) {
       const prefix = pattern.slice(0, -1) // keep trailing path start
       const pre = pattern.slice(0, -2)
-      if (specifier === pre || specifier.startsWith(pre + '/')) {
+      if (specifier === pre || specifier.startsWith(`${pre}/`)) {
         const rest = specifier.slice(pre.length).replace(/^\//, '')
         for (const t of targets) {
           const base = t.endsWith('/*') ? t.slice(0, -1) : t

--- a/core/services/detect-changes.ts
+++ b/core/services/detect-changes.ts
@@ -128,7 +128,7 @@ async function loadHunkLines(
   if (source !== 'committed') {
     staged = (await safeGit(projectPath, ['diff', '-U0', '--cached', '--', ...files])) ?? ''
   }
-  const map = parseChangedLinesFromUnifiedDiff(diff + '\n' + staged)
+  const map = parseChangedLinesFromUnifiedDiff(`${diff}\n${staged}`)
   return map
 }
 

--- a/core/services/staleness-checker.ts
+++ b/core/services/staleness-checker.ts
@@ -142,7 +142,10 @@ class StalenessChecker {
       const needNames =
         status.commitsSinceSync > 0 && status.commitsSinceSync < this.config.commitThreshold
       if (needNames) {
-        const diff = await runGit(['diff', '--name-only', `${status.lastSyncCommit}..HEAD`], gitOpts)
+        const diff = await runGit(
+          ['diff', '--name-only', `${status.lastSyncCommit}..HEAD`],
+          gitOpts
+        )
         // Cap name list so a huge range cannot blow SessionStart memory.
         // Any failure (exit or infra) degrades to an empty list — the
         // count-based verdict above already stands on its own.


### PR DESCRIPTION
## Summary
- Fix 6 Biome **format** errors that failed Quality Checks on main after #589
- Also apply the two `useTemplate` infos (detect-changes + symbol-graph) for a fully clean `bun run check`

## Test plan
- [x] `bun run check` → exit 0
- CI Quality Checks should go green

Generated with [p/](https://www.prjct.app/)