### PR TITLE
feat: build-loop anticipation product package (v3.72.0)

### DIFF
--- a/.prjct/prjct.config.json
+++ b/.prjct/prjct.config.json
@@ -6,5 +6,30 @@
     "paused": false,
     "linkedAt": "2026-06-26T13:45:21.570Z"
   },
-  "maxTokensPerCycle": 1500000
+  "maxTokensPerCycle": 1500000,
+  "persona": {
+    "role": "DEV",
+    "packs": [
+      "code"
+    ],
+    "mcps": [
+      "github"
+    ]
+  },
+  "sdd": {
+    "mode": "advisory"
+  },
+  "tdd": {
+    "mode": "assist"
+  },
+  "maxTurnsPerCycle": 25,
+  "deliveryGeometry": {
+    "mode": "advisory"
+  },
+  "land": {
+    "mode": "strict"
+  },
+  "judgment": {
+    "conflictMode": "advisory"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.72.0] - 2026-07-19
+
+### Added
+- Build-loop anticipation: MCP risks, code defaults, ship compound, auto-infer file on remember
+
 ## [3.71.0] - 2026-07-19
 
 ### Added

--- a/core/__tests__/memory/infer-memory-file.test.ts
+++ b/core/__tests__/memory/infer-memory-file.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { extractRepoRelativePaths, inferMemoryFileTag } from '../../memory/infer-memory-file'
+
+describe('extractRepoRelativePaths', () => {
+  test('pulls backtick and plain repo-relative paths', () => {
+    const text = 'Bug in `src/lib/api.ts` and also core/hooks/pre-edit.ts — not http://x.com/a.ts'
+    const paths = extractRepoRelativePaths(text)
+    expect(paths).toContain('src/lib/api.ts')
+    expect(paths).toContain('core/hooks/pre-edit.ts')
+    expect(paths.some((p) => p.includes('http'))).toBe(false)
+  })
+
+  test('ignores bare basenames without a directory', () => {
+    expect(extractRepoRelativePaths('see index.ts only')).toEqual([])
+  })
+
+  test('ignores node_modules and dist', () => {
+    expect(extractRepoRelativePaths('broken in node_modules/foo/bar.ts and dist/out.js')).toEqual(
+      []
+    )
+  })
+})
+
+describe('inferMemoryFileTag', () => {
+  test('explicit tags.file wins', () => {
+    expect(
+      inferMemoryFileTag({
+        content: 'mentions src/other.ts',
+        tags: { file: 'src/explicit.ts' },
+      })
+    ).toBe('src/explicit.ts')
+  })
+
+  test('uses first path from tags.files when file absent', () => {
+    expect(
+      inferMemoryFileTag({
+        content: 'no path here',
+        tags: { files: 'src/a.ts,src/b.ts' },
+      })
+    ).toBe('src/a.ts')
+  })
+
+  test('infers from content path when no tags', () => {
+    expect(
+      inferMemoryFileTag({
+        content:
+          'TanStack autoCodeSplitting: only uppercase COMPONENT exports block route code-splitting. See src/routes/-route-code-splitting.test.ts for the control case.',
+      })
+    ).toBe('src/routes/-route-code-splitting.test.ts')
+  })
+
+  test('prefers path that exists on disk under projectPath', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-infer-file-'))
+    try {
+      fs.mkdirSync(path.join(root, 'src', 'lib'), { recursive: true })
+      fs.writeFileSync(path.join(root, 'src', 'lib', 'api.ts'), 'export {}')
+      const hit = inferMemoryFileTag({
+        content: 'touch src/lib/api.ts and also src/lib/missing.ts',
+        projectPath: root,
+      })
+      expect(hit).toBe('src/lib/api.ts')
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('promotes cycle file when basename appears in content', () => {
+    expect(
+      inferMemoryFileTag({
+        content: 'MutationCache double toast in api.ts — set meta.skipGlobalError',
+        cycleFiles: ['src/lib/api.ts', 'src/routes/other.tsx'],
+      })
+    ).toBe('src/lib/api.ts')
+  })
+
+  test('returns null when nothing confident', () => {
+    expect(
+      inferMemoryFileTag({
+        content: 'we decided to use advisory mode for conflicts',
+      })
+    ).toBeNull()
+  })
+
+  test('strips absolute path to strong-prefix suffix', () => {
+    expect(
+      inferMemoryFileTag({
+        content: 'edit /Users/jj/Apps/prjct/prjct-cli-app/src/lib/api.ts carefully',
+      })
+    ).toBe('src/lib/api.ts')
+  })
+})

--- a/core/__tests__/memory/project-memory.test.ts
+++ b/core/__tests__/memory/project-memory.test.ts
@@ -708,6 +708,48 @@ describe('predictive risk briefing — recallRisksForFiles (planning-time)', () 
   })
 })
 
+describe('projectMemory.remember — auto-infer tags.file for anticipation', () => {
+  beforeEach(async () => {
+    await fs.mkdir(path.join(tmpRoot, '.prjct'), { recursive: true })
+    await fs.writeFile(
+      path.join(tmpRoot, '.prjct', 'prjct.config.json'),
+      JSON.stringify({ projectId })
+    )
+  })
+
+  it('infers file from content path so recallForFile / risks work without explicit tags', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'gotcha',
+      content:
+        'MutationCache onError always fires with mutation onError — set meta.skipGlobalError in src/lib/api.ts',
+      projectId,
+      requireWrite: true,
+    })
+    const hits = projectMemory.recallForFile(projectId, 'src/lib/api.ts', 3, {
+      preventiveOnly: true,
+    })
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits.some((h) => h.type === 'gotcha' && h.content.includes('MutationCache'))).toBe(true)
+    expect(hits[0]?.tags?.file).toBe('src/lib/api.ts')
+    expect(hits[0]?.tags?.file_source).toBe('inferred')
+  })
+
+  it('does not override an explicit file tag', async () => {
+    await projectMemory.remember(tmpRoot, {
+      type: 'gotcha',
+      content: 'mentions src/other.ts but explicit wins',
+      tags: { file: 'src/explicit.ts' },
+      projectId,
+      requireWrite: true,
+    })
+    const hits = projectMemory.recallForFile(projectId, 'src/explicit.ts', 3, {
+      preventiveOnly: true,
+    })
+    expect(hits.some((h) => h.tags?.file === 'src/explicit.ts')).toBe(true)
+    expect(hits[0]?.tags?.file_source).toBeUndefined()
+  })
+})
+
 describe('projectMemory.remember — topic-key UPSERT (write-side supersession)', () => {
   // remember() resolves the project from the path's config — give tmpRoot one.
   beforeEach(async () => {

--- a/core/__tests__/packs/pack-manager.test.ts
+++ b/core/__tests__/packs/pack-manager.test.ts
@@ -20,6 +20,7 @@ import {
   activatePacks,
   deactivatePacks,
   detectSuggestedPacks,
+  ensureCodingAnticipationDefaults,
   listActivePacks,
 } from '../../packs/pack-manager'
 
@@ -85,6 +86,8 @@ describe('pack-manager', () => {
     expect(config?.deliveryGeometry?.mode).toBe('advisory')
     // Dominance P2: code pack forces land (session-close not optional).
     expect(config?.land?.mode).toBe('strict')
+    // World-class product: anticipation ON (conflictMode advisory).
+    expect(config?.judgment?.conflictMode).toBe('advisory')
 
     await configManager.writeConfig(projectPath, {
       ...config!,
@@ -107,6 +110,7 @@ describe('pack-manager', () => {
     expect(config?.tdd?.mode).toBe('strict')
     expect(config?.deliveryGeometry?.mode).toBe('strict')
     expect(config?.land?.mode).toBe('strict')
+    expect(config?.judgment?.conflictMode).toBe('strict')
   })
 
   test('activatePacks never overwrites an explicit persona role', async () => {
@@ -161,6 +165,64 @@ describe('pack-manager', () => {
   test('detectSuggestedPacks returns only daily when no code signals exist', async () => {
     const suggested = await detectSuggestedPacks(projectPath)
     expect(suggested).toEqual(['daily'])
+  })
+
+  test('ensureCodingAnticipationDefaults activates code pack on package.json repo', async () => {
+    await fs.writeFile(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ name: 'test', version: '1.0.0' }),
+      'utf-8'
+    )
+    const result = await ensureCodingAnticipationDefaults(projectPath)
+    expect(result.healed).toBe(true)
+    expect(result.reason).toBe('activated-code')
+    expect(result.activated).toContain('code')
+
+    const config = await configManager.readConfig(projectPath)
+    expect(config?.persona?.packs).toContain('code')
+    expect(config?.judgment?.conflictMode).toBe('advisory')
+
+    const again = await ensureCodingAnticipationDefaults(projectPath)
+    expect(again.healed).toBe(false)
+    expect(again.reason).toBe('already-coding-pack')
+  })
+
+  test('ensureCodingAnticipationDefaults respects conflictMode off opt-out', async () => {
+    await fs.writeFile(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ name: 'test', version: '1.0.0' }),
+      'utf-8'
+    )
+    const existing = await configManager.readConfig(projectPath)
+    await configManager.writeConfig(projectPath, {
+      ...existing!,
+      judgment: { conflictMode: 'off' },
+    })
+    const result = await ensureCodingAnticipationDefaults(projectPath)
+    expect(result.healed).toBe(false)
+    expect(result.reason).toBe('conflictMode-off')
+    const config = await configManager.readConfig(projectPath)
+    expect(config?.persona?.packs ?? []).not.toContain('code')
+  })
+
+  test('ensureCodingAnticipationDefaults no-ops on non-code repo', async () => {
+    const result = await ensureCodingAnticipationDefaults(projectPath)
+    expect(result.healed).toBe(false)
+    expect(result.reason).toBe('not-code-repo')
+  })
+
+  test('ensureCodingAnticipationDefaults heals missing conflictMode when code pack present', async () => {
+    const existing = await configManager.readConfig(projectPath)
+    await configManager.writeConfig(projectPath, {
+      ...existing!,
+      persona: { role: 'DEV', packs: ['code'] },
+      // no judgment.conflictMode
+    })
+    const result = await ensureCodingAnticipationDefaults(projectPath)
+    expect(result.healed).toBe(true)
+    expect(result.reason).toBe('conflictMode-healed')
+    const config = await configManager.readConfig(projectPath)
+    expect(config?.judgment?.conflictMode).toBe('advisory')
   })
 
   test('manifests expose all declared packs', () => {

--- a/core/__tests__/services/format-risk-for-agent.test.ts
+++ b/core/__tests__/services/format-risk-for-agent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { formatRiskForAgent, type RiskHit } from '../../services/task-service'
+
+/**
+ * CLI `prjct work` and MCP `prjct_task_start` MUST share this line shape so
+ * multi-runtime agents see the same predictive-risk class (P0 build-loop parity).
+ */
+describe('formatRiskForAgent — CLI/MCP risk surface parity', () => {
+  test('formats label, title, file, and id like work --md Risk lines', () => {
+    const risk: RiskHit = {
+      id: 'mem_42',
+      label: 'gotcha',
+      title: 'Daemon caches stale hook code',
+      file: 'core/hooks/pre-edit.ts',
+    }
+    expect(formatRiskForAgent(risk)).toBe(
+      '[gotcha] Daemon caches stale hook code — `core/hooks/pre-edit.ts`  `mem_42`'
+    )
+  })
+
+  test('MCP task_start risk block composition matches CLI header intent', () => {
+    const risks: RiskHit[] = [
+      {
+        id: 'mem_1',
+        label: 'anti-pattern',
+        title: 'Skip guard before edit',
+        file: 'core/mcp/tools/project.ts',
+      },
+      {
+        id: 'mem_2',
+        label: 'gotcha',
+        title: 'Empty likelyFiles yields no risks',
+        file: 'core/services/task-service.ts',
+      },
+    ]
+    // Same section title CLI uses (workflow.ts Risk section)
+    const header = '⚠ Risk — what bit us in this area before (read before you edit):'
+    const body = risks.map((r) => `- ${formatRiskForAgent(r)}`).join('\n')
+    const block = [header, body].join('\n')
+    expect(block).toContain('⚠ Risk — what bit us in this area before')
+    expect(block).toContain(
+      '[anti-pattern] Skip guard before edit — `core/mcp/tools/project.ts`  `mem_1`'
+    )
+    expect(block).toContain(
+      '[gotcha] Empty likelyFiles yields no risks — `core/services/task-service.ts`  `mem_2`'
+    )
+    // Empty risks → no section (parity: CLI only prints when riskLines.length > 0)
+    expect(([] as RiskHit[]).length > 0 ? formatRiskForAgent(risks[0]!) : '').toBe('')
+  })
+})

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -529,29 +529,6 @@ export class ShippingCommands extends PrjctCommandsBase {
 
       const stepsRun = beforeResult.stepsRun.length + afterResult.stepsRun.length
 
-      if (options.md) {
-        const steps = getNextSteps('ship', true)
-        const md = mdOutput(
-          mdDone(`Shipped: ${featureName}`, `Version: ${newVersion}`),
-          mdSection(
-            'Results',
-            mdList([
-              `Version: ${newVersion}`,
-              `Workflow steps run: ${stepsRun > 0 ? [...beforeResult.stepsRun, ...afterResult.stepsRun].join(', ') : 'none'}`,
-              `Hooks failed (non-blocking): ${beforeResult.hooksFailed.length + afterResult.hooksFailed.length}`,
-            ])
-          ),
-          allInstructions.length > 0
-            ? mdSection('Agent Instructions', mdList(allInstructions))
-            : null,
-          mdNextSteps(steps.map((s) => ({ label: s.desc, command: s.cmd })))
-        )
-        console.log(md)
-      } else {
-        out.done(`v${newVersion} shipped`)
-        showNextSteps('ship')
-      }
-
       // Ship-success reinforcement: every memory surfaced during this task
       // just fed work that actually shipped — give it the strong usefulness
       // credit so it ranks higher in future recall. Best-effort; a completed
@@ -563,6 +540,58 @@ export class ShippingCommands extends PrjctCommandsBase {
         } catch {
           /* best-effort */
         }
+      }
+
+      // Compound after ship: judgment receipt so closed-loop metrics move on
+      // the ship path (not only land/Stop). Dynasty receipts were 0 when users
+      // shipped without land — product gap. Best-effort; never block ship.
+      let receiptSummary: string | null = null
+      try {
+        const { synthesizeJudgmentReceipt } = await import('../services/judgment-receipt')
+        const receipt = await synthesizeJudgmentReceipt({
+          projectId,
+          projectPath,
+          cycleDescription: currentTask?.description ?? featureName,
+          cycleId: currentTask?.id ?? null,
+        })
+        if (receipt.wrote) {
+          receiptSummary = receipt.summary ?? 'Judgment receipt written'
+        }
+      } catch {
+        /* never block ship on receipt */
+      }
+
+      if (options.md) {
+        const steps = getNextSteps('ship', true)
+        const md = mdOutput(
+          mdDone(`Shipped: ${featureName}`, `Version: ${newVersion}`),
+          mdSection(
+            'Results',
+            mdList(
+              [
+                `Version: ${newVersion}`,
+                `Workflow steps run: ${stepsRun > 0 ? [...beforeResult.stepsRun, ...afterResult.stepsRun].join(', ') : 'none'}`,
+                `Hooks failed (non-blocking): ${beforeResult.hooksFailed.length + afterResult.hooksFailed.length}`,
+                receiptSummary ? `Compound judgment: ${receiptSummary}` : null,
+              ].filter((s): s is string => s !== null)
+            )
+          ),
+          allInstructions.length > 0
+            ? mdSection('Agent Instructions', mdList(allInstructions))
+            : null,
+          mdNextSteps([
+            ...steps.map((s) => ({ label: s.desc, command: s.cmd })),
+            {
+              label: 'Capture non-obvious learning (compounds next session)',
+              command: 'prjct remember learning "…"',
+            },
+          ])
+        )
+        console.log(md)
+      } else {
+        out.done(`v${newVersion} shipped`)
+        if (receiptSummary) out.info(`Compound: ${receiptSummary}`)
+        showNextSteps('ship')
       }
 
       // Cloud sync (opt-in): push this ship + pull remote in the background.

--- a/core/commands/workflow.ts
+++ b/core/commands/workflow.ts
@@ -18,7 +18,11 @@
 import { safeTruncate } from '../hooks/_shared'
 import { formatLikelyFileForAgent } from '../services/file-cue'
 import { collectActiveTasks } from '../services/task-overview'
-import { formatRelatedContextForAgent, startTask } from '../services/task-service'
+import {
+  formatRelatedContextForAgent,
+  formatRiskForAgent,
+  startTask,
+} from '../services/task-service'
 import { customWorkflowStorage } from '../storage/custom-workflow-storage'
 import { stateStorage } from '../storage/state-storage'
 import type { MdOption } from '../types/cli'
@@ -129,7 +133,7 @@ export class WorkflowCommands extends PrjctCommandsBase {
       // Predictive risk — the preventive memory for the area this cycle touches,
       // surfaced BEFORE the edit. Higher priority than the file map, so it leads.
       const risks = outcome.risks ?? []
-      const riskLines = risks.map((r) => `[${r.label}] ${r.title} — \`${r.file}\`  \`${r.id}\``)
+      const riskLines = risks.map(formatRiskForAgent)
 
       // Project pattern supremacy: match house style; upgrade only real anti-patterns.
       // Prefer durable project style model (recomputed every sync), then related hits.

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -13,7 +13,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { formatLikelyFileForAgent } from '../../services/file-cue'
 import { collectActiveTasks } from '../../services/task-overview'
-import { formatRelatedContextForAgent, setTaskStatus, startTask } from '../../services/task-service'
+import {
+  formatRelatedContextForAgent,
+  formatRiskForAgent,
+  setTaskStatus,
+  startTask,
+} from '../../services/task-service'
 import { recordTaskTokenUsage } from '../../services/work-cost-service'
 import llmAnalysisStorage from '../../storage/llm-analysis-storage'
 import { queueStorage } from '../../storage/queue-storage'
@@ -116,7 +121,7 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
 
   s.tool(
     'prjct_task_start',
-    'Start a work cycle. Fires before/after workflow gates and memory logging through the compatibility task backend; a gate may block the start. Pass linked_spec_id only when a durable intent/spec brief is required. Use when the user begins concrete work.',
+    'Start a work cycle. Fires before/after workflow gates and memory logging through the compatibility task backend; a gate may block the start. Surfaces predictive risks (preventive memory on likely files) — same class as CLI `prjct work` — so MCP agents read traps before editing. Pass linked_spec_id only when a durable intent/spec brief is required. Use when the user begins concrete work.',
     {
       projectPath: optionalProjectPath,
       description: z.string().describe('What the work cycle is — a short intent phrase'),
@@ -165,6 +170,12 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
         if (outcome.instructions && outcome.instructions.length > 0) {
           lines.push('', 'Agent instructions:')
           for (const i of outcome.instructions) lines.push(`- ${i}`)
+        }
+        // Predictive risk FIRST (CLI parity): traps before related context / file map.
+        const risks = outcome.risks ?? []
+        if (risks.length > 0) {
+          lines.push('', '⚠ Risk — what bit us in this area before (read before you edit):')
+          for (const r of risks) lines.push(`- ${formatRiskForAgent(r)}`)
         }
         if (outcome.relatedContext && outcome.relatedContext.length > 0) {
           lines.push('', 'Related second-brain context (pull full bodies with prjct_search):')

--- a/core/memory/infer-memory-file.ts
+++ b/core/memory/infer-memory-file.ts
@@ -1,0 +1,222 @@
+/**
+ * Infer `tags.file` for remember captures so guard / pre-edit / work risks
+ * fire without requiring the agent to pass `--tags file:…` manually.
+ *
+ * Source of truth for the column is still `tags.file` (SQL trigger extracts it).
+ * Explicit `tags.file` always wins. Inference is best-effort and conservative.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+/** Source-ish extensions we will bind for anticipation. */
+const FILE_EXT =
+  'ts|tsx|js|jsx|mjs|cjs|mts|cts|py|go|rs|vue|svelte|css|scss|less|json|md|sql|yml|yaml|toml|swift|kt|java|rb|php|sh'
+
+/**
+ * Repo-relative path candidates in free text.
+ * Requires at least one directory segment (avoids bare `index.ts` false positives).
+ */
+const PATH_RE = new RegExp(
+  String.raw`(?:^|[\s\`"'(:=\[])((?:\.\.?\/)?(?:[\w.@+-]+\/)+[\w.@+-]+\.(?:${FILE_EXT}))\b`,
+  'gi'
+)
+
+const BLOCKED_SEGMENT =
+  /(?:^|\/)(?:node_modules|dist|\.git|build|coverage|vendor|\.next|\.turbo)(?:\/|$)/i
+
+/** Prefer real app/source trees over noise. */
+const STRONG_PREFIX =
+  /^(?:src|core|app|apps|lib|packages|components|hooks|routes|server|services|domain|bin|scripts|tests?|__tests__)\//
+
+/**
+ * Strong roots for stripping absolute paths. Intentionally excludes `app`/`apps`
+ * — on macOS home paths contain `/Apps/` which would steal the suffix.
+ * (Relative paths can still score via STRONG_PREFIX including app/.)
+ */
+const ABS_STRIP_ROOTS = [
+  'src',
+  'core',
+  'packages',
+  'components',
+  'hooks',
+  'routes',
+  'server',
+  'services',
+  'domain',
+  'bin',
+  'scripts',
+  'lib',
+  'test',
+  'tests',
+  '__tests__',
+] as const
+
+export type InferMemoryFileInput = {
+  content: string
+  tags?: Record<string, string>
+  /** Project root — when set, prefer paths that exist on disk. */
+  projectPath?: string | null
+  /**
+   * Optional work-scope / likely-file paths from the active cycle.
+   * Basename hits in content promote those full paths.
+   */
+  cycleFiles?: string[] | null
+}
+
+/**
+ * Resolve the file tag to store (or null if nothing confident).
+ * Never invents paths without a textual or cycle signal.
+ */
+export function inferMemoryFileTag(input: InferMemoryFileInput): string | null {
+  const explicit = cleanPath(input.tags?.file)
+  if (explicit) return explicit
+
+  // Context-style multi-file tag: first usable path becomes the preventive anchor.
+  const fromFilesTag = firstFromCommaList(input.tags?.files)
+  if (fromFilesTag) return fromFilesTag
+
+  const content = input.content ?? ''
+  if (!content.trim()) return null
+
+  const extracted = extractRepoRelativePaths(content)
+  const cycle = (input.cycleFiles ?? []).map(cleanPath).filter((p): p is string => Boolean(p))
+
+  // Promote cycle paths whose basename is mentioned in the content.
+  for (const cf of cycle) {
+    const base = path.basename(cf)
+    if (base.length >= 3 && contentIncludesBasename(content, base)) {
+      extracted.unshift(cf)
+    }
+  }
+
+  if (extracted.length === 0) return null
+
+  const unique = dedupePaths(extracted)
+  const ranked = unique
+    .map((p) => ({ path: p, score: scoreCandidate(p, input.projectPath, content) }))
+    .filter((c) => c.score > 0)
+    .sort((a, b) => b.score - a.score || b.path.length - a.path.length)
+
+  return ranked[0]?.path ?? null
+}
+
+/**
+ * Absolute filesystem paths — cleaned via leftmost strong-root strip
+ * (`/Users/…/repo/src/lib/api.ts` → `src/lib/api.ts`).
+ */
+const ABS_PATH_RE = new RegExp(
+  String.raw`(?:^|[\s\`"'(:=\[])(\/(?:[\w.@+-]+\/)+[\w.@+-]+\.(?:${FILE_EXT}))\b`,
+  'gi'
+)
+
+/** Extract unique repo-relative path strings from free text (order = first seen). */
+export function extractRepoRelativePaths(content: string): string[] {
+  const out: string[] = []
+  PATH_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = PATH_RE.exec(content)) !== null) {
+    const cleaned = cleanPath(m[1])
+    if (cleaned) out.push(cleaned)
+  }
+  ABS_PATH_RE.lastIndex = 0
+  while ((m = ABS_PATH_RE.exec(content)) !== null) {
+    const cleaned = cleanPath(m[1])
+    if (cleaned) out.push(cleaned)
+  }
+  return dedupePaths(out)
+}
+
+function scoreCandidate(
+  filePath: string,
+  projectPath: string | null | undefined,
+  content: string
+): number {
+  if (BLOCKED_SEGMENT.test(filePath)) return 0
+  if (filePath.includes('://')) return 0
+
+  let score = 1
+  if (STRONG_PREFIX.test(filePath)) score += 3
+  // Backtick / explicit citation weight: path appears in backticks in content
+  if (content.includes(`\`${filePath}\``)) score += 2
+  if (projectPath) {
+    try {
+      const abs = path.isAbsolute(filePath) ? filePath : path.join(projectPath, filePath)
+      if (fs.existsSync(abs) && fs.statSync(abs).isFile()) score += 6
+      else score -= 1 // prefer existing when project root known
+    } catch {
+      /* ignore fs errors */
+    }
+  }
+  // Prefer deeper, more specific paths slightly
+  score += Math.min(3, filePath.split('/').length - 1)
+  return score
+}
+
+function firstFromCommaList(raw: string | undefined): string | null {
+  if (!raw) return null
+  for (const part of raw.split(',')) {
+    const cleaned = cleanPath(part)
+    if (cleaned) return cleaned
+  }
+  return null
+}
+
+function cleanPath(raw: string | undefined | null): string | null {
+  if (!raw) return null
+  let p = raw.trim().replace(/\\/g, '/')
+  // strip wrapping quotes/backticks
+  p = p.replace(/^['"`]+|['"`]+$/g, '')
+  // drop leading ./
+  p = p.replace(/^\.\//, '')
+  // absolute / home paths → leftmost strong root (src/ before nested lib/)
+  if (path.isAbsolute(p) || p.startsWith('/')) {
+    const stripped = stripAbsoluteToStrongRelative(p)
+    if (!stripped) return null
+    p = stripped
+  }
+  if (!p || BLOCKED_SEGMENT.test(p)) return null
+  if (!p.includes('/')) return null
+  if (!new RegExp(String.raw`\.(?:${FILE_EXT})$`, 'i').test(p)) return null
+  return p
+}
+
+/** `/Users/…/repo/src/lib/api.ts` → `src/lib/api.ts` (leftmost strong root). */
+function stripAbsoluteToStrongRelative(absPath: string): string | null {
+  const lower = absPath.toLowerCase()
+  let bestIdx = Infinity
+  let best: string | null = null
+  for (const root of ABS_STRIP_ROOTS) {
+    const needle = `/${root}/`
+    const idx = lower.indexOf(needle)
+    if (idx >= 0 && idx < bestIdx) {
+      bestIdx = idx
+      best = absPath.slice(idx + 1) // drop the leading slash
+    }
+  }
+  if (best && new RegExp(String.raw`\.(?:${FILE_EXT})$`, 'i').test(best)) return best
+  return null
+}
+
+function contentIncludesBasename(content: string, base: string): boolean {
+  // Word-ish boundary so "auth.ts" doesn't match "reauth.ts" naively —
+  // require non-identifier char or edges around the basename.
+  const re = new RegExp(`(^|[^\\w.-])${escapeRegExp(base)}([^\\w.-]|$)`, 'i')
+  return re.test(content)
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function dedupePaths(paths: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const p of paths) {
+    const key = p.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(p)
+  }
+  return out
+}

--- a/core/memory/project-memory.ts
+++ b/core/memory/project-memory.ts
@@ -367,6 +367,44 @@ export const projectMemory = {
       }
     }
 
+    // Anticipation bind: if the agent omitted `file:`, infer a repo-relative
+    // path from content / files tag / cycle scope so guard + work risks fire.
+    // Explicit tags.file always wins. Never blocks a capture on inference.
+    if (!tags.file) {
+      try {
+        const { inferMemoryFileTag } = await import('./infer-memory-file')
+        let cycleFiles: string[] | null = null
+        if (projectId) {
+          try {
+            const { stateStorage } = await import('../storage/state-storage')
+            const task = await stateStorage.getCurrentTask(projectId)
+            // Work-scope paths stamped when present (likelyFiles on some hosts).
+            const raw = (task as { likelyFiles?: Array<{ path?: string } | string> } | null)
+              ?.likelyFiles
+            if (Array.isArray(raw)) {
+              cycleFiles = raw
+                .map((f) => (typeof f === 'string' ? f : f?.path))
+                .filter((p): p is string => typeof p === 'string' && p.length > 0)
+            }
+          } catch {
+            cycleFiles = null
+          }
+        }
+        const inferred = inferMemoryFileTag({
+          content: args.content,
+          tags,
+          projectPath,
+          cycleFiles,
+        })
+        if (inferred) {
+          tags.file = inferred
+          tags.file_source = 'inferred'
+        }
+      } catch {
+        /* inference is best-effort */
+      }
+    }
+
     // Dedup net: a verbatim re-capture of the same (type, content) adds no
     // knowledge — it only dilutes recall and burns slots in the fixed-size
     // injection budget. Skip it. This is the universal guard behind EVERY

--- a/core/packs/pack-manager.ts
+++ b/core/packs/pack-manager.ts
@@ -49,6 +49,69 @@ export async function detectSuggestedPacks(projectPath: string): Promise<string[
   return [...out]
 }
 
+export type AnticipationEnsureResult = {
+  healed: boolean
+  activated: string[]
+  reason:
+    | 'no-config'
+    | 'conflictMode-off'
+    | 'already-coding-pack'
+    | 'conflictMode-healed'
+    | 'not-code-repo'
+    | 'activated-code'
+    | 'noop'
+}
+
+/**
+ * Product default for world-class build loop: coding repos get pack `code`
+ * (conflictMode advisory + land strict) without a second `prjct pack add`.
+ *
+ * Heals projects that only have projectId/cloud (pre-pack era) so anticipation
+ * is ON by default. Idempotent. Never overrides explicit `conflictMode: off`.
+ */
+export async function ensureCodingAnticipationDefaults(
+  projectPath: string
+): Promise<AnticipationEnsureResult> {
+  const existing = await configManager.readConfig(projectPath)
+  if (!existing) {
+    return { healed: false, activated: [], reason: 'no-config' }
+  }
+
+  // Explicit opt-out — quiet mode stays quiet.
+  if (existing.judgment?.conflictMode === 'off') {
+    return { healed: false, activated: [], reason: 'conflictMode-off' }
+  }
+
+  const packs = existing.persona?.packs ?? []
+  const hasCodePack = packs.includes('code') || packs.includes('code-strict')
+
+  if (hasCodePack) {
+    // Pack present but conflictMode never stamped (legacy activate path).
+    if (!existing.judgment?.conflictMode && packs.includes('code')) {
+      await configManager.writeConfig(projectPath, {
+        ...existing,
+        judgment: {
+          ...existing.judgment,
+          conflictMode: 'advisory',
+        },
+      })
+      return { healed: true, activated: [], reason: 'conflictMode-healed' }
+    }
+    return { healed: false, activated: [], reason: 'already-coding-pack' }
+  }
+
+  const suggested = await detectSuggestedPacks(projectPath)
+  if (!suggested.includes('code')) {
+    return { healed: false, activated: [], reason: 'not-code-repo' }
+  }
+
+  const result = await activatePacks(projectPath, ['code'], { suggestPersona: true })
+  if (result.activated.includes('code')) {
+    return { healed: true, activated: result.activated, reason: 'activated-code' }
+  }
+  return { healed: false, activated: [], reason: 'noop' }
+}
+
 export async function activatePacks(
   projectPath: string,
   packNames: string[],

--- a/core/services/task-service.ts
+++ b/core/services/task-service.ts
@@ -181,6 +181,14 @@ export function formatRelatedContextForAgent(hit: RelatedContextHit): string {
 }
 
 /**
+ * Compact predictive-risk line for work start (CLI + MCP parity).
+ * Same shape agents already see from `prjct work`: label, title, file, id.
+ */
+export function formatRiskForAgent(risk: RiskHit): string {
+  return `[${risk.label}] ${risk.title} — \`${risk.file}\`  \`${risk.id}\``
+}
+
+/**
  * Start a work cycle: run before/after workflow rules, persist state, link a spec
  * if requested, and log the `task_started` event. Returns structured data;
  * the caller prints. Mirrors the side-effects of `workflow.now`.
@@ -224,6 +232,23 @@ export async function startTask(
   }
 
   const cfg = await configManager.readConfig(projectPath).catch(() => null)
+
+  // Product default: coding repos heal onto pack `code` (conflictMode advisory)
+  // so MCP/CLI agents get predictive risk + pre-edit anticipation without a
+  // second `prjct pack add`. Best-effort; never blocks work start.
+  try {
+    const { ensureCodingAnticipationDefaults } = await import('../packs/pack-manager')
+    const heal = await ensureCodingAnticipationDefaults(projectPath)
+    if (heal.healed && heal.reason === 'activated-code') {
+      console.log(
+        'ℹ Anticipation ON: activated pack `code` (conflictMode advisory) — traps surface before edit'
+      )
+    } else if (heal.healed && heal.reason === 'conflictMode-healed') {
+      console.log('ℹ Anticipation ON: conflictMode → advisory for pack code')
+    }
+  } catch {
+    /* pack heal never blocks a start */
+  }
 
   // Discuss-lock + SDD gate (dominance vs GSD discuss-before-plan):
   //   - strict: every work cycle needs a REVIEWED intent/spec

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.71.0",
+  "version": "3.72.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Summary

World-class product loop that actually helps agents **build**, not abstract harness polish:

- **MCP risks parity** — `prjct_task_start` surfaces predictive risks with the same `formatRiskForAgent` lines as CLI `prjct work`
- **Coding defaults** — `ensureCodingAnticipationDefaults` auto-activates pack `code` (conflictMode advisory) on coding repos at work start
- **Ship compound** — judgment receipt written on ship (not land-only), so closed-loop metrics move
- **Auto-infer `tags.file` on remember** — agents omit `--tags file:…` and guard/pre-edit/work risks still fire when content contains a confident path

Utility trial on `prjct-cli-app` day 0 found vault gotchas without `file` made risks empty; inference closes that gap.

## Test plan

- [x] `bun test` focused: infer-memory-file, project-memory, pack-manager, format-risk-for-agent (89 pass)
- [ ] CI full suite green
- [ ] Smoke: `prjct work` on a coding repo shows Risk when file-tagged/inferred gotchas exist
- [ ] Smoke: `prjct remember gotcha "… src/lib/x.ts"` without file tag → `guard src/lib/x.ts` hits

Generated with [p/](https://www.prjct.app/)