### PR TITLE
feat(agent): owned print-mode agent loop with root-scoped tools

### DIFF
--- a/bin/prjct.ts
+++ b/bin/prjct.ts
@@ -535,9 +535,10 @@ async function main(): Promise<void> {
       'init',
       'eval',
       'analysis-save-llm',
-      // Opt-in owned-loop brain config only (default OFF; does not change guest flow).
+      // Opt-in owned-loop brain + agent only (default OFF; does not change guest flow).
       // Intentionally does NOT include embeddings — preserve pre-existing setup gate.
       'llm',
+      'agent',
     ])
 
     if (!noSetupRequired.has(args[0]) && (!(await fileExists(configPath)) || !routersInstalled)) {

--- a/core/__tests__/services/agent-loop.test.ts
+++ b/core/__tests__/services/agent-loop.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Owned agent loop + path safety + mock LLM tool calls.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import fsPromises from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { buildSystemPrompt, resolveSafePath, runAgent } from '../../agent'
+import { PathDeniedError } from '../../agent/paths'
+import type { ChatCompletionResult, LlmGenerateOptions, LlmProfile, LlmProvider } from '../../llm'
+
+function mockProvider(
+  script: Array<(opts: LlmGenerateOptions) => ChatCompletionResult>,
+  profile?: Partial<LlmProfile>
+): LlmProvider {
+  let i = 0
+  const p: LlmProfile = {
+    name: 'mock',
+    wire: 'openai-compatible',
+    providerLabel: 'Mock',
+    baseUrl: 'http://mock.test/v1',
+    model: 'mock-model',
+    ...profile,
+  }
+  return {
+    profile: p,
+    async generate(opts: LlmGenerateOptions) {
+      const fn = script[i] ?? script[script.length - 1]
+      i++
+      return fn!(opts)
+    },
+  }
+}
+
+describe('resolveSafePath', () => {
+  test('allows relative under root; denies escape and secrets', async () => {
+    const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'prjct-agent-path-'))
+    try {
+      expect(resolveSafePath(root, 'src/a.ts')).toBe(path.join(root, 'src/a.ts'))
+      expect(() => resolveSafePath(root, '../outside')).toThrow(PathDeniedError)
+      expect(() => resolveSafePath(root, '.env')).toThrow(PathDeniedError)
+      expect(() => resolveSafePath(root, 'secrets/id_rsa')).toThrow(PathDeniedError)
+    } finally {
+      await fsPromises.rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('runAgent', () => {
+  test('tool loop: read → edit → final summary', async () => {
+    const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'prjct-agent-run-'))
+    const file = path.join(root, 'hello.ts')
+    fs.writeFileSync(file, 'export const x = 1\n', 'utf-8')
+
+    const provider = mockProvider([
+      () => ({
+        content: null,
+        tool_calls: [
+          {
+            id: '1',
+            type: 'function',
+            function: { name: 'read', arguments: JSON.stringify({ path: 'hello.ts' }) },
+          },
+        ],
+        model: 'mock-model',
+      }),
+      () => ({
+        content: null,
+        tool_calls: [
+          {
+            id: '2',
+            type: 'function',
+            function: {
+              name: 'edit',
+              arguments: JSON.stringify({
+                path: 'hello.ts',
+                old_string: 'export const x = 1',
+                new_string: 'export const x = 2',
+              }),
+            },
+          },
+        ],
+        model: 'mock-model',
+      }),
+      () => ({
+        content: 'Updated hello.ts so x is 2.',
+        tool_calls: [],
+        model: 'mock-model',
+      }),
+    ])
+
+    try {
+      const result = await runAgent({
+        intent: 'Change x to 2 in hello.ts',
+        root,
+        provider,
+        maxSteps: 8,
+      })
+      expect(result.success).toBe(true)
+      expect(result.toolCalls).toBe(2)
+      expect(result.content).toContain('x is 2')
+      expect(fs.readFileSync(file, 'utf-8')).toContain('x = 2')
+    } finally {
+      await fsPromises.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('write creates file', async () => {
+    const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'prjct-agent-write-'))
+    const provider = mockProvider([
+      () => ({
+        content: null,
+        tool_calls: [
+          {
+            id: '1',
+            type: 'function',
+            function: {
+              name: 'write',
+              arguments: JSON.stringify({ path: 'src/new.ts', content: 'export const n = 1\n' }),
+            },
+          },
+        ],
+        model: 'mock',
+      }),
+      () => ({
+        content: 'Created src/new.ts',
+        tool_calls: [],
+        model: 'mock',
+      }),
+    ])
+    try {
+      const result = await runAgent({ intent: 'create file', root, provider })
+      expect(result.success).toBe(true)
+      expect(fs.readFileSync(path.join(root, 'src/new.ts'), 'utf-8')).toContain('n = 1')
+    } finally {
+      await fsPromises.rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('system prompt includes root', () => {
+    expect(buildSystemPrompt('/tmp/proj')).toContain('/tmp/proj')
+  })
+})

--- a/core/agent/index.ts
+++ b/core/agent/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Owned agent runtime (print / one-shot).
+ * Enable with `prjct llm enable` + brain profile, then `prjct agent "…"`.
+ */
+
+export { buildSystemPrompt, runAgent } from './loop'
+export { PathDeniedError, resolveSafePath } from './paths'
+export {
+  bashTool,
+  defaultTools,
+  editTool,
+  getToolMap,
+  readTool,
+  writeTool,
+} from './tools'
+export type {
+  AgentRunOptions,
+  AgentRunResult,
+  AgentStepEvent,
+  AgentTool,
+  AgentToolContext,
+  AgentToolResult,
+} from './types'
+export { toolsToChatDefs } from './types'

--- a/core/agent/loop.ts
+++ b/core/agent/loop.ts
@@ -1,0 +1,155 @@
+/**
+ * Owned agent loop — print / one-shot mode.
+ *
+ * Uses resolveLlmProvider brains + built-in tools. Guest hosts untouched.
+ */
+
+import type { ChatMessage, ChatToolCall } from '../llm'
+import { defaultTools, getToolMap } from './tools'
+import {
+  type AgentRunOptions,
+  type AgentRunResult,
+  type AgentToolContext,
+  toolsToChatDefs,
+} from './types'
+
+const DEFAULT_MAX_STEPS = 12
+
+export function buildSystemPrompt(root: string, append?: string): string {
+  const base = [
+    'You are prjct owned agent (print mode): a careful coding agent.',
+    `Project root: ${root}`,
+    'Use tools to inspect and edit files. Prefer edit over write for small changes.',
+    'Stay inside the project. Do not touch secrets (.env, keys, credentials).',
+    'When done, respond with a short summary of what you changed — no more tool calls.',
+    'If the task is unclear or impossible, say so without inventing files.',
+  ].join('\n')
+  return append ? `${base}\n\n${append}` : base
+}
+
+function parseToolArgs(raw: string): Record<string, unknown> {
+  try {
+    const v = JSON.parse(raw || '{}')
+    if (v && typeof v === 'object' && !Array.isArray(v)) return v as Record<string, unknown>
+    return { value: v }
+  } catch {
+    return { raw }
+  }
+}
+
+export async function runAgent(opts: AgentRunOptions): Promise<AgentRunResult> {
+  const tools = opts.tools ?? defaultTools()
+  const toolMap = getToolMap(tools)
+  const defs = toolsToChatDefs(tools)
+  const maxSteps = opts.maxSteps ?? DEFAULT_MAX_STEPS
+  const ctx: AgentToolContext = { root: opts.root }
+  const profile = opts.provider.profile
+
+  const messages: ChatMessage[] = [
+    { role: 'system', content: buildSystemPrompt(opts.root, opts.systemAppend) },
+    { role: 'user', content: opts.intent },
+  ]
+
+  let toolCalls = 0
+  let steps = 0
+
+  try {
+    for (let step = 1; step <= maxSteps; step++) {
+      steps = step
+      opts.onStep?.({ type: 'generate', step })
+
+      const completion = await opts.provider.generate({
+        messages,
+        tools: defs,
+        temperature: 0.2,
+        max_tokens: 4096,
+        timeoutMs: opts.timeoutMsPerGenerate,
+      })
+
+      const calls = completion.tool_calls ?? []
+      opts.onStep?.({
+        type: 'assistant',
+        step,
+        content: completion.content,
+        tool_calls: calls,
+      })
+
+      if (calls.length === 0) {
+        opts.onStep?.({ type: 'done', step, content: completion.content })
+        return {
+          success: true,
+          content: completion.content,
+          steps,
+          toolCalls,
+          messages: [
+            ...messages,
+            { role: 'assistant', content: completion.content, tool_calls: undefined },
+          ],
+          profile: profile.name,
+          model: completion.model || profile.model,
+        }
+      }
+
+      // Assistant turn with tool calls
+      messages.push({
+        role: 'assistant',
+        content: completion.content,
+        tool_calls: calls,
+      })
+
+      for (const call of calls) {
+        toolCalls++
+        const result = await executeToolCall(call, toolMap, ctx)
+        const preview = result.content.slice(0, 200)
+        opts.onStep?.({
+          type: 'tool',
+          step,
+          name: call.function.name,
+          ok: result.ok,
+          preview,
+        })
+        messages.push({
+          role: 'tool',
+          tool_call_id: call.id,
+          content: result.content,
+          name: call.function.name,
+        })
+      }
+    }
+
+    return {
+      success: false,
+      content: null,
+      steps,
+      toolCalls,
+      messages,
+      error: `Reached maxSteps (${maxSteps}) without a final answer`,
+      profile: profile.name,
+      model: profile.model,
+    }
+  } catch (e) {
+    return {
+      success: false,
+      content: null,
+      steps,
+      toolCalls,
+      messages,
+      error: e instanceof Error ? e.message : String(e),
+      profile: profile.name,
+      model: profile.model,
+    }
+  }
+}
+
+async function executeToolCall(
+  call: ChatToolCall,
+  toolMap: Map<string, ReturnType<typeof defaultTools>[number]>,
+  ctx: AgentToolContext
+): Promise<{ ok: boolean; content: string }> {
+  const tool = toolMap.get(call.function.name)
+  if (!tool) {
+    return { ok: false, content: `Unknown tool: ${call.function.name}` }
+  }
+  const args = parseToolArgs(call.function.arguments)
+  return tool.execute(args, ctx)
+}

--- a/core/agent/paths.ts
+++ b/core/agent/paths.ts
@@ -1,0 +1,59 @@
+/**
+ * Path safety for owned-agent tools — stay inside project root.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const DENY_BASENAME =
+  /^(?:\.env(?:\..+)?|.*\.(?:pem|key|p12|pfx)|id_rsa|id_ed25519|credentials\.json|auth\.json)$/i
+
+const DENY_SEGMENT = /(?:^|\/)(?:\.ssh|\.gnupg|\.aws|\.config\/gcloud)(?:\/|$)/i
+
+export class PathDeniedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PathDeniedError'
+  }
+}
+
+/** Resolve user path under root; throws if escapes or hits deny list. */
+export function resolveSafePath(root: string, userPath: string): string {
+  if (!userPath || typeof userPath !== 'string') {
+    throw new PathDeniedError('path is required')
+  }
+  const rootAbs = path.resolve(root)
+  // Absolute paths must still land under root
+  const candidate = path.isAbsolute(userPath)
+    ? path.resolve(userPath)
+    : path.resolve(rootAbs, userPath)
+
+  const rel = path.relative(rootAbs, candidate)
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new PathDeniedError(`path escapes project root: ${userPath}`)
+  }
+
+  const base = path.basename(candidate)
+  if (DENY_BASENAME.test(base)) {
+    throw new PathDeniedError(`path blocked (secret-like name): ${base}`)
+  }
+  const posix = candidate.split(path.sep).join('/')
+  if (DENY_SEGMENT.test(posix)) {
+    throw new PathDeniedError(`path blocked (sensitive directory): ${userPath}`)
+  }
+
+  return candidate
+}
+
+export function ensureParentDir(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+}
+
+export function fileExists(p: string): boolean {
+  try {
+    fs.accessSync(p)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/core/agent/tools.ts
+++ b/core/agent/tools.ts
@@ -1,0 +1,177 @@
+/**
+ * Built-in tools for the owned agent (Pi-like minimal set).
+ * All FS ops are root-scoped via resolveSafePath.
+ */
+
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import { promisify } from 'node:util'
+import { ensureParentDir, fileExists, PathDeniedError, resolveSafePath } from './paths'
+import type { AgentTool, AgentToolResult } from './types'
+
+const execFileAsync = promisify(execFile)
+
+const DEFAULT_MAX_READ = 256 * 1024
+const DEFAULT_BASH_MS = 30_000
+const DEFAULT_BASH_OUT = 64 * 1024
+
+function ok(content: string): AgentToolResult {
+  return { ok: true, content }
+}
+function fail(content: string): AgentToolResult {
+  return { ok: false, content }
+}
+
+function asString(v: unknown, name: string): string {
+  if (typeof v !== 'string' || !v) throw new Error(`${name} must be a non-empty string`)
+  return v
+}
+
+export const readTool: AgentTool = {
+  name: 'read',
+  description: 'Read a UTF-8 text file under the project root. Path is relative to project root.',
+  parameters: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Relative path from project root' },
+    },
+    required: ['path'],
+  },
+  async execute(args, ctx) {
+    try {
+      const rel = asString(args.path, 'path')
+      const abs = resolveSafePath(ctx.root, rel)
+      if (!fileExists(abs)) return fail(`File not found: ${rel}`)
+      const st = fs.statSync(abs)
+      if (!st.isFile()) return fail(`Not a file: ${rel}`)
+      const max = ctx.maxReadBytes ?? DEFAULT_MAX_READ
+      if (st.size > max) return fail(`File too large (${st.size} > ${max} bytes): ${rel}`)
+      const text = fs.readFileSync(abs, 'utf-8')
+      return ok(text)
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
+export const writeTool: AgentTool = {
+  name: 'write',
+  description:
+    'Create or overwrite a UTF-8 text file under the project root. Creates parent dirs. Prefer edit for small changes.',
+  parameters: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Relative path from project root' },
+      content: { type: 'string', description: 'Full file contents' },
+    },
+    required: ['path', 'content'],
+  },
+  async execute(args, ctx) {
+    try {
+      const rel = asString(args.path, 'path')
+      const content = typeof args.content === 'string' ? args.content : String(args.content ?? '')
+      const abs = resolveSafePath(ctx.root, rel)
+      ensureParentDir(abs)
+      fs.writeFileSync(abs, content, 'utf-8')
+      return ok(`Wrote ${rel} (${content.length} chars)`)
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
+export const editTool: AgentTool = {
+  name: 'edit',
+  description:
+    'Replace an exact substring in a file once. Fails if old_string is missing or not unique.',
+  parameters: {
+    type: 'object',
+    properties: {
+      path: { type: 'string' },
+      old_string: { type: 'string' },
+      new_string: { type: 'string' },
+    },
+    required: ['path', 'old_string', 'new_string'],
+  },
+  async execute(args, ctx) {
+    try {
+      const rel = asString(args.path, 'path')
+      const oldStr = asString(args.old_string, 'old_string')
+      const newStr =
+        typeof args.new_string === 'string' ? args.new_string : String(args.new_string ?? '')
+      const abs = resolveSafePath(ctx.root, rel)
+      if (!fileExists(abs)) return fail(`File not found: ${rel}`)
+      const text = fs.readFileSync(abs, 'utf-8')
+      const count = text.split(oldStr).length - 1
+      if (count === 0) return fail(`old_string not found in ${rel}`)
+      if (count > 1) return fail(`old_string not unique in ${rel} (${count} matches)`)
+      fs.writeFileSync(abs, text.replace(oldStr, newStr), 'utf-8')
+      return ok(`Edited ${rel}`)
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
+/** Deny obviously destructive / networky shell patterns (defense in depth). */
+const BASH_DENY =
+  /\b(?:rm\s+-rf\s+\/|mkfs|dd\s+if=|curl\s+|wget\s+|nc\s+|ncat\s+|ssh\s+|scp\s+|sudo\s+|chmod\s+777)\b/i
+
+export const bashTool: AgentTool = {
+  name: 'bash',
+  description:
+    'Run a short shell command in the project root (cwd fixed). Prefer read/edit/write for file changes. No network/sudo.',
+  parameters: {
+    type: 'object',
+    properties: {
+      command: { type: 'string', description: 'Shell command to run' },
+    },
+    required: ['command'],
+  },
+  async execute(args, ctx) {
+    try {
+      const command = asString(args.command, 'command')
+      if (BASH_DENY.test(command)) {
+        return fail('Command blocked by safety policy')
+      }
+      const timeout = ctx.maxBashMs ?? DEFAULT_BASH_MS
+      const maxOut = ctx.maxBashOutputBytes ?? DEFAULT_BASH_OUT
+      const { stdout, stderr } = await execFileAsync('bash', ['-lc', command], {
+        cwd: ctx.root,
+        timeout,
+        maxBuffer: maxOut,
+        env: {
+          ...process.env,
+          // Avoid leaking host agent config into child accidentally beyond PATH
+          CI: process.env.CI,
+        },
+      })
+      const out = [stdout, stderr].filter(Boolean).join('\n').slice(0, maxOut)
+      return ok(out || '(no output)')
+    } catch (e) {
+      const err = e as {
+        killed?: boolean
+        code?: number
+        stdout?: string
+        stderr?: string
+        message?: string
+      }
+      if (err.killed) return fail(`Command timed out`)
+      const bits = [err.stderr, err.stdout, err.message]
+        .filter(Boolean)
+        .join('\n')
+        .slice(0, DEFAULT_BASH_OUT)
+      return fail(bits || 'Command failed')
+    }
+  },
+}
+
+export function defaultTools(): AgentTool[] {
+  return [readTool, writeTool, editTool, bashTool]
+}
+
+export function getToolMap(tools: AgentTool[]): Map<string, AgentTool> {
+  return new Map(tools.map((t) => [t.name, t]))
+}
+
+export { PathDeniedError }

--- a/core/agent/types.ts
+++ b/core/agent/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Owned agent loop types (print / one-shot mode).
+ * Guest harnesses are unaffected — this runs only when owned LLM is enabled.
+ */
+
+import type { ChatMessage, ChatToolCall, ChatToolDef, LlmProvider } from '../llm'
+
+export interface AgentToolContext {
+  /** Absolute project root; all relative paths resolve under this. */
+  root: string
+  /** Soft cap for bash / read sizes */
+  maxReadBytes?: number
+  maxBashMs?: number
+  maxBashOutputBytes?: number
+}
+
+export interface AgentToolResult {
+  ok: boolean
+  /** Text returned to the model */
+  content: string
+}
+
+export interface AgentTool {
+  name: string
+  description: string
+  /** JSON Schema object for function parameters */
+  parameters: Record<string, unknown>
+  execute(args: Record<string, unknown>, ctx: AgentToolContext): Promise<AgentToolResult>
+}
+
+export interface AgentRunOptions {
+  intent: string
+  root: string
+  provider: LlmProvider
+  maxSteps?: number
+  /** Inject tools (tests); default = built-in registry */
+  tools?: AgentTool[]
+  /** Extra system instructions */
+  systemAppend?: string
+  onStep?: (event: AgentStepEvent) => void
+  timeoutMsPerGenerate?: number
+}
+
+export type AgentStepEvent =
+  | { type: 'generate'; step: number }
+  | { type: 'assistant'; step: number; content: string | null; tool_calls: ChatToolCall[] }
+  | { type: 'tool'; step: number; name: string; ok: boolean; preview: string }
+  | { type: 'done'; step: number; content: string | null }
+
+export interface AgentRunResult {
+  success: boolean
+  content: string | null
+  steps: number
+  toolCalls: number
+  messages: ChatMessage[]
+  error?: string
+  profile: string
+  model: string
+}
+
+export function toolsToChatDefs(tools: AgentTool[]): ChatToolDef[] {
+  return tools.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    },
+  }))
+}

--- a/core/commands/agent.ts
+++ b/core/commands/agent.ts
@@ -1,0 +1,132 @@
+/**
+ * `prjct agent` — owned print-mode agent (one-shot).
+ *
+ * Requires: prjct llm enable + brain profile (set/use/test).
+ * Guest mode (Claude/Grok/Codex) is unchanged.
+ */
+
+import path from 'node:path'
+import { type AgentStepEvent, runAgent } from '../agent'
+import {
+  getActiveLlmProfile,
+  isOwnedLlmEnabled,
+  ownedLlmEnableHint,
+  resolveLlmProvider,
+} from '../llm'
+import type { CommandResult } from '../types/commands'
+import { getErrorMessage } from '../types/fs'
+import { failHard } from '../utils/md-aware'
+import { mdOutput, mdSection, mdStats } from '../utils/md-formatter'
+import out from '../utils/output'
+import { PrjctCommandsBase } from './base'
+
+interface AgentOptions {
+  md?: boolean
+  maxSteps?: number
+  quiet?: boolean
+}
+
+export class AgentCommands extends PrjctCommandsBase {
+  async agent(
+    intent: string | null = null,
+    projectPath: string = process.cwd(),
+    options: AgentOptions = {}
+  ): Promise<CommandResult> {
+    if (!isOwnedLlmEnabled()) {
+      return failHard(
+        `${ownedLlmEnableHint()}\n\nThen: prjct llm set … && prjct agent "<intent>"`,
+        options
+      )
+    }
+
+    const text = (intent ?? '').trim()
+    if (!text) {
+      return failHard(
+        'Usage: prjct agent "<intent>"\nExample: prjct agent "add a hello() function to src/hi.ts"',
+        options
+      )
+    }
+
+    const profile = getActiveLlmProfile()
+    if (!profile) {
+      return failHard(
+        'No LLM brain configured. Run: prjct llm set --name <n> --key <K>  (or Ollama base-url)\nThen: prjct llm test',
+        options
+      )
+    }
+
+    const provider = await resolveLlmProvider()
+    if (!provider) {
+      return failHard('Could not resolve LLM provider for the active profile.', options)
+    }
+
+    const root = path.resolve(projectPath)
+    const maxSteps =
+      typeof options.maxSteps === 'number' && options.maxSteps > 0
+        ? Math.min(options.maxSteps, 40)
+        : 12
+
+    if (!options.md && !options.quiet) {
+      out.info(`Owned agent · ${profile.name} · ${profile.model} · maxSteps=${maxSteps} · ${root}`)
+    }
+
+    const onStep = options.quiet
+      ? undefined
+      : (ev: AgentStepEvent) => {
+          if (options.md) return
+          if (ev.type === 'tool') {
+            out.info(`  tool ${ev.name} ${ev.ok ? 'ok' : 'fail'}: ${ev.preview.slice(0, 80)}`)
+          } else if (ev.type === 'assistant' && ev.tool_calls.length === 0 && ev.content) {
+            // final text printed after run
+          }
+        }
+
+    try {
+      const result = await runAgent({
+        intent: text,
+        root,
+        provider,
+        maxSteps,
+        onStep,
+      })
+
+      if (!result.success) {
+        return failHard(result.error ?? 'Agent failed', options)
+      }
+
+      const summary = (result.content ?? '').trim() || '(no summary)'
+
+      if (options.md) {
+        console.log(
+          mdOutput(
+            mdSection('Agent done', summary),
+            mdStats({
+              profile: result.profile,
+              model: result.model,
+              steps: result.steps,
+              'tool calls': result.toolCalls,
+              root,
+            })
+          )
+        )
+        return {
+          success: true,
+          content: summary,
+          steps: result.steps,
+          toolCalls: result.toolCalls,
+        }
+      }
+
+      out.done(`Agent finished · ${result.steps} step(s) · ${result.toolCalls} tool call(s)`)
+      console.log(summary)
+      return {
+        success: true,
+        content: summary,
+        steps: result.steps,
+        toolCalls: result.toolCalls,
+      }
+    } catch (e) {
+      return failHard(getErrorMessage(e), options)
+    }
+  }
+}

--- a/core/commands/agent.ts
+++ b/core/commands/agent.ts
@@ -27,7 +27,11 @@ interface AgentOptions {
 }
 
 export class AgentCommands extends PrjctCommandsBase {
-  async agent(
+  /**
+   * Handler for `prjct agent` (method name is `run` because base class
+   * already exposes a getter `agent` for host agent detection).
+   */
+  async run(
     intent: string | null = null,
     projectPath: string = process.cwd(),
     options: AgentOptions = {}

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -1071,7 +1071,34 @@ export const COMMANDS: CommandMeta[] = [
       'Does not alter embeddings setup gate or existing verbs',
       'Multi-profile brains: Anthropic / OpenAI / xAI / OpenRouter / Ollama / LM Studio',
       'Partial set merges; clear <name> or clear --all (keys wiped, no orphans)',
-      'Honest probe + HTTP timeouts; no agent loop yet',
+      'Honest probe + HTTP timeouts',
+      'Pairs with prjct agent (print mode) when enabled',
+    ],
+  },
+  {
+    name: 'agent',
+    group: 'setup',
+    surface: 'support',
+    routing: { group: 'agent', method: 'agent' },
+    optionSchema: {
+      numbers: ['maxSteps'],
+      booleans: ['quiet'],
+    },
+    description:
+      'OPT-IN owned print-mode agent (one-shot). Requires prjct llm enable + brain profile. Tools: read/write/edit/bash under project root. Guest hosts unchanged.',
+    usage: {
+      claude: null,
+      terminal: 'prjct agent "<intent>" [--max-steps N] [--quiet] [--md]',
+    },
+    params: '"<intent>"',
+    implemented: true,
+    hasTemplate: false,
+    requiresProject: false,
+    features: [
+      'Blocked unless prjct llm enable (or PRJCT_OWNED_LLM=1) and a brain profile is set',
+      'Print/one-shot only — no interactive TUI yet',
+      'Tools scoped to project root; secret-like paths denied',
+      'Does not replace Claude Code / Grok / Codex guest mode',
     ],
   },
   {

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -1079,7 +1079,7 @@ export const COMMANDS: CommandMeta[] = [
     name: 'agent',
     group: 'setup',
     surface: 'support',
-    routing: { group: 'agent', method: 'agent' },
+    routing: { group: 'agent', method: 'run' },
     optionSchema: {
       numbers: ['maxSteps'],
       booleans: ['quiet'],

--- a/core/commands/register.ts
+++ b/core/commands/register.ts
@@ -67,6 +67,7 @@ export const groupLoaders: Record<CommandRoutingGroup, () => Promise<object>> = 
   spec: lazy(async () => new (await import('./spec')).SpecCommands()),
   embeddings: lazy(async () => new (await import('./embeddings')).EmbeddingsCommands()),
   llm: lazy(async () => new (await import('./llm')).LlmCommands()),
+  agent: lazy(async () => new (await import('./agent')).AgentCommands()),
   guard: lazy(async () => new (await import('./guard')).GuardCommands()),
   memoryExport: lazy(async () => new (await import('./memory-export')).MemoryExportCommands()),
   workflowsReference: lazy(

--- a/core/types/commands.ts
+++ b/core/types/commands.ts
@@ -352,6 +352,7 @@ export type CommandRoutingGroup =
   | 'spec'
   | 'embeddings'
   | 'llm'
+  | 'agent'
   | 'guard'
   | 'lean'
   | 'cloud'


### PR DESCRIPTION
## Summary

- **Fase 2** of the owned harness: `prjct agent \"<intent>\"` one-shot / print mode on top of the multi-brain foundation (#592).
- `core/agent`: tool loop + **read / write / edit / bash** scoped to project root (path escape + secret-like denials).
- Same **opt-in gate** as `prjct llm enable` — default OFF; Guest (Claude/Grok/Codex/…) unchanged.
- Requires an active brain profile (`prjct llm set|use`).

## Usage (after merge)

```bash
prjct llm enable
prjct llm set --name ollama --base-url http://localhost:11434/v1 --model qwen3.5:4b
# or: prjct llm set --name anthropic --key sk-ant-…
prjct agent \"add hello() to src/hi.ts\" --md
```

## Safety

- Opt-in only (`PRJCT_OWNED_LLM` / `prjct llm enable`)
- Tools cannot leave project root; `.env` / keys / `.ssh` blocked
- Bash deny-list for destructive/network patterns + timeout
- No changes to guest installers, hooks, MCP, embeddings

## Test plan

- [x] Hermetic mock LLM: read → edit → write loops
- [x] Path denial tests
- [x] Manifest completeness (handler `run` — avoids base `get agent()` clash)
- [x] `tsc` clean
- [ ] Live dogfood with Ollama / subscription key (post-merge)

## Follow-ups

- Interactive REPL / TUI
- First-class prjct tools (search/guard/work) as structured tools
- Default-on only after dogfood confidence

Generated with [p/](https://www.prjct.app/)