### PR TITLE
feat(agent): prjct body tools + guard prefix on edit/write

### DIFF
--- a/core/__tests__/services/agent-loop.test.ts
+++ b/core/__tests__/services/agent-loop.test.ts
@@ -139,7 +139,19 @@ describe('runAgent', () => {
     }
   })
 
-  test('system prompt includes root', () => {
-    expect(buildSystemPrompt('/tmp/proj')).toContain('/tmp/proj')
+  test('system prompt includes root and prjct tools guidance', () => {
+    const p = buildSystemPrompt('/tmp/proj')
+    expect(p).toContain('/tmp/proj')
+    expect(p).toContain('prjct_search')
+    expect(p).toContain('prjct_guard')
+  })
+
+  test('default tools include prjct body tools', async () => {
+    const { defaultTools } = await import('../../agent')
+    const names = defaultTools().map((t) => t.name)
+    expect(names).toContain('read')
+    expect(names).toContain('prjct_search')
+    expect(names).toContain('prjct_guard')
+    expect(names).toContain('prjct_remember')
   })
 })

--- a/core/agent/index.ts
+++ b/core/agent/index.ts
@@ -5,6 +5,7 @@
 
 export { buildSystemPrompt, runAgent } from './loop'
 export { PathDeniedError, resolveSafePath } from './paths'
+export { fetchGuardHits, guardTool, prjctBodyTools, rememberTool, searchTool } from './prjct-tools'
 export {
   bashTool,
   defaultTools,

--- a/core/agent/loop.ts
+++ b/core/agent/loop.ts
@@ -20,6 +20,8 @@ export function buildSystemPrompt(root: string, append?: string): string {
     'You are prjct owned agent (print mode): a careful coding agent.',
     `Project root: ${root}`,
     'Use tools to inspect and edit files. Prefer edit over write for small changes.',
+    'Prefer prjct_search for project knowledge and prjct_guard before risky edits.',
+    'Persist non-obvious outcomes with prjct_remember (English).',
     'Stay inside the project. Do not touch secrets (.env, keys, credentials).',
     'When done, respond with a short summary of what you changed — no more tool calls.',
     'If the task is unclear or impossible, say so without inventing files.',

--- a/core/agent/prjct-tools.ts
+++ b/core/agent/prjct-tools.ts
@@ -1,0 +1,171 @@
+/**
+ * Structured prjct body tools for the owned agent.
+ * Same SoT as MCP (projectMemory) — no shell out to prjct CLI.
+ * Soft-fail when cwd is not a configured prjct project.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { formatMemoryMd } from '../memory/format'
+import { projectMemory } from '../memory/project-memory'
+import type { AgentTool, AgentToolContext, AgentToolResult } from './types'
+
+function ok(content: string): AgentToolResult {
+  return { ok: true, content }
+}
+function fail(content: string): AgentToolResult {
+  return { ok: false, content }
+}
+
+function asString(v: unknown, name: string): string {
+  if (typeof v !== 'string' || !v.trim()) throw new Error(`${name} must be a non-empty string`)
+  return v.trim()
+}
+
+async function resolveProjectId(root: string): Promise<string | null> {
+  try {
+    const id = await configManager.getProjectId(root)
+    return id || null
+  } catch {
+    return null
+  }
+}
+
+/** Best-effort preventive memory for a path (used by guard tool + edit/write). */
+export async function fetchGuardHits(
+  root: string,
+  filePath: string,
+  limit = 3
+): Promise<string | null> {
+  const projectId = await resolveProjectId(root)
+  if (!projectId) return null
+  try {
+    const hits = projectMemory.recallForFile(projectId, filePath, limit)
+    if (hits.length === 0) return null
+    return formatMemoryMd(hits, { boundary: 'llm', compact: true })
+  } catch {
+    return null
+  }
+}
+
+export const searchTool: AgentTool = {
+  name: 'prjct_search',
+  description:
+    'Search durable project memory (decisions, gotchas, learnings). Prefer this before broad codebase exploration.',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Keyword / topic to search' },
+      limit: { type: 'number', description: 'Max entries (default 10)' },
+    },
+    required: ['query'],
+  },
+  async execute(args, ctx) {
+    try {
+      const query = asString(args.query, 'query')
+      const limit = typeof args.limit === 'number' && args.limit > 0 ? Math.min(args.limit, 25) : 10
+      const projectId = await resolveProjectId(ctx.root)
+      if (!projectId) return ok('(not a prjct project — no memory index)')
+      // Dynamic import avoids loading enrichedRecall on pure FS unit tests
+      const { enrichedRecall } = await import('../memory/enriched-recall')
+      const entries = await enrichedRecall(ctx.root, projectId, {
+        topic: query,
+        limit,
+        expandLinks: false,
+      })
+      if (entries.length === 0) return ok('No matching memories.')
+      return ok(formatMemoryMd(entries, { boundary: 'llm', compact: true }))
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
+export const guardTool: AgentTool = {
+  name: 'prjct_guard',
+  description:
+    'Anticipation: preventive memory for a file (gotchas/anti-patterns) before edit. Empty means clear to edit.',
+  parameters: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Repo-relative file path' },
+      limit: { type: 'number', description: 'Max traps (default 3)' },
+    },
+    required: ['path'],
+  },
+  async execute(args, ctx) {
+    try {
+      const file = asString(args.path, 'path')
+      const limit = typeof args.limit === 'number' && args.limit > 0 ? args.limit : 3
+      const projectId = await resolveProjectId(ctx.root)
+      if (!projectId) return ok('clear to edit (no prjct project)')
+      const hits = projectMemory.recallForFile(projectId, file, limit)
+      if (hits.length === 0) return ok(`No preventive memory for ${file} — clear to edit.`)
+      return ok(formatMemoryMd(hits, { boundary: 'llm', compact: true }))
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
+export const rememberTool: AgentTool = {
+  name: 'prjct_remember',
+  description:
+    'Persist a durable memory in ENGLISH (decision|learning|gotcha|fact|…). Use after resolving something non-obvious.',
+  parameters: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        description: 'Memory type e.g. decision, learning, gotcha, fact',
+      },
+      content: { type: 'string', description: 'Memory body in English' },
+      tags: {
+        type: 'object',
+        description: 'Optional key:value tags',
+        additionalProperties: { type: 'string' },
+      },
+    },
+    required: ['type', 'content'],
+  },
+  async execute(args, ctx) {
+    try {
+      const type = asString(args.type, 'type')
+      const content = asString(args.content, 'content')
+      const tags =
+        args.tags && typeof args.tags === 'object' && !Array.isArray(args.tags)
+          ? (args.tags as Record<string, string>)
+          : undefined
+      const projectId = await resolveProjectId(ctx.root)
+      if (!projectId) return fail('Not a prjct project — cannot remember')
+      await projectMemory.remember(ctx.root, {
+        type: type as Parameters<typeof projectMemory.remember>[1]['type'],
+        content,
+        tags,
+        projectId,
+        requireWrite: true,
+      })
+      return ok(`Saved ${type}: ${content.slice(0, 100)}`)
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
+export function prjctBodyTools(): AgentTool[] {
+  return [searchTool, guardTool, rememberTool]
+}
+
+/** Prefix edit/write results with guard hits when present (anticipation). */
+export async function withGuardPrefix(
+  ctx: AgentToolContext,
+  filePath: string,
+  result: AgentToolResult
+): Promise<AgentToolResult> {
+  if (!result.ok) return result
+  const traps = await fetchGuardHits(ctx.root, filePath, 3)
+  if (!traps) return result
+  return {
+    ok: true,
+    content: `PREVENTIVE MEMORY (review before trusting this edit):\n${traps}\n\n---\n${result.content}`,
+  }
+}

--- a/core/agent/tools.ts
+++ b/core/agent/tools.ts
@@ -6,7 +6,8 @@
 import { execFile } from 'node:child_process'
 import fs from 'node:fs'
 import { promisify } from 'node:util'
-import { ensureParentDir, fileExists, PathDeniedError, resolveSafePath } from './paths'
+import { ensureParentDir, fileExists, resolveSafePath } from './paths'
+import { prjctBodyTools, withGuardPrefix } from './prjct-tools'
 import type { AgentTool, AgentToolResult } from './types'
 
 const execFileAsync = promisify(execFile)
@@ -73,7 +74,7 @@ export const writeTool: AgentTool = {
       const abs = resolveSafePath(ctx.root, rel)
       ensureParentDir(abs)
       fs.writeFileSync(abs, content, 'utf-8')
-      return ok(`Wrote ${rel} (${content.length} chars)`)
+      return withGuardPrefix(ctx, rel, ok(`Wrote ${rel} (${content.length} chars)`))
     } catch (e) {
       return fail(e instanceof Error ? e.message : String(e))
     }
@@ -83,7 +84,7 @@ export const writeTool: AgentTool = {
 export const editTool: AgentTool = {
   name: 'edit',
   description:
-    'Replace an exact substring in a file once. Fails if old_string is missing or not unique.',
+    'Replace an exact substring in a file once. Fails if old_string is missing or not unique. Surfaces preventive memory for the file when present.',
   parameters: {
     type: 'object',
     properties: {
@@ -106,7 +107,7 @@ export const editTool: AgentTool = {
       if (count === 0) return fail(`old_string not found in ${rel}`)
       if (count > 1) return fail(`old_string not unique in ${rel} (${count} matches)`)
       fs.writeFileSync(abs, text.replace(oldStr, newStr), 'utf-8')
-      return ok(`Edited ${rel}`)
+      return withGuardPrefix(ctx, rel, ok(`Edited ${rel}`))
     } catch (e) {
       return fail(e instanceof Error ? e.message : String(e))
     }
@@ -167,11 +168,9 @@ export const bashTool: AgentTool = {
 }
 
 export function defaultTools(): AgentTool[] {
-  return [readTool, writeTool, editTool, bashTool]
+  return [readTool, writeTool, editTool, bashTool, ...prjctBodyTools()]
 }
 
 export function getToolMap(tools: AgentTool[]): Map<string, AgentTool> {
   return new Map(tools.map((t) => [t.name, t]))
 }
-
-export { PathDeniedError }


### PR DESCRIPTION
## Summary

- Extends the owned print-mode agent (#593) with structured **prjct body tools**: `prjct_search`, `prjct_guard`, `prjct_remember` (same `projectMemory` SoT as MCP — no shell-out).
- **edit/write** auto-prefix tool results with preventive memory when hits exist (anticipation without blocking the edit).
- System prompt steers search/guard/remember. Still **opt-in** (`prjct llm enable`); guest harnesses unchanged.

## Test plan

- [x] Existing agent loop mock tests pass
- [x] defaultTools includes prjct_* tools
- [x] System prompt mentions prjct_search / prjct_guard
- [x] tsc + biome clean

## Stack

- #592 multi-brain llm (merged)
- #593 agent print mode (merged)
- **this PR** body tools + guard prefix

Generated with [p/](https://www.prjct.app/)