### PR TITLE
feat: steal g-ai v2.2 authority teeth — stamp, candidate hash, kill switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **gentle-ai v2.2.0 value steals (authority, not ceremony):**
+  - **A1 Content-bound no-stamp fail-closed** — under code-strict, approved judgment without a content-bound stamp hard-blocks `prjct ship` (consent: `--no-judgment-gate` only). `prjct judgment approve` fails closed if stamp cannot be written.
+  - **A2 Judgment ledger RMW** — ledger writes go through `updateDoc` (no silent LWW clobber on concurrent approve/challenge).
+  - **B1 Delivery kill switch** — `delivery.killSwitch: "on"` in `.prjct/prjct.config.json` removes the ship mutation path before task complete / workflow. Outranks `--no-judgment-gate` / `--no-spec-gate` / `--force-pressure`. Lift only by setting `off`.
+  - **C1 Frozen audit candidate hash** — `prjct spec audit` stamps `audit_candidate_hash`; each lens review binds `candidateHash`; body edits clear reviews + demote `reviewed`→`draft`; promote gate refuses drifted candidates. Legacy specs without a hash keep prior lens-only behavior.
+
 ## [3.77.0] - 2026-07-28
 
 ### Fixed

--- a/core/__tests__/commands/spec-update-merge.test.ts
+++ b/core/__tests__/commands/spec-update-merge.test.ts
@@ -86,8 +86,10 @@ describe('spec update --json shallow-merge', () => {
       'X-RateLimit-* headers',
     ])
     expect(refreshed?.content.scope).toEqual(['auth/middleware.ts'])
-    expect(refreshed?.content.reviews?.strategic?.verdict).toBe('pass')
-    expect(refreshed?.content.reviews?.strategic?.notes).toBe('scope is right')
+    // C1: goal is part of the frozen audit candidate — body drift clears
+    // lens results (fail-closed admission). Omitted fields (ACs/scope) still
+    // must survive the shallow merge.
+    expect(refreshed?.content.reviews?.strategic).toBeUndefined()
   })
 
   test('explicit field in patch replaces existing value (not merged into array)', async () => {

--- a/core/__tests__/services/content-bound-stamp.test.ts
+++ b/core/__tests__/services/content-bound-stamp.test.ts
@@ -106,10 +106,16 @@ describe('content-bound-stamp', () => {
     expect(override.reason).toBe('override')
   })
 
-  it('no-stamp and unverified never hard-block', () => {
+  it('no-stamp hard-blocks under code-strict (A1); soft when not hard', () => {
+    const hard = contentBoundDriftVerdict({ stamp: null, currentTreeHash: 'x', hard: true })
+    expect(hard.blocked).toBe(true)
+    expect(hard.reason).toBe('no-stamp')
     expect(
-      contentBoundDriftVerdict({ stamp: null, currentTreeHash: 'x', hard: true }).blocked
+      contentBoundDriftVerdict({ stamp: null, currentTreeHash: 'x', hard: false }).blocked
     ).toBe(false)
+  })
+
+  it('unverified still does not hard-block (IO advisory)', () => {
     const stamp = stampFromContents([{ path: 'a.ts', content: 'ok' }], { stampedAt: 't0' })
     const u = contentBoundDriftVerdict({
       stamp,

--- a/core/__tests__/services/steal-g-ai-v22-authority.test.ts
+++ b/core/__tests__/services/steal-g-ai-v22-authority.test.ts
@@ -1,0 +1,159 @@
+/**
+ * gentle-ai v2.2.0 value steals:
+ *  A1 — content-bound no-stamp fail-closed under hard
+ *  B1 — delivery kill switch outranks gate overrides
+ *  C1 — audit candidate hash binds lens admission
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { ShippingCommands } from '../../commands/shipping'
+import configManager from '../../infrastructure/config-manager'
+import { contentBoundDriftVerdict } from '../../services/content-bound-stamp'
+import {
+  computeAuditCandidateHash,
+  reviewsGatePassedRelational,
+} from '../../services/spec-audit-dispatch'
+import { prjctDb } from '../../storage/database'
+import { specStorage } from '../../storage/spec-storage'
+import { emptySpecContent, type SpecContent } from '../../types/spec'
+import { patchPathManager, restorePathManager } from '../_setup/path-manager-mock'
+
+describe('A1 content-bound no-stamp', () => {
+  it('hard-blocks missing stamp', () => {
+    const v = contentBoundDriftVerdict({
+      stamp: null,
+      currentTreeHash: 'abc',
+      hard: true,
+    })
+    expect(v.blocked).toBe(true)
+    expect(v.reason).toBe('no-stamp')
+    expect(v.message).toMatch(/content-bound stamp missing/i)
+  })
+})
+
+describe('B1 delivery kill switch', () => {
+  let projectPath: string
+  let projectId: string
+  let cmd: ShippingCommands
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-kill-'))
+    await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+    projectId = `kill-${Math.random().toString(36).slice(2, 10)}`
+    await configManager.writeConfig(projectPath, {
+      projectId,
+      dataPath: path.join(projectPath, '.prjct-data'),
+      delivery: { killSwitch: 'on' },
+    })
+    patchPathManager(projectPath)
+    prjctDb.get(projectId, 'SELECT 1')
+    cmd = new ShippingCommands()
+  })
+
+  afterEach(async () => {
+    restorePathManager()
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  })
+
+  it('blocks ship before mutation and outranks --no-judgment-gate', async () => {
+    const result = await cmd.ship('feat x', projectPath, {
+      noJudgmentGate: true,
+      noSpecGate: true,
+      forcePressure: true,
+    })
+    expect(result.success).toBe(false)
+    expect(String(result.error)).toMatch(/kill-switch ON/i)
+    expect(String(result.error)).toMatch(/not via --no-judgment-gate/)
+  })
+
+  it('allows ship path past kill when off', async () => {
+    await configManager.writeConfig(projectPath, {
+      projectId,
+      dataPath: path.join(projectPath, '.prjct-data'),
+      delivery: { killSwitch: 'off' },
+    })
+    // Without active task / workflow the ship may still fail later — but
+    // must NOT fail on kill-switch.
+    const result = await cmd.ship('feat y', projectPath, { noJudgmentGate: true })
+    if (!result.success) {
+      expect(String(result.error)).not.toMatch(/kill-switch/i)
+    }
+  })
+})
+
+describe('C1 audit candidate hash admission', () => {
+  let projectPath: string
+  let projectId: string
+
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'prjct-cand-'))
+    await fs.mkdir(path.join(projectPath, '.prjct'), { recursive: true })
+    projectId = `cand-${Math.random().toString(36).slice(2, 10)}`
+    await configManager.writeConfig(projectPath, {
+      projectId,
+      dataPath: path.join(projectPath, '.prjct-data'),
+    })
+    patchPathManager(projectPath)
+    prjctDb.get(projectId, 'SELECT 1')
+  })
+
+  afterEach(async () => {
+    restorePathManager()
+    if (projectPath) await fs.rm(projectPath, { recursive: true, force: true }).catch(() => {})
+  })
+
+  function body(goal: string): SpecContent {
+    return emptySpecContent(goal)
+  }
+
+  it('computeAuditCandidateHash is stable and sensitive to body', () => {
+    const a = body('ship kill switch')
+    a.acceptance_criteria = ['unit test green']
+    const b = { ...a, acceptance_criteria: ['unit test green', 'e2e green'] }
+    const h1 = computeAuditCandidateHash(a)
+    const h2 = computeAuditCandidateHash(a)
+    const h3 = computeAuditCandidateHash(b)
+    expect(h1).toBe(h2)
+    expect(h1).not.toBe(h3)
+  })
+
+  it('gate fails when body drifts after lens pass on frozen hash', () => {
+    const content = body('candidate bind')
+    content.acceptance_criteria = ['A']
+    content.selected_reviewers = ['architecture', 'strategic', 'design']
+    const hash = computeAuditCandidateHash(content)
+    content.audit_candidate_hash = hash
+    content.reviews = {
+      architecture: { verdict: 'pass', notes: 'ok', ts: 't0', candidateHash: hash },
+      strategic: { verdict: 'pass', notes: 'ok', ts: 't0', candidateHash: hash },
+      design: { verdict: 'pass', notes: 'ok', ts: 't0', candidateHash: hash },
+    }
+    const spec = specStorage.create(projectId, { title: 't', content })
+    expect(reviewsGatePassedRelational(projectId, spec.id)).toBe(true)
+
+    // Mutate body in storage without re-audit (simulates failed invalidation or race)
+    const drifted = {
+      ...content,
+      acceptance_criteria: ['A', 'B new'],
+      // keep old reviews + old frozen hash → gate must fail
+    }
+    specStorage.updateContent(projectId, spec.id, drifted)
+    expect(reviewsGatePassedRelational(projectId, spec.id)).toBe(false)
+  })
+
+  it('legacy specs without audit_candidate_hash keep lens-only gate', () => {
+    const content = body('legacy')
+    content.selected_reviewers = ['architecture', 'strategic', 'design']
+    content.audit_candidate_hash = null
+    content.reviews = {
+      architecture: { verdict: 'pass', notes: 'ok', ts: 't0' },
+      strategic: { verdict: 'pass', notes: 'ok', ts: 't0' },
+      design: { verdict: 'pass', notes: 'ok', ts: 't0' },
+    }
+    const spec = specStorage.create(projectId, { title: 'legacy', content })
+    expect(reviewsGatePassedRelational(projectId, spec.id)).toBe(true)
+  })
+})

--- a/core/commands/judgment.ts
+++ b/core/commands/judgment.ts
@@ -644,17 +644,22 @@ export class JudgmentCommands extends PrjctCommandsBase {
     const ledger = judgmentLedgerStorage.get(proj.value)
     if (!ledger) return failWith('No active ledger — `prjct judgment open` first.', options)
 
-    const stampApprove = async (l: typeof ledger) => {
+    const stampApprove = async (l: typeof ledger): Promise<{ bit: string; ok: boolean }> => {
       try {
         const { shortHash, stampForApprove } = await import('../services/content-bound-stamp')
         const now = getTimestamp()
         const stamp = await stampForApprove(projectPath, l.scopePaths, now)
         l.contentBound = stamp
-        return stamp.pathCount > 0
-          ? ` · content-bound tree=${shortHash(stamp.treeHash)} (${stamp.pathCount} paths)`
-          : ' · content-bound (empty scope)'
-      } catch {
-        return ''
+        const bit =
+          stamp.pathCount > 0
+            ? ` · content-bound tree=${shortHash(stamp.treeHash)} (${stamp.pathCount} paths)`
+            : ' · content-bound (empty scope)'
+        return { bit, ok: true }
+      } catch (err) {
+        // A1: do not silently approve without stamp under non-skip intensity —
+        // ship would then fail-closed on no-stamp under code-strict.
+        const msg = err instanceof Error ? err.message : String(err)
+        return { bit: ` · content-bound FAILED (${msg})`, ok: false }
       }
     }
 
@@ -662,12 +667,18 @@ export class JudgmentCommands extends PrjctCommandsBase {
     if (ledger.findings.length === 0) {
       ledger.verdict = 'approved'
       ledger.updatedAt = getTimestamp()
-      const stampBit = await stampApprove(ledger)
+      const stamped = await stampApprove(ledger)
+      if (!stamped.ok && ledger.intensity !== 'skip') {
+        return failWith(
+          `Cannot approve: content-bound stamp failed${stamped.bit}. Fix git/workspace then re-approve.`,
+          options
+        )
+      }
       judgmentLedgerStorage.set(proj.value, ledger)
       print(
         options,
         '## Judgment APPROVED',
-        `Ledger \`${ledger.id}\` APPROVED (empty review attestation)${stampBit}. Ship gate will pass.`
+        `Ledger \`${ledger.id}\` APPROVED (empty review attestation)${stamped.bit}. Ship gate will pass.`
       )
       return { success: true, ledger, verdict: 'approved', emptyAttestation: true }
     }
@@ -689,7 +700,13 @@ export class JudgmentCommands extends PrjctCommandsBase {
         options
       )
     }
-    const stampBit = await stampApprove(finalized)
+    const stamped = await stampApprove(finalized)
+    if (!stamped.ok && finalized.intensity !== 'skip') {
+      return failWith(
+        `Cannot approve: content-bound stamp failed${stamped.bit}. Fix git/workspace then re-approve.`,
+        options
+      )
+    }
     judgmentLedgerStorage.set(proj.value, finalized)
     print(
       options,
@@ -698,7 +715,7 @@ export class JudgmentCommands extends PrjctCommandsBase {
         (finalized.precisionHint !== undefined
           ? ` · precision≈${Math.round(finalized.precisionHint * 100)}%`
           : '') +
-        `${stampBit}. Ship gate will pass.`
+        `${stamped.bit}. Ship gate will pass.`
     )
     return { success: true, ledger: finalized, verdict: 'approved' }
   }

--- a/core/commands/shipping.ts
+++ b/core/commands/shipping.ts
@@ -78,6 +78,23 @@ export class ShippingCommands extends PrjctCommandsBase {
       if (!proj.ok) return proj.result
       const projectId = proj.value
 
+      // B1: delivery kill switch — removes mutation path without fake approval.
+      // Outranks --no-judgment-gate / --no-spec-gate / --force-pressure.
+      try {
+        const shipConfigEarly = await configManager.readConfig(projectPath)
+        if (shipConfigEarly?.delivery?.killSwitch === 'on') {
+          return {
+            success: false,
+            error:
+              'Delivery kill-switch ON — mutation path removed. ' +
+              'Lift only by setting `delivery.killSwitch` to `off` in `.prjct/prjct.config.json` ' +
+              '(not via --no-judgment-gate / --no-spec-gate).',
+          }
+        }
+      } catch {
+        /* config read best-effort — never invent kill-on from a bad read */
+      }
+
       // Crash recovery: a prior ship that pushed a version but died before
       // recording the shipped row left a marker. Reconcile it idempotently
       // (skip if that version is already recorded) before doing anything.
@@ -282,18 +299,22 @@ export class ShippingCommands extends PrjctCommandsBase {
         }
         if (jv.message) console.log(jv.message)
 
-        // Content-bound stamp (Dynasty D2): approved treeHash must still match
-        // workspace paths — post-approve edits force re-judgment.
-        if (ledger?.contentBound?.treeHash && !options.noJudgmentGate) {
+        // Content-bound stamp (Dynasty D2 + A1): under code-strict, approved
+        // judgment without a stamp hard-blocks; with a stamp, post-approve
+        // edits force re-judgment. Override: --no-judgment-gate only.
+        if (codeStrict && !options.noJudgmentGate && jv.reason === 'approved') {
           try {
             const { contentBoundDriftVerdict, currentTreeHashForStamp } = await import(
               '../services/content-bound-stamp'
             )
-            const current = await currentTreeHashForStamp(projectPath, ledger.contentBound)
+            const stamp = ledger?.contentBound
+            const current = stamp?.treeHash
+              ? await currentTreeHashForStamp(projectPath, stamp)
+              : null
             const cv = contentBoundDriftVerdict({
-              stamp: ledger.contentBound,
+              stamp: stamp ?? null,
               currentTreeHash: current,
-              hard: codeStrict,
+              hard: true,
               override: false,
             })
             if (cv.blocked) {
@@ -303,13 +324,30 @@ export class ShippingCommands extends PrjctCommandsBase {
           } catch (err) {
             // Git infra must not fail-open the content-bound gate under
             // code-strict packs (null treeHash used to mean "unverified → pass").
-            if (codeStrict && err instanceof GitInfraError) {
+            if (err instanceof GitInfraError) {
               return {
                 success: false,
                 error: `Content-bound stamp unevaluable: ${err.message}. Re-run when git is healthy, or override with \`--no-judgment-gate\`.`,
               }
             }
-            /* non-strict / non-infra: best-effort */
+            /* non-infra: best-effort */
+          }
+        } else if (ledger?.contentBound?.treeHash && !options.noJudgmentGate) {
+          // Non-strict: keep advisory drift check when a stamp exists.
+          try {
+            const { contentBoundDriftVerdict, currentTreeHashForStamp } = await import(
+              '../services/content-bound-stamp'
+            )
+            const current = await currentTreeHashForStamp(projectPath, ledger.contentBound)
+            const cv = contentBoundDriftVerdict({
+              stamp: ledger.contentBound,
+              currentTreeHash: current,
+              hard: false,
+              override: false,
+            })
+            if (cv.message) console.log(cv.message)
+          } catch {
+            /* best-effort */
           }
         }
       } catch (err) {

--- a/core/services/content-bound-stamp.ts
+++ b/core/services/content-bound-stamp.ts
@@ -118,6 +118,17 @@ export function contentBoundDriftVerdict(input: {
     return { blocked: false, reason: 'override', message: '' }
   }
   if (!input.stamp?.treeHash) {
+    // A1 (gentle-ai v2.2 steal): under hard/code-strict, approved authority
+    // without a content stamp is fail-closed — not silent pass.
+    if (input.hard) {
+      return {
+        blocked: true,
+        reason: 'no-stamp',
+        message:
+          'Content-bound stamp missing: re-run `prjct judgment approve` so ship binds to the reviewed tree. ' +
+          'Override only with consent: `prjct ship --no-judgment-gate`.',
+      }
+    }
     return { blocked: false, reason: 'no-stamp', message: '' }
   }
   if (input.stamp.pathCount === 0) {

--- a/core/services/spec-audit-dispatch.ts
+++ b/core/services/spec-audit-dispatch.ts
@@ -23,12 +23,31 @@
  * rubric and resolve to the sonnet reviewer tier via the model policy fallback.
  */
 
+import { createHash } from 'node:crypto'
 import prjctDb from '../storage/database'
 import type { AIProviderName } from '../types/provider'
 import type { SpecContent } from '../types/spec'
 import type { DomainDefinition } from '../types/storage/extended'
 import { resolveDispatchMechanism } from './agent-dispatch'
 import { domainLensRubric, GENERIC_RUBRIC, LENS_CATALOG } from './review-lenses'
+
+/**
+ * Canonical digest of the reviewable body of a spec (C1).
+ * Lens results bind to this hash; content edits invalidate admission.
+ */
+export function computeAuditCandidateHash(content: SpecContent): string {
+  const payload = {
+    goal: content.goal,
+    eli10: content.eli10,
+    stakes: content.stakes,
+    acceptance_criteria: content.acceptance_criteria,
+    scope: content.scope,
+    out_of_scope: content.out_of_scope,
+    risks: content.risks,
+    test_plan: content.test_plan,
+  }
+  return createHash('sha256').update(JSON.stringify(payload)).digest('hex')
+}
 
 /**
  * Does this spec touch a domain? A keyword present in the combined text, or a
@@ -99,6 +118,22 @@ export function selectReviewers(content: SpecContent, domains: DomainDefinition[
  * back to the three baseline lenses.
  */
 export function reviewsGatePassedRelational(projectId: string, specId: string): boolean {
+  // Load content blob for candidate-hash admission (C1). Relational tables
+  // only carry verdicts — the frozen hash lives on specs.content.
+  const row = prjctDb.get<{ content: string }>(
+    projectId,
+    'SELECT content FROM specs WHERE id = ?',
+    specId
+  )
+  let content: SpecContent | null = null
+  if (row?.content) {
+    try {
+      content = JSON.parse(row.content) as SpecContent
+    } catch {
+      content = null
+    }
+  }
+
   const selected = prjctDb
     .query<{ lens: string }>(
       projectId,
@@ -115,8 +150,32 @@ export function reviewsGatePassedRelational(projectId: string, specId: string): 
       )
       .map((r) => r.lens)
   )
-  if (selected.length > 0) return selected.every((lens) => passed.has(lens))
-  return passed.has('strategic') && passed.has('architecture') && passed.has('design')
+
+  const lensesPass =
+    selected.length > 0
+      ? selected.every((lens) => passed.has(lens))
+      : passed.has('strategic') && passed.has('architecture') && passed.has('design')
+  if (!lensesPass) return false
+
+  // C1: when audit stamped a frozen candidate, every pass must bind to it
+  // and the body must still hash to the same digest. Legacy specs without
+  // audit_candidate_hash keep prior lens-only behavior.
+  const frozen = content?.audit_candidate_hash
+  if (!frozen) return true
+  if (computeAuditCandidateHash(content!) !== frozen) return false
+  const reviews = content?.reviews ?? {}
+  for (const lens of selected.length > 0 ? selected : Object.keys(reviews)) {
+    const r = reviews[lens]
+    if (!r || r.verdict !== 'pass') continue
+    if (r.candidateHash !== frozen) return false
+  }
+  // selected lenses that passed relationally must also exist with matching hash
+  for (const lens of selected.length > 0 ? selected : ['strategic', 'architecture', 'design']) {
+    if (!passed.has(lens)) continue
+    const r = reviews[lens]
+    if (!r || r.candidateHash !== frozen) return false
+  }
+  return true
 }
 
 /**

--- a/core/services/spec-service.ts
+++ b/core/services/spec-service.ts
@@ -23,7 +23,7 @@ import {
 } from '../types/spec'
 import { getTimestamp } from '../utils/date-helper'
 import { execFileAsync } from '../utils/exec'
-import { reviewsGatePassedRelational } from './spec-audit-dispatch'
+import { computeAuditCandidateHash, reviewsGatePassedRelational } from './spec-audit-dispatch'
 
 /**
  * Read git HEAD sha at `projectPath`. Returns null when not a git repo
@@ -151,7 +151,24 @@ class SpecService {
 
   async update(projectPath: string, id: string, content: SpecContent): Promise<Spec | null> {
     const projectId = await this.requireProjectId(projectPath)
-    return specStorage.updateContent(projectId, id, content)
+    const prev = specStorage.get(projectId, id)
+    if (!prev) return null
+    const prevHash = computeAuditCandidateHash(prev.content)
+    const nextHash = computeAuditCandidateHash(content)
+    let next = content
+    if (prevHash !== nextHash) {
+      // C1: body drifted — invalidate lens admission and demote reviewed → draft.
+      next = {
+        ...content,
+        reviews: {},
+        selected_reviewers: [],
+        audit_candidate_hash: null,
+      }
+      if (prev.status === 'reviewed' || prev.status === 'in_progress') {
+        specStorage.setStatus(projectId, id, 'draft')
+      }
+    }
+    return specStorage.updateContent(projectId, id, next)
   }
 
   async recordReview(
@@ -179,9 +196,25 @@ class SpecService {
       const spec = specStorage.get(projectId, id)
       if (!spec) return null
 
-      const fullReview: SpecReview = { ...review, ts: getTimestamp() }
+      const frozen = spec.content.audit_candidate_hash ?? computeAuditCandidateHash(spec.content)
+      // Refuse recording against a drifted body (hash no longer matches frozen).
+      if (
+        spec.content.audit_candidate_hash &&
+        computeAuditCandidateHash(spec.content) !== spec.content.audit_candidate_hash
+      ) {
+        throw new Error(
+          `SPEC_CANDIDATE_DRIFT: body no longer matches audit_candidate_hash. Re-run \`prjct spec audit ${id}\` then re-record reviews.`
+        )
+      }
+      const fullReview: SpecReview = {
+        ...review,
+        ts: getTimestamp(),
+        candidateHash: frozen,
+      }
       const nextContent: SpecContent = {
         ...spec.content,
+        // Ensure frozen hash is stamped even for legacy audits mid-flight.
+        audit_candidate_hash: frozen,
         reviews: {
           ...(spec.content.reviews ?? {}),
           [reviewer]: fullReview,
@@ -297,9 +330,13 @@ class SpecService {
     const projectId = await this.requireProjectId(projectPath)
     const spec = specStorage.get(projectId, id)
     if (!spec) return null
+    const hash = computeAuditCandidateHash(spec.content)
     return specStorage.updateContent(projectId, id, {
       ...spec.content,
       selected_reviewers: lenses,
+      audit_candidate_hash: hash,
+      // Fresh audit invalidates prior lens results on a previous candidate.
+      reviews: {},
     })
   }
 

--- a/core/storage/judgment-ledger-storage.ts
+++ b/core/storage/judgment-ledger-storage.ts
@@ -27,11 +27,23 @@ class JudgmentLedgerStorage {
   }
 
   set(projectId: string, ledger: JudgmentLedger): JudgmentLedger {
-    const row = JudgmentLedgerSchema.parse({
-      ...ledger,
-      updatedAt: ledger.updatedAt || getTimestamp(),
-    })
-    prjctDb.setDoc(projectId, JUDGMENT_ACTIVE_KEY, row)
+    // A2: RMW via updateDoc so concurrent approve/challenge/add cannot
+    // silently last-write-wins clobber mid-transition (gentle-ai CAS spirit).
+    const stamp = ledger.updatedAt || getTimestamp()
+    const row = prjctDb.updateDoc<JudgmentLedger>(
+      projectId,
+      JUDGMENT_ACTIVE_KEY,
+      () =>
+        JudgmentLedgerSchema.parse({
+          ...ledger,
+          updatedAt: stamp,
+        }),
+      () =>
+        JudgmentLedgerSchema.parse({
+          ...ledger,
+          updatedAt: stamp,
+        })
+    )
     return row
   }
 

--- a/core/types/config.ts
+++ b/core/types/config.ts
@@ -120,6 +120,15 @@ export interface LocalConfig {
     hardBlockShip?: boolean
   }
   /**
+   * Delivery kill switch (gentle-ai v2.2 steal B1).
+   * When `on`, `prjct ship` hard-fails BEFORE task complete / workflow / gate
+   * overrides — removes the mutation path without fabricating approval.
+   * Lift only by setting killSwitch back to `off` (not via --no-judgment-gate).
+   */
+  delivery?: {
+    killSwitch?: 'off' | 'on'
+  }
+  /**
    * Delivery-geometry gate at work start when the working tree is already large.
    *   - off — never
    *   - advisory — surface in work output (default for code pack)

--- a/core/types/spec.ts
+++ b/core/types/spec.ts
@@ -27,6 +27,8 @@ const SpecReviewSchema = z.object({
   verdict: z.enum(['pass', 'fail']),
   notes: z.string(),
   ts: z.string(),
+  /** Hash of frozen audit candidate at the time this lens recorded its verdict. */
+  candidateHash: z.string().optional(),
 })
 export type SpecReview = z.infer<typeof SpecReviewSchema>
 
@@ -62,6 +64,12 @@ export const SpecContentSchema = z.object({
   // and re-runs the loop. Existing specs read as null via Zod's default fill
   // (no DB migration needed; specs.content is a JSON blob).
   tasks_created_at: z.string().nullable().default(null),
+  /**
+   * Frozen candidate body hash at audit time (C1 / gentle-ai v2.2 steal).
+   * Lens results must carry the same hash; content edits clear reviews + demote.
+   * null = legacy / not yet audited under candidate-bound admission.
+   */
+  audit_candidate_hash: z.string().nullable().default(null),
 })
 
 export type SpecContent = z.infer<typeof SpecContentSchema>


### PR DESCRIPTION
## Summary

High-value process safety from [gentle-ai v2.2.0](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.2.0) — **authority, not RDD ceremony**:

| Steal | What |
| --- | --- |
| **A1** | Content-bound **no-stamp fail-closed** under code-strict; approve fails if stamp cannot write |
| **A2** | Judgment ledger via `updateDoc` (RMW, no silent LWW clobber) |
| **B1** | `delivery.killSwitch: "on"` removes ship mutation path; **outranks** gate overrides |
| **C1** | Spec `audit_candidate_hash` freezes body; lens results bind; body drift demotes + refuses promote |

## Why
g-ai 2.2 made Organic RDD stable with CAS authority + kill switch + frozen-candidate review admission. prjct already had stamps/receipts/geometry — residual fail-opens: ship without stamp, stale lens admits new body, no durable kill that outranks `--no-judgment-gate`.

## Usage
```json
// .prjct/prjct.config.json
{ "delivery": { "killSwitch": "on" } }
```
Lift only by setting `"off"` — not via judgment approve or gate overrides.

## Test plan
- [x] `bun test core/__tests__/services/steal-g-ai-v22-authority.test.ts`
- [x] `bun test core/__tests__/services/content-bound-stamp.test.ts`
- [x] `bun test core/__tests__/services/spec-audit-dispatch.test.ts`
- [x] `bun test core/__tests__/services/dominance-gates.test.ts`
- [x] `bun test core/__tests__/services/superiority-gates.test.ts`

Generated with [p/](https://www.prjct.app/)