### PR TITLE
feat: adopt MCP 2026 protocol efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [3.83.0] - 2026-08-10
+
+### Added
+
+- Document MCP 2026 compatibility and efficiency controls
+- MCP `2026-07-28` stdio negotiation with transparent 2025-era compatibility, cacheable discovery/tool catalogs, and a static-list capability that avoids unused subscriptions.
+
+### Changed
+
+- Migrated to the split MCP TypeScript SDK v2 and Zod 4. The default 10-tool catalog is 36.7% smaller than v3.82.0 (7,699 → 4,871 serialized bytes) with an effectively flat server bundle (+0.09%).
+
 ## [3.82.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Remove with `prjct claude uninstall` (hooks only) or `prjct uninstall` (everythi
 
 prjct-cli exposes an MCP server with 6 tool groups (every tool is prefixed `prjct_`):
 
+The stdio server negotiates MCP `2026-07-28` while retaining the legacy 2025 handshake for existing hosts. Modern clients skip `initialize`, cache discovery and the static tool catalog privately for 24 hours, and avoid unnecessary list-change subscriptions. The default `core` tier exposes only 10 high-signal tools; set `PRJCT_MCP_TOOLS=standard|all` when a host needs the larger surface.
+
 | Group | Tools |
 |---|---|
 | **memory** | `mem_save`, `mem_list`, `mem_similar`, `mem_forget`, `guard`, `record_decision` / `record_gotcha` / `record_learning` / `record_fact`, `capture_inbox` |

--- a/bun.lock
+++ b/bun.lock
@@ -6,14 +6,15 @@
       "name": "prjct-cli",
       "dependencies": {
         "@clack/prompts": "1.0.0",
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "chalk": "4.1.2",
         "chokidar": "5.0.0",
         "jsonc-parser": "3.3.1",
-        "zod": "3.25.76",
+        "zod": "4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.13",
+        "@modelcontextprotocol/client": "2.0.0",
         "@types/bun": "latest",
         "@types/chokidar": "2.1.7",
         "@types/node": "^22",
@@ -113,9 +114,11 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
@@ -215,25 +218,11 @@
 
     "@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -243,53 +232,15 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
-
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.3.0", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q=="],
-
-    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -297,43 +248,13 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
-
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
-
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
-
-    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
-
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -341,17 +262,11 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.2.0", "", {}, "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ=="],
-
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
@@ -379,43 +294,17 @@
 
     "lefthook-windows-x64": ["lefthook-windows-x64@2.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-XbO/5nAZQLpUn0tPpgCYfFBFJHnymSglQ73jD6wymNrR1j8I5EcXGlP6YcLhnZ83yzsdLC+gup+N6IqUeiyRdw=="],
 
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
-
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "oxc-parser": ["oxc-parser@0.121.0", "", { "dependencies": { "@oxc-project/types": "^0.121.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.121.0", "@oxc-parser/binding-android-arm64": "0.121.0", "@oxc-parser/binding-darwin-arm64": "0.121.0", "@oxc-parser/binding-darwin-x64": "0.121.0", "@oxc-parser/binding-freebsd-x64": "0.121.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0", "@oxc-parser/binding-linux-arm64-gnu": "0.121.0", "@oxc-parser/binding-linux-arm64-musl": "0.121.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0", "@oxc-parser/binding-linux-riscv64-musl": "0.121.0", "@oxc-parser/binding-linux-s390x-gnu": "0.121.0", "@oxc-parser/binding-linux-x64-gnu": "0.121.0", "@oxc-parser/binding-linux-x64-musl": "0.121.0", "@oxc-parser/binding-openharmony-arm64": "0.121.0", "@oxc-parser/binding-wasm32-wasi": "0.121.0", "@oxc-parser/binding-win32-arm64-msvc": "0.121.0", "@oxc-parser/binding-win32-ia32-msvc": "0.121.0", "@oxc-parser/binding-win32-x64-msvc": "0.121.0" } }, "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg=="],
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-to-regexp": ["path-to-regexp@8.4.0", "", {}, "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -423,53 +312,23 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
-
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
-
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
-
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
@@ -477,11 +336,7 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -489,25 +344,13 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
-
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
-    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "knip/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
   }

--- a/core/__tests__/mcp/protocol-2026.test.ts
+++ b/core/__tests__/mcp/protocol-2026.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test'
+import path from 'node:path'
+import { Client } from '@modelcontextprotocol/client'
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio'
+import { MCP_CATALOG_CACHE_TTL_MS } from '../../mcp/server'
+
+interface CacheableResult {
+  cacheScope?: string
+  capabilities?: { tools?: { listChanged?: boolean } }
+  ttlMs?: number
+}
+
+const REPO_ROOT = path.resolve(__dirname, '../../..')
+const CLIENT_INFO = { name: 'prjct-protocol-test', version: '1.0.0' }
+
+async function connectClient(options?: ConstructorParameters<typeof Client>[1]): Promise<Client> {
+  const client = new Client(CLIENT_INFO, options)
+  await client.connect(
+    new StdioClientTransport({
+      command: process.execPath,
+      args: ['core/mcp/entry.ts'],
+      cwd: REPO_ROOT,
+      stderr: 'pipe',
+    })
+  )
+  return client
+}
+
+describe('MCP 2026-07-28 stdio protocol', () => {
+  it('serves the modern era with a cacheable deterministic catalog', async () => {
+    const client = await connectClient({
+      versionNegotiation: { mode: { pin: '2026-07-28' } },
+    })
+
+    try {
+      expect(client.getProtocolEra()).toBe('modern')
+
+      const discovery = client.getDiscoverResult() as CacheableResult | undefined
+      const catalog = (await client.listTools()) as CacheableResult & {
+        tools: Array<{ name: string }>
+      }
+
+      expect(discovery?.ttlMs).toBe(MCP_CATALOG_CACHE_TTL_MS)
+      expect(discovery?.cacheScope).toBe('private')
+      expect(discovery?.capabilities?.tools?.listChanged).toBe(false)
+      expect(catalog.ttlMs).toBe(MCP_CATALOG_CACHE_TTL_MS)
+      expect(catalog.cacheScope).toBe('private')
+      const names = catalog.tools.map(({ name }) => name)
+      expect(new Set(names).size).toBe(names.length)
+    } finally {
+      await client.close()
+    }
+  })
+
+  it('keeps the legacy handshake for existing MCP hosts', async () => {
+    const client = await connectClient()
+
+    try {
+      expect(client.getProtocolEra()).toBe('legacy')
+      expect((await client.listTools()).tools.length).toBeGreaterThan(0)
+    } finally {
+      await client.close()
+    }
+  })
+})

--- a/core/__tests__/services/project-style-profile.test.ts
+++ b/core/__tests__/services/project-style-profile.test.ts
@@ -126,4 +126,17 @@ describe('project-style-profile', () => {
     expect(snap.conventionCount).toBe(0)
     expect(snap.payload.stack.ecosystem).toBe('JavaScript')
   })
+
+  test('recognizes split MCP v2 packages without duplicate library labels', () => {
+    const snap = buildProjectStyleSnapshot({
+      stats: baseStats,
+      stack: emptyStack,
+      packageDeps: {
+        '@modelcontextprotocol/client': '2.0.0',
+        '@modelcontextprotocol/server': '2.0.0',
+      },
+    })
+
+    expect(snap.payload.stack.keyLibraries.filter((name) => name === 'MCP SDK')).toHaveLength(1)
+  })
 })

--- a/core/mcp/entry.ts
+++ b/core/mcp/entry.ts
@@ -5,17 +5,11 @@
  *
  * Reads project ID from PRJCT_PROJECT_ID env var or auto-detects from cwd.
  */
-
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { serveStdio } from '@modelcontextprotocol/server/stdio'
 import { createServer } from './server'
 
-async function main() {
-  const server = createServer()
-  const transport = new StdioServerTransport()
-  await server.connect(transport)
-}
+const handle = serveStdio(createServer)
+const shutdown = () => void handle.close()
 
-main().catch((error) => {
-  console.error('prjct MCP server failed:', error)
-  process.exit(1)
-})
+process.once('SIGINT', shutdown)
+process.once('SIGTERM', shutdown)

--- a/core/mcp/resolve.ts
+++ b/core/mcp/resolve.ts
@@ -9,10 +9,7 @@ import { z } from 'zod'
 import configManager from '../infrastructure/config-manager'
 
 /** Shared schema field — omit on single-project MCP installs. */
-export const optionalProjectPath = z
-  .string()
-  .optional()
-  .describe('Project root. Omit to use PRJCT_PROJECT_PATH or the MCP server cwd.')
+export const optionalProjectPath = z.string().optional()
 
 /**
  * Resolve filesystem project root for a tool call.

--- a/core/mcp/server.ts
+++ b/core/mcp/server.ts
@@ -7,8 +7,8 @@
  * Schema tax: every registered tool's name+description+JSON schema is
  * loaded into the host model every session. Keep DEFAULT tier lean.
  */
-
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer } from '@modelcontextprotocol/server'
+import { VERSION } from '../utils/version'
 import { registerCodeIntelTools } from './tools/code-intel'
 import { registerFileTools } from './tools/files'
 import { registerMemoryTools } from './tools/memory'
@@ -43,6 +43,12 @@ Use when work needs durable project memory, intent, or harness gates. Prefer too
 export type ToolTier = 'core' | 'standard' | 'all'
 
 export const DEFAULT_MCP_TOOL_TIER: ToolTier = 'core'
+export const MCP_CATALOG_CACHE_TTL_MS = 24 * 60 * 60 * 1_000
+
+const CATALOG_CACHE_HINT = {
+  ttlMs: MCP_CATALOG_CACHE_TTL_MS,
+  cacheScope: 'private' as const,
+}
 
 export function resolveTier(envValue: string | undefined = process.env.PRJCT_MCP_TOOLS): ToolTier {
   const raw = (envValue ?? DEFAULT_MCP_TOOL_TIER).toLowerCase()
@@ -52,8 +58,15 @@ export function resolveTier(envValue: string | undefined = process.env.PRJCT_MCP
 
 export function createServer(): McpServer {
   const server = new McpServer(
-    { name: 'prjct', version: '1.0.0' },
-    { instructions: PRJCT_INSTRUCTIONS }
+    { name: 'prjct', version: VERSION },
+    {
+      capabilities: { tools: { listChanged: false } },
+      instructions: PRJCT_INSTRUCTIONS,
+      cacheHints: {
+        'server/discover': CATALOG_CACHE_HINT,
+        'tools/list': CATALOG_CACHE_HINT,
+      },
+    }
   )
 
   const tier = resolveTier()

--- a/core/mcp/tools/code-intel.ts
+++ b/core/mcp/tools/code-intel.ts
@@ -4,8 +4,7 @@
  * Exposes import graph, co-change analysis, change propagation,
  * symbol search/trace, detect_changes, and combined related-context.
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { affectedDomains, propagateChanges } from '../../domain/change-propagator'
 import {
@@ -31,17 +30,20 @@ type S = any
 export function registerCodeIntelTools(server: McpServer) {
   const s: S = server
 
-  s.tool(
+  s.registerTool(
     'prjct_impact_analysis',
-    'Blast radius + risk for changed files (or git working tree / committed range). Prefer over manual Grep for review scope.',
     {
-      projectPath: optionalProjectPath,
-      changedFiles: z
-        .array(z.string())
-        .optional()
-        .describe(
-          'Changed file paths relative to project root. Omit to auto-detect from git working tree / committed range.'
-        ),
+      description:
+        'Blast radius + risk for changed files (or git working tree / committed range). Prefer over manual Grep for review scope.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        changedFiles: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Changed file paths relative to project root. Omit to auto-detect from git working tree / committed range.'
+          ),
+      }),
     },
     safeMcpCall(
       'prjct_impact_analysis',
@@ -101,13 +103,16 @@ export function registerCodeIntelTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_search_symbols',
-    'Search the structural symbol graph (functions, classes, routes). Run prjct sync first.',
     {
-      projectPath: optionalProjectPath,
-      pattern: z.string().describe('Symbol name substring (case-insensitive)'),
-      limit: z.number().optional().default(30).describe('Max results'),
+      description:
+        'Search the structural symbol graph (functions, classes, routes). Run prjct sync first.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        pattern: z.string().describe('Symbol name substring (case-insensitive)'),
+        limit: z.number().optional().default(30).describe('Max results'),
+      }),
     },
     safeMcpCall(
       'prjct_search_symbols',
@@ -141,18 +146,21 @@ export function registerCodeIntelTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_trace_path',
-    'BFS call-path trace: who calls a function and what it calls. Prefer over Grep for "who uses X?".',
     {
-      projectPath: optionalProjectPath,
-      functionName: z.string().describe('Function/class/method name to trace'),
-      direction: z
-        .enum(['inbound', 'outbound', 'both'])
-        .optional()
-        .default('both')
-        .describe('inbound = callers, outbound = callees'),
-      depth: z.number().optional().default(3).describe('BFS depth 1-5'),
+      description:
+        'BFS call-path trace: who calls a function and what it calls. Prefer over Grep for "who uses X?".',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        functionName: z.string().describe('Function/class/method name to trace'),
+        direction: z
+          .enum(['inbound', 'outbound', 'both'])
+          .optional()
+          .default('both')
+          .describe('inbound = callers, outbound = callees'),
+        depth: z.number().optional().default(3).describe('BFS depth 1-5'),
+      }),
     },
     safeMcpCall(
       'prjct_trace_path',
@@ -214,11 +222,14 @@ export function registerCodeIntelTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_architecture',
-    'Structural architecture overview: languages, symbol kinds, packages, hotspots (call fan-in), routes, entry candidates. One shot — prefer over tree walks.',
     {
-      projectPath: optionalProjectPath,
+      description:
+        'Structural architecture overview: languages, symbol kinds, packages, hotspots (call fan-in), routes, entry candidates. One shot — prefer over tree walks.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+      }),
     },
     safeMcpCall('prjct_architecture', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -227,12 +238,15 @@ export function registerCodeIntelTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_dead_code',
-    'Find functions/methods/classes with zero inbound CALLS (excludes entry points, tests, types). Best-effort graph.',
     {
-      projectPath: optionalProjectPath,
-      limit: z.number().optional().default(50).describe('Max candidates'),
+      description:
+        'Find functions/methods/classes with zero inbound CALLS (excludes entry points, tests, types). Best-effort graph.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        limit: z.number().optional().default(50).describe('Max candidates'),
+      }),
     },
     safeMcpCall('prjct_dead_code', async (args: { projectPath: string; limit: number }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -241,13 +255,19 @@ export function registerCodeIntelTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_import_graph',
-    'Import graph stats + file neighbors (imports/importers). Pass a file for its neighbors, omit for graph stats.',
     {
-      projectPath: optionalProjectPath,
-      file: z.string().optional().describe('File path to get neighbors for (omit for graph stats)'),
-      rebuild: z.boolean().optional().default(false).describe('Force rebuild the import graph'),
+      description:
+        'Import graph stats + file neighbors (imports/importers). Pass a file for its neighbors, omit for graph stats.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        file: z
+          .string()
+          .optional()
+          .describe('File path to get neighbors for (omit for graph stats)'),
+        rebuild: z.boolean().optional().default(false).describe('Force rebuild the import graph'),
+      }),
     },
     safeMcpCall(
       'prjct_import_graph',
@@ -285,14 +305,20 @@ export function registerCodeIntelTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_cochange',
-    'Files that historically change together (Jaccard similarity from git history)',
     {
-      projectPath: optionalProjectPath,
-      seedFiles: z.array(z.string()).describe('Seed files to find co-change partners for'),
-      rebuild: z.boolean().optional().default(false).describe('Force rebuild the co-change matrix'),
-      maxResults: z.number().optional().default(10).describe('Max results (default 10)'),
+      description: 'Files that historically change together (Jaccard similarity from git history)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        seedFiles: z.array(z.string()).describe('Seed files to find co-change partners for'),
+        rebuild: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe('Force rebuild the co-change matrix'),
+        maxResults: z.number().optional().default(10).describe('Max results (default 10)'),
+      }),
     },
     safeMcpCall(
       'prjct_cochange',
@@ -330,13 +356,15 @@ export function registerCodeIntelTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_related_context',
-    'Combined: import neighbors + co-change partners for seed files',
     {
-      projectPath: optionalProjectPath,
-      seedFiles: z.array(z.string()).describe('Seed files to find related context for'),
-      maxResults: z.number().optional().default(15).describe('Max results (default 15)'),
+      description: 'Combined: import neighbors + co-change partners for seed files',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        seedFiles: z.array(z.string()).describe('Seed files to find related context for'),
+        maxResults: z.number().optional().default(15).describe('Max results (default 15)'),
+      }),
     },
     safeMcpCall(
       'prjct_related_context',

--- a/core/mcp/tools/files.ts
+++ b/core/mcp/tools/files.ts
@@ -3,8 +3,7 @@
  *
  * Wraps existing context tools: files-tool, signatures-tool, state-storage.
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { stateStorage } from '../../storage/state-storage'
 import { findRelevantFiles } from '../../tools/context/files-tool'
@@ -19,13 +18,16 @@ type S = any
 export function registerFileTools(server: McpServer) {
   const s: S = server
 
-  s.tool(
+  s.registerTool(
     'prjct_relevant_files',
-    'MUST call before Grep/Glob tree walks. Resolves a constrained work scope via prjct: memory (FTS + semantic embeddings when enabled) + code BM25 + symbol graph + import graph + co-change. Prefer this over scanning the repo. For call chains use prjct_trace_path.',
     {
-      projectPath: optionalProjectPath,
-      query: z.string().describe('Task or query to find relevant files for'),
-      maxFiles: z.number().optional().default(10).describe('Max files to return'),
+      description:
+        'MUST call before Grep/Glob tree walks. Resolves a constrained work scope via prjct: memory (FTS + semantic embeddings when enabled) + code BM25 + symbol graph + import graph + co-change. Prefer this over scanning the repo. For call chains use prjct_trace_path.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        query: z.string().describe('Task or query to find relevant files for'),
+        maxFiles: z.number().optional().default(10).describe('Max files to return'),
+      }),
     },
     safeMcpCall(
       'prjct_relevant_files',
@@ -91,12 +93,15 @@ export function registerFileTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_signatures',
-    'Function/class signatures of a file without bodies (~90% fewer tokens). Use to map an unfamiliar file before deciding whether to Read it fully.',
     {
-      projectPath: optionalProjectPath,
-      filePath: z.string().describe('Relative file path to extract signatures from'),
+      description:
+        'Function/class signatures of a file without bodies (~90% fewer tokens). Use to map an unfamiliar file before deciding whether to Read it fully.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        filePath: z.string().describe('Relative file path to extract signatures from'),
+      }),
     },
     safeMcpCall('prjct_signatures', async (args: { projectPath: string; filePath: string }) => {
       const result = await extractSignatures(args.filePath, args.projectPath)
@@ -126,12 +131,15 @@ export function registerFileTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_history',
-    'Recently completed tasks and how they ended. Use to learn what was just done before continuing related work.',
     {
-      projectPath: optionalProjectPath,
-      limit: z.number().optional().default(10).describe('Max results'),
+      description:
+        'Recently completed tasks and how they ended. Use to learn what was just done before continuing related work.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        limit: z.number().optional().default(10).describe('Max results'),
+      }),
     },
     safeMcpCall('prjct_history', async (args: { projectPath: string; limit: number }) => {
       const projectId = await resolveProjectId(args.projectPath)

--- a/core/mcp/tools/memory.ts
+++ b/core/mcp/tools/memory.ts
@@ -24,8 +24,7 @@
  * `projectMemory` API, so whatever the human types in the terminal
  * is visible here too, and vice versa.
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { enrichedRecall } from '../../memory/enriched-recall'
 import { BASE_MEMORY_TYPES, type MemoryType } from '../../memory/entries'
@@ -49,22 +48,24 @@ const TYPE_DESCRIPTIONS = `Base types: ${BASE_MEMORY_TYPES.join(', ')}. Any lowe
 export function registerMemoryTools(server: McpServer, options: { extended?: boolean } = {}) {
   const s: S = server
 
-  s.tool(
+  s.registerTool(
     'prjct_mem_save',
-    `Save a memory entry. Author content in ENGLISH regardless of the conversation language. ${TYPE_DESCRIPTIONS} Evolving topic? add tags.topic (stable key) — prjct UPSERTS by topic key, superseding prior versions instead of accumulating. Secret-like content is refused unless force=true.`,
     {
-      projectPath: optionalProjectPath,
-      type: z.string().describe('Memory type (fact/decision/learning/... or user-defined)'),
-      content: z.string().describe('The memory content. Freeform text.'),
-      tags: z
-        .record(z.string(), z.string())
-        .optional()
-        .describe('Key:value tags (e.g. {domain: "auth"})'),
-      source: z.string().optional().describe('Task id this memory came from, if any'),
-      force: z
-        .boolean()
-        .optional()
-        .describe('Bypass the secret-like-content refusal. Default false.'),
+      description:
+        'Save durable project memory in English. Use tags.topic for evolving subjects; matching topics supersede older entries.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        type: z
+          .string()
+          .describe('Memory type, such as fact, decision, learning, or a custom type'),
+        content: z.string().describe('Freeform memory text'),
+        tags: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe('Key:value metadata, such as {domain: "auth"}'),
+        source: z.string().optional().describe('Originating task id'),
+        force: z.boolean().optional().describe('Allow content rejected as secret-like'),
+      }),
     },
     safeMcpCall(
       'prjct_mem_save',
@@ -122,18 +123,21 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_mem_list',
-    'Recall memory entries as compact one-line cues (id + type + truncated body). Pull a full body on demand by id (`prjct context memory <id>`). Optional filters: topic (keyword across content + tag values), types, tags, limit.',
     {
-      projectPath: optionalProjectPath,
-      topic: z.string().optional().describe('Keyword to match over content + tag values'),
-      types: z.array(z.string()).optional().describe('Restrict to these types'),
-      tags: z
-        .record(z.string(), z.string())
-        .optional()
-        .describe('Require exact match on these k:v pairs'),
-      limit: z.number().optional().default(25).describe('Max entries (default 25)'),
+      description:
+        'Recall ranked memory as compact, resolvable cues. Filter by topic, types, tags, or limit.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        topic: z.string().optional().describe('Keyword to match over content + tag values'),
+        types: z.array(z.string()).optional().describe('Restrict to these types'),
+        tags: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe('Require exact match on these k:v pairs'),
+        limit: z.number().optional().default(25).describe('Max entries (default 25)'),
+      }),
     },
     safeMcpCall(
       'prjct_mem_list',
@@ -164,13 +168,16 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_mem_similar',
-    'Find memory entries similar to a free-text description. Keyword-based, best-effort. Returns compact one-line cues; pull a full body by id on demand.',
     {
-      projectPath: optionalProjectPath,
-      description: z.string().describe('Free-text description to find similar memories for'),
-      limit: z.number().optional().default(10).describe('Max results (default 10)'),
+      description:
+        'Find ranked memory related to a free-text description; returns compact, resolvable cues.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        description: z.string().describe('Free-text description to find similar memories for'),
+        limit: z.number().optional().default(10).describe('Max results (default 10)'),
+      }),
     },
     safeMcpCall(
       'prjct_mem_similar',
@@ -197,13 +204,16 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_guard',
-    'Anticipation: before editing a file, get the preventive memory recorded against it — gotchas, anti-patterns, recurring bugs only. Empty result means clear to edit. Pull this instead of guessing what might break.',
     {
-      projectPath: optionalProjectPath,
-      file: z.string().describe('File to check (absolute or repo-relative)'),
-      limit: z.number().optional().default(3).describe('Max preventive entries (default 3)'),
+      description:
+        'Before editing a file, retrieve preventive gotchas and recurring failures. Empty means clear to edit.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        file: z.string().describe('File to check (absolute or repo-relative)'),
+        limit: z.number().optional().default(3).describe('Max preventive entries (default 3)'),
+      }),
     },
     safeMcpCall(
       'prjct_guard',
@@ -227,12 +237,14 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_mem_forget',
-    'Remove a memory entry by id. Ids are stable — pull them from `prjct_mem_list`.',
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Memory id (e.g. "mem_42" or "ship_7")'),
+      description: 'Delete a memory by stable id from prjct_mem_list.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Memory id (e.g. "mem_42" or "ship_7")'),
+      }),
     },
     safeMcpCall('prjct_mem_forget', async (args: { projectPath?: string; id: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -281,14 +293,17 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     return { content: [{ type: 'text', text: `Saved ${type}: ${content.slice(0, 80)}` }] }
   }
 
-  s.tool(
+  s.registerTool(
     'prjct_record_decision',
-    'Record a DECISION: what was decided, why, and alternatives. Author in ENGLISH. (Or use prjct_mem_save type=decision.)',
     {
-      projectPath: optionalProjectPath,
-      decision: z.string().describe('What was decided'),
-      rationale: z.string().optional().describe('Why'),
-      alternatives: z.array(z.string()).optional().describe('Rejected options'),
+      description:
+        'Record a DECISION: what was decided, why, and alternatives. Author in ENGLISH. (Or use prjct_mem_save type=decision.)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        decision: z.string().describe('What was decided'),
+        rationale: z.string().optional().describe('Why'),
+        alternatives: z.array(z.string()).optional().describe('Rejected options'),
+      }),
     },
     safeMcpCall(
       'prjct_record_decision',
@@ -307,14 +322,17 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_record_gotcha',
-    'Record a GOTCHA (trap + fix). Tag file for prjct_guard. (Or prjct_mem_save type=gotcha.)',
     {
-      projectPath: optionalProjectPath,
-      symptom: z.string().describe('What goes wrong'),
-      fix: z.string().describe('How to avoid/fix'),
-      file: z.string().optional().describe('File path for guard'),
+      description:
+        'Record a GOTCHA (trap + fix). Tag file for prjct_guard. (Or prjct_mem_save type=gotcha.)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        symptom: z.string().describe('What goes wrong'),
+        fix: z.string().describe('How to avoid/fix'),
+        file: z.string().optional().describe('File path for guard'),
+      }),
     },
     safeMcpCall(
       'prjct_record_gotcha',
@@ -329,13 +347,16 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_record_learning',
-    'Record a LEARNING + evidence. Author in ENGLISH. (Or prjct_mem_save type=learning.)',
     {
-      projectPath: optionalProjectPath,
-      claim: z.string().describe('What was learned'),
-      evidence: z.string().optional().describe('Supporting observation'),
+      description:
+        'Record a LEARNING + evidence. Author in ENGLISH. (Or prjct_mem_save type=learning.)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        claim: z.string().describe('What was learned'),
+        evidence: z.string().optional().describe('Supporting observation'),
+      }),
     },
     safeMcpCall(
       'prjct_record_learning',
@@ -346,13 +367,16 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_record_fact',
-    'Record a FACT about a subject. Author in ENGLISH. (Or prjct_mem_save type=fact.)',
     {
-      projectPath: optionalProjectPath,
-      subject: z.string().describe('Subject'),
-      statement: z.string().describe('The fact'),
+      description:
+        'Record a FACT about a subject. Author in ENGLISH. (Or prjct_mem_save type=fact.)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        subject: z.string().describe('Subject'),
+        statement: z.string().describe('The fact'),
+      }),
     },
     safeMcpCall(
       'prjct_record_fact',
@@ -364,12 +388,14 @@ export function registerMemoryTools(server: McpServer, options: { extended?: boo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_capture_inbox',
-    'Quick INBOX capture for later triage. (Or prjct_mem_save type=inbox.)',
     {
-      projectPath: optionalProjectPath,
-      text: z.string().describe('Note text'),
+      description: 'Quick INBOX capture for later triage. (Or prjct_mem_save type=inbox.)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        text: z.string().describe('Note text'),
+      }),
     },
     safeMcpCall('prjct_capture_inbox', async (args: { projectPath?: string; text: string }) => {
       return saveTyped(args.projectPath, 'inbox', args.text)

--- a/core/mcp/tools/project.ts
+++ b/core/mcp/tools/project.ts
@@ -8,8 +8,7 @@
  * feed lands (e.g. driven by the Stop hook capturing durations),
  * add the relevant tools back here.
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { formatLikelyFileForAgent } from '../../services/file-cue'
 import { collectActiveTasks } from '../../services/task-overview'
@@ -37,11 +36,14 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
   const s: S = server
 
   // Core: managed session resume (high-value land→prime continuity).
-  s.tool(
+  s.registerTool(
     'prjct_session_resume',
-    'Managed session resume card (land→prime continuity): last land stamp, open cycle, session-close hand-off, next actions. Prefer this after a fresh window instead of re-discovering from chat.',
     {
-      projectPath: optionalProjectPath,
+      description:
+        'Resume after a fresh window: active cycle, last hand-off, journal, and next actions.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+      }),
     },
     safeMcpCall('prjct_session_resume', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -77,11 +79,13 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_task_status',
-    'The active work cycle (description, branch, when it started) plus queued work. Read this to see what is in progress before starting new work.',
     {
-      projectPath: optionalProjectPath,
+      description: 'Read active work across worktrees plus queued work.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+      }),
     },
     safeMcpCall('prjct_task_status', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -116,20 +120,23 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_task_start',
-    'Start a work cycle. Fires before/after workflow gates and memory logging through the compatibility task backend; a gate may block the start. Surfaces predictive risks (preventive memory on likely files) — same class as CLI `prjct work` — so MCP agents read traps before editing. Pass linked_spec_id only when a durable intent/spec brief is required. Use when the user begins concrete work.',
     {
-      projectPath: optionalProjectPath,
-      description: z.string().describe('What the work cycle is — a short intent phrase'),
-      linked_spec_id: z
-        .string()
-        .optional()
-        .describe('Intent/spec id to link for high-stakes work (e.g. "spec_12")'),
-      skip_hooks: z
-        .boolean()
-        .optional()
-        .describe('Skip before/after workflow rules. Default false.'),
+      description:
+        'Start a gated work cycle and return predicted file risks and context. Link a spec only when durable intent is required.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        description: z.string().describe('What the work cycle is — a short intent phrase'),
+        linked_spec_id: z
+          .string()
+          .optional()
+          .describe('Intent/spec id to link for high-stakes work (e.g. "spec_12")'),
+        skip_hooks: z
+          .boolean()
+          .optional()
+          .describe('Skip before/after workflow rules. Default false.'),
+      }),
     },
     safeMcpCall(
       'prjct_task_start',
@@ -202,14 +209,17 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_task_set_status',
-    'Change the active work cycle status. Records the transition and drives the workflow state machine. "active"/"resume" promotes paused work back to focus. To report token usage use the dedicated prjct_cost_add tool — this verb only transitions state.',
     {
-      projectPath: optionalProjectPath,
-      status: z
-        .enum(['done', 'completed', 'paused', 'active', 'resume', 'in_progress'])
-        .describe('New status'),
+      description:
+        'Transition the active cycle status. Use prjct_cost_add instead for token usage.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        status: z
+          .enum(['done', 'completed', 'paused', 'active', 'resume', 'in_progress'])
+          .describe('New status'),
+      }),
     },
     safeMcpCall('prjct_task_set_status', async (args: { projectPath: string; status: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -238,15 +248,18 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_analysis',
-    'The stored project analysis: architecture, stack, patterns, anti-patterns, conventions, tech-debt, and insights. Read this instead of re-deriving the architecture from source. Pass mode:"archive" for the history of superseded analyses.',
     {
-      projectPath: optionalProjectPath,
-      mode: z
-        .enum(['active', 'archive'])
-        .optional()
-        .describe('"active" (default) = current analysis; "archive" = superseded history'),
+      description:
+        'Read stored architecture, stack, conventions, risks, and insights. mode:"archive" includes superseded analyses.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        mode: z
+          .enum(['active', 'archive'])
+          .optional()
+          .describe('"active" (default) = current analysis; "archive" = superseded history'),
+      }),
     },
     safeMcpCall(
       'prjct_analysis',
@@ -374,17 +387,19 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
   // Standard+ only — cut ListTools token tax on default core (≤12 tools).
   // CLI parity: prjct cost, prjct context, prjct seed skills, etc.
   if (options.extended) {
-    s.tool(
+    s.registerTool(
       'prjct_cost_add',
-      'Record cycle token usage (cost/ROI). Pass model/runtime when known.',
       {
-        projectPath: optionalProjectPath,
-        tokensIn: z.number().describe('Input tokens'),
-        tokensOut: z.number().describe('Output tokens'),
-        model: z.string().optional().describe('Model id'),
-        runtime: z.string().optional().describe('Host: claude | codex | gemini | …'),
-        isEstimated: z.boolean().optional().describe('True if estimated. Default false.'),
-        workCycleId: z.string().optional().describe('Task id; defaults to active cycle'),
+        description: 'Record cycle token usage (cost/ROI). Pass model/runtime when known.',
+        inputSchema: z.object({
+          projectPath: optionalProjectPath,
+          tokensIn: z.number().describe('Input tokens'),
+          tokensOut: z.number().describe('Output tokens'),
+          model: z.string().optional().describe('Model id'),
+          runtime: z.string().optional().describe('Host: claude | codex | gemini | …'),
+          isEstimated: z.boolean().optional().describe('True if estimated. Default false.'),
+          workCycleId: z.string().optional().describe('Task id; defaults to active cycle'),
+        }),
       },
       safeMcpCall(
         'prjct_cost_add',
@@ -432,10 +447,13 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
       )
     )
 
-    s.tool(
+    s.registerTool(
       'prjct_developer',
-      'Synthesized developer profile (feedback + friction). Act as this developer would.',
-      { projectPath: optionalProjectPath },
+      {
+        description:
+          'Synthesized developer profile (feedback + friction). Act as this developer would.',
+        inputSchema: z.object({ projectPath: optionalProjectPath }),
+      },
       safeMcpCall('prjct_developer', async (args: { projectPath?: string }) => {
         const projectId = await resolveProjectId(args.projectPath)
         const { projectMemory } = await import('../../memory/project-memory')
@@ -451,10 +469,12 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
       })
     )
 
-    s.tool(
+    s.registerTool(
       'prjct_signals',
-      'Machine signals: hot files, skill-misses, friction (transient telemetry).',
-      { projectPath: optionalProjectPath },
+      {
+        description: 'Machine signals: hot files, skill-misses, friction (transient telemetry).',
+        inputSchema: z.object({ projectPath: optionalProjectPath }),
+      },
       safeMcpCall('prjct_signals', async (args: { projectPath?: string }) => {
         const projectId = await resolveProjectId(args.projectPath)
         const { projectMemory } = await import('../../memory/project-memory')
@@ -465,10 +485,12 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
       })
     )
 
-    s.tool(
+    s.registerTool(
       'prjct_skills',
-      'Skill index: name + description + EXACT SKILL.md path for subagent dispatch.',
-      { projectPath: optionalProjectPath },
+      {
+        description: 'Skill index: name + description + EXACT SKILL.md path for subagent dispatch.',
+        inputSchema: z.object({ projectPath: optionalProjectPath }),
+      },
       safeMcpCall('prjct_skills', async (args: { projectPath?: string }) => {
         const path = resolveProjectPath(args.projectPath)
         const projectId = await resolveProjectId(path)
@@ -483,22 +505,26 @@ export function registerProjectTools(server: McpServer, options: { extended?: bo
       })
     )
 
-    s.tool(
+    s.registerTool(
       'prjct_context_tiers',
-      'Context cache tiers L0–L3 + live L0 budget. Never stuff L2 into L0.',
-      { projectPath: optionalProjectPath },
+      {
+        description: 'Context cache tiers L0–L3 + live L0 budget. Never stuff L2 into L0.',
+        inputSchema: z.object({ projectPath: optionalProjectPath }),
+      },
       safeMcpCall('prjct_context_tiers', async () => {
         const { formatContextTiersMd } = await import('../../services/context-tiers')
         return { content: [{ type: 'text', text: formatContextTiersMd() }] }
       })
     )
 
-    s.tool(
+    s.registerTool(
       'prjct_safe_artifacts',
-      'Audit agent outputs: judgment, ships, handoffs, checkpoints, session stamp.',
       {
-        projectPath: optionalProjectPath,
-        limit: z.number().int().min(1).max(20).optional().describe('Max per kind (default 5)'),
+        description: 'Audit agent outputs: judgment, ships, handoffs, checkpoints, session stamp.',
+        inputSchema: z.object({
+          projectPath: optionalProjectPath,
+          limit: z.number().int().min(1).max(20).optional().describe('Max per kind (default 5)'),
+        }),
       },
       safeMcpCall(
         'prjct_safe_artifacts',

--- a/core/mcp/tools/spec.ts
+++ b/core/mcp/tools/spec.ts
@@ -12,8 +12,7 @@
  * them (intent recognition) so a fresh Claude session in the desktop
  * app routes feature/spec talk to the right tool.
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { renderAuditDispatch, selectReviewers } from '../../services/spec-audit-dispatch'
 import { specService } from '../../services/spec-service'
@@ -36,30 +35,33 @@ type S = any
 export function registerSpecTools(server: McpServer) {
   const s: S = server
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_create',
-    'Draft a spec when the user frames a feature/fix/initiative WITH goals or stakes (e.g. "rate limiting on auth", "fix onboarding"). Fields default empty — fill them via `prjct_spec_update`. Skip for routine work (single-file fix, doc tweak, capture); use `prjct_mem_save` with type="inbox" or the CLI `prjct capture` instead.',
     {
-      projectPath: optionalProjectPath,
-      title: z.string().describe("One-line title (what you'd say to a coworker walking by)"),
-      goal: z.string().describe('What success looks like, 1-3 sentences. Concrete, observable.'),
-      eli10: z.string().optional().describe('Plain English a 16-year-old follows, 2-4 sentences'),
-      stakes: z.string().optional().describe('What breaks if we ship the wrong thing'),
-      acceptance_criteria: z
-        .array(z.string())
-        .optional()
-        .describe('Testable, observable list. Each item ends in a verifiable claim.'),
-      scope: z.array(z.string()).optional().describe("What's IN — file paths, modules, surfaces"),
-      out_of_scope: z.array(z.string()).optional().describe("What's OUT — anti-creep shield"),
-      risks: z
-        .array(z.object({ risk: z.string(), mitigation: z.string() }))
-        .optional()
-        .describe('Each risk has a mitigation; a risk without one is just a complaint'),
-      test_plan: z.array(z.string()).optional().describe('How you prove acceptance criteria'),
-      tags: z
-        .record(z.string(), z.string())
-        .optional()
-        .describe('Key:value tags (e.g. {domain: "auth", priority: "high"})'),
+      description:
+        'Draft a spec when the user frames a feature/fix/initiative WITH goals or stakes (e.g. "rate limiting on auth", "fix onboarding"). Fields default empty — fill them via `prjct_spec_update`. Skip for routine work (single-file fix, doc tweak, capture); use `prjct_mem_save` with type="inbox" or the CLI `prjct capture` instead.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        title: z.string().describe("One-line title (what you'd say to a coworker walking by)"),
+        goal: z.string().describe('What success looks like, 1-3 sentences. Concrete, observable.'),
+        eli10: z.string().optional().describe('Plain English a 16-year-old follows, 2-4 sentences'),
+        stakes: z.string().optional().describe('What breaks if we ship the wrong thing'),
+        acceptance_criteria: z
+          .array(z.string())
+          .optional()
+          .describe('Testable, observable list. Each item ends in a verifiable claim.'),
+        scope: z.array(z.string()).optional().describe("What's IN — file paths, modules, surfaces"),
+        out_of_scope: z.array(z.string()).optional().describe("What's OUT — anti-creep shield"),
+        risks: z
+          .array(z.object({ risk: z.string(), mitigation: z.string() }))
+          .optional()
+          .describe('Each risk has a mitigation; a risk without one is just a complaint'),
+        test_plan: z.array(z.string()).optional().describe('How you prove acceptance criteria'),
+        tags: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe('Key:value tags (e.g. {domain: "auth", priority: "high"})'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_create',
@@ -105,16 +107,19 @@ export function registerSpecTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_list',
-    'List specs in this project. Use to check what specs exist before drafting a new one (avoid duplicates) or to find the right spec to link a task to.',
     {
-      projectPath: optionalProjectPath,
-      status: z
-        .enum(SPEC_STATUSES)
-        .optional()
-        .describe('Filter by status: draft|reviewed|in_progress|shipped|archived'),
-      includeArchived: z.boolean().optional().describe('Include archived specs (default: false)'),
+      description:
+        'List specs in this project. Use to check what specs exist before drafting a new one (avoid duplicates) or to find the right spec to link a task to.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        status: z
+          .enum(SPEC_STATUSES)
+          .optional()
+          .describe('Filter by status: draft|reviewed|in_progress|shipped|archived'),
+        includeArchived: z.boolean().optional().describe('Include archived specs (default: false)'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_list',
@@ -148,12 +153,15 @@ export function registerSpecTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_get',
-    'Fetch one spec by id, including all structured fields (goal, acceptance criteria, scope, risks, reviews, linked tasks).',
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Spec id'),
+      description:
+        'Fetch one spec by id, including all structured fields (goal, acceptance criteria, scope, risks, reviews, linked tasks).',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Spec id'),
+      }),
     },
     safeMcpCall('prjct_spec_get', async (args: { projectPath: string; id: string }) => {
       const spec = await specService.get(resolveProjectPath(args.projectPath), args.id)
@@ -166,26 +174,29 @@ export function registerSpecTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_update',
-    "Replace a spec's structured content. Pass the FULL content object (this is a replace, not a merge) — when filling in acceptance_criteria for the first time, fetch with `prjct_spec_get` first and merge in your changes.",
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Spec id'),
-      content: z
-        .object({
-          goal: z.string(),
-          eli10: z.string().optional(),
-          stakes: z.string().optional(),
-          acceptance_criteria: z.array(z.string()).optional(),
-          scope: z.array(z.string()).optional(),
-          out_of_scope: z.array(z.string()).optional(),
-          risks: z.array(z.object({ risk: z.string(), mitigation: z.string() })).optional(),
-          test_plan: z.array(z.string()).optional(),
-          notes: z.string().optional(),
-          linked_tasks: z.array(z.string()).optional(),
-        })
-        .describe('Full SpecContent shape — Zod-validated server-side'),
+      description:
+        "Replace a spec's structured content. Pass the FULL content object (this is a replace, not a merge) — when filling in acceptance_criteria for the first time, fetch with `prjct_spec_get` first and merge in your changes.",
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Spec id'),
+        content: z
+          .object({
+            goal: z.string(),
+            eli10: z.string().optional(),
+            stakes: z.string().optional(),
+            acceptance_criteria: z.array(z.string()).optional(),
+            scope: z.array(z.string()).optional(),
+            out_of_scope: z.array(z.string()).optional(),
+            risks: z.array(z.object({ risk: z.string(), mitigation: z.string() })).optional(),
+            test_plan: z.array(z.string()).optional(),
+            notes: z.string().optional(),
+            linked_tasks: z.array(z.string()).optional(),
+          })
+          .describe('Full SpecContent shape — Zod-validated server-side'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_update',
@@ -210,13 +221,16 @@ export function registerSpecTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_set_status',
-    'Promote/demote a spec lifecycle state: `in_progress` when work starts, `archived` when superseded. (draft → reviewed auto-promotes when reviewers pass; for first ship use `prjct_spec_ship` so the PR is recorded.)',
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Spec id'),
-      status: z.enum(SPEC_STATUSES).describe('Target status'),
+      description:
+        'Promote/demote a spec lifecycle state: `in_progress` when work starts, `archived` when superseded. (draft → reviewed auto-promotes when reviewers pass; for first ship use `prjct_spec_ship` so the PR is recorded.)',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Spec id'),
+        status: z.enum(SPEC_STATUSES).describe('Target status'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_set_status',
@@ -236,12 +250,15 @@ export function registerSpecTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_audit',
-    'Call before implementing a spec. Returns a dispatch prompt for the review specialists the spec raises — a DYNAMIC set (architecture is the floor; security/data/performance/design/strategic + any project DOMAIN experts join when the spec signals them). Run them IN PARALLEL (one Agent block per reviewer, same message). Persist each verdict via `prjct_spec_record_review`; all pass → spec auto-promotes draft → reviewed.',
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Spec id to audit'),
+      description:
+        'Call before implementing a spec. Returns a dispatch prompt for the review specialists the spec raises — a DYNAMIC set (architecture is the floor; security/data/performance/design/strategic + any project DOMAIN experts join when the spec signals them). Run them IN PARALLEL (one Agent block per reviewer, same message). Persist each verdict via `prjct_spec_record_review`; all pass → spec auto-promotes draft → reviewed.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Spec id to audit'),
+      }),
     },
     safeMcpCall('prjct_spec_audit', async (args: { projectPath: string; id: string }) => {
       const spec = await specService.get(resolveProjectPath(args.projectPath), args.id)
@@ -275,15 +292,18 @@ export function registerSpecTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_record_review',
-    "Persist one reviewer's verdict from `prjct_spec_audit` dispatch. Call once per reviewer (strategic, architecture, design). When all three are recorded with verdict=pass, the spec auto-promotes draft → reviewed.",
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Spec id'),
-      reviewer: z.string().min(1).describe('Which lens (e.g. architecture, security, data)'),
-      verdict: z.enum(['pass', 'fail']).describe('Verdict'),
-      notes: z.string().describe('2-4 sentence notes from the subagent'),
+      description:
+        "Persist one reviewer's verdict from `prjct_spec_audit` dispatch. Call once per reviewer (strategic, architecture, design). When all three are recorded with verdict=pass, the spec auto-promotes draft → reviewed.",
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Spec id'),
+        reviewer: z.string().min(1).describe('Which lens (e.g. architecture, security, data)'),
+        verdict: z.enum(['pass', 'fail']).describe('Verdict'),
+        notes: z.string().describe('2-4 sentence notes from the subagent'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_record_review',
@@ -315,13 +335,16 @@ export function registerSpecTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_link_task',
-    'Link a task to its spec (call after starting the task) so `prjct_ship` knows which spec to gate against. Idempotent.',
     {
-      projectPath: optionalProjectPath,
-      specId: z.string().describe('Spec id'),
-      taskId: z.string().describe('Task id (from `prjct_task_start` or stateStorage)'),
+      description:
+        'Link a task to its spec (call after starting the task) so `prjct_ship` knows which spec to gate against. Idempotent.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        specId: z.string().describe('Spec id'),
+        taskId: z.string().describe('Task id (from `prjct_task_start` or stateStorage)'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_link_task',
@@ -341,13 +364,16 @@ export function registerSpecTools(server: McpServer) {
     )
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_spec_ship',
-    'Mark a spec as shipped (after the linked PR merges). Records the PR number on the spec for provenance.',
     {
-      projectPath: optionalProjectPath,
-      id: z.string().describe('Spec id'),
-      pr: z.number().optional().describe('PR / MR number that delivered the spec'),
+      description:
+        'Mark a spec as shipped (after the linked PR merges). Records the PR number on the spec for provenance.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        id: z.string().describe('Spec id'),
+        pr: z.number().optional().describe('PR / MR number that delivered the spec'),
+      }),
     },
     safeMcpCall(
       'prjct_spec_ship',

--- a/core/mcp/tools/workflow.ts
+++ b/core/mcp/tools/workflow.ts
@@ -3,8 +3,7 @@
  *
  * Wraps custom-workflow-storage and workflow-rule-storage.
  */
-
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { McpServer } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import { customWorkflowStorage } from '../../storage/custom-workflow-storage'
 import { workflowRuleStorage } from '../../storage/workflow-rule-storage'
@@ -18,12 +17,15 @@ type S = any
 export function registerWorkflowTools(server: McpServer) {
   const s: S = server
 
-  s.tool(
+  s.registerTool(
     'prjct_workflow_rules',
-    'The gates/hooks/steps registered for a command (task, ship, …). Check before running a lifecycle verb so a gate never surprises you mid-action.',
     {
-      projectPath: optionalProjectPath,
-      command: z.string().describe('Command name (task, done, ship, sync, etc.)'),
+      description:
+        'The gates/hooks/steps registered for a command (task, ship, …). Check before running a lifecycle verb so a gate never surprises you mid-action.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+        command: z.string().describe('Command name (task, done, ship, sync, etc.)'),
+      }),
     },
     safeMcpCall('prjct_workflow_rules', async (args: { projectPath: string; command: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -55,11 +57,14 @@ export function registerWorkflowTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_workflow_list',
-    'Every workflow this project registered (built-in + custom). Use to discover what `prjct workflow run <name>` can execute here.',
     {
-      projectPath: optionalProjectPath,
+      description:
+        'Every workflow this project registered (built-in + custom). Use to discover what `prjct workflow run <name>` can execute here.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+      }),
     },
     safeMcpCall('prjct_workflow_list', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)
@@ -83,11 +88,14 @@ export function registerWorkflowTools(server: McpServer) {
     })
   )
 
-  s.tool(
+  s.registerTool(
     'prjct_workflow_status',
-    'Where the active work cycle sits in its workflow/gates (state + rules currently in force). Read when deciding whether done/ship is allowed next.',
     {
-      projectPath: optionalProjectPath,
+      description:
+        'Where the active work cycle sits in its workflow/gates (state + rules currently in force). Read when deciding whether done/ship is allowed next.',
+      inputSchema: z.object({
+        projectPath: optionalProjectPath,
+      }),
     },
     safeMcpCall('prjct_workflow_status', async (args: { projectPath: string }) => {
       const projectId = await resolveProjectId(args.projectPath)

--- a/core/schemas/eval.ts
+++ b/core/schemas/eval.ts
@@ -21,7 +21,7 @@ export const EvalScenarioSchema = z.object({
   status: z.enum(['pass', 'warn', 'fail']),
   score: z.number().min(0).max(100),
   durationMs: z.number().nonnegative(),
-  metrics: z.record(z.union([z.string(), z.number(), z.boolean()])),
+  metrics: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])),
   actionables: z.array(EvalActionableSchema),
 })
 

--- a/core/services/project-style-profile.ts
+++ b/core/services/project-style-profile.ts
@@ -28,6 +28,8 @@ const KNOWN_LIBS = [
   'zod',
   'better-sqlite3',
   '@modelcontextprotocol/sdk',
+  '@modelcontextprotocol/client',
+  '@modelcontextprotocol/server',
   'chalk',
   'chokidar',
   'commander',
@@ -271,13 +273,13 @@ function buildCommands(commands?: ProjectCommands | null): ProjectStyleCommands 
 }
 
 function collectKeyLibraries(deps: Record<string, string>): string[] {
-  const out: string[] = []
+  const libraries = new Set<string>()
   for (const name of KNOWN_LIBS) {
     if (deps[name]) {
-      out.push(displayLibName(name))
+      libraries.add(displayLibName(name))
     }
   }
-  return out.slice(0, 16)
+  return [...libraries].slice(0, 16)
 }
 
 function displayLibName(pkg: string): string {
@@ -294,6 +296,8 @@ function displayLibName(pkg: string): string {
     zod: 'Zod',
     'better-sqlite3': 'better-sqlite3',
     '@modelcontextprotocol/sdk': 'MCP SDK',
+    '@modelcontextprotocol/client': 'MCP SDK',
+    '@modelcontextprotocol/server': 'MCP SDK',
     biome: 'Biome',
     lefthook: 'Lefthook',
     'drizzle-orm': 'Drizzle',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prjct-cli",
-  "version": "3.82.0",
+  "version": "3.83.0",
   "description": "The agentic harness for AI coding agents — work cycles, bounded RAG context, persistent memory, guardrails, and performance evals.",
   "main": "dist/bin/prjct.mjs",
   "bin": {
@@ -76,11 +76,11 @@
   ],
   "dependencies": {
     "@clack/prompts": "1.0.0",
-    "@modelcontextprotocol/sdk": "1.29.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "chalk": "4.1.2",
     "chokidar": "5.0.0",
     "jsonc-parser": "3.3.1",
-    "zod": "3.25.76"
+    "zod": "4.3.6"
   },
   "overrides": {
     "path-to-regexp": "8.4.0",
@@ -92,6 +92,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.13",
+    "@modelcontextprotocol/client": "2.0.0",
     "@types/bun": "latest",
     "@types/chokidar": "2.1.7",
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- migrate the stdio server to MCP TypeScript SDK v2 and Zod 4
- negotiate MCP 2026-07-28 while retaining legacy 2025 clients
- cache discovery/tool catalogs for 24 hours and disable unused list-change subscriptions
- reduce the default core catalog from 7,699 to 4,871 serialized bytes
- document compatibility and measured efficiency gains

## Validation
- bun run typecheck
- bun run check
- bun run build
- bun test --dots
- bun run knip
- modern and legacy stdio integration tests