### PR TITLE
fix: pnpm upgrade compatibility and live daemon ownership (v3.80.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.80.1] - 2026-08-03
+
+### Fixed
+- Fix pnpm upgrade compatibility and preserve live daemon ownership
+
 ## [3.80.0] - 2026-08-03
 
 ### Added

--- a/core/__tests__/commands/update-registry-only.test.ts
+++ b/core/__tests__/commands/update-registry-only.test.ts
@@ -29,9 +29,14 @@ describe('upgrade installs from npm registry only', () => {
     }
   })
 
-  it('npm/pnpm prefer online registry over local cache', () => {
+  it('uses cache flags only when the selected package manager supports them', () => {
     expect(MANAGERS.npm.installArgs).toContain('--prefer-online')
-    expect(MANAGERS.pnpm.installArgs).toContain('--prefer-online')
+    expect(MANAGERS.pnpm.installArgs).not.toContain('--prefer-online')
+    expect(registryInstallArgs(MANAGERS.pnpm, 'prjct-cli@3.80.0')).toEqual([
+      'add',
+      '-g',
+      'prjct-cli@3.80.0',
+    ])
   })
 
   it('installArgs always name the registry package prjct-cli@…', () => {

--- a/core/__tests__/daemon/client-lifecycle.test.ts
+++ b/core/__tests__/daemon/client-lifecycle.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { forceKillDaemon, shouldUnlinkDaemonSocket } from '../../daemon/client'
+import { DAEMON_PATHS } from '../../daemon/protocol'
+
+describe('daemon client lifecycle safety', () => {
+  let cliHome: string
+  let previousCliHome: string | undefined
+
+  beforeEach(() => {
+    previousCliHome = process.env.PRJCT_CLI_HOME
+    cliHome = fs.mkdtempSync(path.join(os.tmpdir(), 'prjct-daemon-client-'))
+    process.env.PRJCT_CLI_HOME = cliHome
+    fs.mkdirSync(DAEMON_PATHS.runDir(), { recursive: true })
+  })
+
+  afterEach(() => {
+    if (previousCliHome === undefined) delete process.env.PRJCT_CLI_HOME
+    else process.env.PRJCT_CLI_HOME = previousCliHome
+    fs.rmSync(cliHome, { recursive: true, force: true })
+  })
+
+  it('unlinks only sockets that are definitely stale', () => {
+    expect(shouldUnlinkDaemonSocket(Object.assign(new Error('gone'), { code: 'ENOENT' }))).toBe(
+      true
+    )
+    expect(
+      shouldUnlinkDaemonSocket(Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }))
+    ).toBe(true)
+    expect(shouldUnlinkDaemonSocket(Object.assign(new Error('sandbox'), { code: 'EPERM' }))).toBe(
+      false
+    )
+    expect(
+      shouldUnlinkDaemonSocket(Object.assign(new Error('permissions'), { code: 'EACCES' }))
+    ).toBe(false)
+    expect(shouldUnlinkDaemonSocket(new Error('Daemon request timed out'))).toBe(false)
+  })
+
+  it('preserves pid and socket ownership when the process cannot be killed', () => {
+    fs.writeFileSync(DAEMON_PATHS.pid(), '4242')
+    fs.writeFileSync(DAEMON_PATHS.socket(), 'live endpoint placeholder')
+    const kill = spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
+    })
+
+    expect(forceKillDaemon()).toBe(false)
+    expect(fs.existsSync(DAEMON_PATHS.pid())).toBe(true)
+    expect(fs.existsSync(DAEMON_PATHS.socket())).toBe(true)
+
+    kill.mockRestore()
+  })
+
+  it('removes stale ownership files when the recorded process is gone', () => {
+    fs.writeFileSync(DAEMON_PATHS.pid(), '4242')
+    fs.writeFileSync(DAEMON_PATHS.socket(), 'stale endpoint placeholder')
+    const kill = spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+    })
+
+    expect(forceKillDaemon()).toBe(false)
+    expect(fs.existsSync(DAEMON_PATHS.pid())).toBe(false)
+    expect(fs.existsSync(DAEMON_PATHS.socket())).toBe(false)
+
+    kill.mockRestore()
+  })
+})

--- a/core/commands/update/package-managers.ts
+++ b/core/commands/update/package-managers.ts
@@ -51,7 +51,9 @@ export const MANAGERS: Record<PkgManagerName, PkgManager> = {
   },
   pnpm: {
     name: 'pnpm',
-    installArgs: ['add', '-g', 'prjct-cli@latest', '--prefer-online'],
+    // pnpm 10 rejects npm's --prefer-online flag. The exact registry version
+    // pin already prevents a stale dist-tag from selecting an older release.
+    installArgs: ['add', '-g', 'prjct-cli@latest'],
     getInstallRoot: () => {
       try {
         return execFileSync('pnpm', ['root', '-g'], {

--- a/core/daemon/client.ts
+++ b/core/daemon/client.ts
@@ -17,6 +17,18 @@ import { isBunAvailable } from '../utils/runtime'
 import { commandRequestTimeoutMs, DAEMON_PATHS, encodeMessage, isDaemonNamedPipe } from './protocol'
 import { releaseSpawnLock, tryAcquireSpawnLock } from './startup-lock'
 
+function systemErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== 'object' || !('code' in error)) return null
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' ? code : null
+}
+
+/** Only these connect failures prove that no live process owns the endpoint. */
+export function shouldUnlinkDaemonSocket(error: unknown): boolean {
+  const code = systemErrorCode(error)
+  return code === 'ENOENT' || code === 'ECONNREFUSED'
+}
+
 /**
  * Check if the daemon is running (socket file exists + responds to ping)
  */
@@ -42,9 +54,12 @@ export async function isDaemonRunning(): Promise<boolean> {
       { timeoutMs: 1_000 }
     )
     return response.success
-  } catch {
-    // Socket exists but daemon is dead — stale socket. Named pipes are not unlinkable files.
-    if (!namedPipe) {
+  } catch (error) {
+    // Only remove an endpoint when the OS proves there is no listener.
+    // Permission errors (sandbox EACCES/EPERM), timeouts, and malformed
+    // responses do not prove staleness and must not steal a live daemon's
+    // socket. Named pipes are not unlinkable files.
+    if (!namedPipe && shouldUnlinkDaemonSocket(error)) {
       try {
         fs.unlinkSync(socketPath)
       } catch {
@@ -256,19 +271,28 @@ export function forceKillDaemon(): boolean {
   const socketPath = DAEMON_PATHS.socket()
 
   let killed = false
+  let safeToCleanOwnership = !fs.existsSync(pidPath)
 
   // Try to kill via PID file
   if (fs.existsSync(pidPath)) {
     const pid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10)
-    if (!Number.isNaN(pid)) {
+    if (Number.isNaN(pid)) {
+      safeToCleanOwnership = true
+    } else {
       try {
         process.kill(pid, 'SIGKILL')
         killed = true
-      } catch {
-        // Process already dead
+        safeToCleanOwnership = true
+      } catch (error) {
+        // ESRCH proves the PID is stale. EPERM/EACCES or an unknown failure
+        // means a live process may still own the endpoint, so retain both
+        // files rather than orphaning an uncontrollable daemon.
+        safeToCleanOwnership = systemErrorCode(error) === 'ESRCH'
       }
     }
   }
+
+  if (!safeToCleanOwnership) return false
 
   // Clean up stale files
   try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.80.0",
+  "version": "3.80.1",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {


### PR DESCRIPTION
## Fix
- remove npm-only --prefer-online from pnpm global upgrade arguments
- preserve live daemon PID/socket ownership on permission failures and timeouts
- clean stale ownership only after confirmed kill, ESRCH, ENOENT, or ECONNREFUSED

## Regression coverage
- exact pnpm install-argument contract
- EPERM/EACCES ownership preservation
- ESRCH stale cleanup

## Validation
- 2635 tests passed across 319 files
- typecheck, Biome, knip, command validation, and build passed

This is a patch bugfix release classified under CHANGELOG Fixed.

Generated with [p/](https://www.prjct.app/)