### PR TITLE
fix: never persist plans as physical files — SQLite only (v3.77.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [3.77.0] - 2026-07-28
+
+### Fixed
+
+- **Plans and work data: SQLite only — never physical files.** Templates stopped *instructing* `.prjct/sessions/` writes in v2.19.7, but stale customized agents kept dumping `plan.md` / `impl.md` into client repos (not traceable). Every `prjct sync` now (1) **ingests** text from `.prjct/{sessions,audits,deploy}/` into project SQLite (`prjct remember` context, topic `worktree-ghost-ingest`) then **deletes** those dirs (no re-home onto disk), and (2) **force-refreshes** crew agent files / `CLAUDE.md` / `CREW.md` that still instruct disk writes (including `SESSION_ROOT` / `~/.prjct-cli/**/sessions/` hideouts). Durable surface: `prjct plan` / `prjct spec` / `prjct crew record-run` / `prjct remember` — project SQL only. Only hand-editable file under `.prjct/` is `prjct.config.json`.
+
 ## [3.76.1] - 2026-07-22
 
 ### Fixed

--- a/core/__tests__/services/legacy-crew-sweep-hygiene.test.ts
+++ b/core/__tests__/services/legacy-crew-sweep-hygiene.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Worktree hygiene: every `prjct sync` must purge `.prjct/sessions|audits|deploy`
+ * from the customer working tree and rewrite crew agent files that still
+ * instruct disk writes there.
+ *
+ * Customer #3 (2026-07): templates were fixed years ago, but customized
+ * agent files kept telling agents to dump plan.md under `.prjct/sessions/`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import configManager from '../../infrastructure/config-manager'
+import {
+  containsForbiddenWriteInstruction,
+  FORBIDDEN_WORKTREE_WRITE_NEEDLES,
+  legacyCrewSweep,
+  WORKTREE_GHOST_DIRS,
+} from '../../services/legacy-crew-sweep'
+import { prjctDb } from '../../storage/database'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+const STALE_LEADER = `---
+name: leader
+description: stale
+---
+
+# Leader
+
+Write a plan to \`.prjct/sessions/<task-slug>/plan.md\` then hand off.
+Subagents write to \`.prjct/sessions/<task-slug>/<role>.md\`.
+`
+
+const CLEAN_LEADER = `---
+name: leader
+description: clean
+---
+
+# Leader
+
+Never write reports to disk. Use prjct CLI verbs only.
+`
+
+describe('legacyCrewSweep — worktree hygiene', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-hygiene-'))
+    await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+    projectId = `hygiene-${Math.random().toString(36).slice(2, 10)}`
+    await configManager.writeConfig(projectPath, {
+      projectId,
+      dataPath: path.join(projectPath, '.prjct-data'),
+    })
+    patchPathManager(projectPath)
+    prjctDb.get(projectId, 'SELECT 1')
+  })
+
+  afterEach(async () => {
+    restorePathManager()
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  })
+
+  test('exports the hard-law ghost dir + needle lists', () => {
+    expect([...WORKTREE_GHOST_DIRS]).toEqual(['sessions', 'audits', 'deploy'])
+    expect(FORBIDDEN_WORKTREE_WRITE_NEEDLES.some((n) => n.includes('sessions'))).toBe(true)
+  })
+
+  test('detects affirmative write instructions, not mere bans', () => {
+    expect(
+      containsForbiddenWriteInstruction(
+        'Write a plan to `.prjct/sessions/<task-slug>/plan.md` then hand off.'
+      )
+    ).toBe(true)
+    expect(containsForbiddenWriteInstruction('done -> .prjct/sessions/<task-slug>/impl.md')).toBe(
+      true
+    )
+    // "Hide under ~/.prjct-cli" is still a physical file — forbidden
+    expect(
+      containsForbiddenWriteInstruction(
+        'SESSION_ROOT = ~/.prjct-cli/projects/abc/sessions\nWrite under SESSION_ROOT/<task-slug>/'
+      )
+    ).toBe(true)
+    // Ban-only text must NOT force-refresh (false positive protection)
+    expect(
+      containsForbiddenWriteInstruction(
+        'Never write `.prjct/sessions/` into the customer worktree. Forbidden path.'
+      )
+    ).toBe(false)
+    expect(
+      containsForbiddenWriteInstruction(
+        'No client-tree session dumps (`.prjct/sessions/**` must not exist).'
+      )
+    ).toBe(false)
+  })
+
+  test('purges .prjct/sessions and ingests content into SQLite (no disk re-home)', async () => {
+    const sessionsDir = path.join(projectPath, '.prjct', 'sessions', 'some-task')
+    await fs.mkdir(sessionsDir, { recursive: true })
+    await fs.writeFile(path.join(sessionsDir, 'plan.md'), '# plan body for SQL ingest\n', 'utf-8')
+
+    const result = await legacyCrewSweep(projectPath, projectId)
+
+    expect(result.ghostDirsPurged).toContain('sessions')
+    expect(result.ghostFilesIngested).toBeGreaterThanOrEqual(1)
+
+    // Gone from customer worktree — never re-homed onto another disk path
+    await expect(fs.access(path.join(projectPath, '.prjct', 'sessions'))).rejects.toBeDefined()
+
+    // Traceable in SQLite via remember/events
+    const { projectMemory } = await import('../../memory/project-memory')
+    const hits = projectMemory.recall(projectId, { types: ['context'], limit: 25 })
+    expect(hits.some((h) => h.content.includes('plan body for SQL ingest'))).toBe(true)
+
+    // Idempotent: second run is a quiet no-op
+    const again = await legacyCrewSweep(projectPath, projectId)
+    expect(again.ghostDirsPurged).toEqual([])
+    expect(again.ghostFilesIngested).toBe(0)
+  })
+
+  test('purges .prjct/audits and .prjct/deploy without rescue', async () => {
+    await fs.mkdir(path.join(projectPath, '.prjct', 'audits'), { recursive: true })
+    await fs.writeFile(path.join(projectPath, '.prjct', 'audits', 'x.md'), 'x', 'utf-8')
+    await fs.mkdir(path.join(projectPath, '.prjct', 'deploy'), { recursive: true })
+    await fs.writeFile(path.join(projectPath, '.prjct', 'deploy', 'check.md'), 'y', 'utf-8')
+
+    const result = await legacyCrewSweep(projectPath, projectId)
+
+    expect(result.ghostDirsPurged.sort()).toEqual(['audits', 'deploy'])
+    await expect(fs.access(path.join(projectPath, '.prjct', 'audits'))).rejects.toBeDefined()
+    await expect(fs.access(path.join(projectPath, '.prjct', 'deploy'))).rejects.toBeDefined()
+    // config still there
+    const configStat = await fs.stat(path.join(projectPath, '.prjct', 'prjct.config.json'))
+    expect(configStat.isFile()).toBe(true)
+  })
+
+  test('repairs stale crew agent files that instruct .prjct/sessions/ writes', async () => {
+    const leaderPath = path.join(projectPath, '.claude', 'agents', 'leader.md')
+    await fs.mkdir(path.dirname(leaderPath), { recursive: true })
+    await fs.writeFile(leaderPath, STALE_LEADER, 'utf-8')
+
+    // Clean sibling must be left alone
+    const implPath = path.join(projectPath, '.claude', 'agents', 'implementer.md')
+    await fs.writeFile(implPath, CLEAN_LEADER, 'utf-8')
+
+    const result = await legacyCrewSweep(projectPath, projectId)
+
+    expect(result.agentFilesRepaired).toContain('.claude/agents/leader.md')
+    expect(result.agentFilesRepaired).not.toContain('.claude/agents/implementer.md')
+
+    const repaired = await fs.readFile(leaderPath, 'utf-8')
+    expect(repaired).not.toContain('.prjct/sessions/')
+    // Current template hard law is present
+    expect(repaired.toLowerCase()).toMatch(/sqlite|never write|prjct/)
+
+    const untouched = await fs.readFile(implPath, 'utf-8')
+    expect(untouched).toBe(CLEAN_LEADER)
+  })
+
+  test('repairs CLAUDE.md crew block that still points at .prjct/sessions/', async () => {
+    const claude = [
+      '# My project',
+      '',
+      '<!-- prjct:crew:start - DO NOT REMOVE THIS MARKER -->',
+      'Write results to `.prjct/sessions/<task-slug>/<role>.md`.',
+      '<!-- prjct:crew:end - DO NOT REMOVE THIS MARKER -->',
+      '',
+    ].join('\n')
+    await fs.writeFile(path.join(projectPath, 'CLAUDE.md'), claude, 'utf-8')
+
+    const result = await legacyCrewSweep(projectPath, projectId)
+
+    expect(result.agentFilesRepaired).toContain('CLAUDE.md')
+    const next = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    expect(next).toContain('# My project')
+    expect(next).toContain('<!-- prjct:crew:start')
+    expect(next).not.toContain('.prjct/sessions/')
+    expect(next).toMatch(/Hard persistence rule|Never write/i)
+  })
+
+  test('does not touch a clean tree', async () => {
+    const result = await legacyCrewSweep(projectPath, projectId)
+    expect(result.ghostDirsPurged).toEqual([])
+    expect(result.agentFilesRepaired).toEqual([])
+    expect(result.errors).toEqual([])
+  })
+
+  test('collapses duplicate CLAUDE.md crew blocks (short end marker + append)', async () => {
+    const claude = [
+      '# My project',
+      '',
+      '<!-- prjct:crew:start - DO NOT REMOVE THIS MARKER -->',
+      'Write results to `.prjct/sessions/<task-slug>/<role>.md`.',
+      '<!-- prjct:crew:end -->',
+      '',
+      '<!-- prjct:crew:start - DO NOT REMOVE THIS MARKER -->',
+      'Second block already clean.',
+      '<!-- prjct:crew:end - DO NOT REMOVE THIS MARKER -->',
+      '',
+    ].join('\n')
+    await fs.writeFile(path.join(projectPath, 'CLAUDE.md'), claude, 'utf-8')
+
+    const result = await legacyCrewSweep(projectPath, projectId)
+    expect(result.agentFilesRepaired).toContain('CLAUDE.md')
+
+    const next = await fs.readFile(path.join(projectPath, 'CLAUDE.md'), 'utf-8')
+    expect(next).toContain('# My project')
+    expect((next.match(/prjct:crew:start/g) ?? []).length).toBe(1)
+    expect((next.match(/prjct:crew:end/g) ?? []).length).toBe(1)
+    expect(next).not.toContain('.prjct/sessions/<task')
+    expect(next).toMatch(/Hard persistence rule|Never write/i)
+  })
+})

--- a/core/services/legacy-crew-sweep.ts
+++ b/core/services/legacy-crew-sweep.ts
@@ -1,36 +1,120 @@
 /**
- * Legacy-disk sweep for crew persistence v7.
+ * Legacy-disk sweep for crew persistence.
  *
- * Detects `.prjct/CHECKPOINTS.md` and `.prjct/team.json` from pre-spec-
- * a50b32d1 installs and migrates their content into kv_store:
+ * Runs on every `prjct sync` (SessionStart). Best-effort, never throws to
+ * the caller — errors are collected on the result.
  *
+ * ## Phase A — pre-v2.19.8 migrations (kv_store adoption)
  *   .prjct/CHECKPOINTS.md  →  kv_store['crew:checkpoints']    source='migrated'
  *   .prjct/team.json       →  kv_store['team:enrollment']     + atomic mirror regen
+ * Idempotent via mtime flags. Never auto-deletes either file.
  *
- * Idempotent: on second sync, the disk content is compared by mtime to
- * the last-flagged mtime cached in kv_store. Unchanged → no-op. Changed
- * after migration → emit a one-shot inbox warning (hand-edit detected;
- * we do NOT auto-apply because the user moved the source of truth back
- * to DB and shouldn't be silently re-clobbered).
+ * ## Phase B — customer-worktree hygiene (HARD LAW, every sync)
+ * Product invariant: **SQLite is the only persistence surface for plans and
+ * work data.** Physical plan/impl/review/audit files are not traceable and
+ * are forbidden — in the customer worktree AND under ~/.prjct-cli as free
+ * markdown dumps. Durable state goes through prjct verbs:
+ *   - plans → `prjct plan` / `prjct spec` (kv_store + specs table)
+ *   - crew runs → `prjct crew record-run` (kv_store crew-run:*)
+ *   - memory → `prjct remember` (memories / events)
+ * The ONLY hand-editable file under `.prjct/` is `prjct.config.json`.
  *
- * Never auto-deletes either file. The user removes them on their own.
+ * Every sync:
+ *   1. **Purge ghost dirs** under `.prjct/` (`sessions/`, `audits/`, `deploy/`).
+ *      Textual content is **ingested into SQLite** (`prjct remember` context
+ *      rows tagged `worktree-ghost-ingest`) then the directory is deleted.
+ *      Nothing is re-homed onto disk.
+ *   2. **Repair crew agent instructions** that still tell subagents to write
+ *      plan.md / impl.md anywhere on disk. Force-refresh from current templates.
  *
- * See spec a50b32d1 AC #10.
+ * Customer reports:
+ *   #1 pre-2.19.7 — `.prjct/sessions/<task>/<role>.md` ghost files
+ *   #2 post-2.23.7 — `.prjct/audits/`, `.prjct/CHECKPOINTS.md`, deploy checklists
+ *   #3 2026-07    — stale customized crew agents still instructing disk writes
+ *                  long after templates were fixed (alliance-redesign, etc.)
+ *
+ * See spec a50b32d1 AC #10 + product invariant "SQLite only".
  */
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { getTemplateContent } from '../agentic/template-loader'
+import { type AgentRole, getAgentModelPolicy } from '../schemas/model'
 import checkpointsStorage from '../storage/checkpoints-storage'
 import prjctDb from '../storage/database'
 import teamEnrollmentStorage, { type TeamEnrollment } from '../storage/team-enrollment-storage'
 import { writeFileAtomic } from '../utils/file-helper'
 import log from '../utils/logger'
+import { CREW_ROLES } from './agent-dispatch'
 
 const LEGACY_CHECKPOINTS_PATH = '.prjct/CHECKPOINTS.md'
 const LEGACY_TEAM_PATH = '.prjct/team.json'
 
 const FLAG_CHECKPOINTS = 'migration:v2.19.8:last-flagged-checkpoints'
 const FLAG_TEAM = 'migration:v2.19.8:last-flagged-team'
+/** One-shot inbox warn after a worktree ghost purge (avoids SessionStart spam). */
+const FLAG_GHOST_PURGE_WARN = 'migration:v3.77:last-ghost-purge-warn'
+/** One-shot inbox warn after repairing agent files that instructed disk writes. */
+const FLAG_AGENT_REPAIR_WARN = 'migration:v3.77:last-agent-repair-warn'
+
+/**
+ * Subdirectories of `.prjct/` that must NEVER exist in a customer worktree.
+ * Agents historically dumped plan/impl/review/audit notes here.
+ */
+export const WORKTREE_GHOST_DIRS = ['sessions', 'audits', 'deploy'] as const
+
+/**
+ * Affirmative "write here" patterns from pre-fix crew templates.
+ * Mentions that only *ban* the path (e.g. "Never write `.prjct/sessions/`")
+ * must NOT trigger a force-refresh — only instructions that tell agents to
+ * dump plan/impl/review files into the customer worktree.
+ */
+export const FORBIDDEN_WORKTREE_WRITE_PATTERNS: readonly RegExp[] = [
+  // Classic crew anti-broken-telephone contract (customer worktree)
+  /\.prjct\/sessions\/<task/i,
+  /\.prjct\/sessions\/\$\{/i,
+  /->\s*`?\.prjct\/sessions\//i,
+  /write(?:s|n)?\s+(?:a\s+)?(?:plan|report|results?|verdict|findings?)[^\n]{0,120}\.prjct\/sessions\//i,
+  /write(?:s|n)?\s+its\s+results[^\n]{0,80}\.prjct\/sessions\//i,
+  /Session artifacts at `?\.prjct\/sessions\//i,
+  /Implementer report at `?\.prjct\/sessions\//i,
+  /Reviewer verdict at `?\.prjct\/sessions\//i,
+  // Other historically-polluting dumps
+  /\.prjct\/audits\//i,
+  /\.prjct\/deploy\//i,
+  // "Hide it under ~/.prjct-cli/…/sessions/" — still a physical file, still
+  // not traceable. Plans/data must go to SQLite only.
+  /SESSION_ROOT\s*=/i,
+  /Write under `?SESSION_ROOT/i,
+  /~\/\.prjct-cli\/projects\/[^\s`]+\/sessions\//i,
+  /sessions\/<task-slug>\/\{?plan/i,
+]
+
+/** @deprecated Use FORBIDDEN_WORKTREE_WRITE_PATTERNS — kept for external importers/tests. */
+export const FORBIDDEN_WORKTREE_WRITE_NEEDLES = [
+  '.prjct/sessions/<task',
+  '.prjct/audits/',
+  '.prjct/deploy/',
+] as const
+
+const CREW_AGENT_FILES: Array<{ destRelative: string; templateKey: string }> = CREW_ROLES.map(
+  (r) => ({
+    destRelative: `.claude/agents/${r.name}.md`,
+    templateKey: `crew/roles/${r.name}.md`,
+  })
+)
+
+const CLAUDE_FILE = 'CLAUDE.md'
+const CREW_MD_FILE = 'CREW.md'
+const CLAUDE_SNIPPET_TEMPLATE = 'crew/leader-mode.md'
+const SNIPPET_START = '<!-- prjct:crew:start - DO NOT REMOVE THIS MARKER -->'
+/** Canonical end marker (current templates). */
+const SNIPPET_END = '<!-- prjct:crew:end - DO NOT REMOVE THIS MARKER -->'
+/** Older installs used a short end marker without the DO-NOT-REMOVE suffix. */
+const SNIPPET_END_SHORT = '<!-- prjct:crew:end -->'
+const CHECKPOINTS_START =
+  '<!-- prjct:checkpoints:start - DO NOT EDIT (managed by `prjct crew checkpoints set|reset`) -->'
+const CHECKPOINTS_END = '<!-- prjct:checkpoints:end -->'
 
 interface FlagRow {
   mtime_ms: number
@@ -42,6 +126,12 @@ export interface LegacySweepResult {
   checkpointsHandEditWarned: boolean
   teamMigrated: boolean
   teamHandEditWarned: boolean
+  /** Ghost dirs purged from the customer worktree this run (e.g. `sessions`). */
+  ghostDirsPurged: string[]
+  /** Relative paths of crew agent / CLAUDE files force-refreshed this run. */
+  agentFilesRepaired: string[]
+  /** Number of ghost text files ingested into SQLite before purge. */
+  ghostFilesIngested: number
   errors: Array<{ file: string; reason: string }>
 }
 
@@ -69,6 +159,15 @@ async function tryReadFile(filePath: string): Promise<string | null> {
     return await fs.readFile(filePath, 'utf-8')
   } catch {
     return null
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -106,6 +205,82 @@ async function captureInboxWarning(
       error: error instanceof Error ? error.message : String(error),
     })
   }
+}
+
+export function containsForbiddenWriteInstruction(content: string): boolean {
+  return FORBIDDEN_WORKTREE_WRITE_PATTERNS.some((re) => re.test(content))
+}
+
+function stampCrewModelPolicy(content: string, destRelative: string): string {
+  const roleName = CREW_ROLES.find((r) => `.claude/agents/${r.name}.md` === destRelative)?.role as
+    | AgentRole
+    | undefined
+  if (!roleName) return content
+  const { model } = getAgentModelPolicy(roleName)
+  return content.replace(/^model:[ \t].*$/m, `model: ${model}`)
+}
+
+function spliceCheckpoints(reviewerTemplate: string, checkpointsContent: string): string {
+  const startIdx = reviewerTemplate.indexOf(CHECKPOINTS_START)
+  const endIdx = reviewerTemplate.indexOf(CHECKPOINTS_END)
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    // Template without markers (older bundle) — return as-is.
+    return reviewerTemplate
+  }
+  const before = reviewerTemplate.slice(0, startIdx + CHECKPOINTS_START.length)
+  const after = reviewerTemplate.slice(endIdx)
+  return `${before}\n${checkpointsContent.trimEnd()}\n${after}`
+}
+
+/**
+ * Strip EVERY crew marker block (handles short end markers + duplicates from
+ * partial repairs), then append exactly one fresh snippet.
+ */
+function replaceCrewSnippet(claudeContent: string, snippet: string): string {
+  let body = claudeContent
+  // Loop: remove start→end pairs until none remain (covers duplicate blocks).
+  // Prefer the long end marker; fall back to the short historical form.
+  for (;;) {
+    const startIdx = body.indexOf(SNIPPET_START)
+    if (startIdx < 0) break
+    const afterStart = body.slice(startIdx + SNIPPET_START.length)
+    const longEndRel = afterStart.indexOf(SNIPPET_END)
+    const shortEndRel = afterStart.indexOf(SNIPPET_END_SHORT)
+    let endAbs = -1
+    let endLen = 0
+    if (longEndRel >= 0 && (shortEndRel < 0 || longEndRel <= shortEndRel)) {
+      endAbs = startIdx + SNIPPET_START.length + longEndRel
+      endLen = SNIPPET_END.length
+    } else if (shortEndRel >= 0) {
+      endAbs = startIdx + SNIPPET_START.length + shortEndRel
+      endLen = SNIPPET_END_SHORT.length
+    } else {
+      // Orphan start marker — drop from start to EOF and stop.
+      body = body.slice(0, startIdx)
+      break
+    }
+    body = `${body.slice(0, startIdx)}${body.slice(endAbs + endLen)}`
+  }
+  body = body.replace(/\n{3,}/g, '\n\n').trimEnd()
+  const sep = body.length > 0 ? '\n\n' : ''
+  return `${body}${sep}${snippet.trimEnd()}\n`
+}
+
+/**
+ * Custom checkpoints that still list session artifact paths re-inject the
+ * forbidden instruction into reviewer.md on every splice. Strip those lines
+ * (and any other affirmative worktree-write paths) before splicing / storing.
+ */
+function sanitizeCheckpointsContent(content: string): string {
+  if (!containsForbiddenWriteInstruction(content)) return content
+  const cleaned = content
+    .split('\n')
+    .filter((line) => !containsForbiddenWriteInstruction(line))
+    .join('\n')
+    // Collapse runs of blank lines left by removals.
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd()
+  return `${cleaned}\n`
 }
 
 async function sweepCheckpoints(
@@ -223,6 +398,273 @@ async function sweepTeamJson(
 }
 
 /**
+ * Walk a directory tree and yield absolute paths of regular files.
+ */
+async function listFilesRecursive(dir: string): Promise<string[]> {
+  const out: string[] = []
+  let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await listFilesRecursive(full)))
+    } else if (entry.isFile()) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/**
+ * Ingest a ghost text file into SQLite (memories) so content stays traceable,
+ * then the caller deletes the physical path. Caps body size to avoid dumping
+ * huge accidental binaries into memory.
+ */
+async function ingestGhostFileToSql(
+  projectPath: string,
+  projectId: string,
+  absPath: string,
+  relFromProject: string
+): Promise<boolean> {
+  const TEXT_EXT = new Set(['.md', '.txt', '.json', '.yml', '.yaml', '.toml', '.csv', '.log'])
+  const ext = path.extname(absPath).toLowerCase()
+  if (!TEXT_EXT.has(ext) && ext !== '') return false
+
+  let body: string
+  try {
+    const buf = await fs.readFile(absPath)
+    // Skip obvious binaries / huge dumps
+    if (buf.byteLength > 200_000) return false
+    body = buf.toString('utf-8')
+    if (body.includes('\u0000')) return false
+  } catch {
+    return false
+  }
+  if (!body.trim()) return false
+
+  const cap = 12_000
+  const clipped =
+    body.length > cap ? `${body.slice(0, cap)}\n\n…[truncated ${body.length - cap} chars]` : body
+  const content = [
+    `Rescued worktree ghost (physical files are not traceable — ingested to SQLite, disk deleted).`,
+    `source: ${relFromProject}`,
+    '',
+    clipped,
+  ].join('\n')
+
+  try {
+    const { projectMemory } = await import('../memory/project-memory')
+    await projectMemory.remember(projectPath, {
+      type: 'context',
+      content,
+      tags: {
+        topic: 'worktree-ghost-ingest',
+        source_path: relFromProject,
+        'migration:v3.77': '1',
+      },
+      provenance: 'declared',
+      projectId,
+      force: true,
+    })
+    return true
+  } catch (error) {
+    log.debug('Ghost file SQL ingest failed (non-critical)', {
+      file: relFromProject,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+/**
+ * HARD LAW: delete ghost dirs under the customer's `.prjct/`.
+ * Text content is ingested into SQLite first (traceable); physical files
+ * are then removed. Never re-homes content onto another disk path.
+ * Runs on EVERY sync — agents can re-create these between sessions.
+ */
+async function purgeWorktreeGhostDirs(
+  projectPath: string,
+  projectId: string,
+  out: LegacySweepResult
+): Promise<void> {
+  const prjctDir = path.join(projectPath, '.prjct')
+  if (!(await pathExists(prjctDir))) return
+
+  for (const name of WORKTREE_GHOST_DIRS) {
+    const ghostPath = path.join(prjctDir, name)
+    if (!(await pathExists(ghostPath))) continue
+
+    try {
+      const files = await listFilesRecursive(ghostPath)
+      for (const abs of files) {
+        const rel = path.relative(projectPath, abs)
+        const ok = await ingestGhostFileToSql(projectPath, projectId, abs, rel)
+        if (ok) out.ghostFilesIngested += 1
+      }
+      await fs.rm(ghostPath, { recursive: true, force: true })
+      out.ghostDirsPurged.push(name)
+    } catch (error) {
+      out.errors.push({
+        file: `.prjct/${name}/`,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  if (out.ghostDirsPurged.length === 0) return
+
+  // One-shot inbox so SessionStart doesn't spam every subsequent clean sync.
+  const flag = readFlag(projectId, FLAG_GHOST_PURGE_WARN)
+  if (flag === null) {
+    const ingested =
+      out.ghostFilesIngested > 0
+        ? ` ${out.ghostFilesIngested} text file(s) ingested into SQLite (topic:worktree-ghost-ingest) for traceability.`
+        : ''
+    await captureInboxWarning(
+      projectPath,
+      `Purged forbidden prjct ghost dir(s) from the customer worktree: ${out.ghostDirsPurged.map((d) => `.prjct/${d}/`).join(', ')}.${ingested} Product law: plans and work data live ONLY in project SQLite (prjct plan / prjct spec / prjct remember / prjct crew record-run) — never as physical files in the repo or under ~/.prjct-cli. The only hand-editable file under .prjct/ is prjct.config.json.`,
+      { 'migration:v3.77': '1', topic: 'worktree-ghost-purge' }
+    )
+    writeFlag(projectId, FLAG_GHOST_PURGE_WARN, Date.now())
+  }
+}
+
+/**
+ * If installed crew agent files (or CLAUDE.md / CREW.md) still instruct
+ * writing into `.prjct/sessions|audits|deploy/`, force-refresh them from the
+ * current templates. This is the only way to stop agents from re-creating
+ * the ghost dirs we just purged — stale customized agents keep the bug alive.
+ */
+async function repairCrewDiskWriteInstructions(
+  projectPath: string,
+  projectId: string,
+  out: LegacySweepResult
+): Promise<void> {
+  // 0. Sanitize kv_store checkpoints if they still list session-artifact paths.
+  //    Otherwise every reviewer.md splice re-injects the forbidden instruction.
+  try {
+    const row = checkpointsStorage.get(projectId)
+    const sanitized = sanitizeCheckpointsContent(row.content)
+    if (sanitized !== row.content) {
+      // Persist sanitized text. 'default' rows aren't on disk — writing
+      // 'migrated' is correct (we adopted+cleaned the content). User rows
+      // keep 'user' so hand-customization provenance is preserved.
+      const source = row.source === 'user' ? 'user' : 'migrated'
+      checkpointsStorage.set(projectId, sanitized, source)
+      out.agentFilesRepaired.push('kv_store[crew:checkpoints]')
+    }
+  } catch (error) {
+    out.errors.push({
+      file: 'kv_store[crew:checkpoints]',
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  // 1. Native crew agents under .claude/agents/
+  for (const agent of CREW_AGENT_FILES) {
+    const abs = path.join(projectPath, agent.destRelative)
+    const existing = await tryReadFile(abs)
+    if (existing === null) continue
+    if (!containsForbiddenWriteInstruction(existing)) continue
+
+    const template = getTemplateContent(agent.templateKey)
+    if (!template) {
+      out.errors.push({ file: agent.destRelative, reason: 'template missing' })
+      continue
+    }
+    try {
+      let next = template
+      if (agent.destRelative === '.claude/agents/reviewer.md') {
+        const row = checkpointsStorage.get(projectId)
+        next = spliceCheckpoints(next, sanitizeCheckpointsContent(row.content))
+      }
+      next = stampCrewModelPolicy(next, agent.destRelative)
+      await fs.mkdir(path.dirname(abs), { recursive: true })
+      await fs.writeFile(abs, next, 'utf-8')
+      out.agentFilesRepaired.push(agent.destRelative)
+    } catch (error) {
+      out.errors.push({
+        file: agent.destRelative,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  // 2. CLAUDE.md crew block (leader-mode snippet). Also collapse duplicates
+  //    left by partial historical repairs (short end-marker + append).
+  const claudePath = path.join(projectPath, CLAUDE_FILE)
+  const claude = await tryReadFile(claudePath)
+  if (claude !== null) {
+    const startCount = (claude.match(/prjct:crew:start/g) ?? []).length
+    const needsRepair =
+      containsForbiddenWriteInstruction(claude) ||
+      startCount > 1 ||
+      claude.includes(SNIPPET_END_SHORT)
+    if (needsRepair) {
+      const snippet = getTemplateContent(CLAUDE_SNIPPET_TEMPLATE)?.trim()
+      if (!snippet) {
+        out.errors.push({ file: CLAUDE_FILE, reason: 'leader-mode template missing' })
+      } else {
+        try {
+          const next = replaceCrewSnippet(claude, snippet)
+          await fs.writeFile(claudePath, next, 'utf-8')
+          out.agentFilesRepaired.push(CLAUDE_FILE)
+        } catch (error) {
+          out.errors.push({
+            file: CLAUDE_FILE,
+            reason: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+    }
+  }
+
+  // 3. Emulated CREW.md (non-Claude providers)
+  const crewMdPath = path.join(projectPath, CREW_MD_FILE)
+  const crewMd = await tryReadFile(crewMdPath)
+  if (crewMd !== null && containsForbiddenWriteInstruction(crewMd)) {
+    // Emulated protocol is rebuilt on next `prjct crew install`. For sync we
+    // only strip the forbidden paths so agents stop following them: replace
+    // the whole file with a short ban pointing operators at reinstall.
+    try {
+      const ban = [
+        '# CREW.md — reinstall required',
+        '',
+        'This file previously instructed agents to write plans/reports under',
+        '`.prjct/sessions/` (or other worktree paths). That is forbidden.',
+        '',
+        'Run `prjct crew install` to regenerate the emulated crew protocol.',
+        'Durable state goes through `prjct` CLI verbs only (SQLite).',
+        '',
+      ].join('\n')
+      await fs.writeFile(crewMdPath, ban, 'utf-8')
+      out.agentFilesRepaired.push(CREW_MD_FILE)
+    } catch (error) {
+      out.errors.push({
+        file: CREW_MD_FILE,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  if (out.agentFilesRepaired.length === 0) return
+
+  const flag = readFlag(projectId, FLAG_AGENT_REPAIR_WARN)
+  if (flag === null) {
+    await captureInboxWarning(
+      projectPath,
+      `Repaired crew instruction files that still told agents to write plans/reports to disk (${out.agentFilesRepaired.join(', ')}). Refreshed from current prjct templates. Product law: plans + work data ONLY in project SQLite via prjct plan / prjct spec / prjct remember / prjct crew record-run — physical files are not traceable.`,
+      { 'migration:v3.77': '1', topic: 'crew-disk-write-repair' }
+    )
+    writeFlag(projectId, FLAG_AGENT_REPAIR_WARN, Date.now())
+  }
+}
+
+/**
  * Run the legacy sweep. Best-effort: errors are collected and returned
  * but never thrown (sync must not fail on this — it runs every session
  * start and should be a quiet no-op once the user has migrated).
@@ -236,6 +678,9 @@ export async function legacyCrewSweep(
     checkpointsHandEditWarned: false,
     teamMigrated: false,
     teamHandEditWarned: false,
+    ghostDirsPurged: [],
+    agentFilesRepaired: [],
+    ghostFilesIngested: 0,
     errors: [],
   }
   await sweepCheckpoints(projectPath, projectId, out).catch((error) => {
@@ -250,5 +695,47 @@ export async function legacyCrewSweep(
       reason: error instanceof Error ? error.message : String(error),
     })
   })
+  // Phase B: always run. Order matters — purge ghost dirs first, then
+  // rewrite any agent files still instructing agents to recreate them.
+  await purgeWorktreeGhostDirs(projectPath, projectId, out).catch((error) => {
+    out.errors.push({
+      file: '.prjct/*/',
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  })
+  await repairCrewDiskWriteInstructions(projectPath, projectId, out).catch((error) => {
+    out.errors.push({
+      file: '.claude/agents/*',
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  })
+  // Also sanitize a leftover on-disk CHECKPOINTS.md if it still lists
+  // session artifacts (file is non-authoritative post-migration but agents
+  // may still open it if present).
+  await sanitizeLegacyCheckpointsFile(projectPath, out).catch((error) => {
+    out.errors.push({
+      file: LEGACY_CHECKPOINTS_PATH,
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  })
   return out
+}
+
+async function sanitizeLegacyCheckpointsFile(
+  projectPath: string,
+  out: LegacySweepResult
+): Promise<void> {
+  const filePath = path.join(projectPath, LEGACY_CHECKPOINTS_PATH)
+  const content = await tryReadFile(filePath)
+  if (content === null) return
+  if (!containsForbiddenWriteInstruction(content)) return
+  try {
+    await fs.writeFile(filePath, sanitizeCheckpointsContent(content), 'utf-8')
+    out.agentFilesRepaired.push(LEGACY_CHECKPOINTS_PATH)
+  } catch (error) {
+    out.errors.push({
+      file: LEGACY_CHECKPOINTS_PATH,
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  }
 }

--- a/core/services/sync-service.ts
+++ b/core/services/sync-service.ts
@@ -151,15 +151,12 @@ class SyncService {
       // long ago. The pre-v2.19.7 crew-disk sweep below is a separate concern
       // (kv_store CHECKPOINTS/team.json) and stays.
 
-      // 2d. Legacy crew-disk sweep (spec a50b32d1 AC #10) — detect
-      // pre-v2.19.7 `.prjct/CHECKPOINTS.md` and `.prjct/team.json`,
-      // migrate into kv_store, emit one-shot inbox warnings on
-      // post-migration hand-edits. mtime-cached so re-syncs are silent.
-      //
-      // Deprecation track: pre-v2.19.7 was ~12 months ago — every active
-      // install migrated long ago. Set PRJCT_SKIP_CREW_SWEEP=1 to skip this
-      // phase entirely (mirrors PRJCT_SKIP_JSON_MIGRATION). v3.0 removes
-      // the sweep file along with migrate-json.
+      // 2d. Legacy crew-disk sweep (spec a50b32d1 AC #10 + worktree hygiene):
+      //   - pre-v2.19.7 `.prjct/CHECKPOINTS.md` / `.prjct/team.json` → kv_store
+      //   - EVERY sync: purge `.prjct/{sessions,audits,deploy}/` from the
+      //     customer worktree and repair crew agent files that still instruct
+      //     agents to write plans/reports into the repo (customer #3 2026-07).
+      // Set PRJCT_SKIP_CREW_SWEEP=1 to skip (mirrors PRJCT_SKIP_JSON_MIGRATION).
       if (process.env.PRJCT_SKIP_CREW_SWEEP !== '1') {
         await phase('legacy-crew-sweep', async () => {
           try {
@@ -170,6 +167,8 @@ class SyncService {
               result.teamMigrated ||
               result.checkpointsHandEditWarned ||
               result.teamHandEditWarned ||
+              result.ghostDirsPurged.length > 0 ||
+              result.agentFilesRepaired.length > 0 ||
               result.errors.length > 0
             ) {
               log.info('Legacy crew sweep ran', {
@@ -177,6 +176,9 @@ class SyncService {
                 teamMigrated: result.teamMigrated,
                 checkpointsHandEditWarned: result.checkpointsHandEditWarned,
                 teamHandEditWarned: result.teamHandEditWarned,
+                ghostDirsPurged: result.ghostDirsPurged,
+                agentFilesRepaired: result.agentFilesRepaired,
+                ghostFilesIngested: result.ghostFilesIngested,
                 errors: result.errors.length,
               })
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.76.1",
+  "version": "3.77.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {

--- a/templates/crew/leader-mode.md
+++ b/templates/crew/leader-mode.md
@@ -39,5 +39,5 @@ If you need durable state that outlives the session, persist via `prjct` CLI ver
 
 ### Hard persistence rule
 
-Never write audit, checkpoint, review, deploy, or report markdown into any new file or subdirectory under the prjct state folder, and no scratch `.md` anywhere else in the worktree. The ONLY hand-editable file in that folder is `.prjct/prjct.config.json`. Everything else — checkpoints, audits, decisions, learnings, deploy notes — lives in SQLite, written through `prjct` CLI verbs (`prjct crew checkpoints set`, `prjct remember`, `prjct spec record-review`). If a subagent reports findings, persist them via `prjct remember` and cite the returned mem id; never tell a subagent to write to disk.
+Never write audit, checkpoint, review, deploy, plan, or report markdown into any physical file — not under `.prjct/`, not under `~/.prjct-cli/`, not anywhere else on disk. Physical files are not traceable. The ONLY hand-editable file in the project folder is `.prjct/prjct.config.json`. Everything durable lives in **project SQLite** via `prjct plan` / `prjct spec` / `prjct crew record-run` / `prjct remember` / `prjct crew checkpoints set` / `prjct spec record-review`. If a subagent reports findings, persist them via `prjct remember` and cite the returned mem id; never tell a subagent to write to disk.
 <!-- prjct:crew:end - DO NOT REMOVE THIS MARKER -->

--- a/templates/crew/roles/implementer.md
+++ b/templates/crew/roles/implementer.md
@@ -43,7 +43,7 @@ You are an implementer. Your job is to take **one** prjct work cycle from active
 - Every code edit must be accompanied by its test before the next edit.
 - Never declare work `done` without the reviewer's explicit `APPROVED`.
 - Never write debug `console.log` / `print` / scratch files into source. Clean up before handing off.
-- Never write report files into the working tree — no scratch `.md`, no subdirectory under `.prjct/`. Durable state goes through `prjct` CLI verbs only.
+- Never write plan/report files anywhere on disk — no scratch `.md`, no session dump folders, no home-dir markdown caches. Physical files are not traceable. Durable state goes through `prjct` CLI verbs into project SQLite only (`prjct remember`, `prjct plan`, `prjct spec`).
 
 ## Keep your reply tight
 

--- a/templates/crew/roles/leader.md
+++ b/templates/crew/roles/leader.md
@@ -128,4 +128,4 @@ Match the implementer count to the work. One subtask → one implementer. Three 
 
 ## Hard persistence rule
 
-Never write audit, checklist, review, deploy, or report markdown into any new file or subdirectory under the prjct state folder. The ONLY hand-editable file in that folder is `.prjct/prjct.config.json`. Durable state — checkpoints, audits, reviews, decisions, learnings — goes through `prjct` CLI verbs (`prjct crew checkpoints set`, `prjct remember`, `prjct spec record-review`). SQLite is the only allowed persistence surface.
+Never write audit, checklist, review, deploy, plan, or report markdown into any physical file — not under `.prjct/`, not under `~/.prjct-cli/`, not anywhere else on disk. Physical files are not traceable. The ONLY hand-editable file in the project folder is `.prjct/prjct.config.json`. Durable state lives in **project SQLite** via CLI verbs: `prjct plan` / `prjct spec` (plans), `prjct crew record-run` (crew outcomes), `prjct remember` (decisions/learnings), `prjct crew checkpoints set` (gates), `prjct spec record-review` (reviews).


### PR DESCRIPTION
## Summary
- Product law: **plans and work data live only in project SQLite** — physical `plan.md` / `impl.md` files are not traceable and must never land in client repos (or as free markdown under `~/.prjct-cli/**/sessions/`).
- Every `prjct sync` now:
  1. **Ingests** text from `.prjct/{sessions,audits,deploy}/` into SQLite (`remember` context, topic `worktree-ghost-ingest`) then **deletes** those dirs
  2. **Force-refreshes** crew agent files / `CLAUDE.md` / `CREW.md` that still instruct disk writes (including `SESSION_ROOT` hideouts)
  3. Sanitizes kv checkpoints that re-injected session-artifact paths into reviewer templates
- Hard-law copy updated in crew templates (leader / implementer / leader-mode)

## Why
Customer report (alliance-redesign and others): stale customized crew agents kept dumping hundreds of session files into client working trees years after templates were fixed.

## Test plan
- [x] `bun test core/__tests__/services/legacy-crew-sweep-hygiene.test.ts`
- [x] `bun test core/__tests__/commands/crew-templates-no-disk-writes.test.ts`
- [ ] After merge: release workflow publishes `prjct-cli@3.77.0`
- [ ] On a polluted project: `prjct sync` removes `.prjct/sessions/` and repairs agents

Generated with [p/](https://www.prjct.app/)