### PR TITLE
feat(agent): bind print-mode runs to work cycles

### DIFF
--- a/core/__tests__/services/agent-loop.test.ts
+++ b/core/__tests__/services/agent-loop.test.ts
@@ -153,5 +153,47 @@ describe('runAgent', () => {
     expect(names).toContain('prjct_search')
     expect(names).toContain('prjct_guard')
     expect(names).toContain('prjct_remember')
+    expect(names).toContain('prjct_work')
+  })
+
+  test('weakModelAppend only for weak profiles', async () => {
+    const { weakModelAppend } = await import('../../agent')
+    expect(
+      weakModelAppend({
+        name: 'o',
+        wire: 'openai-compatible',
+        providerLabel: 'Ollama',
+        baseUrl: 'http://localhost:11434/v1',
+        model: 'qwen',
+      })
+    ).toContain('Weak-model')
+    expect(
+      weakModelAppend({
+        name: 'a',
+        wire: 'anthropic',
+        providerLabel: 'Anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet',
+        weak: false,
+      })
+    ).toBe('')
+  })
+
+  test('prepareOwnedAgentWorkContext noWork skips start', async () => {
+    const { prepareOwnedAgentWorkContext } = await import('../../agent')
+    const ctx = await prepareOwnedAgentWorkContext({
+      root: '/tmp/not-a-prjct-project-xyz',
+      intent: 'do something',
+      profile: {
+        name: 'm',
+        wire: 'openai-compatible',
+        providerLabel: 'Mock',
+        baseUrl: 'http://x',
+        model: 'm',
+      },
+      noWork: true,
+    })
+    expect(ctx.workStarted).toBe(false)
+    expect(ctx.root).toBe('/tmp/not-a-prjct-project-xyz')
   })
 })

--- a/core/__tests__/services/eval-service.test.ts
+++ b/core/__tests__/services/eval-service.test.ts
@@ -61,6 +61,7 @@ afterEach(async () => {
 })
 
 describe('eval-service', () => {
+  // CI core-b: this suite does real git + multi-scenario eval; 5s default is tight on busy runners.
   test('runs deterministic evals and stores portable artifacts', async () => {
     await createHealthyProject()
 
@@ -81,7 +82,7 @@ describe('eval-service', () => {
     const report = await fs.readFile(run.artifacts?.reportPath ?? '', 'utf-8')
     expect(json).toContain(run.runId)
     expect(report).toContain('## Actionables')
-  })
+  }, 20_000)
 
   test('detects stale user-facing command guidance with concrete files', async () => {
     await createHealthyProject()

--- a/core/agent/index.ts
+++ b/core/agent/index.ts
@@ -5,7 +5,14 @@
 
 export { buildSystemPrompt, runAgent } from './loop'
 export { PathDeniedError, resolveSafePath } from './paths'
-export { fetchGuardHits, guardTool, prjctBodyTools, rememberTool, searchTool } from './prjct-tools'
+export {
+  fetchGuardHits,
+  guardTool,
+  prjctBodyTools,
+  rememberTool,
+  searchTool,
+  workTool,
+} from './prjct-tools'
 export {
   bashTool,
   defaultTools,
@@ -23,3 +30,8 @@ export type {
   AgentToolResult,
 } from './types'
 export { toolsToChatDefs } from './types'
+export {
+  type OwnedAgentWorkContext,
+  prepareOwnedAgentWorkContext,
+  weakModelAppend,
+} from './work-context'

--- a/core/agent/loop.ts
+++ b/core/agent/loop.ts
@@ -22,6 +22,7 @@ export function buildSystemPrompt(root: string, append?: string): string {
     'Use tools to inspect and edit files. Prefer edit over write for small changes.',
     'Prefer prjct_search for project knowledge and prjct_guard before risky edits.',
     'Persist non-obvious outcomes with prjct_remember (English).',
+    'A work cycle may already be open for this intent; use prjct_work only if none is active.',
     'Stay inside the project. Do not touch secrets (.env, keys, credentials).',
     'When done, respond with a short summary of what you changed — no more tool calls.',
     'If the task is unclear or impossible, say so without inventing files.',

--- a/core/agent/prjct-tools.ts
+++ b/core/agent/prjct-tools.ts
@@ -151,8 +151,53 @@ export const rememberTool: AgentTool = {
   },
 }
 
+export const workTool: AgentTool = {
+  name: 'prjct_work',
+  description:
+    'Start a tracked prjct work cycle for an intent (same gates as `prjct work`). Prefer once at the beginning if none is active. Pass a real task description, not a bare CLI verb.',
+  parameters: {
+    type: 'object',
+    properties: {
+      description: {
+        type: 'string',
+        description: 'Work intent (e.g. "fix null guard in auth login")',
+      },
+    },
+    required: ['description'],
+  },
+  async execute(args, ctx) {
+    try {
+      const description = asString(args.description, 'description')
+      const projectId = await resolveProjectId(ctx.root)
+      if (!projectId) return fail('Not a prjct project — cannot start work')
+      const { startTask } = await import('../services/task-service')
+      const outcome = await startTask(projectId, ctx.root, description, {})
+      if (!outcome.ok) {
+        return fail(outcome.blocked ?? 'Work start blocked')
+      }
+      const lines = [
+        `Work started: ${outcome.taskId}`,
+        outcome.description ? `Description: ${outcome.description}` : '',
+        outcome.branch ? `Branch: ${outcome.branch}` : '',
+        outcome.isolation?.worktreePath
+          ? `Worktree: ${outcome.isolation.worktreePath} (cd there for further edits)`
+          : '',
+      ].filter(Boolean)
+      if (outcome.risks?.length) {
+        lines.push('Risks:')
+        for (const r of outcome.risks.slice(0, 5)) {
+          lines.push(`- [${r.file}] ${r.title}`)
+        }
+      }
+      return ok(lines.join('\n'))
+    } catch (e) {
+      return fail(e instanceof Error ? e.message : String(e))
+    }
+  },
+}
+
 export function prjctBodyTools(): AgentTool[] {
-  return [searchTool, guardTool, rememberTool]
+  return [searchTool, guardTool, rememberTool, workTool]
 }
 
 /** Prefix edit/write results with guard hits when present (anticipation). */

--- a/core/agent/work-context.ts
+++ b/core/agent/work-context.ts
@@ -1,0 +1,153 @@
+/**
+ * Bind owned agent runs to a prjct work cycle (same startTask as CLI/MCP).
+ * Best-effort: never blocks the agent if work start fails or project is unset.
+ */
+
+import configManager from '../infrastructure/config-manager'
+import { type LlmProfile, profileImpliesWeakMode } from '../llm'
+import { type StartTaskOutcome, startTask } from '../services/task-service'
+import { stateStorage } from '../storage/state-storage'
+
+export interface OwnedAgentWorkContext {
+  /** Project root the agent should use (may be an isolated worktree). */
+  root: string
+  projectId: string | null
+  workStarted: boolean
+  taskId?: string
+  systemAppend: string
+  isolationPath?: string
+  blocked?: string
+}
+
+function formatStartBrief(outcome: StartTaskOutcome): string {
+  const lines: string[] = []
+  if (outcome.taskId) lines.push(`Work cycle: ${outcome.taskId} — ${outcome.description ?? ''}`)
+  if (outcome.branch) lines.push(`Branch: ${outcome.branch}`)
+  if (outcome.harness) {
+    lines.push(`Harness: ${outcome.harness.level} ${outcome.harness.kind}/${outcome.harness.risk}`)
+  }
+  if (outcome.risks && outcome.risks.length > 0) {
+    lines.push('Risks (read before edit):')
+    for (const r of outcome.risks.slice(0, 8)) {
+      lines.push(`- [${r.file}] ${r.label}: ${r.title}`)
+    }
+  }
+  if (outcome.relatedContext && outcome.relatedContext.length > 0) {
+    lines.push('Related project memory:')
+    for (const c of outcome.relatedContext.slice(0, 6)) {
+      lines.push(`- (${c.type}) ${c.title}: ${c.detail.slice(0, 160)}`)
+    }
+  }
+  if (outcome.likelyFiles && outcome.likelyFiles.length > 0) {
+    lines.push('Likely files:')
+    for (const f of outcome.likelyFiles.slice(0, 10)) {
+      lines.push(`- ${f.path}${f.reason ? ` (${f.reason})` : ''}`)
+    }
+  }
+  if (outcome.instructions && outcome.instructions.length > 0) {
+    lines.push('Instructions:')
+    for (const i of outcome.instructions.slice(0, 8)) lines.push(`- ${i}`)
+  }
+  return lines.join('\n')
+}
+
+export function weakModelAppend(profile: LlmProfile): string {
+  if (!profileImpliesWeakMode(profile)) return ''
+  return [
+    'Weak-model mode: be deliberate and tool-heavy.',
+    '- Prefer prjct_search / prjct_guard before broad exploration.',
+    '- Prefer edit over rewrite; verify with read after edits.',
+    '- One clear goal per step; do not invent files or APIs.',
+    '- When finished, short factual summary only.',
+  ].join('\n')
+}
+
+/**
+ * Start (or attach) a work cycle and build system append for the agent.
+ * @param noWork — skip startTask entirely
+ */
+export async function prepareOwnedAgentWorkContext(opts: {
+  root: string
+  intent: string
+  profile: LlmProfile
+  noWork?: boolean
+}): Promise<OwnedAgentWorkContext> {
+  const parts: string[] = []
+  const weak = weakModelAppend(opts.profile)
+  if (weak) parts.push(weak)
+
+  let projectId: string | null = null
+  try {
+    projectId = (await configManager.getProjectId(opts.root)) || null
+  } catch {
+    projectId = null
+  }
+
+  if (!projectId || opts.noWork) {
+    return {
+      root: opts.root,
+      projectId,
+      workStarted: false,
+      systemAppend: parts.join('\n\n'),
+    }
+  }
+
+  // If a cycle is already active, attach rather than stacking another start.
+  try {
+    const active = await stateStorage.getCurrentTask(projectId)
+    if (active?.description) {
+      parts.push(
+        `Active work cycle already open: ${active.id ?? 'unknown'} — ${active.description}. Continue that intent; do not start a parallel cycle.`
+      )
+      return {
+        root: opts.root,
+        projectId,
+        workStarted: false,
+        taskId: active.id,
+        systemAppend: parts.join('\n\n'),
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const outcome = await startTask(projectId, opts.root, opts.intent, {
+    // Agent path: still run gates/memory; isolation may move root.
+    skipHooks: false,
+  })
+
+  if (!outcome.ok) {
+    parts.push(
+      `Work cycle was not started (${outcome.blocked ?? 'blocked'}). Proceed carefully without a tracked cycle.`
+    )
+    return {
+      root: opts.root,
+      projectId,
+      workStarted: false,
+      blocked: outcome.blocked,
+      systemAppend: parts.join('\n\n'),
+    }
+  }
+
+  const brief = formatStartBrief(outcome)
+  if (brief) parts.push(brief)
+
+  let root = opts.root
+  let isolationPath: string | undefined
+  if (outcome.isolation?.worktreePath) {
+    root = outcome.isolation.worktreePath
+    isolationPath = outcome.isolation.worktreePath
+    parts.push(
+      `Isolated worktree: ${outcome.isolation.worktreePath} (branch ${outcome.isolation.branch}). All file tools use this root.`
+    )
+  }
+
+  return {
+    root,
+    projectId,
+    workStarted: true,
+    taskId: outcome.taskId,
+    isolationPath,
+    systemAppend: parts.join('\n\n'),
+  }
+}

--- a/core/commands/agent.ts
+++ b/core/commands/agent.ts
@@ -2,11 +2,17 @@
  * `prjct agent` — owned print-mode agent (one-shot).
  *
  * Requires: prjct llm enable + brain profile (set/use/test).
- * Guest mode (Claude/Grok/Codex) is unchanged.
+ * Starts a work cycle by default (same startTask as CLI/MCP) so owned runs
+ * compound project memory. Guest mode unchanged.
  */
 
 import path from 'node:path'
-import { type AgentStepEvent, runAgent } from '../agent'
+import {
+  type AgentStepEvent,
+  type OwnedAgentWorkContext,
+  prepareOwnedAgentWorkContext,
+  runAgent,
+} from '../agent'
 import {
   getActiveLlmProfile,
   isOwnedLlmEnabled,
@@ -24,6 +30,8 @@ interface AgentOptions {
   md?: boolean
   maxSteps?: number
   quiet?: boolean
+  /** Skip startTask / work-cycle bind (still runs tools). */
+  noWork?: boolean
 }
 
 export class AgentCommands extends PrjctCommandsBase {
@@ -46,7 +54,8 @@ export class AgentCommands extends PrjctCommandsBase {
     const text = (intent ?? '').trim()
     if (!text) {
       return failHard(
-        'Usage: prjct agent "<intent>"\nExample: prjct agent "add a hello() function to src/hi.ts"',
+        'Usage: prjct agent "<intent>" [--no-work] [--max-steps N]\n' +
+          'Example: prjct agent "add a hello() function to src/hi.ts"',
         options
       )
     }
@@ -64,14 +73,36 @@ export class AgentCommands extends PrjctCommandsBase {
       return failHard('Could not resolve LLM provider for the active profile.', options)
     }
 
-    const root = path.resolve(projectPath)
+    const requestedRoot = path.resolve(projectPath)
     const maxSteps =
       typeof options.maxSteps === 'number' && options.maxSteps > 0
         ? Math.min(options.maxSteps, 40)
         : 12
 
+    let workCtx: OwnedAgentWorkContext
+    try {
+      workCtx = await prepareOwnedAgentWorkContext({
+        root: requestedRoot,
+        intent: text,
+        profile,
+        noWork: options.noWork === true,
+      })
+    } catch (e) {
+      return failHard(`Work context failed: ${getErrorMessage(e)}`, options)
+    }
+
+    const root = workCtx.root
+
     if (!options.md && !options.quiet) {
       out.info(`Owned agent · ${profile.name} · ${profile.model} · maxSteps=${maxSteps} · ${root}`)
+      if (workCtx.workStarted && workCtx.taskId) {
+        out.info(`Work cycle: ${workCtx.taskId}`)
+      } else if (workCtx.blocked) {
+        out.info(`Work not started: ${workCtx.blocked}`)
+      }
+      if (workCtx.isolationPath) {
+        out.info(`Isolated worktree: ${workCtx.isolationPath}`)
+      }
     }
 
     const onStep = options.quiet
@@ -80,8 +111,6 @@ export class AgentCommands extends PrjctCommandsBase {
           if (options.md) return
           if (ev.type === 'tool') {
             out.info(`  tool ${ev.name} ${ev.ok ? 'ok' : 'fail'}: ${ev.preview.slice(0, 80)}`)
-          } else if (ev.type === 'assistant' && ev.tool_calls.length === 0 && ev.content) {
-            // final text printed after run
           }
         }
 
@@ -92,6 +121,7 @@ export class AgentCommands extends PrjctCommandsBase {
         provider,
         maxSteps,
         onStep,
+        systemAppend: workCtx.systemAppend || undefined,
       })
 
       if (!result.success) {
@@ -109,6 +139,7 @@ export class AgentCommands extends PrjctCommandsBase {
               model: result.model,
               steps: result.steps,
               'tool calls': result.toolCalls,
+              work: workCtx.taskId ?? (workCtx.workStarted ? 'started' : 'none'),
               root,
             })
           )
@@ -118,16 +149,20 @@ export class AgentCommands extends PrjctCommandsBase {
           content: summary,
           steps: result.steps,
           toolCalls: result.toolCalls,
+          taskId: workCtx.taskId,
         }
       }
 
       out.done(`Agent finished · ${result.steps} step(s) · ${result.toolCalls} tool call(s)`)
+      if (workCtx.taskId)
+        out.info(`Work cycle still open: ${workCtx.taskId} (prjct done when ready)`)
       console.log(summary)
       return {
         success: true,
         content: summary,
         steps: result.steps,
         toolCalls: result.toolCalls,
+        taskId: workCtx.taskId,
       }
     } catch (e) {
       return failHard(getErrorMessage(e), options)

--- a/core/commands/command-data.ts
+++ b/core/commands/command-data.ts
@@ -1082,13 +1082,13 @@ export const COMMANDS: CommandMeta[] = [
     routing: { group: 'agent', method: 'run' },
     optionSchema: {
       numbers: ['maxSteps'],
-      booleans: ['quiet'],
+      booleans: ['quiet', 'noWork'],
     },
     description:
-      'OPT-IN owned print-mode agent (one-shot). Requires prjct llm enable + brain profile. Tools: read/write/edit/bash under project root. Guest hosts unchanged.',
+      'OPT-IN owned print-mode agent (one-shot). Requires prjct llm enable + brain. Starts a work cycle by default (risks + file map injected). Tools: FS + prjct_search/guard/remember/work. Guest unchanged.',
     usage: {
       claude: null,
-      terminal: 'prjct agent "<intent>" [--max-steps N] [--quiet] [--md]',
+      terminal: 'prjct agent "<intent>" [--max-steps N] [--no-work] [--quiet] [--md]',
     },
     params: '"<intent>"',
     implemented: true,
@@ -1096,6 +1096,7 @@ export const COMMANDS: CommandMeta[] = [
     requiresProject: false,
     features: [
       'Blocked unless prjct llm enable (or PRJCT_OWNED_LLM=1) and a brain profile is set',
+      'Binds to prjct work cycle (startTask) unless --no-work; attaches if one is already open',
       'Print/one-shot only — no interactive TUI yet',
       'Tools scoped to project root; secret-like paths denied',
       'Does not replace Claude Code / Grok / Codex guest mode',


### PR DESCRIPTION
## Summary

- `prjct agent` now **starts (or attaches to) a work cycle** via the same `startTask` path as CLI/MCP — risks, related memory, likely files, and harness brief are injected into the agent system prompt.
- Honors auto-worktree isolation (agent root switches to the worktree when created).
- New tool: **`prjct_work`** for explicit starts mid-run.
- **Weak-model** system append when the active brain is local/small.
- **`--no-work`** to skip cycle bind (tools-only).
- Still opt-in (`prjct llm enable`); Guest unchanged. Cycle stays open after the run (`prjct done` when ready).

## Test plan

- [x] Unit: weakModelAppend, prepareOwnedAgentWorkContext noWork, tools list includes prjct_work
- [x] Existing agent loop mock tests
- [x] tsc + biome

## Stack

- #592 llm · #593 agent · #594 body tools · **this PR** work-cycle bind

Generated with [p/](https://www.prjct.app/)