### PR TITLE
fix: canonical cloud hosts for login (v3.76.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [3.76.1] - 2026-07-22
+
+### Fixed
+
+- login and cloud API defaults: `cli.prjct.app` → `prjct.app`, `cli-api.prjct.app` → `api.prjct.app` (with legacy apiUrl migration)
+
 ## [3.76.0] - 2026-07-21
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ tradeoffs: [docs/storage-and-paths.md](./docs/storage-and-paths.md).
 
 ## Links
 
-- [Website](https://cli.prjct.app)
+- [Website](https://prjct.app)
 - [GitHub](https://github.com/prjct-app/cli)
 - [npm](https://www.npmjs.com/package/prjct-cli)
 - [Changelog](CHANGELOG.md)

--- a/core/__tests__/commands/eval.test.ts
+++ b/core/__tests__/commands/eval.test.ts
@@ -124,6 +124,6 @@ describe('prjct eval command', () => {
     expect(published.dryRun).toBe(true)
     expect(published.target).toBe('cloud')
     expect(published.projectId).toBe('eval-command')
-    expect(published.endpoint).toBe('https://cli-api.prjct.app/benchmarks/evals')
+    expect(published.endpoint).toBe('https://api.prjct.app/benchmarks/evals')
   })
 })

--- a/core/__tests__/services/eval-service.test.ts
+++ b/core/__tests__/services/eval-service.test.ts
@@ -134,7 +134,7 @@ describe('eval-service', () => {
     expect(result.projectId).toBe('eval-test')
     expect(result.repo).toBe('acme/prjct-evals')
     expect(result.runId).toBe(run.runId)
-    expect(result.endpoint).toBe('https://cli-api.prjct.app/benchmarks/evals')
+    expect(result.endpoint).toBe('https://api.prjct.app/benchmarks/evals')
     expect(result.payloadBytes).toBeGreaterThan(0)
     expect(result.url).toBeUndefined()
   })
@@ -156,7 +156,7 @@ describe('eval-service', () => {
     expect(result.comparisonId).toBe(comparison.comparisonId)
     expect(result.target).toBe('cloud')
     expect(result.projectId).toBe('eval-test')
-    expect(result.endpoint).toBe('https://cli-api.prjct.app/benchmarks/evals')
+    expect(result.endpoint).toBe('https://api.prjct.app/benchmarks/evals')
     expect(result.payloadBytes).toBeGreaterThan(0)
   })
 

--- a/core/__tests__/sync/auth-config.test.ts
+++ b/core/__tests__/sync/auth-config.test.ts
@@ -56,7 +56,7 @@ describe('AuthConfig', () => {
     it('returns defaults when file does not exist', async () => {
       const cfg = await authConfig.read()
       expect(cfg.apiKey).toBeNull()
-      expect(cfg.apiUrl).toBe('https://cli-api.prjct.app')
+      expect(cfg.apiUrl).toBe('https://api.prjct.app')
       expect(cfg.userId).toBeNull()
       expect(cfg.email).toBeNull()
       expect(cfg.lastAuth).toBeNull()
@@ -86,11 +86,17 @@ describe('AuthConfig', () => {
       )
 
       const cfg = await authConfig.read()
-      const raw = JSON.parse(await fs.readFile(tmpPath, 'utf-8')) as { apiKey: string | null }
+      const raw = JSON.parse(await fs.readFile(tmpPath, 'utf-8')) as {
+        apiKey: string | null
+        apiUrl: string
+      }
 
       expect(cfg.apiKey).toBe('legacy-key')
       expect(storedToken).toBe('legacy-key')
       expect(raw.apiKey).toBeNull()
+      // Legacy API host rewritten + persisted on read.
+      expect(cfg.apiUrl).toBe('https://api.prjct.app')
+      expect(raw.apiUrl).toBe('https://api.prjct.app')
     })
 
     it('refreshes auth when another process writes the secure token after an unauthenticated read', async () => {
@@ -176,7 +182,23 @@ describe('AuthConfig', () => {
     })
 
     it('returns default api url when unset', async () => {
-      expect(await authConfig.getApiUrl()).toBe('https://cli-api.prjct.app')
+      expect(await authConfig.getApiUrl()).toBe('https://api.prjct.app')
+    })
+
+    it('rewrites legacy cli-api.prjct.app to api.prjct.app', async () => {
+      await fs.mkdir(path.dirname(tmpPath), { recursive: true })
+      await fs.writeFile(
+        tmpPath,
+        JSON.stringify({
+          apiKey: null,
+          apiUrl: 'https://cli-api.prjct.app',
+          userId: 'u',
+          email: 'e@x',
+          lastAuth: null,
+        })
+      )
+
+      expect(await authConfig.getApiUrl()).toBe('https://api.prjct.app')
     })
   })
 

--- a/core/__tests__/sync/cloud-command.test.ts
+++ b/core/__tests__/sync/cloud-command.test.ts
@@ -61,7 +61,7 @@ describe('prjct cloud command', () => {
       syncStatus: 'active',
       billingState: 'active',
       billingInterval: 'monthly',
-      billingUrl: 'https://cli.prjct.app/billing',
+      billingUrl: 'https://prjct.app/billing',
       message: 'Cloud sync is active for this repo.',
     })) as never
   })
@@ -104,7 +104,7 @@ describe('prjct cloud command', () => {
       syncStatus: 'payment_required',
       billingState: 'free',
       billingInterval: null,
-      billingUrl: 'https://cli.prjct.app/billing',
+      billingUrl: 'https://prjct.app/billing',
       message: 'Repo linked. Subscribe to activate Cloud sync.',
     })) as never
 

--- a/core/__tests__/sync/engine-agnostic.test.ts
+++ b/core/__tests__/sync/engine-agnostic.test.ts
@@ -2,7 +2,7 @@
  * Engine-agnostic guard (HARD RULE).
  *
  * The open-source CLI must reveal NOTHING about how the cloud stores data —
- * it knows only "a storage API at cli-api.prjct.app". This test fails CI if any
+ * it knows only "a storage API at api.prjct.app". This test fails CI if any
  * backend-engine name leaks into the sync/cloud subsystem, so a future change
  * can't quietly couple the client to a specific backend. The backend lives in
  * a separate repo.

--- a/core/__tests__/sync/realtime-client.test.ts
+++ b/core/__tests__/sync/realtime-client.test.ts
@@ -77,8 +77,8 @@ const tick = (ms = 25) => new Promise((r) => setTimeout(r, ms))
 
 describe('buildRealtimeUrl', () => {
   it('swaps https→wss and appends auth query params', () => {
-    const url = buildRealtimeUrl('https://cli-api.prjct.app', 'p1', 'pk_live_x', 'd1')
-    expect(url.startsWith('wss://cli-api.prjct.app/ws?')).toBe(true)
+    const url = buildRealtimeUrl('https://api.prjct.app', 'p1', 'pk_live_x', 'd1')
+    expect(url.startsWith('wss://api.prjct.app/ws?')).toBe(true)
     const q = new URL(url).searchParams
     expect(q.get('key')).toBe('pk_live_x')
     expect(q.get('device')).toBe('d1')

--- a/core/commands/setup.ts
+++ b/core/commands/setup.ts
@@ -9,7 +9,7 @@ import chalk from 'chalk'
 import commandInstaller from '../infrastructure/command-installer'
 import configManager from '../infrastructure/config-manager'
 import pathManager from '../infrastructure/path-manager'
-import authConfig from '../sync/auth-config'
+import authConfig, { DEFAULT_API_URL, DEFAULT_WEB_URL } from '../sync/auth-config'
 import {
   buildCliLoginSearchParams,
   buildExchangeBody,
@@ -105,8 +105,8 @@ export class SetupCommands extends PrjctCommandsBase {
       }
     }
 
-    const webUrl = process.env.PRJCT_WEB_URL || 'https://cli.prjct.app'
-    const apiUrl = process.env.PRJCT_API_URL || 'https://cli-api.prjct.app'
+    const webUrl = process.env.PRJCT_WEB_URL || DEFAULT_WEB_URL
+    const apiUrl = process.env.PRJCT_API_URL || DEFAULT_API_URL
     // Verifier/state only in this process for the lifetime of one login.
     const pkce = generatePkceMaterial()
     let settled = false

--- a/core/sync/auth-config.ts
+++ b/core/sync/auth-config.ts
@@ -15,7 +15,14 @@ import type { AuthConfig } from '../types/sync'
 import * as fileHelper from '../utils/file-helper'
 import { clearAuthToken, getAuthToken, setAuthToken } from './secure-auth-token'
 
-const DEFAULT_API_URL = 'https://cli-api.prjct.app'
+/** Canonical cloud API base (login exchange, sync, evals, realtime). */
+export const DEFAULT_API_URL = 'https://api.prjct.app'
+
+/** Canonical web SPA (device login /auth/cli, billing). */
+export const DEFAULT_WEB_URL = 'https://prjct.app'
+
+/** Retired hosts — rewrite stored auth.json so existing logins keep working. */
+const LEGACY_API_URLS = new Set(['https://cli-api.prjct.app'])
 
 const DEFAULT_CONFIG: AuthConfig = {
   apiKey: null,
@@ -98,8 +105,13 @@ class AuthConfigManager {
       merged.hostname = os.hostname()
       mutated = true
     }
+    // Retired hosts (cli-api.prjct.app) → canonical api.prjct.app.
+    if (merged.apiUrl && LEGACY_API_URLS.has(merged.apiUrl)) {
+      merged.apiUrl = DEFAULT_API_URL
+      mutated = true
+    }
     this.cachedConfig = merged
-    // Lazy persist of deviceId/hostname only if we have an existing
+    // Lazy persist of deviceId/hostname/url only if we have an existing
     // file (don't write a fresh auth.json on a CLI that's never been
     // logged in — that would just create empty config files).
     if (mutated && config) {

--- a/core/sync/entity-map.ts
+++ b/core/sync/entity-map.ts
@@ -11,7 +11,7 @@
  * canonical storage-table name so nothing is lost.
  *
  * NOTE: these are STORAGE table names, NOT a backend/engine. The CLI knows
- * only "a storage API at cli-api.prjct.app"; the table vocabulary is the wire
+ * only "a storage API at api.prjct.app"; the table vocabulary is the wire
  * contract and reveals nothing about how the cloud stores it.
  */
 

--- a/core/sync/realtime-client.ts
+++ b/core/sync/realtime-client.ts
@@ -29,7 +29,7 @@ export type RealtimeState = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'c
 
 export interface RealtimeClientOptions {
   projectId: string
-  /** REST base, e.g. `https://cli-api.prjct.app`. */
+  /** REST base, e.g. `https://api.prjct.app`. */
   apiUrl: string
   apiKey: string
   deviceId: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prjct-cli",
-  "version": "3.75.0",
+  "version": "3.76.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prjct-cli",
-      "version": "3.75.0",
+      "version": "3.76.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.76.0",
+  "version": "3.76.1",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {
@@ -106,7 +106,7 @@
   "bugs": {
     "url": "https://github.com/prjct-app/cli/issues"
   },
-  "homepage": "https://cli.prjct.app",
+  "homepage": "https://prjct.app",
   "packageManager": "bun@1.2.23",
   "engines": {
     "bun": ">=1.0.0",


### PR DESCRIPTION
## Summary
- Login web default: `https://cli.prjct.app` → `https://prjct.app`
- API default: `https://cli-api.prjct.app` → `https://api.prjct.app`
- Lazy migration rewrites stored `auth.json` when it still points at `cli-api.prjct.app`
- Homepage / README / tests aligned

## Why
Retired hosts no longer serve HTTP; `prjct login` could not complete device auth.

## Test plan
- [x] `bun test core/__tests__/sync/auth-config.test.ts` (incl. legacy rewrite)
- [ ] `prjct logout && prjct login` opens `https://prjct.app/auth/cli?...`
- [ ] Exchange hits `https://api.prjct.app/auth/cli/exchange`